### PR TITLE
Renaming to fix naming inconsistency

### DIFF
--- a/beanmachine/ppl/utils/single_assignment.py
+++ b/beanmachine/ppl/utils/single_assignment.py
@@ -490,7 +490,7 @@ class SingleAssignment:
             "handle_assign_call_function_expression",
         )
 
-    def _handle_assigned_call_single_regular_arg(self) -> Rule:
+    def _handle_assign_call_single_star_arg(self) -> Rule:
         # Rewrite x = f(*([1]+[2]) into d=[1]+[2]; x = f(*d)
         return PatternRule(
             assign(value=call(func=name(), args=[starred(value=_not_identifier)])),
@@ -506,10 +506,10 @@ class SingleAssignment:
                     ),
                 ),
             ),
-            "handle_assign_call_single_regular_arg",
+            "handle_assign_call_single_star_arg",
         )
 
-    def _handle_assigned_call_two_star_args(self) -> Rule:
+    def _handle_assign_call_two_star_args(self) -> Rule:
         # Rewrite x= f(*[1],*[2]) into x = f(*([1]+[2]))
         # TODO: Ideally, would like to merge [1].ctx with the [0].ctx below
         return PatternRule(
@@ -537,7 +537,7 @@ class SingleAssignment:
             "handle_assign_call_two_star_args",
         )
 
-    def _handle_assigned_call_regular_arg(self) -> Rule:
+    def _handle_assign_call_regular_arg(self) -> Rule:
         # Rewrite x = f(*[1],2) into x = f(*[1],*[2])
         return PatternRule(
             assign(value=call(args=_list_not_starred)),
@@ -549,10 +549,10 @@ class SingleAssignment:
                     keywords=source_term.value.keywords,
                 ),
             ),
-            "_handle_assigned_call_regular_arg",
+            "_handle_assign_call_regular_arg",
         )
 
-    def _handle_assigned_call_empty_regular_arg(self) -> Rule:
+    def _handle_assign_call_empty_regular_arg(self) -> Rule:
         # Rewrite x = f(*[1],2) into x = f(*[1],*[2])
         return PatternRule(
             assign(value=call(args=[])),
@@ -564,7 +564,7 @@ class SingleAssignment:
                     keywords=source_term.value.keywords,
                 ),
             ),
-            "_handle_assigned_call_empty_regular_arg",
+            "_handle_assign_call_empty_regular_arg",
         )
 
     def _handle_asign_call_keyword(self) -> Rule:
@@ -650,10 +650,10 @@ class SingleAssignment:
                 self._handle_asign_call_keyword(),
                 # Acceptable rules
                 self._handle_assign_call_function_expression(),
-                self._handle_assigned_call_single_regular_arg(),
-                self._handle_assigned_call_two_star_args(),
-                self._handle_assigned_call_regular_arg(),
-                self._handle_assigned_call_empty_regular_arg(),
+                self._handle_assign_call_single_star_arg(),
+                self._handle_assign_call_two_star_args(),
+                self._handle_assign_call_regular_arg(),
+                self._handle_assign_call_empty_regular_arg(),
             ]
         )
 

--- a/beanmachine/ppl/utils/single_assignment_test.py
+++ b/beanmachine/ppl/utils/single_assignment_test.py
@@ -823,7 +823,7 @@ a = a1[a2]
 """
         self.check_rewrite(source, expected)
 
-    def test_single_assignment_call_single_regular_arg(self) -> None:
+    def test_single_assignment_call_single_star_arg(self) -> None:
         """Test the assign rule final step in rewriting regular call arguments"""
 
         source = """
@@ -837,13 +837,13 @@ x = f(*r1)
         self.check_rewrite(
             source,
             expected,
-            _some_top_down(self.s._handle_assigned_call_single_regular_arg()),
+            _some_top_down(self.s._handle_assign_call_single_star_arg()),
         )
 
         self.check_rewrite(
             source,
             expected,
-            many(_some_top_down(self.s._handle_assigned_call_single_regular_arg())),
+            many(_some_top_down(self.s._handle_assign_call_single_star_arg())),
         )
 
         expected = """
@@ -867,15 +867,13 @@ x = f(*([1] + [2]))
 """
 
         self.check_rewrite(
-            source,
-            expected,
-            _some_top_down(self.s._handle_assigned_call_two_star_args()),
+            source, expected, _some_top_down(self.s._handle_assign_call_two_star_args())
         )
 
         self.check_rewrite(
             source,
             expected,
-            many(_some_top_down(self.s._handle_assigned_call_two_star_args())),
+            many(_some_top_down(self.s._handle_assign_call_two_star_args())),
         )
 
         expected = """
@@ -899,13 +897,13 @@ x = f(*[1], *[2])
 """
 
         self.check_rewrite(
-            source, expected, _some_top_down(self.s._handle_assigned_call_regular_arg())
+            source, expected, _some_top_down(self.s._handle_assign_call_regular_arg())
         )
 
         self.check_rewrite(
             source,
             expected,
-            many(_some_top_down(self.s._handle_assigned_call_regular_arg())),
+            many(_some_top_down(self.s._handle_assign_call_regular_arg())),
         )
 
         expected = """
@@ -932,13 +930,13 @@ x = f(*[])
         self.check_rewrite(
             source,
             expected,
-            _some_top_down(self.s._handle_assigned_call_empty_regular_arg()),
+            _some_top_down(self.s._handle_assign_call_empty_regular_arg()),
         )
 
         self.check_rewrite(
             source,
             expected,
-            many(_some_top_down(self.s._handle_assigned_call_empty_regular_arg())),
+            many(_some_top_down(self.s._handle_assign_call_empty_regular_arg())),
         )
 
         expected = """


### PR DESCRIPTION
Summary: The word assigned was used in place of the word assign. Also had an instance where the word regular was used in place of the word star. This diff fixes these inconsistencies.

Reviewed By: ericlippert

Differential Revision: D21627206

