### PR TITLE
graph python interface

### DIFF
--- a/graph/graph_test.py
+++ b/graph/graph_test.py
@@ -1,0 +1,217 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import unittest
+
+import torch
+from beanmachine import graph
+
+
+class TestBayesNet(unittest.TestCase):
+    def test_simple_dep(self):
+        g = graph.Graph()
+        c1 = g.add_constant(torch.FloatTensor([0.8, 0.2]))
+        d1 = g.add_distribution(
+            graph.DistributionType.TABULAR, graph.AtomicType.BOOLEAN, [c1]
+        )
+        g.add_operator(graph.OperatorType.SAMPLE, [d1])
+
+    def test_tabular(self):
+        g = graph.Graph()
+        c1 = g.add_constant(torch.FloatTensor([0.8, 0.2]))
+
+        # negative test
+        with self.assertRaises(ValueError) as cm:
+            g.add_distribution(
+                graph.DistributionType.TABULAR, graph.AtomicType.BOOLEAN, []
+            )
+        self.assertTrue(
+            "Tabular distribution first arg must be tensor" in str(cm.exception)
+        )
+
+        g = graph.Graph()
+        c1 = g.add_constant(torch.FloatTensor([0.8, 0.2]))
+        var1 = g.add_operator(
+            graph.OperatorType.SAMPLE,
+            [
+                g.add_distribution(
+                    graph.DistributionType.TABULAR, graph.AtomicType.BOOLEAN, [c1]
+                )
+            ],
+        )
+        var2 = g.add_operator(
+            graph.OperatorType.SAMPLE,
+            [
+                g.add_distribution(
+                    graph.DistributionType.TABULAR, graph.AtomicType.BOOLEAN, [c1]
+                )
+            ],
+        )
+
+        # since the following has two parents it must have a tabular dist with
+        # 3 dimensions in the tensor
+        with self.assertRaises(ValueError) as cm:
+            g.add_operator(
+                graph.OperatorType.SAMPLE,
+                [
+                    g.add_distribution(
+                        graph.DistributionType.TABULAR,
+                        graph.AtomicType.BOOLEAN,
+                        [c1, var1, var2],
+                    )
+                ],
+            )
+        self.assertTrue("expected 3 dims got 1" in str(cm.exception))
+
+        c2 = g.add_constant(torch.FloatTensor([[0.6, 0.4], [0.99, 0.01]]))
+        g.add_distribution(
+            graph.DistributionType.TABULAR,
+            graph.AtomicType.BOOLEAN,
+            [c2, g.add_constant(True)],
+        )
+
+        with self.assertRaises(ValueError) as cm:
+            g.add_distribution(
+                graph.DistributionType.TABULAR,
+                graph.AtomicType.BOOLEAN,
+                [c2, g.add_constant(torch.tensor(1))],
+            )
+        self.assertTrue("only supports boolean parents" in str(cm.exception))
+
+        c3 = g.add_constant(torch.FloatTensor([1.1, -0.1]))
+        with self.assertRaises(ValueError) as cm:
+            g.add_distribution(
+                graph.DistributionType.TABULAR, graph.AtomicType.BOOLEAN, [c3]
+            )
+        self.assertTrue("must be positive" in str(cm.exception))
+
+        c4 = g.add_constant(torch.FloatTensor([0.9, 0.0999]))
+        with self.assertRaises(ValueError) as cm:
+            g.add_distribution(
+                graph.DistributionType.TABULAR, graph.AtomicType.BOOLEAN, [c4]
+            )
+        self.assertTrue("must add to 1" in str(cm.exception))
+
+    def test_bernoulli(self):
+        g = graph.Graph()
+        c1 = g.add_constant(1.0)
+        c2 = g.add_constant(0.8)
+
+        # negative tests on number of parents
+        # 0 parents not allowed
+        with self.assertRaises(ValueError) as cm:
+            g.add_distribution(
+                graph.DistributionType.BERNOULLI, graph.AtomicType.BOOLEAN, []
+            )
+        self.assertTrue(
+            "Bernoulli distribution must have exactly one parent" in str(cm.exception)
+        )
+        # 2 parents not allowed
+        with self.assertRaises(ValueError) as cm:
+            g.add_distribution(
+                graph.DistributionType.BERNOULLI, graph.AtomicType.BOOLEAN, [c1, c2]
+            )
+        self.assertTrue(
+            "Bernoulli distribution must have exactly one parent" in str(cm.exception)
+        )
+
+        # 1 parent is OK
+        d1 = g.add_distribution(
+            graph.DistributionType.BERNOULLI, graph.AtomicType.BOOLEAN, [c1]
+        )
+
+        # negative test on type of parent
+        c3 = g.add_constant(torch.scalar_tensor(1, dtype=torch.int))
+        with self.assertRaises(ValueError) as cm:
+            g.add_distribution(
+                graph.DistributionType.BERNOULLI, graph.AtomicType.BOOLEAN, [c3]
+            )
+        self.assertTrue("must be real-valued" in str(cm.exception))
+
+        # negative test on value of parent
+        c4 = g.add_constant(1.1)
+        with self.assertRaises(ValueError) as cm:
+            g.add_distribution(
+                graph.DistributionType.BERNOULLI, graph.AtomicType.BOOLEAN, [c4]
+            )
+        self.assertTrue("must be between 0 and 1" in str(cm.exception))
+
+        v1 = g.add_operator(graph.OperatorType.SAMPLE, [d1])
+        g.query(v1)
+        samples = g.infer(1)
+        self.assertTrue(samples[0][0].type == graph.AtomicType.BOOLEAN)
+        self.assertTrue(samples[0][0].bool)
+
+    def _create_graph(self):
+        g = graph.Graph()
+        c1 = g.add_constant(torch.FloatTensor([0.8, 0.2]))
+        c2 = g.add_constant(torch.FloatTensor([[0.6, 0.4], [0.99, 0.01]]))
+        c3 = g.add_constant(
+            torch.FloatTensor([[[1, 0], [0.2, 0.8]], [[0.1, 0.9], [0.01, 0.99]]])
+        )
+        Rain = g.add_operator(
+            graph.OperatorType.SAMPLE,
+            [
+                g.add_distribution(
+                    graph.DistributionType.TABULAR, graph.AtomicType.BOOLEAN, [c1]
+                )
+            ],
+        )
+        Sprinkler = g.add_operator(
+            graph.OperatorType.SAMPLE,
+            [
+                g.add_distribution(
+                    graph.DistributionType.TABULAR, graph.AtomicType.BOOLEAN, [c2, Rain]
+                )
+            ],
+        )
+        GrassWet = g.add_operator(
+            graph.OperatorType.SAMPLE,
+            [
+                g.add_distribution(
+                    graph.DistributionType.TABULAR,
+                    graph.AtomicType.BOOLEAN,
+                    [c3, Sprinkler, Rain],
+                )
+            ],
+        )
+        return g, Rain, Sprinkler, GrassWet
+
+    def test_query(self):
+        g, Rain, Sprinkler, GrassWet = self._create_graph()
+        g.query(Rain)
+        g.query(Sprinkler)
+        g.query(GrassWet)
+        g.infer(1)
+
+    def test_observe(self):
+        g, Rain, Sprinkler, GrassWet = self._create_graph()
+        g.observe(GrassWet, True)
+        with self.assertRaises(ValueError) as cm:
+            g.observe(GrassWet, True)
+        self.assertTrue("duplicate observe for node" in str(cm.exception))
+
+        g = graph.Graph()
+        c1 = g.add_constant(1.0)
+        c2 = g.add_constant(0.5)
+        o1 = g.add_operator(graph.OperatorType.MULTIPLY, [c1, c2])
+        d1 = g.add_distribution(
+            graph.DistributionType.BERNOULLI, graph.AtomicType.BOOLEAN, [o1]
+        )
+        o2 = g.add_operator(graph.OperatorType.SAMPLE, [d1])
+        with self.assertRaises(ValueError) as cm:
+            g.observe(o1, True)
+        self.assertTrue("only sample nodes may be observed" in str(cm.exception))
+        g.observe(o2, True)  # ok to observe this node
+
+    def test_inference(self):
+        g, Rain, Sprinkler, GrassWet = self._create_graph()
+        g.observe(GrassWet, True)
+        g.query(Rain)
+        g.query(GrassWet)
+        with self.assertRaises(ValueError) as cm:
+            g.query(Rain)
+        self.assertTrue("duplicate query for node" in str(cm.exception))
+        samples = g.infer(1)
+        self.assertTrue(len(samples) == 1)
+        # since we have observed grass wet is true the query should be true
+        self.assertTrue(samples[0][1].type == graph.AtomicType.BOOLEAN)
+        self.assertTrue(samples[0][1].bool)

