### PR TITLE
Have all ppl implementations inherit from a standard PPL class

### DIFF
--- a/benchmarks/pplbench/ppls/beanmachine-vectorized/robust_regression.py
+++ b/benchmarks/pplbench/ppls/beanmachine-vectorized/robust_regression.py
@@ -1,7 +1,8 @@
 # Copyright (c) Facebook, Inc. and its affiliates
 import time
-from typing import Any, Dict, List, Tuple
+from typing import Dict, List, Tuple
 
+import numpy as np
 import torch
 import torch.distributions as dist
 import torch.tensor as tensor
@@ -9,11 +10,12 @@ from beanmachine.ppl.inference.single_site_newtonian_monte_carlo import (
     SingleSiteNewtonianMonteCarlo,
 )
 from beanmachine.ppl.model.statistical_model import sample
+from ppls.pplbench_ppl import PPLBenchPPL
 from torch import Tensor
 
 
 """
-For model definition, see models/robustRegressionModel.py
+For model definition, see models/robust_regression_model.py
 """
 
 
@@ -81,68 +83,69 @@ class RobustRegressionModel(object):
         return (samples, elapsed_time_sample_beanmachine)
 
 
-def obtain_posterior(
-    data_train: Tuple[Any, Any], args_dict: Dict, model: RobustRegressionModel
-) -> Tuple[List, Dict]:
-    """
-    Beanmachine impmementation of robust regression model.
+class RobustRegression(PPLBenchPPL):
+    def obtain_posterior(
+        self, data_train: Tuple[np.ndarray, np.ndarray], args_dict: Dict, model=None
+    ) -> Tuple[List, Dict]:
+        """
+        Beanmachine impmementation of robust regression model.
 
-    :param data_train: tuple of np.ndarray (x_train, y_train)
-    :param args_dict: a dict of model arguments
-    :returns: samples_beanmachine(dict): posterior samples of all parameters
-    :returns: timing_info(dict): compile_time, inference_time
-    """
-    # shape of x_train: (num_features, num_samples)
-    x_train, y_train = data_train
-    x_train = tensor(x_train, dtype=torch.float32)
-    y_train = tensor(y_train, dtype=torch.float32)
-    N = int(x_train.shape[1])
-    K = int(x_train.shape[0])
+        :param data_train: tuple of np.ndarray (x_train, y_train)
+        :param args_dict: a dict of model arguments
+        :returns: samples_beanmachine(dict): posterior samples of all parameters
+        :returns: timing_info(dict): compile_time, inference_time
+        """
+        # shape of x_train: (num_features, num_samples)
+        x_train, y_train = data_train
+        x_train = tensor(x_train, dtype=torch.float32)
+        y_train = tensor(y_train, dtype=torch.float32)
+        N = int(x_train.shape[1])
+        K = int(x_train.shape[0])
 
-    alpha_scale, beta_scale, beta_loc, sigma_mean = args_dict["model_args"]
-    beta_scale = [beta_scale] * K
-    num_samples = args_dict["num_samples_beanmachine-vectorized"]
-    inference_type = args_dict["inference_type"]
+        alpha_scale, beta_scale, beta_loc, sigma_mean = args_dict["model_args"]
+        beta_scale = [beta_scale] * K
+        num_samples = args_dict["num_samples_beanmachine-vectorized"]
+        inference_type = args_dict["inference_type"]
 
-    start_time = time.time()
-    robust_regression_model = RobustRegressionModel(
-        N,
-        K,
-        alpha_scale,
-        beta_scale,
-        beta_loc,
-        1.0 / sigma_mean,
-        num_samples,
-        inference_type,
-        x_train,
-        y_train,
-    )
-    elapsed_time_compile_beanmachine = time.time() - start_time
-    samples, elapsed_time_sample_beanmachine = robust_regression_model.infer()
+        start_time = time.time()
+        robust_regression_model = RobustRegressionModel(
+            N,
+            K,
+            alpha_scale,
+            beta_scale,
+            beta_loc,
+            1.0 / sigma_mean,
+            num_samples,
+            inference_type,
+            x_train,
+            y_train,
+        )
+        elapsed_time_compile_beanmachine = time.time() - start_time
+        samples, elapsed_time_sample_beanmachine = robust_regression_model.infer()
 
-    # repackage samples into format required by PPLBench
-    # List of dict, where each dict has key = param (string), value = value of param
-    param_keys = ["beta", "nu", "sigma"]
-    samples_formatted = []
-    for i in range(num_samples):
-        sample_dict = {}
-        for j, parameter in enumerate(samples.get_rv_names()):
-            if j == 0:
-                sample_dict[param_keys[j]] = (
-                    samples.get_variable(parameter)[i][1:]
-                    .detach()
-                    .numpy()
-                    .reshape(1, K)
-                )
-                sample_dict["alpha"] = (
-                    samples.get_variable(parameter)[i][0].detach().numpy()
-                )
-            else:
-                sample_dict[param_keys[j]] = samples[parameter][i].item()
-        samples_formatted.append(sample_dict)
+        # repackage samples into format required by PPLBench
+        # List of dict, where each dict has key = param (string), value = value of param
+        param_keys = ["beta", "nu", "sigma"]
+        samples_formatted = []
+        for i in range(num_samples):
+            sample_dict = {}
+            for j, parameter in enumerate(samples.get_rv_names()):
+                if j == 0:
+                    sample_dict[param_keys[j]] = (
+                        samples.get_variable(parameter)[i][1:]
+                        .detach()
+                        .numpy()
+                        .reshape(1, K)
+                    )
+                    sample_dict["alpha"] = (
+                        samples.get_variable(parameter)[i][0].detach().numpy()
+                    )
+                else:
+                    sample_dict[param_keys[j]] = samples[parameter][i].item()
+            samples_formatted.append(sample_dict)
 
-    timing_info = {
-        "compile_time": elapsed_time_compile_beanmachine,
-        "inference_time": elapsed_time_sample_beanmachine,
-    }
-    return (samples_formatted, timing_info)
+        timing_info = {
+            "compile_time": elapsed_time_compile_beanmachine,
+            "inference_time": elapsed_time_sample_beanmachine,
+        }
+        return (samples_formatted, timing_info)

--- a/benchmarks/pplbench/ppls/beanmachine/robust_regression.py
+++ b/benchmarks/pplbench/ppls/beanmachine/robust_regression.py
@@ -1,7 +1,8 @@
 # Copyright (c) Facebook, Inc. and its affiliates
 import time
-from typing import Any, Dict, List, Tuple
+from typing import Dict, List, Tuple
 
+import numpy as np
 import torch
 import torch.distributions as dist
 import torch.tensor as tensor
@@ -9,11 +10,12 @@ from beanmachine.ppl.inference.single_site_ancestral_mh import (
     SingleSiteAncestralMetropolisHastings,
 )
 from beanmachine.ppl.model.statistical_model import sample
+from ppls.pplbench_ppl import PPLBenchPPL
 from torch import Tensor
 
 
 """
-For model definition, see models/robustRegressionModel.py
+For model definition, see models/robust_regression_model.py
 """
 
 
@@ -90,60 +92,61 @@ class RobustRegressionModel(object):
         return (samples_beta.detach().numpy(), samples, elapsed_time_sample_beanmachine)
 
 
-def obtain_posterior(
-    data_train: Tuple[Any, Any], args_dict: Dict, model: RobustRegressionModel
-) -> Tuple[List, Dict]:
-    """
-    Beanmachine impmementation of robust regression model.
+class RobustRegression(PPLBenchPPL):
+    def obtain_posterior(
+        self, data_train: Tuple[np.ndarray, np.ndarray], args_dict: Dict, model=None
+    ) -> Tuple[List, Dict]:
+        """
+        Beanmachine impmementation of robust regression model.
 
-    :param data_train: tuple of np.ndarray (x_train, y_train)
-    :param args_dict: a dict of model arguments
-    :returns: samples_beanmachine(dict): posterior samples of all parameters
-    :returns: timing_info(dict): compile_time, inference_time
-    """
-    # shape of x_train: (num_features, num_samples)
-    x_train, y_train = data_train
-    y_train = [tensor(y) for y in y_train]
-    N = int(x_train.shape[1])
-    K = int(x_train.shape[0])
+        :param data_train: tuple of np.ndarray (x_train, y_train)
+        :param args_dict: a dict of model arguments
+        :returns: samples_beanmachine(dict): posterior samples of all parameters
+        :returns: timing_info(dict): compile_time, inference_time
+        """
+        # shape of x_train: (num_features, num_samples)
+        x_train, y_train = data_train
+        y_train = [tensor(y) for y in y_train]
+        N = int(x_train.shape[1])
+        K = int(x_train.shape[0])
 
-    alpha_scale, beta_scale, beta_loc, sigma_mean = args_dict["model_args"]
-    num_samples = args_dict["num_samples_beanmachine"]
-    inference_type = args_dict["inference_type"]
+        alpha_scale, beta_scale, beta_loc, sigma_mean = args_dict["model_args"]
+        num_samples = args_dict["num_samples_beanmachine"]
+        inference_type = args_dict["inference_type"]
 
-    start_time = time.time()
-    robust_regression_model = RobustRegressionModel(
-        N,
-        K,
-        alpha_scale,
-        beta_scale,
-        beta_loc,
-        1.0 / sigma_mean,
-        num_samples,
-        inference_type,
-        Tensor(x_train),
-        Tensor(y_train),
-    )
-    elapsed_time_compile_beanmachine = time.time() - start_time
-    samples_beta, samples, elapsed_time_sample_beanmachine = (
-        robust_regression_model.infer()
-    )
+        start_time = time.time()
+        robust_regression_model = RobustRegressionModel(
+            N,
+            K,
+            alpha_scale,
+            beta_scale,
+            beta_loc,
+            1.0 / sigma_mean,
+            num_samples,
+            inference_type,
+            Tensor(x_train),
+            Tensor(y_train),
+        )
+        elapsed_time_compile_beanmachine = time.time() - start_time
+        samples_beta, samples, elapsed_time_sample_beanmachine = (
+            robust_regression_model.infer()
+        )
 
-    # repackage samples into format required by PPLBench
-    # List of dict, where each dict has key = param (string), value = value of param
-    param_keys = ["nu", "sigma", "alpha"]
-    samples_formatted = []
-    for i in range(num_samples):
-        sample_dict = {}
-        sample_dict["beta"] = samples_beta[i]
-        for j, parameter in enumerate(samples.get_rv_names()):
-            if j >= len(param_keys):
-                break
-            sample_dict[param_keys[j]] = samples.get_variable(parameter)[i].item()
-        samples_formatted.append(sample_dict)
+        # repackage samples into format required by PPLBench
+        # List of dict, where each dict has key = param (string), value = value of param
+        param_keys = ["nu", "sigma", "alpha"]
+        samples_formatted = []
+        for i in range(num_samples):
+            sample_dict = {}
+            sample_dict["beta"] = samples_beta[i]
+            for j, parameter in enumerate(samples.get_rv_names()):
+                if j >= len(param_keys):
+                    break
+                sample_dict[param_keys[j]] = samples.get_variable(parameter)[i].item()
+            samples_formatted.append(sample_dict)
 
-    timing_info = {
-        "compile_time": elapsed_time_compile_beanmachine,
-        "inference_time": elapsed_time_sample_beanmachine,
-    }
-    return (samples_formatted, timing_info)
+        timing_info = {
+            "compile_time": elapsed_time_compile_beanmachine,
+            "inference_time": elapsed_time_sample_beanmachine,
+        }
+        return (samples_formatted, timing_info)

