### PR TITLE
Sets log_prob to -Inf when outside support

### DIFF
--- a/beanmachine/ppl/world/variable.py
+++ b/beanmachine/ppl/world/variable.py
@@ -231,8 +231,15 @@ class Variable(object):
         """
         Computes the log probability of the value of the random varialble
         """
-        # pyre-fixme
-        self.log_prob = self.distribution.log_prob(self.value).sum()
+        try:
+            # pyre-fixme
+            self.log_prob = self.distribution.log_prob(self.value).sum()
+        except (RuntimeError, ValueError) as e:
+            # pyre-fixme
+            if not self.distribution.support.check(self.value):
+                self.log_prob = tensor(float("-Inf"))
+            else:
+                raise e
 
     def set_transform(self, transform: List):
         """


### PR DESCRIPTION
Summary:
I walked this through with nimar over vc, so let me know if this summary isn't capturing the problem sufficiently.

When `create_child_with_new_distributions` changes `child_var.distribution`, the distribution's support may also change causing the re-used `child_var.value` to be outside of the support.

In the case of `torch.distributions.Categorical`, this throws a `RuntimeError` unless the user calls the constructor with `validate_args=True` (in which case a `ValueError` exception is thrown).

As a beanmachine open-world PPL user, I should be able to specify a Categorical distribution who's support can change between worlds without exceptions being raised.

As a beanmachine user, I should be able to use `pytorch.distributions.Categorical` without remembering to pass in `validate_args` into the constructor every time.

Differential Revision: D21697783

