### PR TITLE
Add multi-threading for multi-chain inference

### DIFF
--- a/beanmachine/graph/graph_test.cpp
+++ b/beanmachine/graph/graph_test.cpp
@@ -110,6 +110,30 @@ TEST(testgraph, infer_bn) {
   // less than 1 in million odds of failing these tests with correct infer
   EXPECT_LT(sum, 60);
   EXPECT_GT(sum, 10);
+  // using multiple chains
+  const auto& all_samples =
+    g.infer(n_iter, graph::InferenceType::REJECTION, 123, 2);
+  ASSERT_EQ(all_samples.size(), 2);
+  ASSERT_EQ(all_samples[0].size(), n_iter);
+  ASSERT_EQ(all_samples[1].size(), n_iter);
+
+  uint eqsum = 0;
+  for (int i = 0; i < n_iter; i++) {
+    const auto& s0 = all_samples[0][i].front();
+    const auto& s1 = all_samples[1][i].front();
+    // @lint-ignore HOWTOEVEN
+    eqsum += (s0._bool == s1._bool) ? 1 : 0;
+  }
+  ASSERT_LT(eqsum, n_iter);
+
+  const auto& all_means =
+    g.infer_mean(n_iter, graph::InferenceType::REJECTION, 123, 2);
+  ASSERT_EQ(all_means.size(), 2);
+  ASSERT_NE(all_means[0].front(), all_means[1].front());
+  ASSERT_GT(all_means[0].front(), 0.1);
+  ASSERT_LT(all_means[0].front(), 0.6);
+  ASSERT_GT(all_means[1].front(), 0.1);
+  ASSERT_LT(all_means[1].front(), 0.6);
 }
 
 TEST(testgraph, clone_graph) {

--- a/beanmachine/graph/graph_test.py
+++ b/beanmachine/graph/graph_test.py
@@ -276,6 +276,16 @@ class TestBayesNet(unittest.TestCase):
         # since we have observed grass wet is true the query should be true
         self.assertEqual(type(samples[0][1]), bool)
         self.assertTrue(samples[0][1])
+        # test parallel inference
+        samples_all = g.infer(num_samples=1, n_chains=2)
+        self.assertTrue(len(samples_all) == 2)
+        self.assertTrue(len(samples_all[0]) == 1)
+        self.assertTrue(len(samples_all[1]) == 1)
+        self.assertEqual(samples[0][0], samples_all[0][0][0])
+        self.assertEqual(samples[0][1], samples_all[0][0][1])
+        self.assertEqual(type(samples_all[1][0][0]), bool)
+        self.assertEqual(type(samples_all[1][0][1]), bool)
+        self.assertTrue(samples_all[1][0][1])
 
     def test_infer_mean(self):
         g = graph.Graph()
@@ -290,6 +300,13 @@ class TestBayesNet(unittest.TestCase):
         means = g.infer_mean(100)
         self.assertAlmostEqual(means[0], 1.0)
         self.assertAlmostEqual(means[1], 1.0)
+        # test parallel inference
+        means_all = g.infer_mean(num_samples=100, n_chains=2)
+        self.assertTrue(len(means_all) == 2)
+        self.assertAlmostEqual(means_all[0][0], 1.0)
+        self.assertAlmostEqual(means_all[0][1], 1.0)
+        self.assertAlmostEqual(means_all[1][0], 1.0)
+        self.assertAlmostEqual(means_all[1][1], 1.0)
         # negative test, don't support aggregating tensors
         c2 = g.add_constant(torch.tensor(0.5))
         op2 = g.add_operator(graph.OperatorType.ADD, [c2, c2])

--- a/beanmachine/graph/pybindings.cpp
+++ b/beanmachine/graph/pybindings.cpp
@@ -161,18 +161,41 @@ PYBIND11_MODULE(graph, module) {
       .def("query", &Graph::query, "query a node", py::arg("node_id"))
       .def(
           "infer_mean",
-          &Graph::infer_mean,
+          (std::vector<double> & (Graph::*)(uint, InferenceType, uint)) &
+              Graph::infer_mean,
           "infer the posterior mean of the queried nodes",
           py::arg("num_samples"),
           py::arg("algorithm") = InferenceType::GIBBS,
           py::arg("seed") = 5123401)
       .def(
+          "infer_mean",
+          (std::vector<std::vector<double>> &
+           (Graph::*)(uint, InferenceType, uint, uint)) &
+              Graph::infer_mean,
+          "infer the posterior mean of the queried nodes using multiple chains",
+          py::arg("num_samples"),
+          py::arg("algorithm") = InferenceType::GIBBS,
+          py::arg("seed") = 5123401,
+          py::arg("n_chains"))
+      .def(
           "infer",
-          &Graph::infer,
+          (std::vector<std::vector<AtomicValue>> &
+           (Graph::*)(uint, InferenceType, uint)) &
+              Graph::infer,
           "infer the empirical distribution of the queried nodes",
           py::arg("num_samples"),
           py::arg("algorithm") = InferenceType::GIBBS,
           py::arg("seed") = 5123401)
+      .def(
+          "infer",
+          (std::vector<std::vector<std::vector<AtomicValue>>> &
+           (Graph::*)(uint, InferenceType, uint, uint)) &
+              Graph::infer,
+          "infer the empirical distribution of the queried nodes using multiple chains",
+          py::arg("num_samples"),
+          py::arg("algorithm") = InferenceType::GIBBS,
+          py::arg("seed") = 5123401,
+          py::arg("n_chains"))
       .def(
           "variational",
           &Graph::variational,


### PR DESCRIPTION
Summary:
- overload the infer and infer_mean method with additional argument n_chains
- add _infer_parallel method to sample multiple chains in parallel.

Differential Revision: D21635662

