### PR TITLE
Makes runs reproducible by seeding python's Random

### DIFF
--- a/beanmachine/ppl/inference/abstract_infer.py
+++ b/beanmachine/ppl/inference/abstract_infer.py
@@ -1,5 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import logging
+import random
 from abc import ABCMeta, abstractmethod
 from enum import Enum
 from typing import Dict, List
@@ -50,6 +51,7 @@ class AbstractInference(object, metaclass=ABCMeta):
     @staticmethod
     def set_seed_for_chain(random_seed: int, chain: int):
         torch.manual_seed(random_seed + chain * 31)
+        random.seed(random_seed + chain * 31)
 
     def _parallel_infer(
         self,
@@ -95,9 +97,7 @@ class AbstractInference(object, metaclass=ABCMeta):
         try:
             self.queries_ = queries
             self.observations_ = observations
-            # pyre-fixme[6]: Expected `Union[bytes, str, typing.SupportsInt]` for
-            #  1st param but got `Tensor`.
-            random_seed = int(torch.randint(2 ** 62, (1,)))
+            random_seed = torch.randint(2 ** 62, (1,)).int().item()
 
             if num_chains > 1 and run_in_parallel:
                 manager = mp.Manager()

--- a/beanmachine/ppl/inference/single_site_ancestral_mh_test.py
+++ b/beanmachine/ppl/inference/single_site_ancestral_mh_test.py
@@ -1,27 +1,38 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import unittest
 
+import beanmachine.ppl as bm
 import torch
 import torch.distributions as dist
-from beanmachine.ppl.inference.single_site_ancestral_mh import (
-    SingleSiteAncestralMetropolisHastings,
-)
-from beanmachine.ppl.model.statistical_model import sample
+from torch import tensor
 
 
 class SingleSiteAncestralMetropolisHastingsTest(unittest.TestCase):
     class SampleModel(object):
-        @sample
+        @bm.random_variable
         def foo(self):
             return dist.Normal(torch.tensor(0.0), torch.tensor(1.0))
 
-        @sample
+        @bm.random_variable
         def bar(self):
             return dist.Normal(self.foo(), torch.tensor(1.0))
 
+    class ReproducibleModel(object):
+        @bm.random_variable
+        def K_minus_one(self):
+            return dist.Poisson(rate=2.0)
+
+        @bm.functional
+        def K(self):
+            return self.K_minus_one() + 1
+
+        @bm.random_variable
+        def mu(self):
+            return dist.Normal(0, 1)
+
     def test_single_site_ancestral_mh(self):
         model = self.SampleModel()
-        mh = SingleSiteAncestralMetropolisHastings()
+        mh = bm.SingleSiteAncestralMetropolisHastings()
         foo_key = model.foo()
         bar_key = model.bar()
         mh.queries_ = [model.foo()]
@@ -34,3 +45,24 @@ class SingleSiteAncestralMetropolisHastingsTest(unittest.TestCase):
         self.assertEqual(bar_key in world_vars, True)
         self.assertEqual(foo_key in world_vars[bar_key].parent, True)
         self.assertEqual(bar_key in world_vars[foo_key].children, True)
+
+    def test_single_site_ancestral_mh_reproducible_results(self):
+        model = self.ReproducibleModel()
+        mh = bm.SingleSiteAncestralMetropolisHastings()
+
+        queries = [model.mu()]
+        observations = {model.K(): tensor(2.0)}
+
+        torch.manual_seed(42)
+        samples = mh.infer(queries, observations, num_samples=5, num_chains=1)
+        run_1 = samples.get_variable(model.mu()).clone()
+
+        torch.manual_seed(42)
+        samples = mh.infer(queries, observations, num_samples=5, num_chains=1)
+        run_2 = samples.get_variable(model.mu()).clone()
+        self.assertTrue(run_1.allclose(run_2))
+
+        torch.manual_seed(43)
+        samples = mh.infer(queries, observations, num_samples=5, num_chains=1)
+        run_3 = samples.get_variable(model.mu()).clone()
+        self.assertFalse(run_1.allclose(run_3))


### PR DESCRIPTION
Summary: https://www.internalfb.com/intern/diffusion/FBS/browse/master/fbcode/beanmachine/beanmachine/ppl/inference/abstract_mh_infer.py?commit=f1642af4484b505b86727b223435bccc86fd2c17&lines=296 is currently unseeded, causing non-reproducible runs.

Differential Revision: D21733816

