### PR TITLE
Fix typo in type fixing

### DIFF
--- a/beanmachine/ppl/compiler/bmg_nodes.py
+++ b/beanmachine/ppl/compiler/bmg_nodes.py
@@ -590,7 +590,7 @@ so is useful for creating probabilities."""
         return Beta
 
     def sample_type(self) -> Any:
-        if self.fixed_types:
+        if self.types_fixed:
             return Probability
         return self.alpha.node_type
 
@@ -1139,7 +1139,7 @@ and the true mean."""
         return StudentT
 
     def sample_type(self) -> Any:
-        if self.fixed_types:
+        if self.types_fixed:
             return float
         return self.df.node_type
 


### PR DESCRIPTION
Summary: I accidentally typed fixed_types when I meant types_fixed; a simple typo in the type fixing code which I have now fixed.

Reviewed By: wtaha

Differential Revision: D21749972