--- a/benchmarks/pplbench/ppls/beanmachine/seismic_location.py
+++ b/benchmarks/pplbench/ppls/beanmachine/seismic_location.py
@@ -11,58 +11,64 @@ from benchmarks.pplbench.ppls.beanmachine.seismic_projection_model import (
 from benchmarks.pplbench.ppls.beanmachine.seismic_proposer import (
     SingleSiteSeismicProposer,
 )
+from ppls.pplbench_ppl import PPLBenchPPL
 
 
-def obtain_posterior(data_train: Dict, args_dict: Dict, model) -> Tuple[List, Dict]:
-    """
-    Obtain samples using beanmachine
+class SeismicLocation(PPLBenchPPL):
+    def obtain_posterior(
+        self, data_train: Dict, args_dict: Dict, model
+    ) -> Tuple[List, Dict]:
+        """
+        Obtain samples using beanmachine
 
-    :param args_dict: arguments dictionary
-    :param model: dictionary with
-        mu(int) = detection probability properties per station
-        theta_k(int) = detection properties per station
-    :returns: generated_data(dict) = {
-        data_train: {
-            is_detected: is_detected for stations 1-9,
-            detection: detection for stations 1-9
-        data_test: {
-            detection_zero: detection for station 0
+        :param args_dict: arguments dictionary
+        :param model: dictionary with
+            mu(int) = detection probability properties per station
+            theta_k(int) = detection properties per station
+        :returns: generated_data(dict) = {
+            data_train: {
+                is_detected: is_detected for stations 1-9,
+                detection: detection for stations 1-9
+            data_test: {
+                detection_zero: detection for station 0
+            }
+        """
+        model_is_detected = data_train["is_detected"]
+        model_detection = data_train["detection"]
+        mu = model["mu"]
+        theta_k = model["theta_k"]
+
+        start_time = time.time()
+        model = SeismicProjectionModel()
+        mh = SingleSiteCompositionalInference(
+            {model.event: SingleSiteSeismicProposer()}
+        )
+        elapsed_time_compile_beanmachine = time.time() - start_time
+
+        obs = {
+            model.holdout_is_detected(): tensor(1.0),
+            model.is_detected(): model_is_detected,
+            model.detection(): model_detection,
+            model.theta_k(): theta_k,
+            model.mu_k_d(): mu,
         }
-    """
-    model_is_detected = data_train["is_detected"]
-    model_detection = data_train["detection"]
-    mu = model["mu"]
-    theta_k = model["theta_k"]
 
-    start_time = time.time()
-    model = SeismicProjectionModel()
-    mh = SingleSiteCompositionalInference({model.event: SingleSiteSeismicProposer()})
-    elapsed_time_compile_beanmachine = time.time() - start_time
+        query = [model.event(), model.event_magnitude()]
+        num_samples = args_dict["num_samples_beanmachine"]
 
-    obs = {
-        model.holdout_is_detected(): tensor(1.0),
-        model.is_detected(): model_is_detected,
-        model.detection(): model_detection,
-        model.theta_k(): theta_k,
-        model.mu_k_d(): mu,
-    }
+        start_time = time.time()
+        mh_infer = mh.infer(query, obs, num_samples, 1)
+        elapsed_time_sample_beanmachine = time.time() - start_time
 
-    query = [model.event(), model.event_magnitude()]
-    num_samples = args_dict["num_samples_beanmachine"]
+        mag = mh_infer[model.event_magnitude()].squeeze().detach()
+        event = mh_infer[model.event()].squeeze().detach()
 
-    start_time = time.time()
-    mh_infer = mh.infer(query, obs, num_samples, 1)
-    elapsed_time_sample_beanmachine = time.time() - start_time
+        samples = []
+        for i in range(num_samples):
+            samples.append((event[i], mag[i]))
 
-    mag = mh_infer[model.event_magnitude()].squeeze().detach()
-    event = mh_infer[model.event()].squeeze().detach()
-
-    samples = []
-    for i in range(num_samples):
-        samples.append((event[i], mag[i]))
-
-    timing_info = {
-        "compile_time": elapsed_time_compile_beanmachine,
-        "inference_time": elapsed_time_sample_beanmachine,
-    }
-    return (samples, timing_info)
+        timing_info = {
+            "compile_time": elapsed_time_compile_beanmachine,
+            "inference_time": elapsed_time_sample_beanmachine,
+        }
+        return (samples, timing_info)

--- a/benchmarks/pplbench/ppls/bootstrapping/logistic_regression.py
+++ b/benchmarks/pplbench/ppls/bootstrapping/logistic_regression.py
@@ -2,7 +2,8 @@
 import time
 from random import choices
 
-from sklearn.linear_model import LogisticRegression
+from ppls.pplbench_ppl import PPLBenchPPL
+from sklearn.linear_model import LogisticRegression as LR
 
 
 """
@@ -10,45 +11,46 @@ For model definition, see models/logisticRegressionModel.py
 """
 
 
-def obtain_posterior(data_train, args_dict, model):
-    """
-    Bootstrap impmementation of logistic regression model.
+class LogisticRegression(PPLBenchPPL):
+    def obtain_posterior(self, data_train, args_dict, model=None):
+        """
+        Bootstrap impmementation of logistic regression model.
 
-    :param data_train: tuple of np.ndarray (x_train, y_train)
-    :param args_dict: a dict of model arguments
-    :returns: samples_bootstrap(dict): posterior samples of all parameters
-    :returns: timing_info(dict): compile_time, inference_time
-    """
+        :param data_train: tuple of np.ndarray (x_train, y_train)
+        :param args_dict: a dict of model arguments
+        :returns: samples_bootstrap(dict): posterior samples of all parameters
+        :returns: timing_info(dict): compile_time, inference_time
+        """
 
-    # shape of x_train: (num_features, num_samples)
-    x_train, y_train = data_train
-    N = int(x_train.shape[1])
-    num_samples = args_dict["num_samples_bootstrapping"]
+        # shape of x_train: (num_features, num_samples)
+        x_train, y_train = data_train
+        N = int(x_train.shape[1])
+        num_samples = args_dict["num_samples_bootstrapping"]
 
-    # x_train is now (num_samples, num_features)
-    x_train = x_train.T
+        # x_train is now (num_samples, num_features)
+        x_train = x_train.T
 
-    samples = []
-    inference_start_time = time.time()
-    for i in range(num_samples):
-        sample_dict = {}
-        # randomnly pick with replacement N training observations
-        indices = [i for i in range(N)]
-        chosen_indices = choices(indices, k=N)
-        x_train_sampled = x_train[chosen_indices, :]
-        y_train_sampled = y_train[chosen_indices]
+        samples = []
+        inference_start_time = time.time()
+        for _i in range(num_samples):
+            sample_dict = {}
+            # randomnly pick with replacement N training observations
+            indices = list(range(N))
+            chosen_indices = choices(indices, k=N)
+            x_train_sampled = x_train[chosen_indices, :]
+            y_train_sampled = y_train[chosen_indices]
 
-        clf = LogisticRegression(random_state=0).fit(x_train_sampled, y_train_sampled)
+            clf = LR(random_state=0).fit(x_train_sampled, y_train_sampled)
 
-        alpha = clf.intercept_
+            alpha = clf.intercept_
 
-        # shape: (1, num_features)
-        beta = clf.coef_
-        sample_dict["alpha"] = alpha
-        sample_dict["beta"] = beta
-        samples.append(sample_dict)
+            # shape: (1, num_features)
+            beta = clf.coef_
+            sample_dict["alpha"] = alpha
+            sample_dict["beta"] = beta
+            samples.append(sample_dict)
 
-    inference_time = time.time() - inference_start_time
+        inference_time = time.time() - inference_start_time
 
-    timing_info = {"compile_time": 0, "inference_time": inference_time}
-    return (samples, timing_info)
+        timing_info = {"compile_time": 0, "inference_time": inference_time}
+        return (samples, timing_info)

--- a/benchmarks/pplbench/ppls/jags/crowd_sourced_annotation.py
+++ b/benchmarks/pplbench/ppls/jags/crowd_sourced_annotation.py
@@ -4,6 +4,7 @@ import time
 
 import numpy as np
 import pyjags
+from ppls.pplbench_ppl import PPLBenchPPL
 
 
 CODE = """
@@ -42,73 +43,75 @@ model {
 """
 
 
-def obtain_posterior(data_train, args_dict, model=None):
-    """
-    Jags impmementation of robust regression model.
+class CrowdSourcedAnnotation(PPLBenchPPL):
+    def obtain_posterior(self, data_train, args_dict, model=None):
+        """
+        Jags impmementation of robust regression model.
 
-    Inputs:
-    - data_train(tuple of np.ndarray): vector_y, vector_J_i, num_labels
-    - args_dict: a dict of model arguments
-    Returns:
-    - samples_jags(dict): posterior samples of all parameters
-    - timing_info(dict): compile_time, inference_time
-    """
-    global CODE
-    vector_y, vector_J_i, num_labels = data_train
-    J = int(args_dict["k"])
-    n_items = len(num_labels)
-    K, _, expected_correctness, concentration = args_dict["model_args"]
-    # item array for jags; change from list-of-lengths format of num_labels
-    # to list-of-items associated with each label and labeler in vector_y, vector_J_i
-    item = []
-    for i in range(len(num_labels)):
-        item.extend(np.repeat(i + 1, num_labels[i]))
-    data_jags = {
-        "n_obs": len(vector_y),
-        "n_items": n_items,
-        "n_labelers": J,
-        "n_categories": K,
-        "expected_correctness": expected_correctness,
-        "concentration": concentration,
-        "labels": [i + 1 for i in vector_y],  # 0-indexed to 1-indexed
-        "labeler": [i + 1 for i in vector_J_i],  # 0-indexed to 1-indexed
-        "item": item,
-    }
+        Inputs:
+        - data_train(tuple of np.ndarray): vector_y, vector_J_i, num_labels
+        - args_dict: a dict of model arguments
+        Returns:
+        - samples_jags(dict): posterior samples of all parameters
+        - timing_info(dict): compile_time, inference_time
+        """
+        global CODE
+        vector_y, vector_J_i, num_labels = data_train
+        J = int(args_dict["k"])
+        n_items = len(num_labels)
+        K, _, expected_correctness, concentration = args_dict["model_args"]
+        # item array for jags; change from list-of-lengths format
+        # of num_labels to list-of-items associated with each label
+        # and labeler in vector_y, vector_J_i
+        item = []
+        for i in range(len(num_labels)):
+            item.extend(np.repeat(i + 1, num_labels[i]))
+        data_jags = {
+            "n_obs": len(vector_y),
+            "n_items": n_items,
+            "n_labelers": J,
+            "n_categories": K,
+            "expected_correctness": expected_correctness,
+            "concentration": concentration,
+            "labels": [i + 1 for i in vector_y],  # 0-indexed to 1-indexed
+            "labeler": [i + 1 for i in vector_J_i],  # 0-indexed to 1-indexed
+            "item": item,
+        }
 
-    # compile the model, time it
-    start_time = time.time()
-    brmodel = pyjags.Model(CODE, data=data_jags, chains=1, adapt=0)
-    elapsed_time_compile_jags = time.time() - start_time
-
-    if args_dict["inference_type"] == "mcmc":
-        # sample the parameter posteriors, time it
+        # compile the model, time it
         start_time = time.time()
-        # Choose the parameters to watch and iterations:
-        samples_jags = brmodel.sample(
-            int(args_dict["num_samples_jags"]), vars=["theta", "pi"]
-        )
-        elapsed_time_sample_jags = time.time() - start_time
-    elif args_dict["inference_type"] == "vi":
-        print("Jags does not support Variational Inference")
-        exit(1)
-    # repackage samples into shape required by PPLBench
-    samples = []
-    # move axes to facilitate iterating over samples
-    # change (sample, chain, values) to (chain, sample, value)
-    samples_jags["pi"] = np.moveaxis(samples_jags["pi"], [0, 1, 2], [2, 1, 0])
-    # change from (J, K, K, samples, chains) to (chains, samples, J, K, K)
-    samples_jags["theta"] = np.moveaxis(samples_jags["theta"], [3, 4], [1, 0])
-    for parameter in samples_jags.keys():
-        if samples_jags[parameter].shape[0] == 1:
-            samples_jags[parameter] = samples_jags[parameter].squeeze()
-    for i in range(int(args_dict["num_samples_jags"])):
-        sample_dict = {}
-        for parameter in samples_jags.keys():
-            sample_dict[parameter] = samples_jags[parameter][i]
-        samples.append(sample_dict)
-    timing_info = {
-        "compile_time": elapsed_time_compile_jags,
-        "inference_time": elapsed_time_sample_jags,
-    }
+        brmodel = pyjags.Model(CODE, data=data_jags, chains=1, adapt=0)
+        elapsed_time_compile_jags = time.time() - start_time
 
-    return (samples, timing_info)
+        if args_dict["inference_type"] == "mcmc":
+            # sample the parameter posteriors, time it
+            start_time = time.time()
+            # Choose the parameters to watch and iterations:
+            samples_jags = brmodel.sample(
+                int(args_dict["num_samples_jags"]), vars=["theta", "pi"]
+            )
+            elapsed_time_sample_jags = time.time() - start_time
+        elif args_dict["inference_type"] == "vi":
+            print("Jags does not support Variational Inference")
+            exit(1)
+        # repackage samples into shape required by PPLBench
+        samples = []
+        # move axes to facilitate iterating over samples
+        # change (sample, chain, values) to (chain, sample, value)
+        samples_jags["pi"] = np.moveaxis(samples_jags["pi"], [0, 1, 2], [2, 1, 0])
+        # change from (J, K, K, samples, chains) to (chains, samples, J, K, K)
+        samples_jags["theta"] = np.moveaxis(samples_jags["theta"], [3, 4], [1, 0])
+        for parameter in samples_jags.keys():
+            if samples_jags[parameter].shape[0] == 1:
+                samples_jags[parameter] = samples_jags[parameter].squeeze()
+        for i in range(int(args_dict["num_samples_jags"])):
+            sample_dict = {}
+            for parameter in samples_jags.keys():
+                sample_dict[parameter] = samples_jags[parameter][i]
+            samples.append(sample_dict)
+        timing_info = {
+            "compile_time": elapsed_time_compile_jags,
+            "inference_time": elapsed_time_sample_jags,
+        }
+
+        return (samples, timing_info)

--- a/benchmarks/pplbench/ppls/jags/logistic_regression.py
+++ b/benchmarks/pplbench/ppls/jags/logistic_regression.py
@@ -4,6 +4,7 @@ import time
 
 import numpy as np
 import pyjags
+from ppls.pplbench_ppl import PPLBenchPPL
 
 
 CODE = """
@@ -23,66 +24,67 @@ model {
 """
 
 
-def obtain_posterior(data_train, args_dict, model=None):
-    """
-    Jags impmementation of logistic regression model.
+class LogisticRegression(PPLBenchPPL):
+    def obtain_posterior(self, data_train, args_dict, model=None):
+        """
+        Jags impmementation of logistic regression model.
 
-    Inputs:
-    - data_train(tuple of np.ndarray): x_train, y_train
-    - args_dict: a dict of model arguments
-    Returns:
-    - samples_jags(dict): posterior samples of all parameters
-    - timing_info(dict): compile_time, inference_time
-    """
-    global CODE
-    x_train, y_train = data_train
-    N = int(x_train.shape[1])
-    K = int(x_train.shape[0])
-    alpha_scale = (args_dict["model_args"])[0]
-    beta_scale = (args_dict["model_args"])[1]
+        Inputs:
+        - data_train(tuple of np.ndarray): x_train, y_train
+        - args_dict: a dict of model arguments
+        Returns:
+        - samples_jags(dict): posterior samples of all parameters
+        - timing_info(dict): compile_time, inference_time
+        """
+        global CODE
+        x_train, y_train = data_train
+        N = int(x_train.shape[1])
+        K = int(x_train.shape[0])
+        alpha_scale = (args_dict["model_args"])[0]
+        beta_scale = (args_dict["model_args"])[1]
 
-    data_jags = {
-        "N": N,
-        "K": K,
-        "X": x_train,
-        "y": y_train,
-        "scale_alpha": alpha_scale,
-        "scale_beta": beta_scale * np.ones(K),
-    }
+        data_jags = {
+            "N": N,
+            "K": K,
+            "X": x_train,
+            "y": y_train,
+            "scale_alpha": alpha_scale,
+            "scale_beta": beta_scale * np.ones(K),
+        }
 
-    # compile the model, time it
-    start_time = time.time()
-    brmodel = pyjags.Model(CODE, data=data_jags, chains=1, adapt=0)
-    elapsed_time_compile_jags = time.time() - start_time
-
-    if args_dict["inference_type"] == "mcmc":
-        # sample the parameter posteriors, time it
+        # compile the model, time it
         start_time = time.time()
-        # Choose the parameters to watch and iterations:
-        samples_jags = brmodel.sample(
-            int(args_dict["num_samples_jags"]), vars=["alpha", "beta"]
-        )
-        elapsed_time_sample_jags = time.time() - start_time
-    elif args_dict["inference_type"] == "vi":
-        print("Jags does not support Variational Inference")
-        exit()
+        brmodel = pyjags.Model(CODE, data=data_jags, chains=1, adapt=0)
+        elapsed_time_compile_jags = time.time() - start_time
 
-    # repackage samples into shape required by PPLBench
-    samples = []
-    # move axes to facilitate iterating over samples
-    # change (sample, chain, values) to (chain, sample, value)
-    samples_jags["beta"] = np.moveaxis(samples_jags["beta"], [0, 1, 2], [1, 0, 2])
-    for parameter in samples_jags.keys():
-        if samples_jags[parameter].shape[0] == 1:
-            samples_jags[parameter] = samples_jags[parameter].squeeze()
-    for i in range(int(args_dict["num_samples_jags"])):
-        sample_dict = {}
+        if args_dict["inference_type"] == "mcmc":
+            # sample the parameter posteriors, time it
+            start_time = time.time()
+            # Choose the parameters to watch and iterations:
+            samples_jags = brmodel.sample(
+                int(args_dict["num_samples_jags"]), vars=["alpha", "beta"]
+            )
+            elapsed_time_sample_jags = time.time() - start_time
+        elif args_dict["inference_type"] == "vi":
+            print("Jags does not support Variational Inference")
+            exit()
+
+        # repackage samples into shape required by PPLBench
+        samples = []
+        # move axes to facilitate iterating over samples
+        # change (sample, chain, values) to (chain, sample, value)
+        samples_jags["beta"] = np.moveaxis(samples_jags["beta"], [0, 1, 2], [1, 0, 2])
         for parameter in samples_jags.keys():
-            sample_dict[parameter] = samples_jags[parameter][i].T
-        samples.append(sample_dict)
-    timing_info = {
-        "compile_time": elapsed_time_compile_jags,
-        "inference_time": elapsed_time_sample_jags,
-    }
+            if samples_jags[parameter].shape[0] == 1:
+                samples_jags[parameter] = samples_jags[parameter].squeeze()
+        for i in range(int(args_dict["num_samples_jags"])):
+            sample_dict = {}
+            for parameter in samples_jags.keys():
+                sample_dict[parameter] = samples_jags[parameter][i].T
+            samples.append(sample_dict)
+        timing_info = {
+            "compile_time": elapsed_time_compile_jags,
+            "inference_time": elapsed_time_sample_jags,
+        }
 
-    return (samples, timing_info)
+        return (samples, timing_info)

--- a/benchmarks/pplbench/ppls/jags/noisy_or_topic.py
+++ b/benchmarks/pplbench/ppls/jags/noisy_or_topic.py
@@ -4,72 +4,76 @@ import time
 
 import numpy as np
 import pyjags
+from ppls.pplbench_ppl import PPLBenchPPL
 
 
-def obtain_posterior(data_train, args_dict, model):
-    """
-    Jags impmementation of Noisy-Or Topic Model.
+class NoisyOrTopic(PPLBenchPPL):
+    def obtain_posterior(self, data_train, args_dict, model):
+        """
+        Jags impmementation of Noisy-Or Topic Model.
 
-    Inputs:
-    - data_train(tuple of np.ndarray): graph, words
-    - args_dict: a dict of model arguments
-    Returns:
-    - samples_jags(dict): posterior samples of all parameters
-    - timing_info(dict): compile_time, inference_time
-    """
-    graph = model
-    words = data_train
-    K = int(args_dict["k"])
-    word_fraction = (args_dict["model_args"])[3]
-    T = int(K * (1 - word_fraction))
-    assert len(words.shape) == 1
-    nodearray = np.concatenate([np.zeros(T), words])
-    mask = np.concatenate((np.ones(T), np.zeros_like(words)))
-    # Construct the jags code for the graph
-    code = "model {\n"
-    for node in range(K):
-        if node == 0:
-            code += "    node[{}] <- 1\n".format(node + 1)
-        else:
-            code += "    prob[{}] <- 1 - exp(-(".format(node + 1)
-            for par, wt in enumerate(graph[:, node]):
-                if wt:
-                    code += "node[{}]*{} + ".format(par + 1, wt)
-            code += "0))\n"
-            code += "    node[{}] ~ dbern(prob[{}])\n".format(node + 1, node + 1)
-    code += "}"
-    data_jags = {"node": np.ma.masked_array(data=nodearray, mask=mask)}
-    # compile the model, time it
-    start_time = time.time()
-    model = pyjags.Model(code, data=data_jags, chains=1, adapt=0)
-    elapsed_time_compile_jags = time.time() - start_time
-    if args_dict["inference_type"] == "mcmc":
-        # sample the parameter posteriors, time it
+        Inputs:
+        - data_train(tuple of np.ndarray): graph, words
+        - args_dict: a dict of model arguments
+        Returns:
+        - samples_jags(dict): posterior samples of all parameters
+        - timing_info(dict): compile_time, inference_time
+        """
+        graph = model
+        words = data_train
+        K = int(args_dict["k"])
+        word_fraction = (args_dict["model_args"])[3]
+        T = int(K * (1 - word_fraction))
+        assert len(words.shape) == 1
+        nodearray = np.concatenate([np.zeros(T), words])
+        mask = np.concatenate((np.ones(T), np.zeros_like(words)))
+        # Construct the jags code for the graph
+        code = "model {\n"
+        for node in range(K):
+            if node == 0:
+                code += "    node[{}] <- 1\n".format(node + 1)
+            else:
+                code += "    prob[{}] <- 1 - exp(-(".format(node + 1)
+                for par, wt in enumerate(graph[:, node]):
+                    if wt:
+                        code += "node[{}]*{} + ".format(par + 1, wt)
+                code += "0))\n"
+                code += "    node[{}] ~ dbern(prob[{}])\n".format(node + 1, node + 1)
+        code += "}"
+        data_jags = {"node": np.ma.masked_array(data=nodearray, mask=mask)}
+        # compile the model, time it
         start_time = time.time()
-        samples_jags = model.sample(int(args_dict["num_samples_jags"]), vars=["node"])
-        elapsed_time_sample_jags = time.time() - start_time
-    elif args_dict["inference_type"] == "vi":
-        print("Jags does not support Variational Inference")
-        exit()
-    # repackage samples into shape required by PPLBench
-    samples = []
-    # move axes to facilitate iterating over samples
-    # change (sample, chain, values) to (chain, sample, value)
-    samples_jags["node"] = np.moveaxis(samples_jags["node"], [0, 1, 2], [1, 0, 2])
-    for parameter in samples_jags.keys():
-        # samples ndarray may have an extra dimension for num_chains which is 1
-        # in PPLbench, we flatten it
-        if samples_jags[parameter].shape[0] == 1:
-            samples_jags[parameter] = samples_jags[parameter].squeeze()
-    for i in range(int(args_dict["num_samples_jags"])):
-        sample_dict = {}
+        model = pyjags.Model(code, data=data_jags, chains=1, adapt=0)
+        elapsed_time_compile_jags = time.time() - start_time
+        if args_dict["inference_type"] == "mcmc":
+            # sample the parameter posteriors, time it
+            start_time = time.time()
+            samples_jags = model.sample(
+                int(args_dict["num_samples_jags"]), vars=["node"]
+            )
+            elapsed_time_sample_jags = time.time() - start_time
+        elif args_dict["inference_type"] == "vi":
+            print("Jags does not support Variational Inference")
+            exit()
+        # repackage samples into shape required by PPLBench
+        samples = []
+        # move axes to facilitate iterating over samples
+        # change (sample, chain, values) to (chain, sample, value)
+        samples_jags["node"] = np.moveaxis(samples_jags["node"], [0, 1, 2], [1, 0, 2])
         for parameter in samples_jags.keys():
-            # convert from [parameter][sample] dict to [sample][parameter]
-            # keep only the topics
-            sample_dict[parameter] = samples_jags[parameter][i].reshape(-1)[:T]
-        samples.append(sample_dict)
-    timing_info = {
-        "compile_time": elapsed_time_compile_jags,
-        "inference_time": elapsed_time_sample_jags,
-    }
-    return (samples, timing_info)
+            # samples ndarray may have an extra dimension for num_chains which is 1
+            # in PPLbench, we flatten it
+            if samples_jags[parameter].shape[0] == 1:
+                samples_jags[parameter] = samples_jags[parameter].squeeze()
+        for i in range(int(args_dict["num_samples_jags"])):
+            sample_dict = {}
+            for parameter in samples_jags.keys():
+                # convert from [parameter][sample] dict to [sample][parameter]
+                # keep only the topics
+                sample_dict[parameter] = samples_jags[parameter][i].reshape(-1)[:T]
+            samples.append(sample_dict)
+        timing_info = {
+            "compile_time": elapsed_time_compile_jags,
+            "inference_time": elapsed_time_sample_jags,
+        }
+        return (samples, timing_info)

--- a/benchmarks/pplbench/ppls/jags/robust_regression.py
+++ b/benchmarks/pplbench/ppls/jags/robust_regression.py
@@ -4,6 +4,7 @@ import time
 
 import numpy as np
 import pyjags
+from ppls.pplbench_ppl import PPLBenchPPL
 
 
 CODE = """
@@ -24,67 +25,69 @@ model {
 """
 
 
-def obtain_posterior(data_train, args_dict, model=None):
-    """
-    Jags impmementation of robust regression model.
+class RobustRegression(PPLBenchPPL):
+    def obtain_posterior(self, data_train, args_dict, model=None):
+        """
+        Jags impmementation of robust regression model.
 
-    Inputs:
-    - data_train(tuple of np.ndarray): x_train, y_train
-    - args_dict: a dict of model arguments
-    Returns:
-    - samples_jags(dict): posterior samples of all parameters
-    - timing_info(dict): compile_time, inference_time
-    """
-    global CODE
-    x_train, y_train = data_train
-    N = int(x_train.shape[1])
-    K = int(x_train.shape[0])
-    alpha_scale, beta_scale, beta_loc, sigma_mean = args_dict["model_args"]
+        Inputs:
+        - data_train(tuple of np.ndarray): x_train, y_train
+        - args_dict: a dict of model arguments
+        Returns:
+        - samples_jags(dict): posterior samples of all parameters
+        - timing_info(dict): compile_time, inference_time
+        """
+        global CODE
+        x_train, y_train = data_train
+        N = int(x_train.shape[1])
+        K = int(x_train.shape[0])
+        alpha_scale, beta_scale, beta_loc, sigma_mean = args_dict["model_args"]
 
-    data_jags = {
-        "N": N,
-        "K": K,
-        "X": x_train,
-        "y": y_train,
-        "scale_alpha": alpha_scale,
-        "scale_beta": beta_scale,
-        "loc_beta": beta_loc,
-        "rate_sigma": 1.0 / sigma_mean,
-    }
+        data_jags = {
+            "N": N,
+            "K": K,
+            "X": x_train,
+            "y": y_train,
+            "scale_alpha": alpha_scale,
+            "scale_beta": beta_scale,
+            "loc_beta": beta_loc,
+            "rate_sigma": 1.0 / sigma_mean,
+        }
 
-    # compile the model, time it
-    start_time = time.time()
-    brmodel = pyjags.Model(CODE, data=data_jags, chains=1, adapt=0)
-    elapsed_time_compile_jags = time.time() - start_time
-
-    if args_dict["inference_type"] == "mcmc":
-        # sample the parameter posteriors, time it
+        # compile the model, time it
         start_time = time.time()
-        # Choose the parameters to watch and iterations:
-        samples_jags = brmodel.sample(
-            int(args_dict["num_samples_jags"]), vars=["nu", "alpha", "beta", "sigma"]
-        )
-        elapsed_time_sample_jags = time.time() - start_time
-    elif args_dict["inference_type"] == "vi":
-        print("Jags does not support Variational Inference")
-        exit()
+        brmodel = pyjags.Model(CODE, data=data_jags, chains=1, adapt=0)
+        elapsed_time_compile_jags = time.time() - start_time
 
-    # repackage samples into shape required by PPLBench
-    samples = []
-    # move axes to facilitate iterating over samples
-    # change (sample, chain, values) to (chain, sample, value)
-    samples_jags["beta"] = np.moveaxis(samples_jags["beta"], [0, 1, 2], [1, 0, 2])
-    for parameter in samples_jags.keys():
-        if samples_jags[parameter].shape[0] == 1:
-            samples_jags[parameter] = samples_jags[parameter].squeeze()
-    for i in range(int(args_dict["num_samples_jags"])):
-        sample_dict = {}
+        if args_dict["inference_type"] == "mcmc":
+            # sample the parameter posteriors, time it
+            start_time = time.time()
+            # Choose the parameters to watch and iterations:
+            samples_jags = brmodel.sample(
+                int(args_dict["num_samples_jags"]),
+                vars=["nu", "alpha", "beta", "sigma"],
+            )
+            elapsed_time_sample_jags = time.time() - start_time
+        elif args_dict["inference_type"] == "vi":
+            print("Jags does not support Variational Inference")
+            exit()
+
+        # repackage samples into shape required by PPLBench
+        samples = []
+        # move axes to facilitate iterating over samples
+        # change (sample, chain, values) to (chain, sample, value)
+        samples_jags["beta"] = np.moveaxis(samples_jags["beta"], [0, 1, 2], [1, 0, 2])
         for parameter in samples_jags.keys():
-            sample_dict[parameter] = samples_jags[parameter][i].T
-        samples.append(sample_dict)
-    timing_info = {
-        "compile_time": elapsed_time_compile_jags,
-        "inference_time": elapsed_time_sample_jags,
-    }
+            if samples_jags[parameter].shape[0] == 1:
+                samples_jags[parameter] = samples_jags[parameter].squeeze()
+        for i in range(int(args_dict["num_samples_jags"])):
+            sample_dict = {}
+            for parameter in samples_jags.keys():
+                sample_dict[parameter] = samples_jags[parameter][i].T
+            samples.append(sample_dict)
+        timing_info = {
+            "compile_time": elapsed_time_compile_jags,
+            "inference_time": elapsed_time_sample_jags,
+        }
 
-    return (samples, timing_info)
+        return (samples, timing_info)

--- a/benchmarks/pplbench/ppls/nmc/logistic_regression.py
+++ b/benchmarks/pplbench/ppls/nmc/logistic_regression.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Tuple
 
 import numpy as np
 import torch
+from ppls.pplbench_ppl import PPLBenchPPL
 from torch import tensor
 from torch.distributions import Bernoulli, Normal
 from tqdm import tqdm
@@ -11,80 +12,81 @@ from tqdm import tqdm
 from .utils import gradients, real_proposer
 
 
-def obtain_posterior(
-    data_train: Tuple[Any, Any], args_dict: Dict, model=None
-) -> Tuple[List, Dict]:
-    """
-    Beanmachine impmementation of logisitc regression model.
+class LogisticRegression(PPLBenchPPL):
+    def obtain_posterior(
+        self, data_train: Tuple[Any, Any], args_dict: Dict, model=None
+    ) -> Tuple[List, Dict]:
+        """
+        Beanmachine impmementation of logisitc regression model.
 
-    :param data_train: tuple of np.ndarray (x_train, y_train)
-    :param args_dict: a dict of model arguments
-    :returns: samples_beanmachine(dict): posterior samples of all parameters
-    :returns: timing_info(dict): compile_time, inference_time
-    """
-    # shape of x_train: (num_features, num_samples)
-    x_train, y_train = data_train
-    y_train = np.array(y_train, dtype=np.float32)
-    x_train = np.array(x_train, dtype=np.float32)
-    x_train = tensor(x_train)
-    y_train = tensor([tensor(y) for y in y_train])
-    N = int(x_train.shape[1])
-    K = int(x_train.shape[0])
-    assert y_train.shape == (N,)
+        :param data_train: tuple of np.ndarray (x_train, y_train)
+        :param args_dict: a dict of model arguments
+        :returns: samples_beanmachine(dict): posterior samples of all parameters
+        :returns: timing_info(dict): compile_time, inference_time
+        """
+        # shape of x_train: (num_features, num_samples)
+        x_train, y_train = data_train
+        y_train = np.array(y_train, dtype=np.float32)
+        x_train = np.array(x_train, dtype=np.float32)
+        x_train = tensor(x_train)
+        y_train = tensor([tensor(y) for y in y_train])
+        N = int(x_train.shape[1])
+        K = int(x_train.shape[0])
+        assert y_train.shape == (N,)
 
-    alpha_scale = float((args_dict["model_args"])[0])
-    beta_scale = float((args_dict["model_args"])[1])
-    beta_loc = float((args_dict["model_args"])[2])
-    num_samples = args_dict["num_samples_nmc"]
+        alpha_scale = float((args_dict["model_args"])[0])
+        beta_scale = float((args_dict["model_args"])[1])
+        beta_loc = float((args_dict["model_args"])[2])
+        num_samples = args_dict["num_samples_nmc"]
 
-    # x_train has shape (K+1) x N
-    x_train = torch.cat((torch.ones((1, N)), x_train))
-    # we construct the prior to have mean and std with shape (K+1)
-    prior = Normal(
-        tensor([0.0] + ([beta_loc] * K)), tensor([alpha_scale] + ([beta_scale] * K))
-    )
-
-    def log_joint(theta):
-        score = prior.log_prob(theta).sum()
-        mu = torch.mm(theta.unsqueeze(dim=0), x_train).squeeze(dim=0)
-        score += Bernoulli(logits=mu).log_prob(y_train).sum()
-        return score
-
-    def get_score_and_proposer(theta):
-        theta.requires_grad_(True)
-        score = log_joint(theta)
-        grad, hess = gradients(score, theta)
-        grad = grad.detach()
-        hess = hess.detach()
-        theta.requires_grad_(False)
-        proposer = real_proposer(theta, grad, hess)
-        return score, proposer
-
-    # initialize to zero
-    samples = []
-    theta = torch.zeros(K + 1, requires_grad=True)
-    score, proposer = get_score_and_proposer(theta)
-    t1 = time.time()
-    for _i in tqdm(range(num_samples), desc="inference", leave=False):
-        theta2 = proposer.sample()
-        score2, proposer2 = get_score_and_proposer(theta2)
-        logacc = (
-            score2
-            - score
-            + proposer2.log_prob(theta).sum()
-            - proposer.log_prob(theta2).sum()
+        # x_train has shape (K+1) x N
+        x_train = torch.cat((torch.ones((1, N)), x_train))
+        # we construct the prior to have mean and std with shape (K+1)
+        prior = Normal(
+            tensor([0.0] + ([beta_loc] * K)), tensor([alpha_scale] + ([beta_scale] * K))
         )
-        if logacc > 0 or Bernoulli(probs=torch.exp(logacc)).sample().item():
-            theta, score, proposer = theta2, score2, proposer2
-        samples.append(theta.clone())
-    t2 = time.time()
-    samples_formatted = []
-    for i in tqdm(range(num_samples), desc="collect", leave=False):
-        sample_dict = {
-            "alpha": samples[i][0].item(),
-            "beta": samples[i][1:].detach().numpy(),
-        }
-        samples_formatted.append(sample_dict)
 
-    timing_info = {"compile_time": 0, "inference_time": t2 - t1}
-    return (samples_formatted, timing_info)
+        def log_joint(theta):
+            score = prior.log_prob(theta).sum()
+            mu = torch.mm(theta.unsqueeze(dim=0), x_train).squeeze(dim=0)
+            score += Bernoulli(logits=mu).log_prob(y_train).sum()
+            return score
+
+        def get_score_and_proposer(theta):
+            theta.requires_grad_(True)
+            score = log_joint(theta)
+            grad, hess = gradients(score, theta)
+            grad = grad.detach()
+            hess = hess.detach()
+            theta.requires_grad_(False)
+            proposer = real_proposer(theta, grad, hess)
+            return score, proposer
+
+        # initialize to zero
+        samples = []
+        theta = torch.zeros(K + 1, requires_grad=True)
+        score, proposer = get_score_and_proposer(theta)
+        t1 = time.time()
+        for _i in tqdm(range(num_samples), desc="inference", leave=False):
+            theta2 = proposer.sample()
+            score2, proposer2 = get_score_and_proposer(theta2)
+            logacc = (
+                score2
+                - score
+                + proposer2.log_prob(theta).sum()
+                - proposer.log_prob(theta2).sum()
+            )
+            if logacc > 0 or Bernoulli(probs=torch.exp(logacc)).sample().item():
+                theta, score, proposer = theta2, score2, proposer2
+            samples.append(theta.clone())
+        t2 = time.time()
+        samples_formatted = []
+        for i in tqdm(range(num_samples), desc="collect", leave=False):
+            sample_dict = {
+                "alpha": samples[i][0].item(),
+                "beta": samples[i][1:].detach().numpy(),
+            }
+            samples_formatted.append(sample_dict)
+
+        timing_info = {"compile_time": 0, "inference_time": t2 - t1}
+        return (samples_formatted, timing_info)

--- a/benchmarks/pplbench/ppls/nmc/robust_regression.py
+++ b/benchmarks/pplbench/ppls/nmc/robust_regression.py
@@ -3,6 +3,7 @@ import time
 from typing import Any, Dict, List, Tuple
 
 import torch
+from ppls.pplbench_ppl import PPLBenchPPL
 from torch import tensor
 from torch.distributions import Bernoulli, Exponential, Gamma, Normal, StudentT
 from tqdm import tqdm
@@ -10,158 +11,165 @@ from tqdm import tqdm
 from .utils import gradients, halfspace_proposer, real_proposer
 
 
-def obtain_posterior(
-    data_train: Tuple[Any, Any], args_dict: Dict, model=None
-) -> Tuple[List, Dict]:
-    """
-    Beanmachine impmementation of logisitc regression model.
+class RobustRegression(PPLBenchPPL):
+    def obtain_posterior(
+        self, data_train: Tuple[Any, Any], args_dict: Dict, model=None
+    ) -> Tuple[List, Dict]:
+        """
+        Beanmachine impmementation of logisitc regression model.
 
-    :param data_train: tuple of np.ndarray (x_train, y_train)
-    :param args_dict: a dict of model arguments
-    :returns: samples_beanmachine(dict): posterior samples of all parameters
-    :returns: timing_info(dict): compile_time, inference_time
-    """
-    # shape of x_train: (num_features, num_samples)
-    x_train, y_train = data_train
-    y_train = tensor(y_train, dtype=torch.float32)
-    x_train = tensor(x_train, dtype=torch.float32)
-    N = int(x_train.shape[1])
-    K = int(x_train.shape[0])
-    assert y_train.shape == (N,)
-    # reshape x_train to (K+1) x N with an extra row 1 at the top
-    x_train = torch.cat((torch.ones((1, N)), x_train))
+        :param data_train: tuple of np.ndarray (x_train, y_train)
+        :param args_dict: a dict of model arguments
+        :returns: samples_beanmachine(dict): posterior samples of all parameters
+        :returns: timing_info(dict): compile_time, inference_time
+        """
+        # shape of x_train: (num_features, num_samples)
+        x_train, y_train = data_train
+        y_train = tensor(y_train, dtype=torch.float32)
+        x_train = tensor(x_train, dtype=torch.float32)
+        N = int(x_train.shape[1])
+        K = int(x_train.shape[0])
+        assert y_train.shape == (N,)
+        # reshape x_train to (K+1) x N with an extra row 1 at the top
+        x_train = torch.cat((torch.ones((1, N)), x_train))
 
-    alpha_scale, beta_scale, beta_loc, sigma_mean = args_dict["model_args"]
-    num_samples = args_dict["num_samples_nmc"]
+        alpha_scale, beta_scale, beta_loc, sigma_mean = args_dict["model_args"]
+        num_samples = args_dict["num_samples_nmc"]
 
-    prior_sigma = Exponential(tensor(1.0 / sigma_mean))
-    prior_nu = Gamma(tensor(2.0), tensor(0.1))
-    prior_beta = Normal(
-        tensor([0.0] + [float(beta_loc)] * K),
-        tensor([float(alpha_scale)] + [float(beta_scale)] * K),
-    )
-
-    class State:
-        def __init__(self, nu=None, sigma=None, beta=None):
-            # initialize reals to zero and real+ to 1
-            self.nu = tensor(1.0, requires_grad=False) if nu is None else nu
-            self.sigma = tensor(1.0, requires_grad=False) if sigma is None else sigma
-            self.beta = (
-                torch.zeros(K + 1, requires_grad=False) if beta is None else beta
-            )
-
-        def clone(self):
-            return State(self.nu.clone(), self.sigma.clone(), self.beta.clone())
-
-        def compute_score_(self):
-            self.score = prior_sigma.log_prob(self.sigma)
-            self.score += prior_nu.log_prob(self.nu)
-            self.score += prior_beta.log_prob(self.beta).sum()
-            # (K+1)x1 * (K+1)xN => (K+1)xN .sum(0) => N
-            mu = (self.beta.unsqueeze(1) * x_train).sum(axis=0)
-            self.score += StudentT(self.nu, mu, self.sigma).log_prob(y_train).sum()
-
-        def compute_nu_gradients_(self):
-            self.nu.requires_grad_(True)
-            self.compute_score_()
-            self.nu_grad, = torch.autograd.grad(self.score, self.nu, create_graph=True)
-            self.nu_hess, = torch.autograd.grad(self.nu_grad, self.nu)
-            self.nu_grad.detach_()
-            self.nu_hess.detach_()
-            self.nu.requires_grad_(False)
-
-        def compute_nu_proposer_(self):
-            # proposer for nu
-            self.compute_nu_gradients_()
-            self.nu_proposer = halfspace_proposer(self.nu, self.nu_grad, self.nu_hess)
-
-        def compute_sigma_gradients_(self):
-            self.sigma.requires_grad_(True)
-            self.compute_score_()
-            self.sigma_grad, = torch.autograd.grad(
-                self.score, self.sigma, create_graph=True
-            )
-            self.sigma_hess, = torch.autograd.grad(self.sigma_grad, self.sigma)
-            self.sigma_grad.detach_()
-            self.sigma_hess.detach_()
-            self.sigma.requires_grad_(False)
-
-        def compute_sigma_proposer_(self):
-            # proposer for sigma
-            self.compute_sigma_gradients_()
-            self.sigma_proposer = halfspace_proposer(
-                self.sigma, self.sigma_grad, self.sigma_hess
-            )
-
-        def compute_beta_gradients_(self):
-            self.beta.requires_grad_(True)
-            self.compute_score_()
-            grad, hess = gradients(self.score, self.beta)
-            self.beta_grad = grad.detach()
-            self.beta_hess = hess.detach()
-            self.beta.requires_grad_(False)
-
-        def compute_beta_proposer_(self):
-            self.compute_beta_gradients_()
-            self.beta_proposer = real_proposer(
-                self.beta, self.beta_grad, self.beta_hess
-            )
-
-    samples = []
-    t1 = time.time()
-    theta = State()
-    for _i in tqdm(range(num_samples), desc="inference", leave=False):
-        # propose nu
-        theta.compute_nu_proposer_()
-        nu = theta.nu_proposer.sample()
-        theta2 = State(nu.clone(), theta.sigma.clone(), theta.beta.clone())
-        theta2.compute_nu_proposer_()
-        logacc = (
-            theta2.score
-            - theta.score
-            + theta2.nu_proposer.log_prob(theta.nu)
-            - theta.nu_proposer.log_prob(theta2.nu)
+        prior_sigma = Exponential(tensor(1.0 / sigma_mean))
+        prior_nu = Gamma(tensor(2.0), tensor(0.1))
+        prior_beta = Normal(
+            tensor([0.0] + [float(beta_loc)] * K),
+            tensor([float(alpha_scale)] + [float(beta_scale)] * K),
         )
-        if logacc > 0 or Bernoulli(probs=torch.exp(logacc)).sample().item():
-            theta = theta2
-        # propose sigma
-        theta.compute_sigma_proposer_()
-        sigma = theta.sigma_proposer.sample()
-        theta2 = State(theta.nu.clone(), sigma.clone(), theta.beta.clone())
-        theta2.compute_sigma_proposer_()
-        logacc = (
-            theta2.score
-            - theta.score
-            + theta2.sigma_proposer.log_prob(theta.sigma)
-            - theta.sigma_proposer.log_prob(theta2.sigma)
-        )
-        if logacc > 0 or Bernoulli(probs=torch.exp(logacc)).sample().item():
-            theta = theta2
-        # propose beta
-        theta.compute_beta_proposer_()
-        beta = theta.beta_proposer.sample()
-        theta2 = State(theta.nu.clone(), theta.sigma.clone(), beta.clone())
-        theta2.compute_beta_proposer_()
-        logacc = (
-            theta2.score
-            - theta.score
-            + theta2.beta_proposer.log_prob(theta.beta)
-            - theta.beta_proposer.log_prob(theta2.beta)
-        )
-        if logacc > 0 or Bernoulli(probs=torch.exp(logacc)).sample().item():
-            theta = theta2
-        samples.append(theta.clone())
-    t2 = time.time()
-    samples_formatted = []
-    for i in tqdm(range(num_samples), desc="collect samples", leave=False):
-        theta = samples[i]
-        sample_dict = {
-            "sigma": theta.sigma.item(),
-            "nu": theta.nu.item(),
-            "alpha": theta.beta[0].item(),
-            "beta": theta.beta[1:].numpy(),
-        }
-        samples_formatted.append(sample_dict)
 
-    timing_info = {"compile_time": 0, "inference_time": t2 - t1}
-    return (samples_formatted, timing_info)
+        class State:
+            def __init__(self, nu=None, sigma=None, beta=None):
+                # initialize reals to zero and real+ to 1
+                self.nu = tensor(1.0, requires_grad=False) if nu is None else nu
+                self.sigma = (
+                    tensor(1.0, requires_grad=False) if sigma is None else sigma
+                )
+                self.beta = (
+                    torch.zeros(K + 1, requires_grad=False) if beta is None else beta
+                )
+
+            def clone(self):
+                return State(self.nu.clone(), self.sigma.clone(), self.beta.clone())
+
+            def compute_score_(self):
+                self.score = prior_sigma.log_prob(self.sigma)
+                self.score += prior_nu.log_prob(self.nu)
+                self.score += prior_beta.log_prob(self.beta).sum()
+                # (K+1)x1 * (K+1)xN => (K+1)xN .sum(0) => N
+                mu = (self.beta.unsqueeze(1) * x_train).sum(axis=0)
+                self.score += StudentT(self.nu, mu, self.sigma).log_prob(y_train).sum()
+
+            def compute_nu_gradients_(self):
+                self.nu.requires_grad_(True)
+                self.compute_score_()
+                self.nu_grad, = torch.autograd.grad(
+                    self.score, self.nu, create_graph=True
+                )
+                self.nu_hess, = torch.autograd.grad(self.nu_grad, self.nu)
+                self.nu_grad.detach_()
+                self.nu_hess.detach_()
+                self.nu.requires_grad_(False)
+
+            def compute_nu_proposer_(self):
+                # proposer for nu
+                self.compute_nu_gradients_()
+                self.nu_proposer = halfspace_proposer(
+                    self.nu, self.nu_grad, self.nu_hess
+                )
+
+            def compute_sigma_gradients_(self):
+                self.sigma.requires_grad_(True)
+                self.compute_score_()
+                self.sigma_grad, = torch.autograd.grad(
+                    self.score, self.sigma, create_graph=True
+                )
+                self.sigma_hess, = torch.autograd.grad(self.sigma_grad, self.sigma)
+                self.sigma_grad.detach_()
+                self.sigma_hess.detach_()
+                self.sigma.requires_grad_(False)
+
+            def compute_sigma_proposer_(self):
+                # proposer for sigma
+                self.compute_sigma_gradients_()
+                self.sigma_proposer = halfspace_proposer(
+                    self.sigma, self.sigma_grad, self.sigma_hess
+                )
+
+            def compute_beta_gradients_(self):
+                self.beta.requires_grad_(True)
+                self.compute_score_()
+                grad, hess = gradients(self.score, self.beta)
+                self.beta_grad = grad.detach()
+                self.beta_hess = hess.detach()
+                self.beta.requires_grad_(False)
+
+            def compute_beta_proposer_(self):
+                self.compute_beta_gradients_()
+                self.beta_proposer = real_proposer(
+                    self.beta, self.beta_grad, self.beta_hess
+                )
+
+        samples = []
+        t1 = time.time()
+        theta = State()
+        for _i in tqdm(range(num_samples), desc="inference", leave=False):
+            # propose nu
+            theta.compute_nu_proposer_()
+            nu = theta.nu_proposer.sample()
+            theta2 = State(nu.clone(), theta.sigma.clone(), theta.beta.clone())
+            theta2.compute_nu_proposer_()
+            logacc = (
+                theta2.score
+                - theta.score
+                + theta2.nu_proposer.log_prob(theta.nu)
+                - theta.nu_proposer.log_prob(theta2.nu)
+            )
+            if logacc > 0 or Bernoulli(probs=torch.exp(logacc)).sample().item():
+                theta = theta2
+            # propose sigma
+            theta.compute_sigma_proposer_()
+            sigma = theta.sigma_proposer.sample()
+            theta2 = State(theta.nu.clone(), sigma.clone(), theta.beta.clone())
+            theta2.compute_sigma_proposer_()
+            logacc = (
+                theta2.score
+                - theta.score
+                + theta2.sigma_proposer.log_prob(theta.sigma)
+                - theta.sigma_proposer.log_prob(theta2.sigma)
+            )
+            if logacc > 0 or Bernoulli(probs=torch.exp(logacc)).sample().item():
+                theta = theta2
+            # propose beta
+            theta.compute_beta_proposer_()
+            beta = theta.beta_proposer.sample()
+            theta2 = State(theta.nu.clone(), theta.sigma.clone(), beta.clone())
+            theta2.compute_beta_proposer_()
+            logacc = (
+                theta2.score
+                - theta.score
+                + theta2.beta_proposer.log_prob(theta.beta)
+                - theta.beta_proposer.log_prob(theta2.beta)
+            )
+            if logacc > 0 or Bernoulli(probs=torch.exp(logacc)).sample().item():
+                theta = theta2
+            samples.append(theta.clone())
+        t2 = time.time()
+        samples_formatted = []
+        for i in tqdm(range(num_samples), desc="collect samples", leave=False):
+            theta = samples[i]
+            sample_dict = {
+                "sigma": theta.sigma.item(),
+                "nu": theta.nu.item(),
+                "alpha": theta.beta[0].item(),
+                "beta": theta.beta[1:].numpy(),
+            }
+            samples_formatted.append(sample_dict)
+
+        timing_info = {"compile_time": 0, "inference_time": t2 - t1}
+        return (samples_formatted, timing_info)

--- a/benchmarks/pplbench/ppls/numpyro/logistic_regression.py
+++ b/benchmarks/pplbench/ppls/numpyro/logistic_regression.py
@@ -6,6 +6,7 @@ from jax import random
 from numpyro.distributions import Bernoulli, Normal
 from numpyro.mcmc import MCMC, NUTS
 from numpyro.primitives import sample
+from ppls.pplbench_ppl import PPLBenchPPL
 
 
 def logistic_regression(x, y, model_args):
@@ -17,46 +18,47 @@ def logistic_regression(x, y, model_args):
     return sample("y", Bernoulli(logits=x @ beta + alpha), obs=y)
 
 
-def obtain_posterior(data_train, args_dict, model=None):
-    """
-    Numpyro implementation of logistic regression model.
+class LogisticRegression(PPLBenchPPL):
+    def obtain_posterior(self, data_train, args_dict, model=None):
+        """
+        Numpyro implementation of logistic regression model.
 
-    Inputs:
-    - data_train(tuple of np.ndarray): x_train, y_train
-    - args_dict: a dict of model arguments
-    Returns:
-    - samples_numpyro(dict): posterior samples of all parameters
-    - timing_info(dict): compile_time, inference_time
-    """
-    model_args = args_dict["model_args"]
+        Inputs:
+        - data_train(tuple of np.ndarray): x_train, y_train
+        - args_dict: a dict of model arguments
+        Returns:
+        - samples_numpyro(dict): posterior samples of all parameters
+        - timing_info(dict): compile_time, inference_time
+        """
+        model_args = args_dict["model_args"]
 
-    # x_train is (num_features, num_observations)
-    x_train, y_train = data_train
-    # x_train is (num_observations, num_features)
-    x_train = x_train.T
-    start_time = time.time()
+        # x_train is (num_features, num_observations)
+        x_train, y_train = data_train
+        # x_train is (num_observations, num_features)
+        x_train = x_train.T
+        start_time = time.time()
 
-    num_warmup = 500
-    num_samples = args_dict["num_samples_numpyro"] - num_warmup
+        num_warmup = 500
+        num_samples = args_dict["num_samples_numpyro"] - num_warmup
 
-    assert num_samples > 0
-    # Run inference to generate samples from the posterior
-    kernel = NUTS(model=logistic_regression)
-    mcmc = MCMC(kernel, num_warmup=num_warmup, num_samples=num_samples)
-    mcmc.run(random.PRNGKey(1), x=x_train, y=y_train, model_args=model_args)
-    samples_numpyro = mcmc.get_samples()
-    elapsed_time_sample_pyro = time.time() - start_time
+        assert num_samples > 0
+        # Run inference to generate samples from the posterior
+        kernel = NUTS(model=logistic_regression)
+        mcmc = MCMC(kernel, num_warmup=num_warmup, num_samples=num_samples)
+        mcmc.run(random.PRNGKey(1), x=x_train, y=y_train, model_args=model_args)
+        samples_numpyro = mcmc.get_samples()
+        elapsed_time_sample_pyro = time.time() - start_time
 
-    # repackage samples into shape required by PPLBench
-    samples = []
+        # repackage samples into shape required by PPLBench
+        samples = []
 
-    for i in range(num_samples):
-        sample_dict = {}
-        sample_dict["alpha"] = onp.asarray(samples_numpyro["alpha"][i])
-        sample_dict["beta"] = onp.asarray(samples_numpyro["beta"][i])
-        samples.append(sample_dict)
-    timing_info = {
-        "compile_time": 0,
-        "inference_time": elapsed_time_sample_pyro,
-    }  # no compiliation for pyro
-    return (samples, timing_info)
+        for i in range(num_samples):
+            sample_dict = {}
+            sample_dict["alpha"] = onp.asarray(samples_numpyro["alpha"][i])
+            sample_dict["beta"] = onp.asarray(samples_numpyro["beta"][i])
+            samples.append(sample_dict)
+        timing_info = {
+            "compile_time": 0,
+            "inference_time": elapsed_time_sample_pyro,
+        }  # no compiliation for pyro
+        return (samples, timing_info)

--- a/benchmarks/pplbench/ppls/pplbench_ppl.py
+++ b/benchmarks/pplbench/ppls/pplbench_ppl.py
@@ -1,0 +1,19 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+from abc import ABCMeta, abstractmethod
+from typing import Dict, List, Tuple
+
+
+class PPLBenchPPL(object, metaclass=ABCMeta):
+    @abstractmethod
+    def obtain_posterior(self, data_train, args_dict, model=None) -> Tuple[List, Dict]:
+        """
+        Returns posterior samples and timing info
+        :param data_train: data to train the model on
+        :param args_dict: model specific parameters like number of observations etc
+
+        :returns: Tuple of
+        1) posterior_samples: List where each element is a dictionary with key as
+        name of random variable and value as sample.
+        2) Timing Info: {"compile_time": ..., "inference_time": ...}
+        """
+        raise NotImplementedError("PPLBenchPPL must implement obtain_posterior.")

--- a/benchmarks/pplbench/ppls/pymc3/crowd_sourced_annotation.py
+++ b/benchmarks/pplbench/ppls/pymc3/crowd_sourced_annotation.py
@@ -4,71 +4,77 @@ import time
 
 import numpy as np
 import pymc3 as pm
+from ppls.pplbench_ppl import PPLBenchPPL
 
 
-def obtain_posterior(data_train, args_dict, model=None):
-    """
-    PyMC3 implementation of crowdsourced annotation model
+class CrowdSourcedAnnotation(PPLBenchPPL):
+    def obtain_posterior(self, data_train, args_dict, model=None):
+        """
+        PyMC3 implementation of crowdsourced annotation model
 
-    Inputs:
-    - data_train(tuple of np.ndarray): vector_y, vector_J_i, num_labels
-    - args_dict: a dict of model arguments
-    Returns:
-    - samples(dict): posterior samples of all parameters
-    - timing_info(dict): compile_time, inference_time
-    """
-    vector_y, vector_J_i, num_labels = data_train
-    n_labelers = int(args_dict["k"])
-    n_items = len(num_labels)
-    K, labeler_rate, expected_correctness, concentration = args_dict["model_args"]
-    num_samples = args_dict["num_samples_pymc3"]
-    # item array for pymc3; change from list-of-lengths format of num_labels
-    # to list-of-items associated with each label and labeler in vector_y, vector_J_i
-    item = []
-    for i in range(len(num_labels)):
-        item.extend(np.repeat(i, num_labels[i]))
-    # set prior that each labeler on average has 50% chance of getting true label
-    alpha = ((1 - expected_correctness) / (K - 1)) * np.ones([K, K]) + (
-        expected_correctness - (1 - expected_correctness) / (K - 1)
-    ) * np.eye(K)
-    alpha *= concentration
-    # set prior that each item is equally likely to be in any given label
-    beta = 1 / K * np.ones(K)
-    # sample the parameter posteriors, time it
-    start_time = time.time()
+        Inputs:
+        - data_train(tuple of np.ndarray): vector_y, vector_J_i, num_labels
+        - args_dict: a dict of model arguments
+        Returns:
+        - samples(dict): posterior samples of all parameters
+        - timing_info(dict): compile_time, inference_time
+        """
+        vector_y, vector_J_i, num_labels = data_train
+        n_labelers = int(args_dict["k"])
+        n_items = len(num_labels)
+        K, labeler_rate, expected_correctness, concentration = args_dict["model_args"]
+        num_samples = args_dict["num_samples_pymc3"]
+        # item array for pymc3; change from list-of-lengths format
+        # of num_labels to list-of-items associated with each label
+        # and labeler in vector_y, vector_J_i
+        item = []
+        for i in range(len(num_labels)):
+            item.extend(np.repeat(i, num_labels[i]))
+        # set prior that each labeler on average has 50% chance of getting true label
+        alpha = ((1 - expected_correctness) / (K - 1)) * np.ones([K, K]) + (
+            expected_correctness - (1 - expected_correctness) / (K - 1)
+        ) * np.eye(K)
+        alpha *= concentration
+        # set prior that each item is equally likely to be in any given label
+        beta = 1 / K * np.ones(K)
+        # sample the parameter posteriors, time it
+        start_time = time.time()
 
-    # Define model and sample
-    if args_dict["inference_type"] == "mcmc":
-        with pm.Model():
-            # sample a true class z for each item
-            pi = pm.Dirichlet("pi", beta)
-            z = pm.Categorical("z", p=pi, shape=n_items)
-            # sample confusion matrices theta for labelers from this dirichlet prior
-            theta = pm.Dirichlet("theta", a=alpha, shape=(n_labelers, K, K))
-            # likelihood
-            pm.Categorical(
-                "labels", p=theta[vector_J_i, z[item]], observed=vector_y, shape=n_items
-            )
-            elapsed_time_compile_pymc3 = time.time() - start_time
-            start_time = time.time()
-            samples_pymc3 = pm.sample(
-                num_samples, cores=1, chains=1, discard_tuned_samples=False
-            )
+        # Define model and sample
+        if args_dict["inference_type"] == "mcmc":
+            with pm.Model():
+                # sample a true class z for each item
+                pi = pm.Dirichlet("pi", beta)
+                z = pm.Categorical("z", p=pi, shape=n_items)
+                # sample confusion matrices theta for labelers from this dirichlet prior
+                theta = pm.Dirichlet("theta", a=alpha, shape=(n_labelers, K, K))
+                # likelihood
+                pm.Categorical(
+                    "labels",
+                    p=theta[vector_J_i, z[item]],
+                    observed=vector_y,
+                    shape=n_items,
+                )
+                elapsed_time_compile_pymc3 = time.time() - start_time
+                start_time = time.time()
+                samples_pymc3 = pm.sample(
+                    num_samples, cores=1, chains=1, discard_tuned_samples=False
+                )
 
-    elif args_dict["inference_type"] == "vi":
-        raise NotImplementedError
+        elif args_dict["inference_type"] == "vi":
+            raise NotImplementedError
 
-    elapsed_time_sample_pymc3 = time.time() - start_time
-    # repackage samples into shape required by PPLBench
-    samples = []
-    for i in range(0, int(args_dict["num_samples_pymc3"])):
-        sample_dict = {}
-        for parameter in ["theta", "pi"]:
-            sample_dict[parameter] = samples_pymc3[parameter][i]
-        samples.append(sample_dict)
-    timing_info = {
-        "compile_time": elapsed_time_compile_pymc3,
-        "inference_time": elapsed_time_sample_pymc3,
-    }
+        elapsed_time_sample_pymc3 = time.time() - start_time
+        # repackage samples into shape required by PPLBench
+        samples = []
+        for i in range(0, int(args_dict["num_samples_pymc3"])):
+            sample_dict = {}
+            for parameter in ["theta", "pi"]:
+                sample_dict[parameter] = samples_pymc3[parameter][i]
+            samples.append(sample_dict)
+        timing_info = {
+            "compile_time": elapsed_time_compile_pymc3,
+            "inference_time": elapsed_time_sample_pymc3,
+        }
 
-    return (samples, timing_info)
+        return (samples, timing_info)

--- a/benchmarks/pplbench/ppls/pymc3/hidden_markov.py
+++ b/benchmarks/pplbench/ppls/pymc3/hidden_markov.py
@@ -6,102 +6,104 @@ import numpy as np
 import pymc3 as pm
 import torch
 from numpy import array
+from ppls.pplbench_ppl import PPLBenchPPL
 
 
 # from torch import tensor
 
 
-def obtain_posterior(data_train, args_dict, model=None):
-    """
-    PyMC3 impmementation of HMM prediction.
+class HiddenMarkov(PPLBenchPPL):
+    def obtain_posterior(self, data_train, args_dict, model=None):
+        """
+        PyMC3 impmementation of HMM prediction.
 
-    :param data_train:
-    :param args_dict: a dict of model arguments
-    :returns: samples_beanmachine(dict): posterior samples of all parameters
-    :returns: timing_info(dict): compile_time, inference_time
-    """
-    # true_theta = model["theta"]
-    # true_theta = torch.stack(true_theta).numpy()
+        :param data_train:
+        :param args_dict: a dict of model arguments
+        :returns: samples_beanmachine(dict): posterior samples of all parameters
+        :returns: timing_info(dict): compile_time, inference_time
+        """
+        # true_theta = model["theta"]
+        # true_theta = torch.stack(true_theta).numpy()
 
-    N = int(args_dict["n"])
-    K = int(args_dict["k"])
-    concentration, mu_loc, mu_scale, sigma_shape, sigma_rate, observe_model = list(
-        map(float, args_dict["model_args"])
-    )
-    num_samples = int(args_dict["num_samples"])
-    observations = data_train
-    observations = torch.stack(observations).numpy()
-
-    start_time = time.time()
-
-    Xs = {}
-    Ys = {}
-    with pm.Model():
-        if observe_model:
-            theta = pm.Dirichlet(
-                "theta",
-                a=np.ones(K) * concentration / K,
-                shape=(K, K),
-                observed=model["theta"].numpy(),
-            )
-            mus = pm.Normal(
-                "mus", mu_loc, mu_scale, shape=(K,), observed=model["mus"].numpy()
-            )
-            sigmas = pm.Gamma(
-                "sigmas",
-                sigma_shape,
-                sigma_rate,
-                shape=(K,),
-                observed=model["sigmas"].numpy(),
-            )
-        else:
-            theta = pm.Dirichlet(
-                "theta", a=np.ones(K) * concentration / K, shape=(K, K)
-            )
-            mus = pm.Normal("mus", mu_loc, mu_scale, shape=(K,))
-            sigmas = pm.Gamma("sigmas", sigma_shape, sigma_rate, shape=(K,))
-
-        Xs[0] = pm.Categorical("X[0]", p=array([1] + [0] * (K - 1)), observed=0)
-        Ys[0] = pm.Normal(
-            "Y[0]", mu=mus[Xs[0]], sigma=sigmas[Xs[0]], observed=observations[0]
+        N = int(args_dict["n"])
+        K = int(args_dict["k"])
+        concentration, mu_loc, mu_scale, sigma_shape, sigma_rate, observe_model = list(
+            map(float, args_dict["model_args"])
         )
-        for i in range(1, N):
-            Xs[i] = pm.Categorical("X[" + str(i) + "]", p=theta[Xs[i - 1]])
-            Ys[i] = pm.Normal(
-                "Y[" + str(i) + "]",
-                mu=mus[Xs[i]],
-                sigma=sigmas[Xs[i]],
-                observed=observations[i],
-            )
+        num_samples = int(args_dict["num_samples"])
+        observations = data_train
+        observations = torch.stack(observations).numpy()
 
-        elapsed_time_compile_pymc3 = time.time() - start_time
         start_time = time.time()
-        samples_pymc3 = pm.sample(
-            draws=0,
-            chains=1,
-            cores=1,
-            tune=num_samples,
-            discard_tuned_samples=False,
-            compute_convergence_checks=False,
-        )
 
-    elapsed_time_sample_pymc3 = time.time() - start_time
+        Xs = {}
+        Ys = {}
+        with pm.Model():
+            if observe_model:
+                theta = pm.Dirichlet(
+                    "theta",
+                    a=np.ones(K) * concentration / K,
+                    shape=(K, K),
+                    observed=model["theta"].numpy(),
+                )
+                mus = pm.Normal(
+                    "mus", mu_loc, mu_scale, shape=(K,), observed=model["mus"].numpy()
+                )
+                sigmas = pm.Gamma(
+                    "sigmas",
+                    sigma_shape,
+                    sigma_rate,
+                    shape=(K,),
+                    observed=model["sigmas"].numpy(),
+                )
+            else:
+                theta = pm.Dirichlet(
+                    "theta", a=np.ones(K) * concentration / K, shape=(K, K)
+                )
+                mus = pm.Normal("mus", mu_loc, mu_scale, shape=(K,))
+                sigmas = pm.Gamma("sigmas", sigma_shape, sigma_rate, shape=(K,))
 
-    # repackage samples into shape required by PPLBench
-    xn1str = "X[" + str(N - 1) + "]"
-    samples = []
-    for i in range(num_samples):
-        result = {}
-        if not observe_model:
-            result["theta"] = samples_pymc3["theta"][i]
-            result["mus"] = samples_pymc3["mus"][i]
-            result["sigmas"] = samples_pymc3["sigmas"][i]
-        result[xn1str] = samples_pymc3["X[" + str(N - 1) + "]"][i]
-        samples.append(result)
+            Xs[0] = pm.Categorical("X[0]", p=array([1] + [0] * (K - 1)), observed=0)
+            Ys[0] = pm.Normal(
+                "Y[0]", mu=mus[Xs[0]], sigma=sigmas[Xs[0]], observed=observations[0]
+            )
+            for i in range(1, N):
+                Xs[i] = pm.Categorical("X[" + str(i) + "]", p=theta[Xs[i - 1]])
+                Ys[i] = pm.Normal(
+                    "Y[" + str(i) + "]",
+                    mu=mus[Xs[i]],
+                    sigma=sigmas[Xs[i]],
+                    observed=observations[i],
+                )
 
-    timing_info = {
-        "compile_time": elapsed_time_compile_pymc3,
-        "inference_time": elapsed_time_sample_pymc3,
-    }
+            elapsed_time_compile_pymc3 = time.time() - start_time
+            start_time = time.time()
+            samples_pymc3 = pm.sample(
+                draws=0,
+                chains=1,
+                cores=1,
+                tune=num_samples,
+                discard_tuned_samples=False,
+                compute_convergence_checks=False,
+            )
 
-    return (samples, timing_info)
+        elapsed_time_sample_pymc3 = time.time() - start_time
+
+        # repackage samples into shape required by PPLBench
+        xn1str = "X[" + str(N - 1) + "]"
+        samples = []
+        for i in range(num_samples):
+            result = {}
+            if not observe_model:
+                result["theta"] = samples_pymc3["theta"][i]
+                result["mus"] = samples_pymc3["mus"][i]
+                result["sigmas"] = samples_pymc3["sigmas"][i]
+            result[xn1str] = samples_pymc3["X[" + str(N - 1) + "]"][i]
+            samples.append(result)
+
+        timing_info = {
+            "compile_time": elapsed_time_compile_pymc3,
+            "inference_time": elapsed_time_sample_pymc3,
+        }
+
+        return (samples, timing_info)

--- a/benchmarks/pplbench/ppls/pymc3/logistic_regression.py
+++ b/benchmarks/pplbench/ppls/pymc3/logistic_regression.py
@@ -3,52 +3,58 @@
 import time
 
 import pymc3 as pm
+from ppls.pplbench_ppl import PPLBenchPPL
 
 
-def obtain_posterior(data_train, args_dict, model=None):
-    """
-    PyMC3 implementation of logistic regression model.
+class LogisticRegression(PPLBenchPPL):
+    def obtain_posterior(self, data_train, args_dict, model=None):
+        """
+        PyMC3 implementation of logistic regression model.
 
-    Inputs:
-    - data_train(tuple of np.ndarray): x_train, y_train
-    - args_dict: a dict of model arguments
-    Returns:
-    - samples(dict): posterior samples of all parameters
-    - timing_info(dict): compile_time, inference_time
-    """
-    x_train, y_train = data_train
-    K = int(x_train.shape[0])
-    alpha_scale, beta_scale, beta_loc, _ = args_dict["model_args"]
-    num_samples = int(args_dict["num_samples_pymc3"])
+        Inputs:
+        - data_train(tuple of np.ndarray): x_train, y_train
+        - args_dict: a dict of model arguments
+        Returns:
+        - samples(dict): posterior samples of all parameters
+        - timing_info(dict): compile_time, inference_time
+        """
+        x_train, y_train = data_train
+        K = int(x_train.shape[0])
+        alpha_scale, beta_scale, beta_loc, _ = args_dict["model_args"]
+        num_samples = int(args_dict["num_samples_pymc3"])
 
-    # Define model and sample
-    if args_dict["inference_type"] == "mcmc":
-        start_time = time.time()
-        with pm.Model():
-            alpha = pm.Normal("alpha", mu=0, sigma=alpha_scale)
-            beta = pm.Normal("beta", mu=beta_loc, sigma=beta_scale, shape=K)
-            mean = (alpha + x_train.T * beta).T
-            pm.Bernoulli("y_observed", logit_p=mean, observed=y_train)
-            elapsed_time_compile_pymc3 = time.time() - start_time
+        # Define model and sample
+        if args_dict["inference_type"] == "mcmc":
             start_time = time.time()
-            samples_pymc3 = pm.sample(
-                num_samples, cores=1, chains=1, tune=200, discard_tuned_samples=False
-            )
+            with pm.Model():
+                alpha = pm.Normal("alpha", mu=0, sigma=alpha_scale)
+                beta = pm.Normal("beta", mu=beta_loc, sigma=beta_scale, shape=K)
+                mean = (alpha + x_train.T * beta).T
+                pm.Bernoulli("y_observed", logit_p=mean, observed=y_train)
+                elapsed_time_compile_pymc3 = time.time() - start_time
+                start_time = time.time()
+                samples_pymc3 = pm.sample(
+                    num_samples,
+                    cores=1,
+                    chains=1,
+                    tune=200,
+                    discard_tuned_samples=False,
+                )
 
-    elif args_dict["inference_type"] == "vi":
-        raise NotImplementedError
+        elif args_dict["inference_type"] == "vi":
+            raise NotImplementedError
 
-    elapsed_time_sample_pymc3 = time.time() - start_time
-    # repackage samples into shape required by PPLBench
-    samples = []
-    for i in range(0, int(args_dict["num_samples_pymc3"])):
-        sample_dict = {}
-        for parameter in ["alpha", "beta"]:
-            sample_dict[parameter] = samples_pymc3[parameter][i]
-        samples.append(sample_dict)
-    timing_info = {
-        "compile_time": elapsed_time_compile_pymc3,
-        "inference_time": elapsed_time_sample_pymc3,
-    }
+        elapsed_time_sample_pymc3 = time.time() - start_time
+        # repackage samples into shape required by PPLBench
+        samples = []
+        for i in range(0, int(args_dict["num_samples_pymc3"])):
+            sample_dict = {}
+            for parameter in ["alpha", "beta"]:
+                sample_dict[parameter] = samples_pymc3[parameter][i]
+            samples.append(sample_dict)
+        timing_info = {
+            "compile_time": elapsed_time_compile_pymc3,
+            "inference_time": elapsed_time_sample_pymc3,
+        }
 
-    return (samples, timing_info)
+        return (samples, timing_info)

--- a/benchmarks/pplbench/ppls/pymc3/noisy_or_topic.py
+++ b/benchmarks/pplbench/ppls/pymc3/noisy_or_topic.py
@@ -5,79 +5,81 @@ import time
 import numpy as np
 import pymc3 as pm
 import theano.tensor as t
+from ppls.pplbench_ppl import PPLBenchPPL
 
 
-def obtain_posterior(data_train, args_dict, model=None):
-    """
-    PyMC3 implementation of noisy-or topic model
+class NoisyOrTopic(PPLBenchPPL):
+    def obtain_posterior(self, data_train, args_dict, model=None):
+        """
+        PyMC3 implementation of noisy-or topic model
 
-    Inputs:
-    - data_train(tuple of np.ndarray): graph, words
-    - args_dict: a dict of model arguments
-    Returns:
-    - samples_jags(dict): posterior samples of all parameters
-    - timing_info(dict): compile_time, inference_time
-    """
-    graph = model
-    words = data_train
-    K = int(args_dict["k"])
-    word_fraction = (args_dict["model_args"])[3]
-    T = int(K * (1 - word_fraction))
-    assert len(words.shape) == 1
-    num_samples = int(args_dict["num_samples_pymc3"])
-    nodearray = np.concatenate([np.zeros(T), words])
-    prob = np.zeros_like(nodearray)
-    nodearray = list(nodearray)
-    prob = list(prob)
-    # sample the parameter posteriors, time it
-    start_time = time.time()
-    # Define model and sample
-    if args_dict["inference_type"] == "mcmc":
-        with pm.Model():
-            # traverse through nodes
-            for node in range(K):
-                # leak node
-                if node == 0:
-                    nodearray[node] = 1
-                else:
-                    # compute the weighted sum of parent activations
-                    parent_accumulator = t.zeros(1)
-                    for par, wt in enumerate(graph[:, node]):
-                        if wt:
-                            parent_accumulator += nodearray[par] * wt
-                    prob[node] = pm.Deterministic(
-                        f"prob_{node}", 1 - t.exp(-t.sum(parent_accumulator))
-                    )
-                    # topics are not observed; sample them and update the nodearray
-                    if node < T:
-                        nodearray[node] = pm.Bernoulli(f"node_{node}", p=prob[node])
-                    # words are observed
+        Inputs:
+        - data_train(tuple of np.ndarray): graph, words
+        - args_dict: a dict of model arguments
+        Returns:
+        - samples_jags(dict): posterior samples of all parameters
+        - timing_info(dict): compile_time, inference_time
+        """
+        graph = model
+        words = data_train
+        K = int(args_dict["k"])
+        word_fraction = (args_dict["model_args"])[3]
+        T = int(K * (1 - word_fraction))
+        assert len(words.shape) == 1
+        num_samples = int(args_dict["num_samples_pymc3"])
+        nodearray = np.concatenate([np.zeros(T), words])
+        prob = np.zeros_like(nodearray)
+        nodearray = list(nodearray)
+        prob = list(prob)
+        # sample the parameter posteriors, time it
+        start_time = time.time()
+        # Define model and sample
+        if args_dict["inference_type"] == "mcmc":
+            with pm.Model():
+                # traverse through nodes
+                for node in range(K):
+                    # leak node
+                    if node == 0:
+                        nodearray[node] = 1
                     else:
-                        pm.Bernoulli(
-                            f"node_{node}", p=prob[node], observed=nodearray[node]
+                        # compute the weighted sum of parent activations
+                        parent_accumulator = t.zeros(1)
+                        for par, wt in enumerate(graph[:, node]):
+                            if wt:
+                                parent_accumulator += nodearray[par] * wt
+                        prob[node] = pm.Deterministic(
+                            f"prob_{node}", 1 - t.exp(-t.sum(parent_accumulator))
                         )
-            elapsed_time_compile_pymc3 = time.time() - start_time
-            # Start sampling process
-            start_time = time.time()
-            samples_pymc3 = pm.sample(
-                num_samples, cores=1, chains=1, discard_tuned_samples=False
-            )
-    elif args_dict["inference_type"] == "vi":
-        raise NotImplementedError
-    parameters = [f"node_{i}" for i in range(1, T)]
-    elapsed_time_sample_pymc3 = time.time() - start_time
-    # repackage samples into shape required by PPLBench
-    samples = []
-    for i in range(0, num_samples):
-        sample_dict = {}
-        sample_dict["node"] = np.zeros(T)
-        sample_dict["node"][0] = 1
-        for nodeid, parameter in enumerate(parameters):
-            sample_dict["node"][nodeid + 1] = samples_pymc3[parameter][i]
-        samples.append(sample_dict)
-    timing_info = {
-        "compile_time": elapsed_time_compile_pymc3,
-        "inference_time": elapsed_time_sample_pymc3,
-    }
+                        # topics are not observed; sample them and update the nodearray
+                        if node < T:
+                            nodearray[node] = pm.Bernoulli(f"node_{node}", p=prob[node])
+                        # words are observed
+                        else:
+                            pm.Bernoulli(
+                                f"node_{node}", p=prob[node], observed=nodearray[node]
+                            )
+                elapsed_time_compile_pymc3 = time.time() - start_time
+                # Start sampling process
+                start_time = time.time()
+                samples_pymc3 = pm.sample(
+                    num_samples, cores=1, chains=1, discard_tuned_samples=False
+                )
+        elif args_dict["inference_type"] == "vi":
+            raise NotImplementedError
+        parameters = [f"node_{i}" for i in range(1, T)]
+        elapsed_time_sample_pymc3 = time.time() - start_time
+        # repackage samples into shape required by PPLBench
+        samples = []
+        for i in range(0, num_samples):
+            sample_dict = {}
+            sample_dict["node"] = np.zeros(T)
+            sample_dict["node"][0] = 1
+            for nodeid, parameter in enumerate(parameters):
+                sample_dict["node"][nodeid + 1] = samples_pymc3[parameter][i]
+            samples.append(sample_dict)
+        timing_info = {
+            "compile_time": elapsed_time_compile_pymc3,
+            "inference_time": elapsed_time_sample_pymc3,
+        }
 
-    return (samples, timing_info)
+        return (samples, timing_info)

--- a/benchmarks/pplbench/ppls/pymc3/robust_regression.py
+++ b/benchmarks/pplbench/ppls/pymc3/robust_regression.py
@@ -3,54 +3,56 @@
 import time
 
 import pymc3 as pm
+from ppls.pplbench_ppl import PPLBenchPPL
 
 
-def obtain_posterior(data_train, args_dict, model=None):
-    """
-    PyMC3 implementation of robust regression model.
+class RobustRegression(PPLBenchPPL):
+    def obtain_posterior(self, data_train, args_dict, model=None):
+        """
+        PyMC3 implementation of robust regression model.
 
-    Inputs:
-    - data_train(tuple of np.ndarray): x_train, y_train
-    - args_dict: a dict of model arguments
-    Returns:
-    - samples(dict): posterior samples of all parameters
-    - timing_info(dict): compile_time, inference_time
-    """
-    x_train, y_train = data_train
-    K = int(x_train.shape[0])
-    alpha_scale, beta_scale, beta_loc, sigma_mean = args_dict["model_args"]
-    num_samples = int(args_dict["num_samples_pymc3"])
+        Inputs:
+        - data_train(tuple of np.ndarray): x_train, y_train
+        - args_dict: a dict of model arguments
+        Returns:
+        - samples(dict): posterior samples of all parameters
+        - timing_info(dict): compile_time, inference_time
+        """
+        x_train, y_train = data_train
+        K = int(x_train.shape[0])
+        alpha_scale, beta_scale, beta_loc, sigma_mean = args_dict["model_args"]
+        num_samples = int(args_dict["num_samples_pymc3"])
 
-    # Define model and sample
-    if args_dict["inference_type"] == "mcmc":
-        start_time = time.time()
-        with pm.Model():
-            alpha = pm.Normal("alpha", mu=0, sigma=alpha_scale)
-            beta = pm.Normal("beta", mu=beta_loc, sigma=beta_scale, shape=K)
-            sigma = pm.Exponential("sigma", lam=1.0 / sigma_mean)
-            nu = pm.Gamma("nu", alpha=2, beta=10)
-            mean = (alpha + x_train.T * beta).T
-            pm.StudentT("y_observed", nu=nu, mu=mean, sigma=sigma, observed=y_train)
-            elapsed_time_compile_pymc3 = time.time() - start_time
+        # Define model and sample
+        if args_dict["inference_type"] == "mcmc":
             start_time = time.time()
-            samples_pymc3 = pm.sample(
-                num_samples, cores=1, chains=1, discard_tuned_samples=False
-            )
+            with pm.Model():
+                alpha = pm.Normal("alpha", mu=0, sigma=alpha_scale)
+                beta = pm.Normal("beta", mu=beta_loc, sigma=beta_scale, shape=K)
+                sigma = pm.Exponential("sigma", lam=1.0 / sigma_mean)
+                nu = pm.Gamma("nu", alpha=2, beta=10)
+                mean = (alpha + x_train.T * beta).T
+                pm.StudentT("y_observed", nu=nu, mu=mean, sigma=sigma, observed=y_train)
+                elapsed_time_compile_pymc3 = time.time() - start_time
+                start_time = time.time()
+                samples_pymc3 = pm.sample(
+                    num_samples, cores=1, chains=1, discard_tuned_samples=False
+                )
 
-    elif args_dict["inference_type"] == "vi":
-        raise NotImplementedError
+        elif args_dict["inference_type"] == "vi":
+            raise NotImplementedError
 
-    elapsed_time_sample_pymc3 = time.time() - start_time
-    # repackage samples into shape required by PPLBench
-    samples = []
-    for i in range(0, int(args_dict["num_samples_pymc3"])):
-        sample_dict = {}
-        for parameter in ["alpha", "beta", "nu", "sigma"]:
-            sample_dict[parameter] = samples_pymc3[parameter][i]
-        samples.append(sample_dict)
-    timing_info = {
-        "compile_time": elapsed_time_compile_pymc3,
-        "inference_time": elapsed_time_sample_pymc3,
-    }
+        elapsed_time_sample_pymc3 = time.time() - start_time
+        # repackage samples into shape required by PPLBench
+        samples = []
+        for i in range(0, int(args_dict["num_samples_pymc3"])):
+            sample_dict = {}
+            for parameter in ["alpha", "beta", "nu", "sigma"]:
+                sample_dict[parameter] = samples_pymc3[parameter][i]
+            samples.append(sample_dict)
+        timing_info = {
+            "compile_time": elapsed_time_compile_pymc3,
+            "inference_time": elapsed_time_sample_pymc3,
+        }
 
-    return (samples, timing_info)
+        return (samples, timing_info)

--- a/benchmarks/pplbench/ppls/pyro/logistic_regression.py
+++ b/benchmarks/pplbench/ppls/pyro/logistic_regression.py
@@ -8,6 +8,7 @@ import pyro.distributions as dist
 import pyro.infer
 import pyro.optim
 import torch
+from ppls.pplbench_ppl import PPLBenchPPL
 
 
 def logistic_model(x_train, y_train=None):
@@ -22,79 +23,82 @@ def logistic_model(x_train, y_train=None):
     return pyro.sample("y", dist.Bernoulli(logits=mu), obs=y_train)
 
 
-def obtain_posterior(data_train, args_dict, model=None):
-    """
-    Pyro implementation of logistic regression model.
+class LogisticRegression(PPLBenchPPL):
+    def obtain_posterior(self, data_train, args_dict, model=None):
+        """
+        Pyro implementation of logistic regression model.
 
-    Inputs:
-    - data_train(tuple of np.ndarray): x_train, y_train
-    - args_dict: a dict of model arguments
-    Returns:
-    - samples_jags(dict): posterior samples of all parameters
-    - timing_info(dict): compile_time, inference_time
-    """
-    assert pyro.__version__.startswith("0.4.1")
-    global model_args
-    model_args = args_dict["model_args"]
-    LEARNING_RATE = 0.009
-    NUM_STEPS = 3000
-    losses = []
+        Inputs:
+        - data_train(tuple of np.ndarray): x_train, y_train
+        - args_dict: a dict of model arguments
+        Returns:
+        - samples_jags(dict): posterior samples of all parameters
+        - timing_info(dict): compile_time, inference_time
+        """
+        assert pyro.__version__.startswith("0.4.1")
+        global model_args
+        model_args = args_dict["model_args"]
+        LEARNING_RATE = 0.009
+        NUM_STEPS = 3000
+        losses = []
 
-    # x_train is (num_features, num_observations)
-    x_train, y_train = data_train
-    # x_train is (num_observations, num_features)
-    x_train = x_train.T
-    # convert them to tensors
-    x_train = torch.tensor(x_train, dtype=torch.float32)
-    y_train = torch.tensor(y_train, dtype=torch.float32)
+        # x_train is (num_features, num_observations)
+        x_train, y_train = data_train
+        # x_train is (num_observations, num_features)
+        x_train = x_train.T
+        # convert them to tensors
+        x_train = torch.tensor(x_train, dtype=torch.float32)
+        y_train = torch.tensor(y_train, dtype=torch.float32)
 
-    start_time = time.time()
-    # the guide serves as an approximation to the posterior
-    guide = autoguide.AutoDiagonalNormal(logistic_model)
-    optimiser = pyro.optim.Adam({"lr": LEARNING_RATE})
-    loss = pyro.infer.JitTrace_ELBO(vectorize_particles=True)
+        start_time = time.time()
+        # the guide serves as an approximation to the posterior
+        guide = autoguide.AutoDiagonalNormal(logistic_model)
+        optimiser = pyro.optim.Adam({"lr": LEARNING_RATE})
+        loss = pyro.infer.JitTrace_ELBO(vectorize_particles=True)
 
-    # set up the inference algorithm
-    svi = pyro.infer.SVI(
-        logistic_model,
-        guide,
-        optimiser,
-        loss,
-        num_samples=args_dict["num_samples_pyro"],
-    )
-    pyro.clear_param_store()
+        # set up the inference algorithm
+        svi = pyro.infer.SVI(
+            logistic_model,
+            guide,
+            optimiser,
+            loss,
+            num_samples=args_dict["num_samples_pyro"],
+        )
+        pyro.clear_param_store()
 
-    # do the gradient steps
-    for _step in range(NUM_STEPS):
-        loss = svi.step(x_train, y_train)
-        losses.append(loss)
+        # do the gradient steps
+        for _step in range(NUM_STEPS):
+            loss = svi.step(x_train, y_train)
+            losses.append(loss)
 
-    elapsed_time_sample_pyro = time.time() - start_time
+        elapsed_time_sample_pyro = time.time() - start_time
 
-    # plot the ELBO loss to test for convergence
+        # plot the ELBO loss to test for convergence
 
-    plt.plot([i for i in range(NUM_STEPS)], losses)
-    plt.title(
-        "ELBO Loss \n Steps: {} | Learning Rate: {}".format(NUM_STEPS, LEARNING_RATE)
-    )
-    plt.xlabel("Step")
-    plt.ylabel("ELBO Loss")
-    plt.savefig(os.path.join(args_dict["output_dir"], "pyro_elbo_loss.png"))
-    plt.clf()
+        plt.plot(list(range(NUM_STEPS)), losses)
+        plt.title(
+            "ELBO Loss \n Steps: {} | Learning Rate: {}".format(
+                NUM_STEPS, LEARNING_RATE
+            )
+        )
+        plt.xlabel("Step")
+        plt.ylabel("ELBO Loss")
+        plt.savefig(os.path.join(args_dict["output_dir"], "pyro_elbo_loss.png"))
+        plt.clf()
 
-    # repackage samples into shape required by PPLBench
-    samples = []
-    posterior = svi.run(x_train, y_train)
+        # repackage samples into shape required by PPLBench
+        samples = []
+        posterior = svi.run(x_train, y_train)
 
-    # approximate posterior distribution we can get samples from
-    trace = posterior.exec_traces
-    for i in range(args_dict["num_samples_pyro"]):
-        sample_dict = {}
-        sample_dict["alpha"] = trace[i].nodes["alpha"]["value"].detach().numpy()
-        sample_dict["beta"] = trace[i].nodes["beta"]["value"].detach().numpy()
-        samples.append(sample_dict)
-    timing_info = {
-        "compile_time": 0,
-        "inference_time": elapsed_time_sample_pyro,
-    }  # no compiliation for pyro
-    return (samples, timing_info)
+        # approximate posterior distribution we can get samples from
+        trace = posterior.exec_traces
+        for i in range(args_dict["num_samples_pyro"]):
+            sample_dict = {}
+            sample_dict["alpha"] = trace[i].nodes["alpha"]["value"].detach().numpy()
+            sample_dict["beta"] = trace[i].nodes["beta"]["value"].detach().numpy()
+            samples.append(sample_dict)
+        timing_info = {
+            "compile_time": 0,
+            "inference_time": elapsed_time_sample_pyro,
+        }  # no compiliation for pyro
+        return (samples, timing_info)

--- a/benchmarks/pplbench/ppls/stan/crowd_sourced_annotation.py
+++ b/benchmarks/pplbench/ppls/stan/crowd_sourced_annotation.py
@@ -5,6 +5,7 @@ import pickle
 import time
 
 import pystan
+from ppls.pplbench_ppl import PPLBenchPPL
 
 
 CODE = """
@@ -69,76 +70,81 @@ model {
 """
 
 
-def obtain_posterior(data_train, args_dict, model=None):
-    """
-    Stan implementation of crowdsourced annotation model
+class CrowdSourcedAnnotation(PPLBenchPPL):
+    def obtain_posterior(self, data_train, args_dict, model=None):
+        """
+        Stan implementation of crowdsourced annotation model
 
-    Inputs:
-    - data_train(tuple of np.ndarray): vector_y, vector_J_i, num_labels
-    - args_dict: a dict of model arguments
-    Returns:
-    - samples_stan(dict): posterior samples of all parameters
-    - timing_info(dict): compile_time, inference_time
-    """
-    global CODE
-    vector_y, vector_J_i, num_labels = data_train
-    n_labelers = int(args_dict["k"])
-    n_items = len(num_labels)
-    n_categories, _, expected_correctness, concentration = args_dict["model_args"]
+        Inputs:
+        - data_train(tuple of np.ndarray): vector_y, vector_J_i, num_labels
+        - args_dict: a dict of model arguments
+        Returns:
+        - samples_stan(dict): posterior samples of all parameters
+        - timing_info(dict): compile_time, inference_time
+        """
+        global CODE
+        vector_y, vector_J_i, num_labels = data_train
+        n_labelers = int(args_dict["k"])
+        n_items = len(num_labels)
+        n_categories, _, expected_correctness, concentration = args_dict["model_args"]
 
-    data_stan = {
-        "n_obs": len(vector_y),
-        "n_items": n_items,
-        "n_labelers": n_labelers,
-        "n_categories": n_categories,
-        "expected_correctness": expected_correctness,
-        "concentration": concentration,
-        "n_labels": num_labels,
-        "labels": [i + 1 for i in vector_y],
-        "labeler": [i + 1 for i in vector_J_i],
-    }  # Stan uses 1 indexing
+        data_stan = {
+            "n_obs": len(vector_y),
+            "n_items": n_items,
+            "n_labelers": n_labelers,
+            "n_categories": n_categories,
+            "expected_correctness": expected_correctness,
+            "concentration": concentration,
+            "n_labels": num_labels,
+            "labels": [i + 1 for i in vector_y],
+            "labeler": [i + 1 for i in vector_J_i],
+        }  # Stan uses 1 indexing
 
-    code_loaded = None
-    pkl_filename = os.path.join(
-        args_dict["output_dir"], "stan_crowdSourcedAnnotation.pkl"
-    )
-    if os.path.isfile(pkl_filename):
-        model, code_loaded, elapsed_time_compile_stan = pickle.load(
-            open(pkl_filename, "rb")
+        code_loaded = None
+        pkl_filename = os.path.join(
+            args_dict["output_dir"], "stan_crowdSourcedAnnotation.pkl"
         )
-    if code_loaded != CODE:
-        # compile the model, time it
+        if os.path.isfile(pkl_filename):
+            model, code_loaded, elapsed_time_compile_stan = pickle.load(
+                open(pkl_filename, "rb")
+            )
+        if code_loaded != CODE:
+            # compile the model, time it
+            start_time = time.time()
+            model = pystan.StanModel(
+                model_code=CODE, model_name="crowd_sourced_annotation"
+            )
+            elapsed_time_compile_stan = time.time() - start_time
+            # save it to the file 'model.pkl' for later use
+            with open(pkl_filename, "wb") as f:
+                pickle.dump((model, CODE, elapsed_time_compile_stan), f)
+
+        # sample the parameter posteriors, time it
         start_time = time.time()
-        model = pystan.StanModel(model_code=CODE, model_name="crowd_sourced_annotation")
-        elapsed_time_compile_stan = time.time() - start_time
-        # save it to the file 'model.pkl' for later use
-        with open(pkl_filename, "wb") as f:
-            pickle.dump((model, CODE, elapsed_time_compile_stan), f)
-
-    # sample the parameter posteriors, time it
-    start_time = time.time()
-    if args_dict["inference_type"] == "mcmc":
-        fit = model.sampling(
-            data=data_stan, iter=int(args_dict["num_samples_stan"]), chains=1
+        if args_dict["inference_type"] == "mcmc":
+            fit = model.sampling(
+                data=data_stan, iter=int(args_dict["num_samples_stan"]), chains=1
+            )
+        elif args_dict["inference_type"] == "vi":
+            fit = model.vb(data=data_stan, iter=args_dict["num_samples_stan"])
+        samples_stan = fit.extract(
+            pars=["theta", "pi"], permuted=False, inc_warmup=True
         )
-    elif args_dict["inference_type"] == "vi":
-        fit = model.vb(data=data_stan, iter=args_dict["num_samples_stan"])
-    samples_stan = fit.extract(pars=["theta", "pi"], permuted=False, inc_warmup=True)
-    elapsed_time_sample_stan = time.time() - start_time
+        elapsed_time_sample_stan = time.time() - start_time
 
-    # repackage samples into shape required by PPLBench
-    samples = []
-    for i in range(int(args_dict["num_samples_stan"])):
-        sample_dict = {}
-        for parameter in samples_stan.keys():
-            sample_dict[parameter] = samples_stan[parameter][i]
-            # theta samples have shape (1, J, K, K), need to squeeze the 1 out
-            if sample_dict[parameter].shape[0] == 1:
-                sample_dict[parameter] = sample_dict[parameter].squeeze()
-        samples.append(sample_dict)
-    timing_info = {
-        "compile_time": elapsed_time_compile_stan,
-        "inference_time": elapsed_time_sample_stan,
-    }
+        # repackage samples into shape required by PPLBench
+        samples = []
+        for i in range(int(args_dict["num_samples_stan"])):
+            sample_dict = {}
+            for parameter in samples_stan.keys():
+                sample_dict[parameter] = samples_stan[parameter][i]
+                # theta samples have shape (1, J, K, K), need to squeeze the 1 out
+                if sample_dict[parameter].shape[0] == 1:
+                    sample_dict[parameter] = sample_dict[parameter].squeeze()
+            samples.append(sample_dict)
+        timing_info = {
+            "compile_time": elapsed_time_compile_stan,
+            "inference_time": elapsed_time_sample_stan,
+        }
 
-    return (samples, timing_info)
+        return (samples, timing_info)

--- a/benchmarks/pplbench/ppls/stan/noisy_or_topic.py
+++ b/benchmarks/pplbench/ppls/stan/noisy_or_topic.py
@@ -6,148 +6,150 @@ import time
 
 import numpy as np
 import pystan
+from ppls.pplbench_ppl import PPLBenchPPL
 
 
-def obtain_posterior(data_train, args_dict, model):
-    """
-    Stan impmementation of Noisy-Or Topic Model.
-
-    Inputs:
-    - data_train(tuple of np.ndarray): graph, words
-    - args_dict: a dict of model arguments
-    - model: the model object
-    Returns:
-    - samples_stan(dict): posterior samples of all parameters
-    - timing_info(dict): compile_time, inference_time
-    """
-    graph = model
-    words = data_train
-    K = int(args_dict["k"])
-    word_fraction = (args_dict["model_args"])[3]
-    T = int(K * (1 - word_fraction))
-    assert len(words.shape) == 1
-    # construct the Stan code for the graph
-    tokens = graph[T:]
-    topics = graph[:T]
-    code = """
-data {{
-    int num_tokens;
-    int tokens[num_tokens];
-    real tau;
-}}
-
-transformed data {{
-    int NUM_TOKENS = {};  // this better match num_tokens in input!
-    int NUM_TOPICS = {};
-}}
-
-parameters {{
-    // these two gumbel parameters control the sampling probability
-    // for each node in the graph
-    vector[2] gumbel_topics[NUM_TOPICS];
-}}
-
-transformed parameters {{
-    vector[NUM_TOKENS] token_prob;
-    vector[NUM_TOPICS] topic_prob;
-
-    matrix[NUM_TOPICS, 2] topic;  // the state of each topic [True, False]
-
-    """.format(
-        len(tokens), len(topics) - 1
-    )
-    for node in range(1, T):
-        code += """
-    topic_prob[{}] = 1 - exp(""".format(
-            node
-        )
-        for par, wt in enumerate(graph[:, node]):
-            if par == 0:
-                code += "-{}".format(wt)
-            elif wt:
-                code += "- topic[{}] * [{}, 0]'".format(par, wt)
-        code += """);
-    topic[{}] = softmax((log([topic_prob[{}], 1-topic_prob[{}]]')
-        + gumbel_topics[{}])/tau)';
-        """.format(
-            node, node, node, node
-        )
-    # add the token probabilities
-    for node in range(T, K):
-        code += """
-    token_prob[{}] = 1 - exp(""".format(
-            node + 1 - T
-        )
-        for par, wt in enumerate(graph[:, node]):
-            if par == 0:
-                code += "-{}".format(wt)
-            elif wt:
-                code += "- topic[{}] * [{}, 0]'".format(par, wt)
-        code += """);
+class NoisyOrTopic(PPLBenchPPL):
+    def obtain_posterior(self, data_train, args_dict, model):
         """
-    # add the rest of the model
-    code += """
-}
+        Stan impmementation of Noisy-Or Topic Model.
 
-model {
-    for  (n in 1:NUM_TOPICS) {
-        gumbel_topics[n] ~ gumbel(0, 1);
-    }
-    tokens ~ bernoulli(token_prob);
-}
-"""
-    data_stan = {
-        "num_tokens": len(tokens),
-        "tau": 0.1,
-        "tokens": np.array(words, dtype=int),
-    }
-    code_loaded = None
-    if os.path.isfile("./ppls/stan/noisyOrTopic.pkl"):
-        model, code_loaded, elapsed_time_compile_stan = pickle.load(
-            open("./ppls/stan/noisyOrTopic.pkl", "rb")
-        )
-    if code_loaded != code:
-        # compile the model, time it
-        start_time = time.time()
-        model = pystan.StanModel(model_code=code, model_name="noisy_or_topic")
-        elapsed_time_compile_stan = time.time() - start_time
-        # save it to the file 'model.pkl' for later use
-        with open("./ppls/stan/noisyOrTopic.pkl", "wb") as f:
-            pickle.dump((model, code, elapsed_time_compile_stan), f)
+        Inputs:
+        - data_train(tuple of np.ndarray): graph, words
+        - args_dict: a dict of model arguments
+        - model: the model object
+        Returns:
+        - samples_stan(dict): posterior samples of all parameters
+        - timing_info(dict): compile_time, inference_time
+        """
+        graph = model
+        words = data_train
+        K = int(args_dict["k"])
+        word_fraction = (args_dict["model_args"])[3]
+        T = int(K * (1 - word_fraction))
+        assert len(words.shape) == 1
+        # construct the Stan code for the graph
+        tokens = graph[T:]
+        topics = graph[:T]
+        code = """
+    data {{
+        int num_tokens;
+        int tokens[num_tokens];
+        real tau;
+    }}
 
-    if args_dict["inference_type"] == "mcmc":
-        # sample the parameter posteriors, time it
-        start_time = time.time()
-        fit = model.sampling(
-            data=data_stan,
-            iter=int(args_dict["num_samples_stan"]),
-            chains=1,
-            check_hmc_diagnostics=False,
-        )
-        samples_stan = fit.extract(pars=["topic"], permuted=False, inc_warmup=True)
-        elapsed_time_sample_stan = time.time() - start_time
+    transformed data {{
+        int NUM_TOKENS = {};  // this better match num_tokens in input!
+        int NUM_TOPICS = {};
+    }}
 
-    elif args_dict["inference_type"] == "vi":
-        # sample the parameter posteriors, time it
-        start_time = time.time()
-        fit = model.vb(
-            data=data_stan, iter=args_dict["num_samples_stan"], pars=["topic"]
+    parameters {{
+        // these two gumbel parameters control the sampling probability
+        // for each node in the graph
+        vector[2] gumbel_topics[NUM_TOPICS];
+    }}
+
+    transformed parameters {{
+        vector[NUM_TOKENS] token_prob;
+        vector[NUM_TOPICS] topic_prob;
+
+        matrix[NUM_TOPICS, 2] topic;  // the state of each topic [True, False]
+
+        """.format(
+            len(tokens), len(topics) - 1
         )
-        samples_stan = fit.extract(pars=["topic"], permuted=False, inc_warmup=True)
-        elapsed_time_sample_stan = time.time() - start_time
-    # convert shape of samples from prob(1), prob(0) to 1s and 0s
-    samples_stan["topic"] = 1 - samples_stan["topic"].argmax(axis=3)
-    # append the leak node as 1 in each sample as it is not sampled in the model
-    samples_stan["topic"] = np.insert(samples_stan["topic"], 0, 1, axis=2)
-    # repackage samples into shape required by PPLBench
-    samples = []
-    for i in range(int(args_dict["num_samples_stan"])):
-        sample_dict = {}
-        for parameter in samples_stan.keys():
-            sample_dict["node"] = samples_stan[parameter][i].reshape(-1)
-        samples.append(sample_dict)
-    timing_info = {
-        "compile_time": elapsed_time_compile_stan,
-        "inference_time": elapsed_time_sample_stan,
+        for node in range(1, T):
+            code += """
+        topic_prob[{}] = 1 - exp(""".format(
+                node
+            )
+            for par, wt in enumerate(graph[:, node]):
+                if par == 0:
+                    code += "-{}".format(wt)
+                elif wt:
+                    code += "- topic[{}] * [{}, 0]'".format(par, wt)
+            code += """);
+        topic[{}] = softmax((log([topic_prob[{}], 1-topic_prob[{}]]')
+            + gumbel_topics[{}])/tau)';
+            """.format(
+                node, node, node, node
+            )
+        # add the token probabilities
+        for node in range(T, K):
+            code += """
+        token_prob[{}] = 1 - exp(""".format(
+                node + 1 - T
+            )
+            for par, wt in enumerate(graph[:, node]):
+                if par == 0:
+                    code += "-{}".format(wt)
+                elif wt:
+                    code += "- topic[{}] * [{}, 0]'".format(par, wt)
+            code += """);
+            """
+        # add the rest of the model
+        code += """
     }
-    return (samples, timing_info)
+
+    model {
+        for  (n in 1:NUM_TOPICS) {
+            gumbel_topics[n] ~ gumbel(0, 1);
+        }
+        tokens ~ bernoulli(token_prob);
+    }
+    """
+        data_stan = {
+            "num_tokens": len(tokens),
+            "tau": 0.1,
+            "tokens": np.array(words, dtype=int),
+        }
+        code_loaded = None
+        if os.path.isfile("./ppls/stan/noisyOrTopic.pkl"):
+            model, code_loaded, elapsed_time_compile_stan = pickle.load(
+                open("./ppls/stan/noisyOrTopic.pkl", "rb")
+            )
+        if code_loaded != code:
+            # compile the model, time it
+            start_time = time.time()
+            model = pystan.StanModel(model_code=code, model_name="noisy_or_topic")
+            elapsed_time_compile_stan = time.time() - start_time
+            # save it to the file 'model.pkl' for later use
+            with open("./ppls/stan/noisyOrTopic.pkl", "wb") as f:
+                pickle.dump((model, code, elapsed_time_compile_stan), f)
+
+        if args_dict["inference_type"] == "mcmc":
+            # sample the parameter posteriors, time it
+            start_time = time.time()
+            fit = model.sampling(
+                data=data_stan,
+                iter=int(args_dict["num_samples_stan"]),
+                chains=1,
+                check_hmc_diagnostics=False,
+            )
+            samples_stan = fit.extract(pars=["topic"], permuted=False, inc_warmup=True)
+            elapsed_time_sample_stan = time.time() - start_time
+
+        elif args_dict["inference_type"] == "vi":
+            # sample the parameter posteriors, time it
+            start_time = time.time()
+            fit = model.vb(
+                data=data_stan, iter=args_dict["num_samples_stan"], pars=["topic"]
+            )
+            samples_stan = fit.extract(pars=["topic"], permuted=False, inc_warmup=True)
+            elapsed_time_sample_stan = time.time() - start_time
+        # convert shape of samples from prob(1), prob(0) to 1s and 0s
+        samples_stan["topic"] = 1 - samples_stan["topic"].argmax(axis=3)
+        # append the leak node as 1 in each sample as it is not sampled in the model
+        samples_stan["topic"] = np.insert(samples_stan["topic"], 0, 1, axis=2)
+        # repackage samples into shape required by PPLBench
+        samples = []
+        for i in range(int(args_dict["num_samples_stan"])):
+            sample_dict = {}
+            for parameter in samples_stan.keys():
+                sample_dict["node"] = samples_stan[parameter][i].reshape(-1)
+            samples.append(sample_dict)
+        timing_info = {
+            "compile_time": elapsed_time_compile_stan,
+            "inference_time": elapsed_time_sample_stan,
+        }
+        return (samples, timing_info)

--- a/benchmarks/pplbench/ppls/stan/robust_regression.py
+++ b/benchmarks/pplbench/ppls/stan/robust_regression.py
@@ -5,6 +5,7 @@ import pickle
 import time
 
 import pystan
+from ppls.pplbench_ppl import PPLBenchPPL
 
 
 CODE = """
@@ -52,82 +53,85 @@ model {
 """
 
 
-def obtain_posterior(data_train, args_dict, model=None):
-    """
-    Stan impmementation of robust regression model.
+class RobustRegression(PPLBenchPPL):
+    def obtain_posterior(self, data_train, args_dict, model=None):
+        """
+        Stan impmementation of robust regression model.
 
-    Inputs:
-    - data_train(tuple of np.ndarray): x_train, y_train
-    - args_dict: a dict of model arguments
-    Returns:
-    - samples_stan(dict): posterior samples of all parameters
-    - timing_info(dict): compile_time, inference_time
-    """
-    global CODE
-    x_train, y_train = data_train
-    N = int(x_train.shape[1])
-    K = int(x_train.shape[0])
-    alpha_scale, beta_scale, beta_loc, sigma_mean = args_dict["model_args"]
+        Inputs:
+        - data_train(tuple of np.ndarray): x_train, y_train
+        - args_dict: a dict of model arguments
+        Returns:
+        - samples_stan(dict): posterior samples of all parameters
+        - timing_info(dict): compile_time, inference_time
+        """
+        global CODE
+        x_train, y_train = data_train
+        N = int(x_train.shape[1])
+        K = int(x_train.shape[0])
+        alpha_scale, beta_scale, beta_loc, sigma_mean = args_dict["model_args"]
 
-    data_stan = {
-        "N": N,
-        "K": K,
-        "X": x_train.T,
-        "y": y_train,
-        "scale_alpha": alpha_scale,
-        "scale_beta": beta_scale,
-        "loc_beta": beta_loc,
-        "rate_sigma": 1.0 / sigma_mean,
-    }
+        data_stan = {
+            "N": N,
+            "K": K,
+            "X": x_train.T,
+            "y": y_train,
+            "scale_alpha": alpha_scale,
+            "scale_beta": beta_scale,
+            "loc_beta": beta_loc,
+            "rate_sigma": 1.0 / sigma_mean,
+        }
 
-    code_loaded = None
-    pkl_filename = os.path.join(args_dict["output_dir"], "stan_robustRegression.pkl")
-    if os.path.isfile(pkl_filename):
-        model, code_loaded, elapsed_time_compile_stan = pickle.load(
-            open(pkl_filename, "rb")
+        code_loaded = None
+        pkl_filename = os.path.join(
+            args_dict["output_dir"], "stan_robustRegression.pkl"
         )
-    if code_loaded != CODE:
-        # compile the model, time it
-        start_time = time.time()
-        model = pystan.StanModel(model_code=CODE, model_name="robust_regression")
-        elapsed_time_compile_stan = time.time() - start_time
-        # save it to the file 'model.pkl' for later use
-        with open(pkl_filename, "wb") as f:
-            pickle.dump((model, CODE, elapsed_time_compile_stan), f)
+        if os.path.isfile(pkl_filename):
+            model, code_loaded, elapsed_time_compile_stan = pickle.load(
+                open(pkl_filename, "rb")
+            )
+        if code_loaded != CODE:
+            # compile the model, time it
+            start_time = time.time()
+            model = pystan.StanModel(model_code=CODE, model_name="robust_regression")
+            elapsed_time_compile_stan = time.time() - start_time
+            # save it to the file 'model.pkl' for later use
+            with open(pkl_filename, "wb") as f:
+                pickle.dump((model, CODE, elapsed_time_compile_stan), f)
 
-    if args_dict["inference_type"] == "mcmc":
-        # sample the parameter posteriors, time it
-        start_time = time.time()
-        fit = model.sampling(
-            data=data_stan,
-            iter=int(args_dict["num_samples_stan"]),
-            chains=1,
-            check_hmc_diagnostics=False,
-        )
-        samples_stan = fit.extract(
-            pars=["alpha", "beta", "sigma", "nu"], permuted=False, inc_warmup=True
-        )
-        elapsed_time_sample_stan = time.time() - start_time
+        if args_dict["inference_type"] == "mcmc":
+            # sample the parameter posteriors, time it
+            start_time = time.time()
+            fit = model.sampling(
+                data=data_stan,
+                iter=int(args_dict["num_samples_stan"]),
+                chains=1,
+                check_hmc_diagnostics=False,
+            )
+            samples_stan = fit.extract(
+                pars=["alpha", "beta", "sigma", "nu"], permuted=False, inc_warmup=True
+            )
+            elapsed_time_sample_stan = time.time() - start_time
 
-    elif args_dict["inference_type"] == "vi":
-        # sample the parameter posteriors, time it
-        start_time = time.time()
-        fit = model.vb(data=data_stan, iter=args_dict["num_samples_stan"])
-        samples_stan = fit.extract(
-            pars=["alpha", "beta", "sigma", "nu"], permuted=False, inc_warmup=True
-        )
-        elapsed_time_sample_stan = time.time() - start_time
+        elif args_dict["inference_type"] == "vi":
+            # sample the parameter posteriors, time it
+            start_time = time.time()
+            fit = model.vb(data=data_stan, iter=args_dict["num_samples_stan"])
+            samples_stan = fit.extract(
+                pars=["alpha", "beta", "sigma", "nu"], permuted=False, inc_warmup=True
+            )
+            elapsed_time_sample_stan = time.time() - start_time
 
-    # repackage samples into shape required by PPLBench
-    samples = []
-    for i in range(int(args_dict["num_samples_stan"])):
-        sample_dict = {}
-        for parameter in samples_stan.keys():
-            sample_dict[parameter] = samples_stan[parameter][i]
-        samples.append(sample_dict)
-    timing_info = {
-        "compile_time": elapsed_time_compile_stan,
-        "inference_time": elapsed_time_sample_stan,
-    }
+        # repackage samples into shape required by PPLBench
+        samples = []
+        for i in range(int(args_dict["num_samples_stan"])):
+            sample_dict = {}
+            for parameter in samples_stan.keys():
+                sample_dict[parameter] = samples_stan[parameter][i]
+            samples.append(sample_dict)
+        timing_info = {
+            "compile_time": elapsed_time_compile_stan,
+            "inference_time": elapsed_time_sample_stan,
+        }
 
-    return (samples, timing_info)
+        return (samples, timing_info)


### PR DESCRIPTION
Summary: To enforce the implementation of the ```obtain_posterior ``` function, and to have better code quality in general, all ppl implementations now have to inherit from an abstract PPL class.

Differential Revision: D20378788

