### PR TITLE
Start fixing malformed addition and multiplication nodes by identifying them

### DIFF
--- a/beanmachine/ppl/compiler/bmg_types.py
+++ b/beanmachine/ppl/compiler/bmg_types.py
@@ -18,7 +18,13 @@ Probability   -- a real between 0.0 and 1.0
 Positive Real -- what it says on the tin
 Natural       -- a non-negative integer
 
-The type definitions are the objects which represent the last three."""
+The type definitions are the objects which represent the last three.
+
+During construction of a graph we may create nodes which need to be
+"fixed up" later; for example, a multiplication node with a tensor
+on one side and a real on the other cannot be represented in the BMG
+type system. We will mark such nodes as having the "Malformed" type.
+"""
 
 # TODO: We might also need:
 # * Bounded natural -- a sample from a categorical
@@ -35,4 +41,8 @@ class PositiveReal:
 
 
 class Natural:
+    pass
+
+
+class Malformed:
     pass


### PR DESCRIPTION
Summary:
The BMG type system requires that the left and right inputs to a multiplication or addition be of the same type (real, positive real, and so on), and that the operand type is the output type.

When constructing a graph by executing a Python program, we record the actual Python types of the quantities, and fix them up to match the BMG type system rules after the accumulation is complete. In order to do so, an obvious first step is to identify which nodes are currently failing to meet the requirements. This diff adds a "malformed" node type; binary operator nodes with unequal input types are automatically marked as malformed.

Reviewed By: nimar

Differential Revision: D21646041

