### PR TITLE
Re-sync with internal repository

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,9 @@ commands:
           name: "Install pytorch"
           command: sudo pip install --progress-bar off torch==1.3.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
       - run:
+          name: "Create symlink to graph in beanmachine/"
+          command: ln -s ${PWD}/graph beanmachine/
+      - run:
           name: "Install beanmachine[dev]"
           command: sudo pip install -v -e .[dev]
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
+# the beanmachine/graph/ directory is a temporary symlink to graph/
+beanmachine/graph
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
The internal and external repositories are out of sync. This attempts to brings them back in sync by patching the GitHub repository. Please carefully review this patch. You must disable ShipIt for your project in order to merge this pull request. DO NOT IMPORT this pull request. Instead, merge it directly on GitHub using the MERGE BUTTON. Re-enable ShipIt after merging.