### PR TITLE
Fix RuntimeError in block sampling categorical with changing support

### DIFF
--- a/beanmachine/ppl/inference/compositional_infer_test.py
+++ b/beanmachine/ppl/inference/compositional_infer_test.py
@@ -1,7 +1,9 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import unittest
+from unittest.mock import patch
 
 import beanmachine.ppl as bm
+import torch
 import torch.distributions as dist
 import torch.tensor as tensor
 from beanmachine.ppl.inference.proposer.single_site_ancestral_proposer import (
@@ -48,6 +50,36 @@ class CompositionalInferenceTest(unittest.TestCase):
         @bm.random_variable
         def foobar(self, i):
             return dist.Normal(self.foo(i) + self.bar(i), tensor(1.0))
+
+    class ChangingSupportSameShapeModel(object):
+        # the support of `component` is changing, but (because we indexed alpha
+        # by k) all random_variables have the same shape
+        @bm.random_variable
+        def K(self):
+            return dist.Poisson(rate=2.0)
+
+        @bm.random_variable
+        def alpha(self, k):
+            return dist.Dirichlet(torch.ones(k))
+
+        @bm.random_variable
+        def component(self, i):
+            alpha = self.alpha(self.K().int().item() + 1)
+            return dist.Categorical(alpha)
+
+    class ChangingShapeModel(object):
+        # here since we did not index alpha, its shape in each world is changing
+        @bm.random_variable
+        def K(self):
+            return dist.Poisson(rate=2.0)
+
+        @bm.random_variable
+        def alpha(self):
+            return dist.Dirichlet(torch.ones(self.K().int().item() + 1))
+
+        @bm.random_variable
+        def component(self, i):
+            return dist.Categorical(self.alpha())
 
     def test_single_site_compositionl_inference(self):
         model = self.SampleModel()
@@ -259,3 +291,24 @@ class CompositionalInferenceTest(unittest.TestCase):
             children_log_updates.item(),
             delta=0.001,
         )
+
+    def test_block_inference_changing_support(self):
+        torch.manual_seed(41)
+        model = self.ChangingSupportSameShapeModel()
+        queries = [model.K()] + [model.component(j) for j in range(10)]
+        mh = bm.CompositionalInference()
+        mh.add_sequential_proposer([model.K, model.component])
+        with patch.object(
+            mh, "block_propose_change", wraps=mh.block_propose_change
+        ) as block_propose_spy:
+            mh.infer(queries, {}, num_samples=10, num_chains=1)
+            block_propose_spy.assert_called()
+
+    def test_block_inference_changing_shape(self):
+        model = self.ChangingShapeModel()
+        queries = [model.K()] + [model.component(j) for j in range(10)]
+        mh = bm.CompositionalInference()
+
+        # TODO: we should never raise RuntimeError, blocked by T67717820
+        with self.assertRaises(RuntimeError):
+            mh.infer(queries, {}, num_samples=10, num_chains=1)

--- a/beanmachine/ppl/inference/proposer/abstract_single_site_single_step_proposer.py
+++ b/beanmachine/ppl/inference/proposer/abstract_single_site_single_step_proposer.py
@@ -6,6 +6,7 @@ import torch.distributions as dist
 from beanmachine.ppl.inference.proposer.abstract_single_site_proposer import (
     AbstractSingleSiteProposer,
 )
+from beanmachine.ppl.inference.utils import safe_log_prob_sum
 from beanmachine.ppl.model.utils import RVIdentifier
 from beanmachine.ppl.world import ProposalDistribution, Variable, World
 from torch import Tensor
@@ -106,7 +107,7 @@ class AbstractSingleSiteSingleStepProposer(
         ):
             old_value = old_value.reshape(-1)
 
-        positive_log_update = proposal_distribution.log_prob(old_value).sum()
+        positive_log_update = safe_log_prob_sum(proposal_distribution, old_value)
 
         if requires_transform:
             positive_log_update = positive_log_update - node_var.jacobian

--- a/beanmachine/ppl/inference/utils.py
+++ b/beanmachine/ppl/inference/utils.py
@@ -4,6 +4,7 @@ from enum import Enum
 from typing import List
 
 from beanmachine.ppl.model.utils import RVIdentifier
+from torch import Tensor, tensor
 
 
 class BlockType(Enum):
@@ -27,3 +28,14 @@ class Block:
     first_node: RVIdentifier
     type: BlockType
     block: List[str]
+
+
+def safe_log_prob_sum(distrib, value: Tensor) -> Tensor:
+    "Computes log_prob, converting out of support exceptions to -Infinity."
+    try:
+        return distrib.log_prob(value).sum()
+    except (RuntimeError, ValueError) as e:
+        if not distrib.support.check(value):
+            return tensor(float("-Inf"))
+        else:
+            raise e

--- a/beanmachine/ppl/world/variable.py
+++ b/beanmachine/ppl/world/variable.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional, Set
 import torch
 import torch.distributions as dist
 import torch.tensor as tensor
+from beanmachine.ppl.inference.utils import safe_log_prob_sum
 from beanmachine.ppl.model.utils import RVIdentifier, float_types
 from beanmachine.ppl.world.utils import get_transforms, is_discrete
 from torch import Tensor
@@ -231,15 +232,7 @@ class Variable(object):
         """
         Computes the log probability of the value of the random varialble
         """
-        try:
-            # pyre-fixme
-            self.log_prob = self.distribution.log_prob(self.value).sum()
-        except (RuntimeError, ValueError) as e:
-            # pyre-fixme
-            if not self.distribution.support.check(self.value):
-                self.log_prob = tensor(float("-Inf"))
-            else:
-                raise e
+        self.log_prob = safe_log_prob_sum(self.distribution, self.value)
 
     def set_transform(self, transform: List):
         """


### PR DESCRIPTION
Summary: Handles changing support in sequential block update by returning -Infty log prob instead of a RuntimeError

Differential Revision: D21791285

