### PR TITLE
RWMH with Gamma noise for half number line

### DIFF
--- a/beanmachine/ppl/tests/conjugate_tests/random_walk_conjugate_test.py
+++ b/beanmachine/ppl/tests/conjugate_tests/random_walk_conjugate_test.py
@@ -12,10 +12,24 @@ class SingleSiteRandomWalkConjugateTest(unittest.TestCase, AbstractConjugateTest
         pass
 
     def test_gamma_gamma_conjugate_run(self):
-        pass
+        expected_mean, expected_std, queries, observations = (
+            self.compute_gamma_gamma_moments()
+        )
+        mh = SingleSiteRandomWalk(step_size=1.0)
+        predictions = mh.infer(queries, observations, 2000)
+        mean, _ = self.compute_statistics(predictions.get_chain()[queries[0]])
+        self.assertAlmostEqual(abs((mean - expected_mean).sum().item()), 0, delta=0.2)
 
     def test_gamma_normal_conjugate_run(self):
-        pass
+        # Converges with 10k and more iterations but will use a bigger delta for
+        # now to have a faster test.
+        expected_mean, expected_std, queries, observations = (
+            self.compute_gamma_normal_moments()
+        )
+        mh = SingleSiteRandomWalk(step_size=1.0)
+        predictions = mh.infer(queries, observations, 2000)
+        mean, _ = self.compute_statistics(predictions.get_chain()[queries[0]])
+        self.assertAlmostEqual(abs((mean - expected_mean).sum().item()), 0, delta=0.5)
 
     def test_normal_normal_conjugate_run(self):
         # Converges with 10k and more iterations but will use a bigger delta for


### PR DESCRIPTION
Summary:
Add use of Gamma distributed noise for a positive half-space in RWMH inference.

This Diff includes unit and integration tests.

Diff also includes minor adjustments to unit tests, where the conjugate models were accidentally duplicated from the `examples/` folder.

Differential Revision: D17943591

