### PR TITLE
Clean up @random_variable/@functional and fix AST pattern utils (#3)

### DIFF
--- a/beanmachine/ppl/compiler/bmg_nodes.py
+++ b/beanmachine/ppl/compiler/bmg_nodes.py
@@ -737,10 +737,10 @@ we generate a different node in BMG."""
     # is straightforward, we do not yet have the gear to implement
     # this for stochastic counts. Consider this contrived case:
     #
-    # @sample def a(): return Binomial(2, 0.5)
-    # @sample def b(): return Binomial(a() + 1, 0.4)
-    # @sample def c(i): return Normal(0.0, 2.0)
-    # @sample def d(): return Normal(c(b()), 3.0)
+    # @bm.random_variable def a(): return Binomial(2, 0.5)
+    # @bm.random_variable def b(): return Binomial(a() + 1, 0.4)
+    # @bm.random_variable def c(i): return Normal(0.0, 2.0)
+    # @bm.random_variable def d(): return Normal(c(b()), 3.0)
     #
     # The support of a() is 0, 1, 2 -- easy.
     #
@@ -1520,15 +1520,15 @@ multiple control flows based on the value of a stochastic node."""
 
     # For example, suppose we have this contrived model:
     #
-    #   @sample def weird(i):
+    #   @bm.random_variable def weird(i):
     #     if i == 0:
     #       return Normal(0.0, 1.0)
     #     return Normal(1.0, 1.0)
     #
-    #   @sample def flips():
+    #   @bm.random_variable def flips():
     #     return Binomial(2, 0.5)
     #
-    #   @sample def really_weird():
+    #   @bm.random_variable def really_weird():
     #     return Normal(weird(flips()), 1.0)
     #
     # There are three possibilities for weird(flips()) on the last line;
@@ -2093,7 +2093,7 @@ to the inference engine that the user is interested in
 getting a distribution of values of that node. It always
 points to an operator node.
 
-We represent queries in models with the @query annotation;
+We represent queries in models with the @bm.functional annotation;
 the compiler causes the returned nodes of such models
 to have a query node accumulated into the graph builder.
 """

--- a/beanmachine/ppl/diagnostics/diagnostics_test.py
+++ b/beanmachine/ppl/diagnostics/diagnostics_test.py
@@ -5,11 +5,8 @@ import beanmachine.ppl.diagnostics.common_statistics as common_statistics
 import pandas as pd
 import torch
 import torch.distributions as dist
+import beanmachine.ppl as bm
 from beanmachine.ppl.diagnostics.diagnostics import Diagnostics
-from beanmachine.ppl.inference.single_site_ancestral_mh import (
-    SingleSiteAncestralMetropolisHastings,
-)
-from beanmachine.ppl.model.statistical_model import sample
 from statsmodels.tsa.stattools import acf
 
 
@@ -22,22 +19,22 @@ beta_dis = dist.Beta(torch.tensor([1.0, 2.0, 3.0]), torch.tensor([9.0, 8.0, 7.0]
 normal_dis = dist.Normal(torch.tensor([0.0, 1.0, 2.0]), torch.tensor([0.5, 1.0, 1.5]))
 
 
-@sample
+@bm.random_variable
 def diri(i, j):
     return diri_dis
 
 
-@sample
+@bm.random_variable
 def beta(i):
     return beta_dis
 
 
-@sample
+@bm.random_variable
 def normal():
     return normal_dis
 
 
-@sample
+@bm.random_variable
 def foo():
     return dist.Normal(0, 1)
 
@@ -133,7 +130,7 @@ class DiagnosticsTest(unittest.TestCase):
                 index += 1
 
         torch.manual_seed(123)
-        mh = SingleSiteAncestralMetropolisHastings()
+        mh = bm.SingleSiteAncestralMetropolisHastings()
         query_list = [beta(0), diri(1, 5), normal()]
         num_chains = 2
         samples = mh.infer(query_list, {}, 1000, num_chains)
@@ -156,7 +153,7 @@ class DiagnosticsTest(unittest.TestCase):
         _test_autocorr_object(Diagnostics(samples), query, query_samples)
 
     def test_r_hat_one_chain(self):
-        mh = SingleSiteAncestralMetropolisHastings()
+        mh = bm.SingleSiteAncestralMetropolisHastings()
         samples = mh.infer([normal()], {}, 50, 1)
         diagnostics = Diagnostics(samples)
         with self.assertWarns(UserWarning):
@@ -164,7 +161,7 @@ class DiagnosticsTest(unittest.TestCase):
         self.assertTrue(results.empty)
 
     def test_r_hat_column(self):
-        mh = SingleSiteAncestralMetropolisHastings()
+        mh = bm.SingleSiteAncestralMetropolisHastings()
         samples = mh.infer([normal()], {}, 100, 2)
         diagnostics = Diagnostics(samples)
 
@@ -175,7 +172,7 @@ class DiagnosticsTest(unittest.TestCase):
         self.assertTrue("r_hat" not in out_df.columns)
 
     def test_r_hat_no_column(self):
-        mh = SingleSiteAncestralMetropolisHastings()
+        mh = bm.SingleSiteAncestralMetropolisHastings()
         samples = mh.infer([normal()], {}, 100, 1)
         out_df = Diagnostics(samples).summary()
         self.assertTrue("r_hat" not in out_df.columns)
@@ -222,7 +219,7 @@ class DiagnosticsTest(unittest.TestCase):
         self.assertAlmostEqual(dim2, 15.1438, delta=0.001)
 
     def test_effective_sample_size_columns(self):
-        mh = SingleSiteAncestralMetropolisHastings()
+        mh = bm.SingleSiteAncestralMetropolisHastings()
         samples = mh.infer([normal()], {}, 100, 2)
         out_df = Diagnostics(samples).summary()
         self.assertTrue("n_eff" in out_df.columns)

--- a/beanmachine/ppl/examples/conjugate_models/beta_binomial.py
+++ b/beanmachine/ppl/examples/conjugate_models/beta_binomial.py
@@ -1,6 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates
+import beanmachine.ppl as bm
 import torch.distributions as dist
-from beanmachine.ppl.model.statistical_model import sample
 from torch import Tensor
 
 
@@ -10,10 +10,10 @@ class BetaBinomialModel(object):
         self.beta_ = beta
         self.trials_ = trials
 
-    @sample
+    @bm.random_variable
     def beta(self):
         return dist.Beta(self.alpha_, self.beta_)
 
-    @sample
+    @bm.random_variable
     def binomial(self):
         return dist.Binomial(self.trials_, self.beta())

--- a/beanmachine/ppl/examples/conjugate_models/categorical_dirichlet.py
+++ b/beanmachine/ppl/examples/conjugate_models/categorical_dirichlet.py
@@ -1,6 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates
+import beanmachine.ppl as bm
 import torch.distributions as dist
-from beanmachine.ppl.model.statistical_model import sample
 from torch import Tensor
 
 
@@ -8,10 +8,10 @@ class CategoricalDirichletModel(object):
     def __init__(self, alpha: Tensor):
         self.alpha_ = alpha
 
-    @sample
+    @bm.random_variable
     def dirichlet(self):
         return dist.Dirichlet(self.alpha_)
 
-    @sample
+    @bm.random_variable
     def categorical(self):
         return dist.Categorical(self.dirichlet())

--- a/beanmachine/ppl/examples/conjugate_models/gamma_gamma.py
+++ b/beanmachine/ppl/examples/conjugate_models/gamma_gamma.py
@@ -1,6 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates
+import beanmachine.ppl as bm
 import torch.distributions as dist
-from beanmachine.ppl.model.statistical_model import sample
 from torch import Tensor
 
 
@@ -10,10 +10,10 @@ class GammaGammaModel(object):
         self.rate_ = rate
         self.alpha_ = alpha
 
-    @sample
+    @bm.random_variable
     def gamma_p(self):
         return dist.Gamma(self.shape_, self.rate_)
 
-    @sample
+    @bm.random_variable
     def gamma(self):
         return dist.Gamma(self.alpha_, self.gamma_p())

--- a/beanmachine/ppl/examples/conjugate_models/gamma_normal.py
+++ b/beanmachine/ppl/examples/conjugate_models/gamma_normal.py
@@ -1,7 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates
+import beanmachine.ppl as bm
 import torch
 import torch.distributions as dist
-from beanmachine.ppl.model.statistical_model import sample
 from torch import Tensor
 
 
@@ -11,10 +11,10 @@ class GammaNormalModel(object):
         self.rate_ = rate
         self.mu_ = mu
 
-    @sample
+    @bm.random_variable
     def gamma(self):
         return dist.Gamma(self.shape_, self.rate_)
 
-    @sample
+    @bm.random_variable
     def normal(self):
         return dist.Normal(self.mu_, 1 / torch.sqrt(self.gamma()))

--- a/beanmachine/ppl/examples/conjugate_models/normal_normal.py
+++ b/beanmachine/ppl/examples/conjugate_models/normal_normal.py
@@ -1,6 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates
+import beanmachine.ppl as bm
 import torch.distributions as dist
-from beanmachine.ppl.model.statistical_model import sample
 from torch import Tensor
 
 
@@ -10,10 +10,10 @@ class NormalNormalModel(object):
         self.std_ = std
         self.sigma_ = sigma
 
-    @sample
+    @bm.random_variable
     def normal_p(self):
         return dist.Normal(self.mu_, self.std_)
 
-    @sample
+    @bm.random_variable
     def normal(self):
         return dist.Normal(self.normal_p(), self.sigma_)

--- a/beanmachine/ppl/inference/compositional_infer_test.py
+++ b/beanmachine/ppl/inference/compositional_infer_test.py
@@ -3,7 +3,7 @@ import unittest
 
 import torch.distributions as dist
 import torch.tensor as tensor
-from beanmachine.ppl.inference.compositional_infer import CompositionalInference
+import beanmachine.ppl as bm
 from beanmachine.ppl.inference.proposer.single_site_ancestral_proposer import (
     SingleSiteAncestralProposer,
 )
@@ -14,45 +14,44 @@ from beanmachine.ppl.inference.proposer.single_site_uniform_proposer import (
     SingleSiteUniformProposer,
 )
 from beanmachine.ppl.inference.utils import Block, BlockType
-from beanmachine.ppl.model.statistical_model import sample
 from beanmachine.ppl.world.variable import Variable
 from beanmachine.ppl.world.world import World
 
 
 class CompositionalInferenceTest(unittest.TestCase):
     class SampleModel(object):
-        @sample
+        @bm.random_variable
         def foo(self):
             return dist.Normal(tensor(0.0), tensor(1.0))
 
-        @sample
+        @bm.random_variable
         def foobar(self):
             return dist.Categorical(tensor([0.5, 0, 5]))
 
-        @sample
+        @bm.random_variable
         def foobaz(self):
             return dist.Bernoulli(0.1)
 
-        @sample
+        @bm.random_variable
         def bazbar(self):
             return dist.Poisson(tensor([4]))
 
     class SampleNormalModel(object):
-        @sample
+        @bm.random_variable
         def foo(self, i):
             return dist.Normal(tensor(2.0), tensor(2.0))
 
-        @sample
+        @bm.random_variable
         def bar(self, i):
             return dist.Normal(tensor(10.0), tensor(1.0))
 
-        @sample
+        @bm.random_variable
         def foobar(self, i):
             return dist.Normal(self.foo(i) + self.bar(i), tensor(1.0))
 
     def test_single_site_compositionl_inference(self):
         model = self.SampleModel()
-        c = CompositionalInference()
+        c = bm.CompositionalInference()
         foo_key = model.foo()
         c.world_ = World()
         distribution = dist.Bernoulli(0.1)
@@ -152,7 +151,7 @@ class CompositionalInferenceTest(unittest.TestCase):
 
     def test_single_site_compositionl_inference_with_input(self):
         model = self.SampleModel()
-        c = CompositionalInference({model.foo: SingleSiteAncestralProposer()})
+        c = bm.CompositionalInference({model.foo: SingleSiteAncestralProposer()})
         foo_key = model.foo()
         c.world_ = World()
         distribution = dist.Normal(0.1, 1)
@@ -181,7 +180,7 @@ class CompositionalInferenceTest(unittest.TestCase):
 
     def test_proposer_for_block(self):
         model = self.SampleNormalModel()
-        ci = CompositionalInference()
+        ci = bm.CompositionalInference()
         ci.add_sequential_proposer([model.foo, model.bar])
         ci.queries_ = [
             model.foo(0),

--- a/beanmachine/ppl/inference/monte_carlo_samples_test.py
+++ b/beanmachine/ppl/inference/monte_carlo_samples_test.py
@@ -3,25 +3,22 @@ import unittest
 
 import torch
 import torch.distributions as dist
-from beanmachine.ppl.inference.single_site_ancestral_mh import (
-    SingleSiteAncestralMetropolisHastings,
-)
-from beanmachine.ppl.model.statistical_model import sample
+import beanmachine.ppl as bm
 
 
 class MonteCarloSamplesTest(unittest.TestCase):
     class SampleModel(object):
-        @sample
+        @bm.random_variable
         def foo(self):
             return dist.Normal(torch.tensor(0.0), torch.tensor(1.0))
 
-        @sample
+        @bm.random_variable
         def bar(self):
             return dist.Normal(self.foo(), torch.tensor(1.0))
 
     def test_default_four_chains(self):
         model = self.SampleModel()
-        mh = SingleSiteAncestralMetropolisHastings()
+        mh = bm.SingleSiteAncestralMetropolisHastings()
         foo_key = model.foo()
         mcs = mh.infer([foo_key], {}, 10)
 
@@ -44,7 +41,7 @@ class MonteCarloSamplesTest(unittest.TestCase):
 
     def test_one_chain(self):
         model = self.SampleModel()
-        mh = SingleSiteAncestralMetropolisHastings()
+        mh = bm.SingleSiteAncestralMetropolisHastings()
         foo_key = model.foo()
         bar_key = model.bar()
         mcs = mh.infer([foo_key, bar_key], {}, 10, 1)
@@ -68,7 +65,7 @@ class MonteCarloSamplesTest(unittest.TestCase):
 
     def test_chain_exceptions(self):
         model = self.SampleModel()
-        mh = SingleSiteAncestralMetropolisHastings()
+        mh = bm.SingleSiteAncestralMetropolisHastings()
         foo_key = model.foo()
         mcs = mh.infer([foo_key], {}, 10)
 
@@ -88,7 +85,7 @@ class MonteCarloSamplesTest(unittest.TestCase):
 
     def test_num_adaptive_samples(self):
         model = self.SampleModel()
-        mh = SingleSiteAncestralMetropolisHastings()
+        mh = bm.SingleSiteAncestralMetropolisHastings()
         foo_key = model.foo()
         mcs = mh.infer([foo_key], {}, 10, num_adaptive_samples=3)
 

--- a/beanmachine/ppl/inference/proposer/abstract_single_site_single_step_proposer_test.py
+++ b/beanmachine/ppl/inference/proposer/abstract_single_site_single_step_proposer_test.py
@@ -2,14 +2,13 @@
 import unittest
 from typing import Dict, Tuple
 
+import beanmachine.ppl as bm
 import torch
 import torch.distributions as dist
 import torch.tensor as tensor
-from beanmachine.ppl.inference.compositional_infer import CompositionalInference
 from beanmachine.ppl.inference.proposer.abstract_single_site_single_step_proposer import (
     AbstractSingleSiteSingleStepProposer,
 )
-from beanmachine.ppl.model.statistical_model import sample
 from beanmachine.ppl.model.utils import RVIdentifier
 from beanmachine.ppl.world import ProposalDistribution, Variable, World
 
@@ -50,17 +49,17 @@ class SingleSiteCustomProposerTest(unittest.TestCase):
                 )
 
     class SampleGammaModel(object):
-        @sample
+        @bm.random_variable
         def foo(self):
             return dist.Gamma(tensor(2.0), tensor(2.0))
 
-        @sample
+        @bm.random_variable
         def bar(self):
             return dist.Gamma(self.foo(), torch.tensor(1.0))
 
     def test_custom_proposer(self):
         model = self.SampleGammaModel()
-        ci = CompositionalInference({model.foo: self.CustomProposer()})
+        ci = bm.CompositionalInference({model.foo: self.CustomProposer()})
         ci.queries_ = [model.foo()]
         ci.observations_ = {model.bar(): tensor(2.0)}
         ci._infer(2)

--- a/beanmachine/ppl/inference/proposer/single_site_half_space_newtonian_monte_carlo_proposer_test.py
+++ b/beanmachine/ppl/inference/proposer/single_site_half_space_newtonian_monte_carlo_proposer_test.py
@@ -1,41 +1,41 @@
 # Copyright (c) Facebook, Inc. and its affiliates
 import unittest
 
+import beanmachine.ppl as bm
 import torch
 import torch.distributions as dist
 import torch.tensor as tensor
 from beanmachine.ppl.inference.proposer.single_site_half_space_newtonian_monte_carlo_proposer import (
     SingleSiteHalfSpaceNewtonianMonteCarloProposer,
 )
-from beanmachine.ppl.model.statistical_model import sample
 from beanmachine.ppl.world.variable import Variable
 from beanmachine.ppl.world.world import World
 
 
 class SingleSiteHalfSpaceNewtonianMonteCarloProposerTest(unittest.TestCase):
     class SampleNormalModel(object):
-        @sample
+        @bm.random_variable
         def foo(self):
             return dist.Normal(tensor(2.0), tensor(2.0))
 
-        @sample
+        @bm.random_variable
         def bar(self):
             return dist.Normal(self.foo(), torch.tensor(1.0))
 
     class SampleLogisticRegressionModel(object):
-        @sample
+        @bm.random_variable
         def theta_0(self):
             return dist.Normal(tensor(0.0), tensor(1.0))
 
-        @sample
+        @bm.random_variable
         def theta_1(self):
             return dist.Normal(tensor(0.0), tensor(1.0))
 
-        @sample
+        @bm.random_variable
         def x(self, i):
             return dist.Normal(tensor(0.0), tensor(1.0))
 
-        @sample
+        @bm.random_variable
         def y(self, i):
             y = self.theta_1() * self.x(i) + self.theta_0()
             probs = 1 / (1 + (y * -1).exp())

--- a/beanmachine/ppl/inference/proposer/single_site_real_space_newtonian_monte_carlo_proposer_test.py
+++ b/beanmachine/ppl/inference/proposer/single_site_real_space_newtonian_monte_carlo_proposer_test.py
@@ -1,44 +1,41 @@
 # Copyright (c) Facebook, Inc. and its affiliates
 import unittest
 
+import beanmachine.ppl as bm
 import torch
 import torch.distributions as dist
 import torch.tensor as tensor
 from beanmachine.ppl.inference.proposer.single_site_real_space_newtonian_monte_carlo_proposer import (
     SingleSiteRealSpaceNewtonianMonteCarloProposer,
 )
-from beanmachine.ppl.inference.single_site_newtonian_monte_carlo import (
-    SingleSiteNewtonianMonteCarlo,
-)
-from beanmachine.ppl.model.statistical_model import sample
 from beanmachine.ppl.world.variable import Variable
 from beanmachine.ppl.world.world import World
 
 
 class SingleSiteRealSpaceNewtonianMonteCarloProposerTest(unittest.TestCase):
     class SampleNormalModel(object):
-        @sample
+        @bm.random_variable
         def foo(self):
             return dist.Normal(tensor(2.0), tensor(2.0))
 
-        @sample
+        @bm.random_variable
         def bar(self):
             return dist.Normal(self.foo(), torch.tensor(1.0))
 
     class SampleLogisticRegressionModel(object):
-        @sample
+        @bm.random_variable
         def theta_0(self):
             return dist.Normal(tensor(0.0), tensor(1.0))
 
-        @sample
+        @bm.random_variable
         def theta_1(self):
             return dist.Normal(tensor(0.0), tensor(1.0))
 
-        @sample
+        @bm.random_variable
         def x(self, i):
             return dist.Normal(tensor(0.0), tensor(1.0))
 
-        @sample
+        @bm.random_variable
         def y(self, i):
             y = self.theta_1() * self.x(i) + self.theta_0()
             probs = 1 / (1 + (y * -1).exp())
@@ -46,7 +43,7 @@ class SingleSiteRealSpaceNewtonianMonteCarloProposerTest(unittest.TestCase):
 
     def test_mean_scale_tril_for_node_with_child(self):
         model = self.SampleNormalModel()
-        nw = SingleSiteNewtonianMonteCarlo()
+        nw = bm.SingleSiteNewtonianMonteCarlo()
         nw.world_ = World()
         nw_proposer = SingleSiteRealSpaceNewtonianMonteCarloProposer()
         foo_key = model.foo()
@@ -105,7 +102,7 @@ class SingleSiteRealSpaceNewtonianMonteCarloProposerTest(unittest.TestCase):
 
     def test_mean_scale_tril(self):
         model = self.SampleNormalModel()
-        nw = SingleSiteNewtonianMonteCarlo()
+        nw = bm.SingleSiteNewtonianMonteCarlo()
         nw.world_ = World()
         nw_proposer = SingleSiteRealSpaceNewtonianMonteCarloProposer()
         foo_key = model.foo()
@@ -144,7 +141,7 @@ class SingleSiteRealSpaceNewtonianMonteCarloProposerTest(unittest.TestCase):
 
     def test_mean_scale_tril_for_iids(self):
         model = self.SampleNormalModel()
-        nw = SingleSiteNewtonianMonteCarlo()
+        nw = bm.SingleSiteNewtonianMonteCarlo()
         nw.world_ = World()
         nw_proposer = SingleSiteRealSpaceNewtonianMonteCarloProposer()
         foo_key = model.foo()
@@ -183,7 +180,7 @@ class SingleSiteRealSpaceNewtonianMonteCarloProposerTest(unittest.TestCase):
 
     def test_multi_mean_scale_tril_computation_in_inference(self):
         model = self.SampleLogisticRegressionModel()
-        nw = SingleSiteNewtonianMonteCarlo()
+        nw = bm.SingleSiteNewtonianMonteCarlo()
         nw.world_ = World()
         nw_proposer = SingleSiteRealSpaceNewtonianMonteCarloProposer()
 

--- a/beanmachine/ppl/inference/proposer/single_site_simplex_newtonian_monte_carlo_proposer_test.py
+++ b/beanmachine/ppl/inference/proposer/single_site_simplex_newtonian_monte_carlo_proposer_test.py
@@ -1,41 +1,41 @@
 # Copyright (c) Facebook, Inc. and its affiliates
 import unittest
 
+import beanmachine.ppl as bm
 import torch
 import torch.distributions as dist
 import torch.tensor as tensor
 from beanmachine.ppl.inference.proposer.single_site_simplex_newtonian_monte_carlo_proposer import (
     SingleSiteSimplexNewtonianMonteCarloProposer,
 )
-from beanmachine.ppl.model.statistical_model import sample
 from beanmachine.ppl.world.variable import Variable
 from beanmachine.ppl.world.world import World
 
 
 class SingleSiteSimplexNewtonianMonteCarloProposerTest(unittest.TestCase):
     class SampleNormalModel(object):
-        @sample
+        @bm.random_variable
         def foo(self):
             return dist.Normal(tensor(2.0), tensor(2.0))
 
-        @sample
+        @bm.random_variable
         def bar(self):
             return dist.Normal(self.foo(), torch.tensor(1.0))
 
     class SampleLogisticRegressionModel(object):
-        @sample
+        @bm.random_variable
         def theta_0(self):
             return dist.Normal(tensor(0.0), tensor(1.0))
 
-        @sample
+        @bm.random_variable
         def theta_1(self):
             return dist.Normal(tensor(0.0), tensor(1.0))
 
-        @sample
+        @bm.random_variable
         def x(self, i):
             return dist.Normal(tensor(0.0), tensor(1.0))
 
-        @sample
+        @bm.random_variable
         def y(self, i):
             y = self.theta_1() * self.x(i) + self.theta_0()
             probs = 1 / (1 + (y * -1).exp())

--- a/beanmachine/ppl/inference/single_site_ancestral_mh_test.py
+++ b/beanmachine/ppl/inference/single_site_ancestral_mh_test.py
@@ -4,7 +4,6 @@ import unittest
 import beanmachine.ppl as bm
 import torch
 import torch.distributions as dist
-from torch import tensor
 
 
 class SingleSiteAncestralMetropolisHastingsTest(unittest.TestCase):
@@ -51,7 +50,7 @@ class SingleSiteAncestralMetropolisHastingsTest(unittest.TestCase):
         mh = bm.SingleSiteAncestralMetropolisHastings()
 
         queries = [model.mu()]
-        observations = {model.K(): tensor(2.0)}
+        observations = {model.K(): torch.tensor(2.0)}
 
         torch.manual_seed(42)
         samples = mh.infer(queries, observations, num_samples=5, num_chains=1)

--- a/beanmachine/ppl/inference/single_site_hamiltonian_monte_carlo_test.py
+++ b/beanmachine/ppl/inference/single_site_hamiltonian_monte_carlo_test.py
@@ -4,32 +4,29 @@ import unittest
 import torch
 import torch.distributions as dist
 import torch.tensor as tensor
-from beanmachine.ppl.inference.single_site_hamiltonian_monte_carlo import (
-    SingleSiteHamiltonianMonteCarlo,
-)
-from beanmachine.ppl.model.statistical_model import sample
+import beanmachine.ppl as bm
 
 
 class SingleSiteHamiltonianMonteCarloTest(unittest.TestCase):
     class SampleNormalModel(object):
-        @sample
+        @bm.random_variable
         def foo(self):
             return dist.Normal(tensor(2.0), tensor(2.0))
 
-        @sample
+        @bm.random_variable
         def bar(self):
             return dist.Normal(self.foo(), torch.tensor(1.0))
 
     class ChangingParentsModel(object):
-        @sample
+        @bm.random_variable
         def parent_one(self):
             return dist.Normal(0.0, torch.tensor(1.0))
 
-        @sample
+        @bm.random_variable
         def parent_two(self):
             return dist.Normal(0.0, torch.tensor(1.0))
 
-        @sample
+        @bm.random_variable
         def bad_child(self):
             if self.parent_one() > 0:
                 return dist.Normal(self.parent_one(), torch.tensor(1.0))
@@ -38,7 +35,7 @@ class SingleSiteHamiltonianMonteCarloTest(unittest.TestCase):
 
     def test_single_site_hamiltonian_monte_carlo(self):
         model = self.SampleNormalModel()
-        hmc = SingleSiteHamiltonianMonteCarlo(0.1, 10)
+        hmc = bm.SingleSiteHamiltonianMonteCarlo(0.1, 10)
         foo_key = model.foo()
         bar_key = model.bar()
         hmc.queries_ = [model.foo()]
@@ -53,7 +50,7 @@ class SingleSiteHamiltonianMonteCarloTest(unittest.TestCase):
 
     def test_single_site_hamiltonian_monte_carlo_parents_changed(self):
         model = self.ChangingParentsModel()
-        hmc = SingleSiteHamiltonianMonteCarlo(0.1, 10)
+        hmc = bm.SingleSiteHamiltonianMonteCarlo(0.1, 10)
 
         parent_one_key = model.parent_one()
         child_key = model.bad_child()

--- a/beanmachine/ppl/inference/single_site_newtonian_monte_carlo_test.py
+++ b/beanmachine/ppl/inference/single_site_newtonian_monte_carlo_test.py
@@ -4,36 +4,33 @@ import unittest
 import torch
 import torch.distributions as dist
 import torch.tensor as tensor
-from beanmachine.ppl.inference.single_site_newtonian_monte_carlo import (
-    SingleSiteNewtonianMonteCarlo,
-)
-from beanmachine.ppl.model.statistical_model import sample
+import beanmachine.ppl as bm
 
 
 class SingleSiteNewtonianMonteCarloTest(unittest.TestCase):
     class SampleNormalModel(object):
-        @sample
+        @bm.random_variable
         def foo(self):
             return dist.Normal(tensor(2.0), tensor(2.0))
 
-        @sample
+        @bm.random_variable
         def bar(self):
             return dist.Normal(self.foo(), torch.tensor(1.0))
 
     class SampleLogisticRegressionModel(object):
-        @sample
+        @bm.random_variable
         def theta_0(self):
             return dist.Normal(tensor(0.0), tensor(1.0))
 
-        @sample
+        @bm.random_variable
         def theta_1(self):
             return dist.Normal(tensor(0.0), tensor(1.0))
 
-        @sample
+        @bm.random_variable
         def x(self, i):
             return dist.Normal(tensor(0.0), tensor(1.0))
 
-        @sample
+        @bm.random_variable
         def y(self, i):
             y = self.theta_1() * self.x(i) + self.theta_0()
             probs = 1 / (1 + (y * -1).exp())
@@ -41,7 +38,7 @@ class SingleSiteNewtonianMonteCarloTest(unittest.TestCase):
 
     def test_single_site_newtonian_monte_carlo(self):
         model = self.SampleNormalModel()
-        nw = SingleSiteNewtonianMonteCarlo()
+        nw = bm.SingleSiteNewtonianMonteCarlo()
         foo_key = model.foo()
         bar_key = model.bar()
         nw.queries_ = [model.foo()]

--- a/beanmachine/ppl/inference/single_site_uniform_mh_test.py
+++ b/beanmachine/ppl/inference/single_site_uniform_mh_test.py
@@ -1,39 +1,36 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import unittest
 
+import beanmachine.ppl as bm
 import torch
 import torch.distributions as dist
 from beanmachine.ppl.inference.proposer.single_site_uniform_proposer import (
     SingleSiteUniformProposer,
 )
-from beanmachine.ppl.inference.single_site_uniform_mh import (
-    SingleSiteUniformMetropolisHastings,
-)
-from beanmachine.ppl.model.statistical_model import sample
 
 
 class SingleSiteUniformMetropolisHastingsTest(unittest.TestCase):
     class SampleBernoulliModel(object):
-        @sample
+        @bm.random_variable
         def foo(self):
             return dist.Beta(torch.tensor(2.0), torch.tensor(2.0))
 
-        @sample
+        @bm.random_variable
         def bar(self):
             return dist.Bernoulli(self.foo())
 
     class SampleCategoricalModel(object):
-        @sample
+        @bm.random_variable
         def foo(self):
             return dist.Dirichlet(torch.tensor([0.5, 0.5]))
 
-        @sample
+        @bm.random_variable
         def bar(self):
             return dist.Categorical(self.foo())
 
     def test_single_site_uniform_mh_with_bernoulli(self):
         model = self.SampleBernoulliModel()
-        mh = SingleSiteUniformMetropolisHastings()
+        mh = bm.SingleSiteUniformMetropolisHastings()
         foo_key = model.foo()
         bar_key = model.bar()
         mh.queries_ = [model.foo()]
@@ -50,7 +47,7 @@ class SingleSiteUniformMetropolisHastingsTest(unittest.TestCase):
 
     def test_single_site_uniform_mh_with_categorical(self):
         model = self.SampleCategoricalModel()
-        mh = SingleSiteUniformMetropolisHastings()
+        mh = bm.SingleSiteUniformMetropolisHastings()
         foo_key = model.foo()
         bar_key = model.bar()
         mh.queries_ = [model.foo()]

--- a/beanmachine/ppl/model/statistical_model.py
+++ b/beanmachine/ppl/model/statistical_model.py
@@ -11,22 +11,22 @@ class StatisticalModel(object):
     Parent class to all statistical models implemented in Bean Machine.
 
     every random variable in the model needs to be defined with function
-    declaration accompanied with @sample decorator.
+    declaration accompanied with @bm.random_variable decorator.
 
     for instance, here is Gaussian Mixture Model implementation:
 
 
     K, alpha, beta, gamma = init()
 
-    @sample
+    @bm.random_variable
     def mu():
         return Normal(alpha, beta)
 
-    @sample
+    @bm.random_variable
     def z(i):
         return Uniform(K)
 
-    @sample
+    @bm.random_variable
     def y(i):
         return Normal(mu(z(i)), gamma)
     """

--- a/beanmachine/ppl/model/statistical_model_test.py
+++ b/beanmachine/ppl/model/statistical_model_test.py
@@ -1,13 +1,12 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import unittest
 
+import beanmachine.ppl as bm
 import torch
 import torch.distributions as dist
 from beanmachine.ppl.model.statistical_model import (
     RVIdentifier,
     StatisticalModel,
-    query,
-    sample,
 )
 from beanmachine.ppl.model.utils import Mode
 
@@ -18,44 +17,44 @@ class StatisticalModelTest(unittest.TestCase):
         StatisticalModel.reset()
 
     class SampleModel(object):
-        @sample
+        @bm.random_variable
         def foo(self):
             return dist.Normal(torch.tensor(0.0), torch.tensor(1.0))
 
-        @sample
+        @bm.random_variable
         def bar(self):
             return dist.Normal(self.foo(), torch.tensor(1.0))
 
-        @sample
+        @bm.random_variable
         def baz(self):
             return dist.Normal(self.foo(), self.bar())
 
     class SampleLargeModel(object):
-        @sample
+        @bm.random_variable
         def foo(self):
             return dist.Normal(torch.tensor(0.0), torch.tensor(1.0))
 
-        @sample
+        @bm.random_variable
         def bar(self):
             return dist.Normal(self.foo(), torch.tensor(1.0))
 
-        @sample
+        @bm.random_variable
         def baz(self):
             return dist.Normal(self.foo(), self.bar())
 
-        @sample
+        @bm.random_variable
         def foobar(self):
             return dist.Normal(self.baz(), self.bar())
 
-        @sample
+        @bm.random_variable
         def bazbar(self, i):
             return dist.Normal(self.baz(), self.foo())
 
-        @sample
+        @bm.random_variable
         def foobaz(self):
             return dist.Normal(self.bazbar(1), self.foo())
 
-        @query
+        @bm.functional
         def avg(self):
             return self.foo() + 1
 

--- a/beanmachine/ppl/tests/conjugate_tests/adaptive_random_walk_conjugate_test.py
+++ b/beanmachine/ppl/tests/conjugate_tests/adaptive_random_walk_conjugate_test.py
@@ -1,7 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import unittest
 
-from beanmachine.ppl.inference.single_site_random_walk import SingleSiteRandomWalk
+import beanmachine.ppl as bm
 from beanmachine.ppl.tests.conjugate_tests.abstract_conjugate import (
     AbstractConjugateTests,
 )
@@ -11,23 +11,23 @@ class SingleSiteAdaptiveRandomWalkConjugateTest(
     unittest.TestCase, AbstractConjugateTests
 ):
     def setUp(self):
-        self.mh = SingleSiteRandomWalk(step_size=5.0)
+        self.mh = bm.SingleSiteRandomWalk(step_size=5.0)
 
     def test_beta_binomial_conjugate_run(self):
-        self.mh = SingleSiteRandomWalk(step_size=1.0)
+        self.mh = bm.SingleSiteRandomWalk(step_size=1.0)
         self.beta_binomial_conjugate_run(
             self.mh, num_samples=3000, num_adaptive_samples=1600, delta=0.2
         )
         # self.assertTrue(False)
 
     def test_gamma_gamma_conjugate_run(self):
-        self.mh = SingleSiteRandomWalk(step_size=3.0)
+        self.mh = bm.SingleSiteRandomWalk(step_size=3.0)
         self.gamma_gamma_conjugate_run(
             self.mh, num_samples=2000, num_adaptive_samples=500, delta=0.2
         )
 
     def test_gamma_normal_conjugate_run(self):
-        self.mh = SingleSiteRandomWalk(step_size=5.0)
+        self.mh = bm.SingleSiteRandomWalk(step_size=5.0)
         self.gamma_normal_conjugate_run(
             self.mh, num_samples=2000, num_adaptive_samples=1000, delta=0.2
         )

--- a/beanmachine/ppl/tests/conjugate_tests/compositional_inference_test.py
+++ b/beanmachine/ppl/tests/conjugate_tests/compositional_inference_test.py
@@ -1,7 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import unittest
 
-from beanmachine.ppl.inference.compositional_infer import CompositionalInference
+import beanmachine.ppl as bm
 from beanmachine.ppl.tests.conjugate_tests.abstract_conjugate import (
     AbstractConjugateTests,
 )
@@ -9,7 +9,7 @@ from beanmachine.ppl.tests.conjugate_tests.abstract_conjugate import (
 
 class CompositionalInferenceConjugateTest(unittest.TestCase, AbstractConjugateTests):
     def setUp(self):
-        self.mh = CompositionalInference()
+        self.mh = bm.CompositionalInference()
 
     def test_beta_binomial_conjugate_run(self):
         self.beta_binomial_conjugate_run(self.mh)

--- a/beanmachine/ppl/tests/conjugate_tests/hamiltonian_monte_carlo_adaptive_conjugate_test.py
+++ b/beanmachine/ppl/tests/conjugate_tests/hamiltonian_monte_carlo_adaptive_conjugate_test.py
@@ -1,9 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import unittest
 
-from beanmachine.ppl.inference.single_site_hamiltonian_monte_carlo import (
-    SingleSiteHamiltonianMonteCarlo,
-)
+import beanmachine.ppl as bm
 from beanmachine.ppl.tests.conjugate_tests.abstract_conjugate import (
     AbstractConjugateTests,
 )
@@ -25,13 +23,13 @@ class SingleSiteAdaptiveHamiltonianMonteCarloConjugateTest(
         pass
 
     def test_normal_normal_conjugate_run(self):
-        hmc = SingleSiteHamiltonianMonteCarlo(0.5)
+        hmc = bm.SingleSiteHamiltonianMonteCarlo(0.5)
         self.normal_normal_conjugate_run(hmc, num_samples=300, delta=0.15)
 
     def test_distant_normal_normal_conjugate_run(self):
-        hmc = SingleSiteHamiltonianMonteCarlo(1.0)
+        hmc = bm.SingleSiteHamiltonianMonteCarlo(1.0)
         self.distant_normal_normal_conjugate_run(hmc, num_samples=500, delta=0.15)
 
     def test_dirichlet_categorical_conjugate_run(self):
-        hmc = SingleSiteHamiltonianMonteCarlo(0.1)
+        hmc = bm.SingleSiteHamiltonianMonteCarlo(0.1)
         self.dirichlet_categorical_conjugate_run(hmc, num_samples=200, delta=0.15)

--- a/beanmachine/ppl/tests/conjugate_tests/hamiltonian_monte_carlo_conjugate_test.py
+++ b/beanmachine/ppl/tests/conjugate_tests/hamiltonian_monte_carlo_conjugate_test.py
@@ -1,9 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import unittest
 
-from beanmachine.ppl.inference.single_site_hamiltonian_monte_carlo import (
-    SingleSiteHamiltonianMonteCarlo,
-)
+import beanmachine.ppl as bm
 from beanmachine.ppl.tests.conjugate_tests.abstract_conjugate import (
     AbstractConjugateTests,
 )
@@ -13,11 +11,11 @@ class SingleSiteHamiltonianMonteCarloConjugateTest(
     unittest.TestCase, AbstractConjugateTests
 ):
     def test_beta_binomial_conjugate_run(self):
-        hmc = SingleSiteHamiltonianMonteCarlo(0.5, 0.05)
+        hmc = bm.SingleSiteHamiltonianMonteCarlo(0.5, 0.05)
         self.beta_binomial_conjugate_run(hmc, num_samples=150, delta=0.15)
 
     def test_gamma_gamma_conjugate_run(self):
-        hmc = SingleSiteHamiltonianMonteCarlo(0.1, 0.01)
+        hmc = bm.SingleSiteHamiltonianMonteCarlo(0.1, 0.01)
         self.gamma_gamma_conjugate_run(hmc, num_samples=200, delta=0.15)
 
     def test_gamma_normal_conjugate_run(self):
@@ -25,13 +23,13 @@ class SingleSiteHamiltonianMonteCarloConjugateTest(
         pass
 
     def test_normal_normal_conjugate_run(self):
-        hmc = SingleSiteHamiltonianMonteCarlo(0.5, 0.05)
+        hmc = bm.SingleSiteHamiltonianMonteCarlo(0.5, 0.05)
         self.normal_normal_conjugate_run(hmc, num_samples=500, delta=0.1)
 
     def test_distant_normal_normal_conjugate_run(self):
-        hmc = SingleSiteHamiltonianMonteCarlo(1.0, 0.1)
+        hmc = bm.SingleSiteHamiltonianMonteCarlo(1.0, 0.1)
         self.distant_normal_normal_conjugate_run(hmc, num_samples=500, delta=0.1)
 
     def test_dirichlet_categorical_conjugate_run(self):
-        hmc = SingleSiteHamiltonianMonteCarlo(0.1, 0.01)
+        hmc = bm.SingleSiteHamiltonianMonteCarlo(0.1, 0.01)
         self.dirichlet_categorical_conjugate_run(hmc, num_samples=200, delta=0.15)

--- a/beanmachine/ppl/tests/conjugate_tests/mh_conjugate_test.py
+++ b/beanmachine/ppl/tests/conjugate_tests/mh_conjugate_test.py
@@ -1,9 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import unittest
 
-from beanmachine.ppl.inference.single_site_ancestral_mh import (
-    SingleSiteAncestralMetropolisHastings,
-)
+import beanmachine.ppl as bm
 from beanmachine.ppl.tests.conjugate_tests.abstract_conjugate import (
     AbstractConjugateTests,
 )
@@ -13,7 +11,7 @@ class SingleSiteAncestralMetropolisHastingsConjugateTest(
     unittest.TestCase, AbstractConjugateTests
 ):
     def setUp(self):
-        self.mh = SingleSiteAncestralMetropolisHastings()
+        self.mh = bm.SingleSiteAncestralMetropolisHastings()
 
     def test_beta_binomial_conjugate_run(self):
         self.beta_binomial_conjugate_run(self.mh)

--- a/beanmachine/ppl/tests/conjugate_tests/newtonian_monte_carlo_conjugate_test.py
+++ b/beanmachine/ppl/tests/conjugate_tests/newtonian_monte_carlo_conjugate_test.py
@@ -1,9 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import unittest
 
-from beanmachine.ppl.inference.single_site_newtonian_monte_carlo import (
-    SingleSiteNewtonianMonteCarlo,
-)
+import beanmachine.ppl as bm
 from beanmachine.ppl.tests.conjugate_tests.abstract_conjugate import (
     AbstractConjugateTests,
 )
@@ -13,31 +11,31 @@ class SingleSiteNewtonianMonteCarloConjugateTest(
     unittest.TestCase, AbstractConjugateTests
 ):
     def test_beta_binomial_conjugate_run(self):
-        nw = SingleSiteNewtonianMonteCarlo()
+        nw = bm.SingleSiteNewtonianMonteCarlo()
         self.beta_binomial_conjugate_run(nw, num_samples=350, delta=0.15)
         # failing for transform proposer because hessian is extremely close to 0
         # NMC has a covariance that is too large to produce good samples
 
     def test_gamma_gamma_conjugate_run(self):
-        nw_transform = SingleSiteNewtonianMonteCarlo()
+        nw_transform = bm.SingleSiteNewtonianMonteCarlo()
         self.gamma_gamma_conjugate_run(nw_transform, num_samples=200, delta=0.15)
 
     def test_gamma_normal_conjugate_run(self):
-        nw = SingleSiteNewtonianMonteCarlo()
+        nw = bm.SingleSiteNewtonianMonteCarlo()
         self.gamma_normal_conjugate_run(nw, num_samples=600, delta=0.15)
 
     def test_normal_normal_conjugate_run(self):
-        nw = SingleSiteNewtonianMonteCarlo()
+        nw = bm.SingleSiteNewtonianMonteCarlo()
         self.normal_normal_conjugate_run(nw, num_samples=500, delta=0.15)
 
     def test_distant_normal_normal_conjugate_run(self):
-        nw = SingleSiteNewtonianMonteCarlo()
+        nw = bm.SingleSiteNewtonianMonteCarlo()
         self.distant_normal_normal_conjugate_run(nw, num_samples=800, delta=0.15)
 
     def test_dirichlet_categorical_conjugate_run(self):
-        nw = SingleSiteNewtonianMonteCarlo()
+        nw = bm.SingleSiteNewtonianMonteCarlo()
         self.dirichlet_categorical_conjugate_run(nw, num_samples=100, delta=0.15)
-        nw_transform = SingleSiteNewtonianMonteCarlo(True)
+        nw_transform = bm.SingleSiteNewtonianMonteCarlo(True)
         self.dirichlet_categorical_conjugate_run(
             nw_transform, num_samples=100, delta=0.15
         )

--- a/beanmachine/ppl/tests/conjugate_tests/random_walk_conjugate_test.py
+++ b/beanmachine/ppl/tests/conjugate_tests/random_walk_conjugate_test.py
@@ -1,7 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import unittest
 
-from beanmachine.ppl.inference.single_site_random_walk import SingleSiteRandomWalk
+import beanmachine.ppl as bm
 from beanmachine.ppl.tests.conjugate_tests.abstract_conjugate import (
     AbstractConjugateTests,
 )
@@ -9,10 +9,10 @@ from beanmachine.ppl.tests.conjugate_tests.abstract_conjugate import (
 
 class SingleSiteRandomWalkConjugateTest(unittest.TestCase, AbstractConjugateTests):
     def setUp(self):
-        self.mh = SingleSiteRandomWalk(step_size=1.0)
+        self.mh = bm.SingleSiteRandomWalk(step_size=1.0)
 
     def test_beta_binomial_conjugate_run(self):
-        mh = SingleSiteRandomWalk(step_size=0.3)
+        mh = bm.SingleSiteRandomWalk(step_size=0.3)
         self.beta_binomial_conjugate_run(mh, num_samples=2000, delta=0.5)
 
     def test_gamma_gamma_conjugate_run(self):
@@ -22,11 +22,11 @@ class SingleSiteRandomWalkConjugateTest(unittest.TestCase, AbstractConjugateTest
         self.gamma_normal_conjugate_run(self.mh, num_samples=2000, delta=0.5)
 
     def test_normal_normal_conjugate_run(self):
-        mh = SingleSiteRandomWalk(step_size=1.5)
+        mh = bm.SingleSiteRandomWalk(step_size=1.5)
         self.normal_normal_conjugate_run(mh, num_samples=1000, delta=0.3)
 
     def test_distant_normal_normal_conjugate_run(self):
-        mh = SingleSiteRandomWalk(step_size=3.0)
+        mh = bm.SingleSiteRandomWalk(step_size=3.0)
         self.normal_normal_conjugate_run(mh, num_samples=5000, delta=1.0)
 
     def test_dirichlet_categorical_conjugate_run(self):

--- a/beanmachine/ppl/tests/conjugate_tests/uniform_mh_conjugate_test.py
+++ b/beanmachine/ppl/tests/conjugate_tests/uniform_mh_conjugate_test.py
@@ -1,9 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import unittest
 
-from beanmachine.ppl.inference.single_site_uniform_mh import (
-    SingleSiteUniformMetropolisHastings,
-)
+import beanmachine.ppl as bm
 from beanmachine.ppl.tests.conjugate_tests.abstract_conjugate import (
     AbstractConjugateTests,
 )
@@ -13,7 +11,7 @@ class SingleSiteUniformMetropolisHastingsConjugateTest(
     unittest.TestCase, AbstractConjugateTests
 ):
     def setUp(self):
-        self.mh = SingleSiteUniformMetropolisHastings()
+        self.mh = bm.SingleSiteUniformMetropolisHastings()
 
     def test_beta_binomial_conjugate_run(self):
         self.beta_binomial_conjugate_run(self.mh)

--- a/beanmachine/ppl/utils/bm_graph_builder.py
+++ b/beanmachine/ppl/utils/bm_graph_builder.py
@@ -842,7 +842,7 @@ that has the receiver, if any, as its first member."""
 
     def handle_sample(self, operand: Any) -> SampleNode:
         """As we execute the lifted program, this method is called every
-time a model function decorated with @sample returns; we verify that the
+time a model function decorated with @bm.random_variable returns; we verify that the
 returned value is a distribution that we know how to accumulate into the
 graph, and add a sample node to the graph."""
         if isinstance(operand, DistributionNode):
@@ -919,7 +919,7 @@ graph, and add a sample node to the graph."""
         return node
 
     def handle_query(self, value: Any) -> Any:
-        # When we have an @query function, we need to put a node
+        # When we have an @bm.functional function, we need to put a node
         # in the graph indicating that the value returned is of
         # interest to the user, and the inference engine should
         # accumulate information about it.  Under what circumstances
@@ -1074,7 +1074,7 @@ the "right"."""
     #
     # For example a model which contains
     #
-    # @sample
+    # @bm.random_variable
     # def flip():
     #   return Bernoulli(tensor(0.5))
     #

--- a/beanmachine/ppl/utils/end_to_end_test.py
+++ b/beanmachine/ppl/utils/end_to_end_test.py
@@ -18,44 +18,44 @@ def tidy(s: str) -> str:
 # * No use of a sample as an index.
 #
 source_1 = """
-from beanmachine.ppl.model.statistical_model import sample
+import beanmachine.ppl as bm
 import torch
 from torch import tensor
 from torch.distributions import Bernoulli, Beta, Binomial, HalfCauchy, Normal, StudentT
 
-@sample
+@bm.random_variable
 def flip_straight_constant():
   return Bernoulli(tensor(0.5))
 
-@sample
+@bm.random_variable
 def flip_logit_constant():
   return Bernoulli(logits=tensor(-2.0))
 
-@sample
+@bm.random_variable
 def standard_normal():
   return Normal(0.0, 1.0)
 
-@sample
+@bm.random_variable
 def flip_logit_normal():
   return Bernoulli(logits=standard_normal())
 
-@sample
+@bm.random_variable
 def beta_constant():
   return Beta(1.0, 1.0)
 
-@sample
+@bm.random_variable
 def hc(i):
   return HalfCauchy(1.0)
 
-@sample
+@bm.random_variable
 def beta_hc():
   return Beta(hc(1), hc(2))
 
-@sample
+@bm.random_variable
 def student_t():
   return StudentT(hc(1), standard_normal(), hc(2))
 
-@sample
+@bm.random_variable
 def bin_constant():
   return Binomial(3, 0.5)
 
@@ -213,22 +213,22 @@ n23 = g.add_operator(graph.OperatorType.SAMPLE, [n22])
 # These are cases where we have a type conversion on a sample.
 
 source_2 = """
-from beanmachine.ppl.model.statistical_model import sample
+import beanmachine.ppl as bm
 import torch
 from torch import tensor
 from torch.distributions import Bernoulli, Beta, Binomial, HalfCauchy, Normal, StudentT
 
-@sample
+@bm.random_variable
 def flip():
   # Sample is a Boolean
   return Bernoulli(tensor(0.5))
 
-@sample
+@bm.random_variable
 def normal():
   # Converts Boolean to real, positive real
   return Normal(flip(), flip())
 
-@sample
+@bm.random_variable
 def binomial():
   # Converts Boolean to natural and probability
   return Binomial(flip(), flip())

--- a/beanmachine/ppl/utils/probabilistic_test.py
+++ b/beanmachine/ppl/utils/probabilistic_test.py
@@ -17,11 +17,11 @@ class ProbabilisticTest(unittest.TestCase):
 
         # x is 0 or 1, we use that to choose from two different distributions:
         #
-        # @sample
+        # @bm.random_variable
         # def x():
         #   return Bernoulli(0.5)
         #
-        # @sample
+        # @bm.random_variable
         # def sample_function_1(p):
         #   return Bernoulli((p + 0.5) * 0.5)
         #
@@ -93,7 +93,7 @@ class ProbabilisticTest(unittest.TestCase):
         # x is 0 or 1
         # y is 2 or 3
         # We want a Bernoulli(0.02) or (0.03) or (0.04)
-        # @sample
+        # @bm.random_variable
         # def sample_function_2(x, y):
         #   return Bernoulli((x + y) * 0.01)
         # We would lower that to something like:

--- a/beanmachine/ppl/utils/rules_test.py
+++ b/beanmachine/ppl/utils/rules_test.py
@@ -11,6 +11,7 @@ from beanmachine.ppl.utils.ast_patterns import (
     ast_domain,
     ast_false,
     ast_true,
+    attribute,
     binop,
     constant_tensor_any,
     expr,
@@ -287,16 +288,19 @@ try_once(
         result = _all(_all(if_then(even, add_one)))(t).expect_success()
         self.assertEqual(ast.dump(result), ast.dump(ast.parse("1; 1; 3; 3; 5; 5 + 6")))
 
-    def test_find_samples(self) -> None:
+    def test_find_random_variables(self) -> None:
         """Find all the functions that have a decorator, delete everything else."""
 
         self.maxDiff = None
         _all = ast_domain.all_children
 
+        # decorator_list=[Attribute(value=Name(id='bm', ctx=Load()), attr='random_variable', ctx=Load())]
         rule = pattern_rules(
             [
                 (
-                    function_def(decorator_list=ListAny(name(id="sample"))),
+                    function_def(
+                        decorator_list=ListAny(attribute(attr="random_variable"))
+                    ),
                     lambda f: ast.FunctionDef(
                         name=f.name,
                         args=f.args,
@@ -310,11 +314,11 @@ try_once(
         )
         source = """
 # foo.py
-@sample
+@bm.random_variable
 def bias() -> Beta:
     return Beta(1, 1)
 
-@sample
+@bm.random_variable
 def toss(i) -> Bernoulli:
     return Bernoulli(bias())
 

--- a/beanmachine/ppl/world/diff_stack_test.py
+++ b/beanmachine/ppl/world/diff_stack_test.py
@@ -1,20 +1,21 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import unittest
 
+import beanmachine.ppl as bm
 import torch.distributions as dist
 import torch.tensor as tensor
-from beanmachine.ppl.model.statistical_model import StatisticalModel, sample
+from beanmachine.ppl.model.statistical_model import StatisticalModel
 from beanmachine.ppl.model.utils import Mode
 from beanmachine.ppl.world import Diff, Variable
 
 
 class DiffStackTest(unittest.TestCase):
     class SampleModel(object):
-        @sample
+        @bm.random_variable
         def foo(self):
             return dist.Normal(tensor(0.0), tensor(1.0))
 
-        @sample
+        @bm.random_variable
         def bar(self):
             return dist.Normal(self.foo(), tensor(1.0))
 

--- a/beanmachine/ppl/world/variable.py
+++ b/beanmachine/ppl/world/variable.py
@@ -34,7 +34,7 @@ class Variable(object):
 
     for instance, for the following randodm variable:
 
-    @sample
+    @bm.random_variable
     def bar(self):
         if not self.foo():
             return dist.Bernoulli(torch.tensor(0.1))

--- a/beanmachine/ppl/world/world.py
+++ b/beanmachine/ppl/world/world.py
@@ -35,11 +35,11 @@ class World(object):
 
     for instance for model below:
 
-    @sample
+    @bm.random_variable
     def foo():
         return dist.Bernoulli(torch.tensor(0.1))
 
-    @sample
+    @bm.random_variable
     def bar():
         if not foo().item():
             return dist.Bernoulli(torch.tensor(0.1))

--- a/beanmachine/ppl/world/world_test.py
+++ b/beanmachine/ppl/world/world_test.py
@@ -1,54 +1,55 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import unittest
 
+import beanmachine.ppl as bm
 import torch.distributions as dist
 import torch.tensor as tensor
-from beanmachine.ppl.model.statistical_model import StatisticalModel, sample
+from beanmachine.ppl.model.statistical_model import StatisticalModel
 from beanmachine.ppl.model.utils import Mode
 from beanmachine.ppl.world import Variable, World
 
 
 class WorldTest(unittest.TestCase):
     class SampleModel(object):
-        @sample
+        @bm.random_variable
         def foo(self):
             return dist.Normal(tensor(0.0), tensor(1.0))
 
-        @sample
+        @bm.random_variable
         def bar(self):
             return dist.Normal(self.foo(), tensor(1.0))
 
     class SampleModelWithParentUpdate(object):
-        @sample
+        @bm.random_variable
         def foo(self):
             return dist.Normal(tensor(0.0), tensor(1.0))
 
-        @sample
+        @bm.random_variable
         def baz(self):
             return dist.Normal(tensor(0.0), tensor(1.0))
 
-        @sample
+        @bm.random_variable
         def bar(self):
             if self.foo().item() > 0.3:
                 return dist.Normal(self.foo(), tensor(1.0))
             return dist.Normal(self.baz(), tensor(1.0))
 
     class SampleLargeModelUpdate(object):
-        @sample
+        @bm.random_variable
         def foo(self):
             return dist.Normal(tensor(0.0), tensor(1.0))
 
-        @sample
+        @bm.random_variable
         def baz(self):
             return dist.Normal(self.foo(), tensor(1.0))
 
-        @sample
+        @bm.random_variable
         def foobar(self):
             if self.foo().item() < 1:
                 return dist.Normal(self.foo(), tensor(1.0))
             return dist.Normal(tensor(0.0), tensor(1.0))
 
-        @sample
+        @bm.random_variable
         def bar(self):
             if self.foo().item() < 0.3:
                 return dist.Normal(self.foo(), tensor(1.0))
@@ -58,34 +59,34 @@ class WorldTest(unittest.TestCase):
                 return dist.Normal(self.foobar(), tensor(1.0))
             return dist.Normal(self.foobaz(), tensor(1.0))
 
-        @sample
+        @bm.random_variable
         def foobaz(self):
             if self.foo().item() < 1:
                 return dist.Normal(self.foobar(), 1)
             return dist.Normal(tensor(0.0), tensor(1.0))
 
     class SampleLargeModelWithAncesters(object):
-        @sample
+        @bm.random_variable
         def X(self):
             return dist.Categorical([0.5, 0.5])
 
-        @sample
+        @bm.random_variable
         def A(self, i):
             return dist.Normal(0.0, 1.0)
 
-        @sample
+        @bm.random_variable
         def B(self, i):
             return dist.Normal(self.A(i), tensor(1.0))
 
-        @sample
+        @bm.random_variable
         def C(self, i):
             return dist.Normal(self.B(i), tensor(1.0))
 
-        @sample
+        @bm.random_variable
         def D(self, i):
             return dist.Normal(self.B(i), abs(self.C(i).item()) + 0.1)
 
-        @sample
+        @bm.random_variable
         def Y(self):
             return dist.Normal(self.D(self.X().item()), tensor(1.0))
 


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookresearch/pplbench/pull/3

Cleans up imports to use our blessed "bm" aliased top-level package, makes use of `random_variable` and `functional` instead of  `sample` and `query` (which are scheduled for deprecation).

This diff also affects the behavior of the AST pattern library: both `sample` and `whateveryoualiasedbeanmachinepplto.random_variable` now match for the corresponding AST rules

Reviewed By: nimar

Differential Revision: D21745281

