### PR TITLE
RWMH with Beta noise for cts. finite intervals

### DIFF
--- a/beanmachine/ppl/inference/proposer/single_site_random_walk_proposer.py
+++ b/beanmachine/ppl/inference/proposer/single_site_random_walk_proposer.py
@@ -26,6 +26,7 @@ class SingleSiteRandomWalkProposer(SingleSiteAncestralProposer):
 
         :param step_size: Standard Deviation of the noise used for Diff proposals.
         """
+
         self.step_size = step_size
         super().__init__(world)
 
@@ -49,6 +50,7 @@ class SingleSiteRandomWalkProposer(SingleSiteAncestralProposer):
 
             negative_proposal_log_update = -1 * distribution.log_prob(new_value).sum()
             return (new_value, negative_proposal_log_update)
+
         # Half number line
         # Does not yet support PositiveDefinite or LessThan (TODO?)
         if isinstance(
@@ -67,6 +69,26 @@ class SingleSiteRandomWalkProposer(SingleSiteAncestralProposer):
 
             new_value = new_sample + lower_bound
             return (new_value, negative_proposal_log_update)
+
+        # Interval
+        if isinstance(node_distribution.support, dist.constraints._Interval):
+            lower_bound = node_distribution.support.lower_bound
+            width = node_distribution.support.upper_bound - lower_bound
+            # Compute first and second moments of the perturbation distribution
+            # by rescaling the support
+            mu = (node_var.value - lower_bound) / width
+            sigma = torch.ones(node_var.value.shape) * self.step_size / width
+
+            node_var.proposal_distribution = self.beta_distbn_from_moments(mu, sigma)
+
+            sampled_value = node_var.proposal_distribution.sample()
+            negative_proposal_log_update = -1 * (
+                node_var.proposal_distribution.log_prob(sampled_value).sum()
+            )
+            # undo rescale proposal
+            new_value = (sampled_value * width) + lower_bound
+            return (new_value, negative_proposal_log_update)
+
         return super().propose(node)
 
     def post_process(self, node: RVIdentifier) -> Tensor:
@@ -102,10 +124,38 @@ class SingleSiteRandomWalkProposer(SingleSiteAncestralProposer):
             ).sum()
             return positive_proposal_log_update
 
+        if isinstance(node_distribution.support, dist.constraints._Interval):
+            lower_bound = node_distribution.support.lower_bound
+            width = node_distribution.support.upper_bound - lower_bound
+            # Compute first and second moments of the perturbation distribution
+            # by rescaling the support
+            mu = (node_var.value - lower_bound) / width
+            sigma = torch.ones(node_var.value.shape) * self.step_size / width
+
+            node_var.proposal_distribution = self.beta_distbn_from_moments(mu, sigma)
+
+            transformed_old_value = (old_node_var.value - lower_bound) / width
+            positive_proposal_log_update = node_var.proposal_distribution.log_prob(
+                transformed_old_value
+            ).sum()
+            return positive_proposal_log_update
+
         return super().post_process(node)
 
-    def gamma_distbn_from_moments(self, expectation, variance):
-        beta = expectation / variance
+    def gamma_distbn_from_moments(self, expectation, sigma):
+        beta = expectation / (sigma ** 2)
         alpha = expectation * beta
         distribution = dist.Gamma(concentration=alpha, rate=beta)
+        return distribution
+
+    def beta_distbn_from_moments(self, mu, sigma):
+        if torch.norm(mu) < 1e-5:
+            mu = 1e-5 * torch.ones(mu.shape)
+        """
+        https://stats.stackexchange.com/questions/12232/calculating-the-
+        parameters-of-a-beta-distribution-using-the-mean-and-variance
+        """
+        alpha = ((1.0 - mu) / (sigma ** 2) - (1.0 / mu)) * (mu ** 2)
+        beta = alpha * (1.0 - mu) / mu
+        distribution = dist.Beta(concentration1=alpha, concentration0=beta)
         return distribution

--- a/beanmachine/ppl/tests/conjugate_tests/random_walk_conjugate_test.py
+++ b/beanmachine/ppl/tests/conjugate_tests/random_walk_conjugate_test.py
@@ -9,7 +9,14 @@ from beanmachine.ppl.tests.conjugate_tests.abstract_conjugate import (
 
 class SingleSiteRandomWalkConjugateTest(unittest.TestCase, AbstractConjugateTests):
     def test_beta_binomial_conjugate_run(self):
-        pass
+        expected_mean, expected_std, queries, observations = (
+            self.compute_beta_binomial_moments()
+        )
+        mh = SingleSiteRandomWalk(step_size=2.0)
+        predictions = mh.infer(queries, observations, 2000)
+        mean, _ = self.compute_statistics(predictions.get_chain()[queries[0]])
+        # Smaller delta, within reasonable time, would likely require a burn-in period
+        self.assertAlmostEqual(abs((mean - expected_mean).sum().item()), 0, delta=0.5)
 
     def test_gamma_gamma_conjugate_run(self):
         expected_mean, expected_std, queries, observations = (


### PR DESCRIPTION
Summary:
Use Beta-distributed noise for proposals on a finite interval of the real number line. This primarily requres rescaling the beta distribution between [0,1] and whichever necessary [a,b].

I set a floor for the expectation `mu` of the beta distribution at `1e-5`, although in theory this value can fall anywhere in (0,1). Setting this floor resolved some strange divide-by-zero errors which were not trigged in Python, but fell through to Caffe2/Aten.

Differential Revision: D17957624

