### PR TITLE
Implement conversion of Boolean values to positive reals in BMG type system

### DIFF
--- a/beanmachine/ppl/utils/bm_graph_builder.py
+++ b/beanmachine/ppl/utils/bm_graph_builder.py
@@ -1265,8 +1265,6 @@ possibly creating a new node."""
         raise ValueError("Conversion to real node not yet implemented.")
 
     def _bool_to_real(self, node: BMGNode) -> BMGNode:
-        # TODO: If there is a query node pointing to the original node
-        # then it needs to be retargetted to the new one.
         one = self.add_real(1.0)
         zero = self.add_real(0.0)
         return self.add_if_then_else(node, one, zero)
@@ -1290,7 +1288,14 @@ possibly creating a new node."""
             return node
         if isinstance(node, ConstantNode):
             return self._constant_to_pos_real(node)
+        if node.node_type == bool:
+            return self._bool_to_pos_real(node)
         raise ValueError("Conversion to positive real node not yet implemented.")
+
+    def _bool_to_pos_real(self, node: BMGNode) -> BMGNode:
+        one = self.add_pos_real(1.0)
+        zero = self.add_pos_real(0.0)
+        return self.add_if_then_else(node, one, zero)
 
     def _constant_to_pos_real(self, node: ConstantNode) -> PositiveRealNode:
         if isinstance(node, TensorNode):


### PR DESCRIPTION
Summary:
We now can generate correctly-typed graphs when a Boolean quantity, such as a sample from a Bernoulli, is used in a context expecting a positive real, such as the variance of a normal.

Two things to note, first, this is mathematically questionable. When treating a Boolean as a real value it should be either 0.0 or 1.0, but one of those is not a "positive real"; zero is a non-negative real.

Second, in service of the first point, as you can see in the output below, BMG silently corrects the error so that the zero value is treated as 0.0000000001.

Differential Revision: D21600991

