### PR TITLE
Increase min value of mu for beta distribution in random walk

### DIFF
--- a/beanmachine/ppl/inference/proposer/single_site_random_walk_proposer.py
+++ b/beanmachine/ppl/inference/proposer/single_site_random_walk_proposer.py
@@ -144,8 +144,7 @@ class SingleSiteRandomWalkProposer(SingleSiteAncestralProposer):
         :param sigma: sigma value
         :returns: returns the Beta distribution given mu and sigma.
         """
-        if torch.norm(mu) < 1e-5:
-            mu = 1e-5 * torch.ones(mu.shape)
+        mu = torch.clamp(mu, 1e-3, 1)
         """
         https://stats.stackexchange.com/questions/12232/calculating-the-
         parameters-of-a-beta-distribution-using-the-mean-and-variance


### PR DESCRIPTION
Summary: Clamped the mu to be in the range 1e-3 and 1 (same values as NMC)

Differential Revision: D19379549

