### PR TITLE
Add verbose reporting to internal compiler errors

### DIFF
--- a/beanmachine/ppl/compiler/internal_error.py
+++ b/beanmachine/ppl/compiler/internal_error.py
@@ -1,8 +1,32 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 """Error reporting for internal compiler errors"""
 
+import os
 from ast import AST
 from typing import Optional
+
+import beanmachine.ppl.compiler.ast_tools as ast_tools
+
+
+_BEANSTALK_VERBOSE_EXCEPTIONS = "BEANSTALK_VERBOSE_EXCEPTIONS"
+
+_help_verbose = f"""Set environment variable {_BEANSTALK_VERBOSE_EXCEPTIONS}
+to 1 for extended error information.
+"""
+
+
+def _check_environment(variable: str) -> bool:
+    return os.environ.get(variable) == "1"
+
+
+# You can change this to True for debugging purposes.
+_always_verbose_exceptions = False
+
+
+def _verbose_exceptions() -> bool:
+    return _always_verbose_exceptions or _check_environment(
+        _BEANSTALK_VERBOSE_EXCEPTIONS
+    )
 
 
 class InternalError(Exception):
@@ -29,10 +53,27 @@ compiling the lifted code."""
         # TODO: Consider adding a compiler version number, hash
         # or other identifier to help debug.
 
-        message = f"""Compilation of the lifted AST failed.
+        brief = f"""Compilation of the lifted AST failed.
 This typically indicates an internal error in the rewrite phase of the compiler.
 ### Exception thrown ###
 {original_exception}
 """
+
+        verbose = f"""### Internal compiler error ###
+{brief}
+### Model source ###
+{source}
+### Abstract syntax tree ###
+from ast import *
+failed = {ast_tools.print_python(ast)}
+### End internal compiler error ###
+"""
+
+        use_verbose = _verbose_exceptions()
+
+        help_text = "" if use_verbose else _help_verbose
+
+        message = verbose if use_verbose else brief
+        message += help_text
 
         InternalError.__init__(self, message, original_exception)


### PR DESCRIPTION
Summary:
I've added optional verbose reporting to internal compiler errors; the verbose report includes:

* The complete text of the model that was being compiled at the time of the failure
* A Python program which when executed creates the AST that failed to compile

You can get the verbose error message either programmatically by setting the global variable in the module, or by setting an environment variable.

Differential Revision: D21699421

