### PR TITLE
Rename @sample->@random_variable and @query->@functional

### DIFF
--- a/beanmachine/ppl/__init__.py
+++ b/beanmachine/ppl/__init__.py
@@ -1,5 +1,7 @@
 import logging
 
+from beanmachine.ppl.model import functional, random_variable
+
 
 console_handler = logging.StreamHandler()
 console_handler.setLevel(logging.WARNING)
@@ -11,3 +13,5 @@ LOGGER.setLevel(logging.INFO)
 LOGGER.handlers.clear()
 LOGGER.addHandler(console_handler)
 LOGGER.addHandler(file_handler)
+
+__all__ = ["functional", "random_variable"]

--- a/beanmachine/ppl/model/__init__.py
+++ b/beanmachine/ppl/model/__init__.py
@@ -1,6 +1,20 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
-from beanmachine.ppl.model.statistical_model import StatisticalModel, query, sample
+from beanmachine.ppl.model.statistical_model import (
+    StatisticalModel,
+    functional,
+    query,
+    random_variable,
+    sample,
+)
 from beanmachine.ppl.model.utils import Mode, RVIdentifier
 
 
-__all__ = ["StatisticalModel", "sample", "Mode", "query", "RVIdentifier"]
+__all__ = [
+    "Mode",
+    "RVIdentifier",
+    "StatisticalModel",
+    "functional",
+    "query",
+    "random_variable",
+    "sample",
+]

--- a/beanmachine/ppl/model/statistical_model.py
+++ b/beanmachine/ppl/model/statistical_model.py
@@ -1,4 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
+import warnings
 from functools import wraps
 
 from beanmachine.ppl.model.utils import Mode, RVIdentifier
@@ -80,6 +81,14 @@ class StatisticalModel(object):
 
     @staticmethod
     def sample(f):
+        warnings.warn(
+            "@sample will be deprecated, use @random_variable instead",
+            DeprecationWarning,
+        )
+        return StatisticalModel.random_variable(f)
+
+    @staticmethod
+    def random_variable(f):
         """
         Decorator to be used for every stochastic random variable defined in
         all statistical models.
@@ -98,6 +107,13 @@ class StatisticalModel(object):
 
     @staticmethod
     def query(f):
+        warnings.warn(
+            "@query will be deprecated, use @functional instead", DeprecationWarning
+        )
+        return StatisticalModel.functional(f)
+
+    @staticmethod
+    def functional(f):
         """
         Decorator to be used for every query defined in statistical model.
         """
@@ -113,5 +129,8 @@ class StatisticalModel(object):
         return wrapper
 
 
-sample = StatisticalModel.sample
-query = StatisticalModel.query
+random_variable = StatisticalModel.random_variable
+sample = random_variable
+
+functional = StatisticalModel.functional
+query = functional

--- a/beanmachine/ppl/tests/smoke_test.py
+++ b/beanmachine/ppl/tests/smoke_test.py
@@ -1,0 +1,17 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import unittest
+
+import beanmachine.ppl as bmp
+import torch.distributions as dist
+
+
+class ToplevelSmokeTest(unittest.TestCase):
+    def test_toplevel_package_imports(self):
+        # these decorators should execute without error
+        @bmp.random_variable
+        def foo(i):
+            return dist.Bernoulli(0.5)
+
+        @bmp.functional
+        def foo_sum(n):
+            return sum(foo(i) for i in range(n))


### PR DESCRIPTION
Summary:
As a beanmachine user, I should be able to easily understand the semantics from the name of bean machine decorators.

This diff renames `sample` to `random_variable` and `query` to `functional`, and also exposes the new names in the `beanmachine.ppl` top-level package. The previous names are flagged for deprecation and intentionally omitted from export.

Differential Revision: D21654220

