### PR TITLE
Add new helper method to AST visualizers

### DIFF
--- a/beanmachine/ppl/compiler/ast_tools.py
+++ b/beanmachine/ppl/compiler/ast_tools.py
@@ -10,6 +10,7 @@ from typing import Any, List, Tuple
 
 import beanmachine.ppl.utils.dotbuilder as db
 import beanmachine.ppl.utils.treeprinter as tp
+import black
 
 
 def _get_name(node: Any) -> str:
@@ -46,3 +47,9 @@ representation of the tree as a graph."""
         return []
 
     return db.print_graph([node], get_children, None, _get_name)
+
+
+def print_python(node: AST) -> str:
+    """Takes an AST and produces a string containing a human-readable
+Python expression that builds the AST node."""
+    return black.format_str(ast.dump(node), mode=black.FileMode())

--- a/beanmachine/ppl/compiler/ast_tools_test.py
+++ b/beanmachine/ppl/compiler/ast_tools_test.py
@@ -7,8 +7,8 @@ import beanmachine.ppl.compiler.ast_tools as ast_tools
 
 
 class ASTToolsTest(unittest.TestCase):
-    def test_1(self) -> None:
-        """Test 1"""
+    def test_ast_tools_print_tree(self) -> None:
+        """test_ast_tools_print_tree"""
         node = ast.parse("2 + 3")
         observed = ast_tools.print_tree(node, False)
         expected = """
@@ -25,6 +25,9 @@ Module
         self.maxDiff = None
         self.assertEqual(observed.strip(), expected.strip())
 
+    def test_ast_tools_print_graph(self) -> None:
+        """test_ast_tools_print_graph"""
+        node = ast.parse("2 + 3")
         observed = ast_tools.print_graph(node)
         expected = """
 digraph "graph" {
@@ -46,4 +49,26 @@ digraph "graph" {
   N4 -> N8[label=n];
   N6 -> N7[label=n];
 }"""
+        self.maxDiff = None
+        self.assertEqual(observed.strip(), expected.strip())
+
+    def test_ast_tools_print_python(self) -> None:
+        """test_ast_tools_print_python"""
+        node = ast.parse("x = f(2 + 3)")
+        observed = ast_tools.print_python(node)
+        expected = """
+Module(
+    body=[
+        Assign(
+            targets=[Name(id="x", ctx=Store())],
+            value=Call(
+                func=Name(id="f", ctx=Load()),
+                args=[BinOp(left=Num(n=2), op=Add(), right=Num(n=3))],
+                keywords=[],
+            ),
+        )
+    ]
+)
+"""
+        self.maxDiff = None
         self.assertEqual(observed.strip(), expected.strip())

--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,7 @@ setup(
         "statsmodels>=0.8.0",
         "tqdm>=4.40.2",
         "astor>=0.7.1",
+        "black>=19.3b0",
     ],
     packages=find_packages(),
     ext_modules=[


### PR DESCRIPTION
Summary: When debugging the compiler it is helpful to be able to dump an AST in a form that can be used to construct the AST node in question.

Reviewed By: wtaha

Differential Revision: D21676542

