### PR TITLE
Fix CircleCI build error on Diff "Add a copy constructor to Graph"

### DIFF
--- a/beanmachine/graph/graph.cpp
+++ b/beanmachine/graph/graph.cpp
@@ -458,7 +458,7 @@ std::vector<uint> Graph::get_parent_ids(const std::vector<Node*>& parent_nodes) 
 Graph::Graph(const Graph& other) {
   // This copy constructor does not copy the inference results (if available)
   // from the source graph.
-  for (int i = 0; i < other.nodes.size(); i++) {
+  for (uint i = 0; i < other.nodes.size(); i++) {
     Node* node = other.nodes[i].get();
     std::vector<uint> parent_ids = get_parent_ids(node->in_nodes);
     switch(node->node_type) {


### PR DESCRIPTION
Summary:
Fix this:
beanmachine/graph/graph.cpp:461:21: error: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<std::unique_ptr<beanmachine::graph::Node> >::size_type’ {aka ‘long unsigned int’} [-Werror=sign-compare]
       for (int i = 0; i < other.nodes.size(); i++) {
                       ~~^~~~~~~~~~~~~~~~~~~~

Reviewed By: nazanint

Differential Revision: D21644244

