### PR TITLE
Fix Variable.__str__ for non-scalar Variable.value

### DIFF
--- a/beanmachine/ppl/world/variable.py
+++ b/beanmachine/ppl/world/variable.py
@@ -85,7 +85,7 @@ class Variable(object):
                 )
 
     def __str__(self) -> str:
-        return str(self.value.item()) + " from " + str(self.distribution)
+        return str(self.value) + " from " + str(self.distribution)
 
     def initialize_value(self, obs: Optional[Tensor]) -> Tensor:
         """

--- a/beanmachine/ppl/world/variable_test.py
+++ b/beanmachine/ppl/world/variable_test.py
@@ -2,6 +2,7 @@
 import unittest
 from collections import namedtuple
 
+import torch
 import torch.distributions as dist
 import torch.tensor as tensor
 from beanmachine.ppl.world.variable import Variable
@@ -100,3 +101,25 @@ class VariableTest(unittest.TestCase):
         )
 
         self.assertAlmostEqual(expected_log_prob.item(), log_prob.item(), delta=0.01)
+
+    def test_str_nonscalar(self):
+        distribution = dist.MultivariateNormal(tensor([0.0, 0.0]), torch.eye(2))
+        var = Variable(
+            distribution=distribution,
+            value=None,
+            log_prob=None,
+            parent=set(),
+            children=set(),
+            proposal_distribution=None,
+            extended_val=None,
+            is_discrete=None,
+            transforms=[],
+            unconstrained_value=None,
+            jacobian=None,
+        )
+        value = var.initialize_value(None)
+        var.update_value(value)
+        try:
+            str(var)
+        except Exception:
+            self.fail("str(Variable) raised an Exception!")


### PR DESCRIPTION
Summary: As a beanmachine developer, I should be able to print a `Variable` with a non-scalar `Tensor` value.

Differential Revision: D21697907

