### PR TITLE
cache the ancestors of nodes to build graph faster in CAVI

### DIFF
--- a/graph/cavi.cpp
+++ b/graph/cavi.cpp
@@ -57,13 +57,10 @@ void Graph::cavi(uint num_iters, uint steps_per_iter, std::mt19937& gen) {
       // the deterministic nodes have to be evaluated in topological order
       std::set<uint> det_set;
       for (auto id : logprob_nodes) {
-        std::vector<uint> det_anc;
-        std::vector<uint> sto_anc;
-        std::tie(det_anc, sto_anc) = compute_ancestors(id, supp);
-        for (auto id2 : det_anc) {
+        for (auto id2 : node_ptrs[id]->det_anc) {
           det_set.insert(id2);
         }
-        for (auto id2 : sto_anc) {
+        for (auto id2 : node_ptrs[id]->sto_anc) {
           if (id2 != node_id and observed.find(id2) == observed.end()) {
             sample_set.insert(id2);
           }

--- a/graph/graph.h
+++ b/graph/graph.h
@@ -74,6 +74,8 @@ class Node {
   uint index; // index in Graph::nodes
   std::vector<Node*> in_nodes;
   std::vector<Node*> out_nodes;
+  std::vector<uint> det_anc; // deterministic (operator) ancestors
+  std::vector<uint> sto_anc; // stochastic ancestors
   AtomicValue value;
   bool is_stochastic() const;
   double log_prob() const; // only valid for stochastic nodes
@@ -140,7 +142,7 @@ struct Graph {
   std::tuple<std::vector<uint>, std::vector<uint>> compute_descendants(
       uint node_id, const std::set<uint> &support);
   std::tuple<std::vector<uint>, std::vector<uint>> compute_ancestors(
-      uint node_id, const std::set<uint> &support);
+      uint node_id);
 
  private:
   uint add_node(std::unique_ptr<Node> node, std::vector<uint> parents);

--- a/graph/support.cpp
+++ b/graph/support.cpp
@@ -95,54 +95,19 @@ std::tuple<std::vector<uint>, std::vector<uint>> Graph::compute_descendants(
 
 // compute the ancestors of the current node
 // returns vector of deterministic nodes and vector of stochastic nodes
-// that are operators and ancestors of the current node and in the support
+// that are operators and ancestors of the current node
 // NOTE: we don't return ancestors of stochastic ancestors
 // NOTE: current node is not returned
 std::tuple<std::vector<uint>, std::vector<uint>> Graph::compute_ancestors(
-    uint root_id, const std::set<uint> &support) {
+    uint root_id) {
   // check for the validity of root_id since this method is not private
   if (root_id >= nodes.size()) {
     throw std::out_of_range(
         "node_id (" + std::to_string(root_id) + ") must be less than "
         + std::to_string(nodes.size()));
   }
-  std::list<uint> queue;
   const Node* root = nodes[root_id].get();
-  for (const auto& par : root->in_nodes) {
-    queue.push_back(par->index);
-  }
-  std::vector<uint> det_anc;
-  std::vector<uint> sto_anc;
-  // we will do a BFS starting from the current node and ending at stochastic
-  // nodes going up in the parent direction
-  std::set<uint> visited;
-  // BFS loop
-  while (queue.size() > 0) {
-    uint node_id = queue.front();
-    queue.pop_front();
-    if (visited.find(node_id) != visited.end()) {
-      continue;
-    }
-    visited.insert(node_id);
-    const Node* node = nodes[node_id].get();
-    // we stop looking at ancestors when we hit a stochastic node
-    if (node->is_stochastic()) {
-      if  (support.find(node_id) != support.end()) {
-        sto_anc.push_back(node_id);
-      }
-      continue;
-    }
-    else if (node->node_type == NodeType::OPERATOR and
-      support.find(node_id) != support.end()) {
-      det_anc.push_back(node_id);
-    }
-    for (const auto& par : node->in_nodes) {
-      queue.push_back(par->index);
-    }
-  }
-  std::sort(det_anc.begin(), det_anc.end());
-  std::sort(sto_anc.begin(), sto_anc.end());
-  return std::make_tuple(det_anc, sto_anc);
+  return std::make_tuple(root->det_anc, root->sto_anc);
 }
 
 } // namespace graph

--- a/graph/support_test.cpp
+++ b/graph/support_test.cpp
@@ -65,17 +65,19 @@ TEST(testgraph, support) {
   EXPECT_EQ(sto_nodes.front(), o4);
   std::vector<uint> det_anc;
   std::vector<uint> sto_anc;
-  std::tie(det_anc, sto_anc) = g.compute_ancestors(o4, supp);
+  std::tie(det_anc, sto_anc) = g.compute_ancestors(o4);
   // o4 -ancestors-> det: c3, c4, o3, d2 sto:
-  // restricting to support: det: o3 sto:
+  // restricting to operators: det: o3 sto:
   EXPECT_EQ(det_anc.size(), 1);
   EXPECT_EQ(det_anc.front(), o3);
   EXPECT_EQ(sto_anc.size(), 0);
-  std::tie(det_anc, sto_anc) = g.compute_ancestors(o8, supp);
-  // restricting to support, ancestors(o8) = det: o3 sto: <none>
-  EXPECT_EQ(det_anc.size(), 1);
+  std::tie(det_anc, sto_anc) = g.compute_ancestors(o8);
+  // restricting to operators, ancestors(o8) = det: o3, o7 sto: o6
+  EXPECT_EQ(det_anc.size(), 2);
   EXPECT_EQ(det_anc.front(), o3);
-  EXPECT_EQ(sto_anc.size(), 0);
+  EXPECT_EQ(det_anc.back(), o7);
+  EXPECT_EQ(sto_anc.size(), 1);
+  EXPECT_EQ(sto_anc.front(), o6);
   // query o5 so support is now 11 nodes:
   //   c1, c2, o1, d1, o2, c3, c4, o3, d2, o4, o5
   // but we only include operators o1, o2, o3, o4, and o5
@@ -92,7 +94,7 @@ TEST(testgraph, support) {
   EXPECT_EQ(det_nodes.front(), o5);
   EXPECT_EQ(sto_nodes.size(), 1);
   EXPECT_EQ(sto_nodes.front(), o4);
-  std::tie(det_anc, sto_anc) = g.compute_ancestors(o5, supp);
+  std::tie(det_anc, sto_anc) = g.compute_ancestors(o5);
   // ancestors(o5) = det: sto: o2 o4
   EXPECT_EQ(det_anc.size(), 0);
   EXPECT_EQ(sto_anc.size(), 2);


### PR DESCRIPTION
Summary: Cache the ancestors of a node to avoid recomputing this in CAVI while building the Markov blankets of each node.

Differential Revision: D17504607

