### PR TITLE
remove symlink command from circleci command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,6 @@ commands:
           name: "Install pytorch"
           command: sudo pip install --progress-bar off torch==1.3.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
       - run:
-          name: "Create symlink to graph in beanmachine/"
-          command: ln -s ${PWD}/graph beanmachine/
-      - run:
           name: "Install beanmachine[dev]"
           command: sudo pip install -v -e .[dev]
 


### PR DESCRIPTION
Summary: remove the symlink from circleci command

Differential Revision: D19873954

