### PR TITLE
Fix github build

### DIFF
--- a/beanmachine/ppl/utils/single_assignment.py
+++ b/beanmachine/ppl/utils/single_assignment.py
@@ -223,7 +223,7 @@ class SingleAssignment:
         )
         rewritten = (
             original[:index]
-            + [ast.Starred(ast.List(elts=[value], ctx=ast.Load()), ctx=ast.Load())]
+            + [ast.Starred(ast.List(elts=[value], ctx=ast.Load()), ast.Load())]
             + original[index + 1 :]
         )
 
@@ -560,7 +560,7 @@ class SingleAssignment:
                 targets=source_term.targets,
                 value=ast.Call(
                     func=source_term.value.func,
-                    args=[ast.Starred(ast.List([], ctx=ast.Load()), ctx=ast.Load())],
+                    args=[ast.Starred(ast.List([], ast.Load()), ast.Load())],
                     keywords=source_term.value.keywords,
                 ),
             ),


### PR DESCRIPTION
Summary:
There is some sort of version mismatch causing the version of the ast module on the github build to reject usages of ast type constructors that have a mix of named and positional arguments. This fixes a couple of those that have crept in.

We'll solve the versioning problem in a later diff.

Differential Revision: D21587048

