### PR TITLE
HMM for BeanMachine in PPLBench

### DIFF
--- a/benchmarks/pplbench/models/hiddenMarkovModel.py
+++ b/benchmarks/pplbench/models/hiddenMarkovModel.py
@@ -1,0 +1,191 @@
+# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+
+import numpy as np
+import scipy.special
+import torch
+import torch.distributions as dist
+from torch import tensor
+
+
+"""
+Module for Hidden Markov Model
+
+Module contains following methods:
+get_defaults()
+generate_model()
+generate_data()
+evaluate_posterior_predictive()
+
+Specification:
+This is an HMM with discrete hidden state space that evolves
+according to some transition matrix,
+and has observable emissions with Gaussian noise.
+
+Length of sequence of observed timesteps: N
+Size of state space of hidden state: K
+
+Y_i | X_i ~ Normal(mus[X_i], sigmas[X_i])
+
+mus[j] ~ Normal(mu_loc, mu_scale)
+sigmas[j] ~ Gamma(sigma_shape, sigma_scale)
+
+X_{i+1} | X_i ~ M[X_i]
+M[j] ~ Dirichlet(torch.ones(K) * concentration / K)
+
+X_0 = 0
+
+Model specific arguments:
+Pass these arguments in following order -
+[concentration, mu_loc, mu_scale, sigma_shape, sigma_scale]
+"""
+
+
+def get_defaults():
+    defaults = {
+        "n": 60,
+        "k": 12,
+        "train_test_ratio": 0.5,
+        "runtime": 80,
+        "trials": 10,
+        "model_args": [0.1, 1.0, 5.0, 3.0, 3.0],
+    }
+    defaults["rng_seed"] = int(np.random.random() * 1000.0)
+    return defaults
+
+
+# Generate Samples Helpers
+
+
+def generate_hiddens(model, N):
+    """
+    Given the generated model, sample a sequence of values for X_0 ... X_{N-1}
+    """
+    theta = model["theta"]
+    distbns = {j: dist.Categorical(v) for j, v in enumerate(theta)}
+
+    current = torch.tensor(0)
+    chain = [current.item()]
+    for _ in range(N - 1):
+        current = distbns[current.item()].sample()
+        chain.append(current.item())
+    return chain
+
+
+def observe_hiddens(model, hiddens):
+    """
+    Given the generated model, and a sequence of values for X_0 ... X_{N-1},
+    sample a sequence of values for Y_0 ... Y_{N-1},
+    """
+    mus = model["mus"]
+    sigmas = model["sigmas"]
+
+    def observe(val):
+        return dist.Normal(mus[val], sigmas[val]).sample()
+
+    return list(map(observe, hiddens))
+
+
+# PPLBench API
+
+
+def generate_model(args_dict):
+    """
+    Given model args, sample a valid instance of our model. Consists of:
+    - theta : Transition matrix for hidden states
+    - mu_j , sigma_j : Parameters of emission distribution for hidden state X_j
+    """
+
+    K = int(args_dict["k"])
+    concentration, mu_loc, mu_scale, sigma_shape, sigma_scale = list(
+        map(float, args_dict["model_args"])
+    )
+
+    alpha = torch.ones(K) * concentration / K
+    theta = dist.Dirichlet(alpha).sample((K,))
+    mus = dist.Normal(mu_loc, mu_scale).sample((K,))
+    sigmas = dist.Gamma(sigma_shape, sigma_scale).sample((K,))
+    return {"theta": theta, "mus": mus, "sigmas": sigmas, "K": K}
+
+
+def generate_data(args_dict, model=None):
+
+    """
+    Generate data for hidden Markov model.
+    Inputs:
+    - N(int) = number of data points to generate
+    - K(int) = length of sequence
+
+    Returns:
+    - generated_data(dict) = samples of the hidden state value trajectories
+    """
+
+    print("Generating data")
+    N = int(args_dict["n"])
+    train_test_ratio = float(args_dict["train_test_ratio"])
+    theta = model["theta"]
+    mus = model["mus"]
+    sigmas = model["sigmas"]
+
+    # Train data
+    hiddens = generate_hiddens(model, N)
+    observs = observe_hiddens(model, hiddens)
+    train_data = observs
+
+    # Test data
+    xk = hiddens[-1]
+    # want many samples of obs Y(K+1)
+    dctxk = dist.Categorical(theta[xk])
+    xk1samples = dctxk.sample((int(train_test_ratio * N),))
+    yk1samples = [dist.Normal(mus[xk1], sigmas[xk1]).sample() for xk1 in xk1samples]
+    test_data = yk1samples
+
+    return {"data_train": train_data, "data_test": test_data}
+
+
+def evaluate_posterior_predictive(samples, data_test, model=None):
+    """
+    Computes the likelihood of held-out testset wrt parameter samples
+    The testset is values of Y(self.N) simulated from the true value of X(self.N - 1)
+    The parameter samples are samples of X(self.N - 1)
+
+    input-
+    samples(dict): samples, inferred by PPL, of X(self.N - 1)
+    data_test: simulated values of Y(self.N), based on the true value of X(self.N - 1)
+    model: args_dict
+
+    returns- pred_log_lik_array(np.ndarray): log-likelihoods of data
+            wrt parameter samples
+    """
+
+    K = model["K"]
+
+    # Log-prob of observing (Y(N+1) = yn1 | X(N+1) ~ hidden_transition_pmf)
+    # hidden_transition_pmf is determined by X(N) (outside of this fnc.'s scope)
+    # Compute by summing over possible values of X(N+1).
+    def log_prob_obs(yn1, hidden_transition_pmf, mus, sigmas):
+
+        ls = [
+            dist.Normal(mus[xn1], sigmas[xn1]).log_prob(tensor(float(yn1)))
+            + hidden_transition_pmf.log_prob(tensor(float(xn1)))
+            for xn1 in range(K)
+        ]
+        return scipy.special.logsumexp(ls)
+
+    pred_log_lik_array = []
+    for sample in samples:
+        # transition likelihood:
+        theta = sample["theta"]
+        mus = sample["mus"]
+        sigmas = sample["sigmas"]
+        xn = sample["x[N]"]
+
+        hidden_transition_pmf = dist.Categorical(torch.from_numpy(theta[int(xn)]))
+        pred_log_lik_array.append(
+            np.sum(
+                log_prob_obs(yn1, hidden_transition_pmf, mus, sigmas)
+                for yn1 in data_test
+            )
+        )
+
+    # return as a numpy array of sum of log likelihood over test data
+    return pred_log_lik_array

