### PR TITLE
use inverse of neg hessian if possible else fallback to eig decomp

### DIFF
--- a/beanmachine/ppl/inference/proposer/single_site_real_space_newtonian_monte_carlo_proposer.py
+++ b/beanmachine/ppl/inference/proposer/single_site_real_space_newtonian_monte_carlo_proposer.py
@@ -5,7 +5,8 @@ import torch
 import torch.distributions as dist
 import torch.tensor as tensor
 from beanmachine.ppl.inference.proposer.newtonian_monte_carlo_utils import (
-    compute_eigvals_eigvecs,
+    is_valid,
+    symmetric_inverse,
     zero_grad,
 )
 from beanmachine.ppl.inference.proposer.normal_eig import NormalEig
@@ -13,8 +14,8 @@ from beanmachine.ppl.inference.proposer.single_site_ancestral_proposer import (
     SingleSiteAncestralProposer,
 )
 from beanmachine.ppl.model.utils import RVIdentifier
+from beanmachine.ppl.utils import tensorops
 from beanmachine.ppl.world import ProposalDistribution, Variable, World
-from torch import Tensor
 
 
 class SingleSiteRealSpaceNewtonianMonteCarloProposer(SingleSiteAncestralProposer):
@@ -25,43 +26,6 @@ class SingleSiteRealSpaceNewtonianMonteCarloProposer(SingleSiteAncestralProposer
     def __init__(self, alpha: float = 10.0, beta: float = 1.0):
         self.alpha_ = alpha
         self.beta_ = beta
-
-    def compute_normal_mean_covar(
-        self, node_var: Variable, world: World
-    ) -> Tuple[bool, Tensor, Tensor, Tensor, Tensor]:
-        """
-        Computes mean and covariance of the MultivariateNormal given the node.
-            mean = x - first_grad * hessian_inverse
-            covariance = -1 * hessian_inverse
-
-        :param node_var: the node Variable we're proposing a new value for
-        :returns: is_valid, eigen values and eigen vectors, diff (distance
-        between node value and mean) and node value
-        """
-        node_val = node_var.unconstrained_value
-        score = world.compute_score(node_var)
-        zero_grad(node_val)
-        is_valid_neg_invserse_hessian, first_gradient, eig_vecs, eig_vals = compute_eigvals_eigvecs(
-            score, node_val
-        )
-        zero_grad(node_val)
-        node_val.detach()
-        if not is_valid_neg_invserse_hessian:
-            return False, tensor(0.0), tensor(0.0), tensor(0.0), tensor(0.0)
-
-        # node value may of any arbitrary shape, so here, we transform it into a
-        # 1D vector using reshape(-1) and with unsqueeze(0), we change 1D vector
-        # of size (N) to (1 x N) matrix.
-        node_reshaped = node_val.reshape(-1).unsqueeze(0)
-        # here we again call unsqueeze(0) on first_gradient to transform it into
-        # a matrix in order to be able to perform matrix multiplication.
-        # pyre-fixme
-        distance = (
-            eig_vecs
-            @ (torch.eye(len(eig_vals)) * eig_vals)
-            @ (eig_vecs.T @ first_gradient.unsqueeze(1))
-        ).T
-        return True, eig_vals, eig_vecs, distance, node_reshaped
 
     def get_proposal_distribution(
         self,
@@ -97,49 +61,74 @@ class SingleSiteRealSpaceNewtonianMonteCarloProposer(SingleSiteAncestralProposer
             frac_dist = auxiliary_variables["frac_dist"]
         number_of_variables = world.get_number_of_variables()
         if node_var.proposal_distribution is not None and number_of_variables == 1:
-            distance = node_var.proposal_distribution.arguments["distance"]
-            node_val_reshaped = node_var.proposal_distribution.arguments[
-                "node_val_reshaped"
-            ]
-            eig_vals, eig_vecs = (
-                # pyre-fixme
-                node_var.proposal_distribution.proposal_distribution.singular_eig_decompositions
-            )
-
+            _arguments = node_var.proposal_distribution.arguments
+            distance = _arguments["distance"]
+            node_val_reshaped = _arguments["node_val_reshaped"]
             mean = (node_val_reshaped + distance * frac_dist).squeeze(0)
+            if "covar" in _arguments:
+                _proposer = dist.MultivariateNormal(mean, _arguments["covar"])
+            else:
+                (eig_vals, eig_vecs) = _arguments["eig_decomp"]
+                _proposer = NormalEig(mean, eig_vecs, eig_vecs)
             return (
                 ProposalDistribution(
-                    proposal_distribution=NormalEig(mean, eig_vals, eig_vecs),
+                    proposal_distribution=_proposer,
                     requires_transform=node_var.proposal_distribution.requires_transform,
                     requires_reshape=True,
-                    arguments={
-                        "distance": distance,
-                        "node_val_reshaped": node_val_reshaped,
-                    },
+                    arguments=_arguments,
                 ),
                 aux_vars,
             )
 
-        is_valid, eig_vals, eig_vecs, distance, node_val_reshaped = self.compute_normal_mean_covar(
-            node_var, world
-        )
-        if not is_valid:
+        node_val = node_var.unconstrained_value
+        score = world.compute_score(node_var)
+        zero_grad(node_val)
+        # pyre-fixme
+        first_gradient, hessian = tensorops.gradients(score, node_val)
+        zero_grad(node_val)
+        node_val.detach()
+        if not is_valid(first_gradient) or not is_valid(hessian):
             return super().get_proposal_distribution(node, node_var, world, {})
+        # node value may of any arbitrary shape, so here, we transform it into a
+        # 1D vector using reshape(-1) and with unsqueeze(0), we change 1D vector
+        # of size (N) to (1 x N) matrix.
+        node_val_reshaped = node_val.reshape(-1).unsqueeze(0)
+        neg_hessian = -1 * hessian.detach()
+        _arguments = {"node_val_reshaped": node_val_reshaped}
+        # we will first attempt a covariance-inverse-based proposer
+        try:
+            # pyre-fixme
+            covar = neg_hessian.inverse()
+            distance = (covar @ first_gradient.unsqueeze(1)).T
+            _arguments["distance"] = distance
+            mean = (node_val_reshaped + distance * frac_dist).squeeze(0)
+            _proposer = dist.MultivariateNormal(mean, covar)
+            _arguments["covar"] = covar
+        except RuntimeError:
+            # pyre-fixme
+            eig_vecs, eig_vals = symmetric_inverse(neg_hessian)
+            # pyre-fixme
+            distance = (
+                eig_vecs
+                @ (torch.eye(len(eig_vals)) * eig_vals)
+                @ (eig_vecs.T @ first_gradient.unsqueeze(1))
+            ).T
+            _arguments["distance"] = distance
+            mean = (node_val_reshaped + distance * frac_dist).squeeze(0)
+            _proposer = NormalEig(mean, eig_vals, eig_vecs)
+            # pyre-fixme
+            _arguments["eig_decomp"] = (eig_vals, eig_vecs)
 
-        mean = (node_val_reshaped + distance * frac_dist).squeeze(0)
         requires_transform = False
         # pyre-fixme
         if not isinstance(node_var.distribution.support, dist.constraints._Real):
             requires_transform = True
         return (
             ProposalDistribution(
-                proposal_distribution=NormalEig(mean, eig_vals, eig_vecs),
+                proposal_distribution=_proposer,
                 requires_transform=requires_transform,
                 requires_reshape=True,
-                arguments={
-                    "distance": distance,
-                    "node_val_reshaped": node_val_reshaped,
-                },
+                arguments=_arguments,
             ),
             aux_vars,
         )

--- a/benchmarks/pplbench/ppls/nmc/robustRegression.py
+++ b/benchmarks/pplbench/ppls/nmc/robustRegression.py
@@ -4,14 +4,7 @@ from typing import Any, Dict, List, Tuple
 
 import torch
 from torch import tensor
-from torch.distributions import (
-    Bernoulli,
-    Exponential,
-    Gamma,
-    MultivariateNormal,
-    Normal,
-    StudentT,
-)
+from torch.distributions import Bernoulli, Exponential, Gamma, Normal, StudentT
 from tqdm import tqdm
 
 from .utils import gradients, halfspace_proposer, real_proposer
@@ -103,9 +96,9 @@ def obtain_posterior(
         def compute_beta_gradients_(self):
             self.beta.requires_grad_(True)
             self.compute_score_()
-            self.beta_grad, self.beta_hess = gradients(self.score, self.beta)
-            self.beta_grad.detach_()
-            self.beta_hess.detach_()
+            grad, hess = gradients(self.score, self.beta)
+            self.beta_grad = grad.detach()
+            self.beta_hess = hess.detach()
             self.beta.requires_grad_(False)
 
         def compute_beta_proposer_(self):

--- a/benchmarks/pplbench/ppls/nmc/utils.py
+++ b/benchmarks/pplbench/ppls/nmc/utils.py
@@ -1,12 +1,15 @@
 # Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
 # The proposers in this file are documented in the Newtonian Monte Carlo paper.
 # https://arxiv.org/abs/2001.05567
+from typing import Tuple
+
 import torch
+from torch import Tensor
 from torch.distributions import Dirichlet, Exponential, Gamma, MultivariateNormal
 
 
 # python implementation of gradient computation
-def py_gradients(output, inp):
+def py_gradients(output: Tensor, inp: Tensor) -> Tuple[Tensor, Tensor]:
     grad = torch.autograd.grad(output, inp, create_graph=True)[0]
     n = inp.numel()
     hess = torch.zeros(n, n)
@@ -25,7 +28,7 @@ except ImportError:
     gradients = py_gradients
 
 
-def halfspace_proposer(val, grad, hess):
+def halfspace_proposer(val: Tensor, grad: Tensor, hess: Tensor) -> Tensor:
     """
     proposer for 1-d R+ variable
     """


### PR DESCRIPTION
Summary: the inverse of the neg hessian is used as the covariance of a multivariate normal distribution if possible. Otherwise we fallback to the eigen decomposition-based version.

Differential Revision: D19688821

