### PR TITLE
num_samples refers to samples after adaptation

### DIFF
--- a/beanmachine/ppl/inference/abstract_infer.py
+++ b/beanmachine/ppl/inference/abstract_infer.py
@@ -79,7 +79,7 @@ class AbstractInference(object, metaclass=ABCMeta):
 
         :param queries: random variables to query
         :param observations: observed random variables with their values
-        :params num_samples: number of samples to collect for the query.
+        :params num_samples: number of samples excluding adaptation to collect.
         :params num_chains: number of chains to run
         :params num_adapt_steps: number of steps to allow proposer adaptation.
         :param verbose: Integer indicating how much output to print to stdio

--- a/beanmachine/ppl/inference/abstract_mh_infer.py
+++ b/beanmachine/ppl/inference/abstract_mh_infer.py
@@ -242,7 +242,7 @@ class AbstractMHInference(AbstractInference, metaclass=ABCMeta):
         """
         Run inference algorithms.
 
-        :param num_samples: number of samples to collect for the query.
+        :param num_samples: number of samples excluding adaptation.
         :param num_adapt_steps: number of steps to adapt/tune the proposer.
         :param verbose: Integer indicating how much output to print to stdio
         :returns: samples for the query
@@ -251,7 +251,7 @@ class AbstractMHInference(AbstractInference, metaclass=ABCMeta):
         queries_sample = defaultdict()
 
         for iteration in tqdm(
-            iterable=range(num_samples),
+            iterable=range(num_samples + num_adapt_steps),
             desc="Samples collected",
             disable=not bool(verbose.value),
         ):

--- a/beanmachine/ppl/inference/monte_carlo_samples_test.py
+++ b/beanmachine/ppl/inference/monte_carlo_samples_test.py
@@ -92,5 +92,9 @@ class MonteCarloSamplesTest(unittest.TestCase):
         foo_key = model.foo()
         mcs = mh.infer([foo_key], {}, 10, num_adapt_steps=3)
 
-        self.assertEqual(mcs[foo_key].shape, torch.zeros(4, 7).shape)
-        self.assertEqual(mcs.get_variable(foo_key).shape, torch.zeros(4, 7).shape)
+        self.assertEqual(mcs[foo_key].shape, torch.zeros(4, 10).shape)
+        self.assertEqual(mcs.get_variable(foo_key).shape, torch.zeros(4, 10).shape)
+        self.assertEqual(
+            mcs.get_variable(foo_key, include_adapt_steps=True).shape,
+            torch.zeros(4, 13).shape,
+        )


### PR DESCRIPTION
Summary:
num_samples used to include adaptation, which is different from most PPLs

num_samples now refers to the number of samples that we run after the adapation phase

Differential Revision: D21007840