--- a/graph/operator_test.py
+++ b/graph/operator_test.py
@@ -1,0 +1,103 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import unittest
+
+import beanmachine.graph as bmg
+import torch
+
+
+class TestOperators(unittest.TestCase):
+    def test_oper_args(self):
+        """
+        We will test test number of arguments for each operator 0, 1, 2, 3 etc.
+        """
+        g = bmg.Graph()
+        c1 = g.add_constant(torch.FloatTensor([0, 1, -1]))
+        c2 = g.add_constant(torch.FloatTensor([0, 1, -1]))
+        c3 = g.add_constant(torch.FloatTensor([0, 1, -1]))
+        # test TO_REAL
+        with self.assertRaises(ValueError):
+            g.add_operator(bmg.OperatorType.TO_REAL, [])
+        g.add_operator(bmg.OperatorType.TO_REAL, [c1])
+        with self.assertRaises(ValueError):
+            g.add_operator(bmg.OperatorType.TO_REAL, [c1, c2])
+        # test EXP
+        with self.assertRaises(ValueError):
+            g.add_operator(bmg.OperatorType.EXP, [])
+        g.add_operator(bmg.OperatorType.EXP, [c1])
+        with self.assertRaises(ValueError):
+            g.add_operator(bmg.OperatorType.EXP, [c1, c2])
+        # test NEGATE
+        with self.assertRaises(ValueError):
+            g.add_operator(bmg.OperatorType.NEGATE, [])
+        g.add_operator(bmg.OperatorType.NEGATE, [c1])
+        with self.assertRaises(ValueError):
+            g.add_operator(bmg.OperatorType.NEGATE, [c1, c2])
+        # test MULTIPLY
+        with self.assertRaises(ValueError):
+            g.add_operator(bmg.OperatorType.MULTIPLY, [])
+        with self.assertRaises(ValueError):
+            g.add_operator(bmg.OperatorType.MULTIPLY, [c1])
+        g.add_operator(bmg.OperatorType.MULTIPLY, [c1, c2])
+        g.add_operator(bmg.OperatorType.MULTIPLY, [c1, c2, c3])
+        # test ADD
+        with self.assertRaises(ValueError):
+            g.add_operator(bmg.OperatorType.ADD, [])
+        with self.assertRaises(ValueError):
+            g.add_operator(bmg.OperatorType.ADD, [c1])
+        g.add_operator(bmg.OperatorType.ADD, [c1, c2])
+        g.add_operator(bmg.OperatorType.ADD, [c1, c2, c3])
+
+    def test_arithmetic(self):
+        g = bmg.Graph()
+        const1 = torch.FloatTensor([0, 1, -1])
+        c1 = g.add_constant(const1)
+        o1 = g.add_operator(bmg.OperatorType.NEGATE, [c1])
+        o2 = g.add_operator(bmg.OperatorType.EXP, [o1])
+        o3 = g.add_operator(bmg.OperatorType.MULTIPLY, [o2, c1])
+        o4 = g.add_operator(bmg.OperatorType.ADD, [c1, c1, o3])
+        g.query(o4)
+        samples = g.infer(2)
+        # both samples should have exactly the same value since we are doing
+        # deterministic operators only
+        self.assertEqual(samples[0][0].type, bmg.AtomicType.TENSOR)
+        self.assertTrue((samples[0][0].tensor == samples[1][0].tensor).all().item())
+        # the result should be identical to doing this math directly on tensors
+        result = const1 + const1 + torch.exp(-const1) * const1
+        self.assertTrue((samples[0][0].tensor == result).all().item())
+
+    def test_sample(self):
+        # negative test we can't exponentiate the sample from a Bernoulli
+        g = bmg.Graph()
+        c1 = g.add_constant(0.6)
+        d1 = g.add_distribution(
+            bmg.DistributionType.BERNOULLI, bmg.AtomicType.BOOLEAN, [c1]
+        )
+        s1 = g.add_operator(bmg.OperatorType.SAMPLE, [d1])
+        o1 = g.add_operator(bmg.OperatorType.EXP, [s1])
+        g.query(o1)
+        # note: this error is raised by the torch library so we don't want to
+        # assert on the error message here
+        with self.assertRaises(RuntimeError) as cm:
+            g.infer(1)
+        self.assertTrue("invalid parent type" in str(cm.exception))
+
+        # the proper way to do it is to convert to floating point first
+        g = bmg.Graph()
+        c1 = g.add_constant(0.6)
+        d1 = g.add_distribution(
+            bmg.DistributionType.BERNOULLI, bmg.AtomicType.BOOLEAN, [c1]
+        )
+        s1 = g.add_operator(bmg.OperatorType.SAMPLE, [d1])
+        o1 = g.add_operator(bmg.OperatorType.TO_REAL, [s1])
+        # o2 and o3 both compute the same value
+        o2 = g.add_operator(bmg.OperatorType.EXP, [o1])
+        o3 = g.add_operator(bmg.OperatorType.EXP, [o1])
+        o4 = g.add_operator(bmg.OperatorType.NEGATE, [o3])
+        o5 = g.add_operator(bmg.OperatorType.ADD, [o2, o4])
+        # o5 should be 0 in all possible worlds
+        g.query(o5)
+        samples = g.infer(10)
+        self.assertEqual(samples[0][0].type, bmg.AtomicType.REAL)
+        self.assertEqual(
+            [s[0].real for s in samples], [0.0] * 10, "all samples should be zero"
+        )


### PR DESCRIPTION
Summary:
Add the python interface to beanmachine graph and the python unit tests as well. These changes have already been reviewed and are simply being moved over.

Also, added an interactive terminal target for playing with Bean Machine.

Differential Revision: D16826447