--- a/benchmarks/pplbench/ppls/beanmachine/hiddenMarkov.py
+++ b/benchmarks/pplbench/ppls/beanmachine/hiddenMarkov.py
@@ -1,0 +1,157 @@
+# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+
+import time
+from typing import Dict, List, Tuple
+
+import torch
+import torch.distributions as dist
+from beanmachine.ppl.inference.single_site_compositional_infer import (
+    SingleSiteCompositionalInference,
+)
+from beanmachine.ppl.model.statistical_model import sample
+from torch import Tensor, tensor
+
+
+class HiddenMarkovModel(object):
+    def __init__(
+        self,
+        N: int,
+        K: int,
+        observations: List,
+        num_samples: int,
+        concentration,
+        mu_loc,
+        mu_scale,
+        sigma_shape,
+        sigma_scale,
+    ) -> None:
+        self.observations = observations
+        self.N = N
+        self.K = K
+        self.num_samples = num_samples
+
+        self.concentration: float = concentration
+        self.mu_loc = mu_loc
+        self.mu_scale = mu_scale
+        self.sigma_shape = sigma_shape
+        self.sigma_scale = sigma_scale
+
+    @sample
+    def Theta(self, k):
+        assert k in range(self.K)
+        return dist.Dirichlet(self.concentration * torch.ones(self.K))
+
+    @sample
+    def Mu(self, k):
+        assert k in range(self.K)
+        return dist.Normal(self.mu_loc, self.mu_scale)
+
+    @sample
+    def Sigma(self, k):
+        assert k in range(self.K)
+        return dist.Gamma(self.sigma_shape, self.sigma_scale)
+
+    # Hidden states
+    @sample
+    def X(self, n: int):
+        assert n in range(self.N + 1)
+        if n == 0:
+            return dist.Categorical(tensor([1.0] + [0.0] * (self.K - 1)))
+        else:
+            return dist.Categorical(self.Theta(self.X(n - 1)))
+
+    # Noisy observations/emissions
+    @sample
+    def Y(self, n: int):
+        assert n in range(self.N + 1)
+        return dist.Normal(self.Mu(self.X(n)), self.Sigma(self.X(n)))
+
+    def infer(self):
+        mh = SingleSiteCompositionalInference()
+        queries = (
+            # list(map(self.X, range(self.N)))
+            [self.X(self.N - 1)]
+            + [self.Theta(k) for k in range(self.K)]
+            + [self.Mu(k) for k in range(self.K)]
+            + [self.Sigma(k) for k in range(self.K)]
+        )
+
+        observations_dict = [(self.Y(n), self.observations[n]) for n in range(self.N)]
+        # + [(self.Theta(k), theta[k]) for k in range(self.K)]
+        observations_dict = dict(observations_dict)
+        start_time = time.time()
+        inferred = mh.infer(queries, observations_dict, self.num_samples)
+        elapsed_time_sample_beanmachine = time.time() - start_time
+        # Return as a tuple of: thetas, mus, sigmas, xNs
+        samples = (
+            [
+                inferred.get_chain()[self.Theta(k)].detach().numpy()
+                for k in range(self.K)
+            ],
+            [inferred.get_chain()[self.Mu(k)].detach().numpy() for k in range(self.K)],
+            [
+                inferred.get_chain()[self.Sigma(k)].detach().numpy()
+                for k in range(self.K)
+            ],
+            inferred.get_chain()[self.X(self.N - 1)].detach().numpy(),
+        )
+        return (samples, elapsed_time_sample_beanmachine)
+
+
+def obtain_posterior(
+    data_train: List, args_dict: Dict, model: Tensor
+) -> Tuple[List, Dict]:
+    """
+    Beanmachine impmementation of HMM prediction.
+
+    :param data_train:
+    :param args_dict: a dict of model arguments
+    :returns: samples_beanmachine(dict): posterior samples of all parameters
+    :returns: timing_info(dict): compile_time, inference_time
+    """
+    concentration, mu_loc, mu_scale, sigma_shape, sigma_scale = list(
+        map(float, args_dict["model_args"])
+    )
+    N = int(args_dict["n"])
+    K = int(args_dict["k"])
+    # sigma = float(args_dict["model_args"][0])
+    num_samples = int(args_dict["num_samples"])
+
+    start_time = time.time()
+    # hmm = HiddenMarkovModel(N, K, theta, sigma, data_train, num_samples)
+    hmm = HiddenMarkovModel(
+        N,
+        K,
+        data_train,
+        num_samples,
+        concentration,
+        mu_loc,
+        mu_scale,
+        sigma_shape,
+        sigma_scale,
+    )
+    elapsed_time_compile_beanmachine = time.time() - start_time
+
+    samples, elapsed_time_sample_beanmachine = hmm.infer()
+
+    thetas, mus, sigmas, xNs = samples
+    # Want to swap the way these are ordered, so we can iterate through.
+    thetas = [[thetasK[i] for thetasK in thetas] for i in range(num_samples)]
+    mus = [[musK[i] for musK in mus] for i in range(num_samples)]
+    sigmas = [[sigmasK[i] for sigmasK in sigmas] for i in range(num_samples)]
+
+    samples_formatted = []
+    for theta, mu, sigma, xN in zip(thetas, mus, sigmas, xNs):
+        result = {}
+        result["theta"] = theta
+        result["mus"] = mu
+        result["sigmas"] = sigma
+        result["x[N]"] = xN
+        samples_formatted.append(result)
+
+    # samples_formatted = [{"x[N]": sample} for sample in samples]
+    timing_info = {
+        "compile_time": elapsed_time_compile_beanmachine,
+        "inference_time": elapsed_time_sample_beanmachine,
+    }
+    return (samples_formatted, timing_info)


### PR DESCRIPTION
Summary:
HMM with discrete hidden state and Gaussian-noised observations.

```
O_i | X_i ~ Normal(X_i, sigma)

X_{i+1} | X_i ~ Categorical(theta[X_i])

# theta defines a stationary Markov Chain

X_0 = 0
```

Small problem: I'm not sure how to pass `args_dict` to `evaluate_posterior_predictive`, but I need to (see lines 153-154 in `hiddenMarkovModel.py`, I may be defining `model` incorrectly.

Differential Revision: D18843968

