### PR TITLE
remove symlink from build system

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,6 @@ commands:
           name: "Install pytorch"
           command: sudo pip install --progress-bar off torch==1.3.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
       - run:
-          name: "Create symlink to graph in beanmachine/"
-          command: ln -s ${PWD}/graph beanmachine/
-      - run:
           name: "Install beanmachine[dev]"
           command: sudo pip install -v -e .[dev]
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-# the beanmachine/graph/ directory is a temporary symlink to graph/
-beanmachine/graph
-
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
Summary: remove the symlink beanmachine/graph from the circleci build system since this directory is being directly mapped by shipit now.

Differential Revision: D19887183

