### PR TITLE
Rewrite for lifting single keyword argument

### DIFF
--- a/beanmachine/ppl/utils/single_assignment_test.py
+++ b/beanmachine/ppl/utils/single_assignment_test.py
@@ -856,6 +856,35 @@ x = f(*r1)
 """
         self.check_rewrite(source, expected)
 
+    def test_single_assignment_call_single_double_star_arg(self) -> None:
+        """Test the assign rule final step in rewriting keyword call arguments"""
+
+        source = """
+x = f(*d, **({x: 5}))
+"""
+        expected = """
+r1 = {x: 5}
+x = f(*d, **r1)
+"""
+
+        self.check_rewrite(
+            source,
+            expected,
+            _some_top_down(self.s._handle_assign_call_single_double_star_arg()),
+        )
+
+        self.check_rewrite(
+            source,
+            expected,
+            many(_some_top_down(self.s._handle_assign_call_single_double_star_arg())),
+        )
+
+        expected = """
+a2 = 5
+r1 = {x: a2}
+x = f(*d, **r1)"""
+        self.check_rewrite(source, expected)
+
     def test_single_assignment_call_two_star_args(self) -> None:
         """Test the assign rule for merging starred call arguments"""
 


### PR DESCRIPTION
Summary: This rewrite is part of the set of rewrites that will be used to complete the rewriting of function calls by handling keyword arguments. In this case, we handle the case where there is a single keyword argument, which means it is a single argument that is double starred. This is the last rewrite that we need to get function calls to the normal form that we want to have by the time we are ready to pass it to BMG. As is noted in the body of the code, an example of this rewrite is to transform x = f(**({x:5}) into d={x:5}; x = f(*d). Technically, the rule requires that all processing of regular arguments is done. This is marked by having exacted one starred argument consisting of a variable. Also as explained in the comment in the new code, this rule is a slight generalization of what is needed, but this generalization a small optimization that is expected to be safe.

Differential Revision: D21645745

