### PR TITLE
Export Diagnostics from top-level package

### DIFF
--- a/beanmachine/ppl/__init__.py
+++ b/beanmachine/ppl/__init__.py
@@ -1,5 +1,6 @@
 import logging
 
+from beanmachine.ppl.diagnostics import Diagnostics
 from beanmachine.ppl.inference import (
     CompositionalInference,
     SingleSiteAncestralMetropolisHastings,
@@ -24,6 +25,7 @@ LOGGER.addHandler(file_handler)
 
 __all__ = [
     "CompositionalInference",
+    "Diagnostics",
     "SingleSiteAncestralMetropolisHastings",
     "SingleSiteHamiltonianMonteCarlo",
     "SingleSiteNewtonianMonteCarlo",

--- a/beanmachine/ppl/diagnostics/__init__.py
+++ b/beanmachine/ppl/diagnostics/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+from beanmachine.ppl.diagnostics.diagnostics import Diagnostics
+
+
+__all__ = ["Diagnostics"]

--- a/beanmachine/ppl/diagnostics/diagnostics.py
+++ b/beanmachine/ppl/diagnostics/diagnostics.py
@@ -5,8 +5,6 @@ import math
 import warnings
 from typing import Callable, Dict, List, Optional, Tuple
 
-import beanmachine.ppl.diagnostics.common_plots as common_plots
-import beanmachine.ppl.diagnostics.common_statistics as common_stats
 import numpy as np
 import pandas as pd
 import plotly
@@ -14,6 +12,8 @@ from beanmachine.ppl.inference.monte_carlo_samples import MonteCarloSamples
 from beanmachine.ppl.model.utils import RVIdentifier
 from plotly.subplots import make_subplots
 from torch import Tensor
+
+from . import common_plots, common_statistics as common_stats
 
 
 class BaseDiagnostics:

--- a/beanmachine/ppl/tests/smoke_test.py
+++ b/beanmachine/ppl/tests/smoke_test.py
@@ -17,4 +17,7 @@ class ToplevelSmokeTest(unittest.TestCase):
             return sum(foo(i) for i in range(n))
 
         # exercise invocation from top-level package directly
-        bm.CompositionalInference().infer([foo_sum(3)], {foo(0): False}, 1000, 1)
+        samples = bm.CompositionalInference().infer(
+            [foo_sum(3)], {foo(0): False}, 1000, 1
+        )
+        bm.Diagnostics(samples)


### PR DESCRIPTION
Summary:
Exports `bm.Diagnostics`.

Fixes a failing import in CircleCI `pytest`, see https://app.circleci.com/pipelines/github/facebookincubator/beanmachine/791/workflows/948b3c04-e8fa-441b-b2e7-d48ac8fa7c1e/jobs/886

Differential Revision: D21765536

