### PR TITLE
Remove unused imports and fix circle ci build

### DIFF
--- a/benchmarks/pplbench/PPLBench.py
+++ b/benchmarks/pplbench/PPLBench.py
@@ -3,11 +3,9 @@
 import argparse
 import datetime
 import importlib
-import multiprocessing
 import os
 import pickle
 import pkgutil
-import random
 import time
 import traceback
 


### PR DESCRIPTION
Summary: multiprocessing and random are imported but unused and this was breaking the build.

Differential Revision: D20370914

