### PR TITLE
Use tqdm for single site infer

### DIFF
--- a/beanmachine/ppl/inference/abstract_single_site_mh_infer.py
+++ b/beanmachine/ppl/inference/abstract_single_site_mh_infer.py
@@ -10,6 +10,7 @@ from beanmachine.ppl.inference.abstract_infer import AbstractInference
 from beanmachine.ppl.model.statistical_model import StatisticalModel
 from beanmachine.ppl.model.utils import Mode, RVIdentifier
 from torch import Tensor
+from tqdm import tqdm
 
 
 class AbstractSingleSiteMHInference(AbstractInference, metaclass=ABCMeta):
@@ -122,7 +123,7 @@ class AbstractSingleSiteMHInference(AbstractInference, metaclass=ABCMeta):
         self.initialize_world()
         queries_sample = defaultdict()
 
-        for _ in range(num_samples):
+        for _ in tqdm(iterable=range(num_samples), desc="Samples collected"):
             for node in self.world_.get_all_world_vars().copy():
                 if node in self.observations_:
                     continue

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ setup(
         "plotly>=2.2.1",
         "scipy>=0.16",
         "statsmodels>=0.8.0",
+        "tqdm>=4.40.2",
     ],
     packages=[
         "beanmachine.ppl.diagnostics",


### PR DESCRIPTION
Summary: Use tqdm for the loop over `num_iter` in the implementation of `infer` in `abstract_single_site_mh_infer`.

Differential Revision: D18839451

