### PR TITLE
Makes RVIdentifier serializable using dill

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ commands:
           command: sudo pip install --progress-bar off numpy
       - run:
           name: "Install pytorch"
-          command: sudo pip install --progress-bar off torch==1.4.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
+          command: sudo pip install --progress-bar off torch==1.5.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
 
   pip_dev_install:
     description: "Install beanmachine[dev] via pip"

--- a/beanmachine/ppl/model/utils.py
+++ b/beanmachine/ppl/model/utils.py
@@ -7,13 +7,30 @@ from typing import Any
 import torch
 
 
-@dataclass(eq=True, frozen=True)
+@dataclass(frozen=True)
 class RVIdentifier:
     function: Any
     arguments: Any
 
     def __str__(self):
         return str(self.function.__name__) + str(self.arguments)
+
+    def __eq__(self, other):
+        # NOTE: equality comparison on function is overridden because
+        # deserialization may result in the function id changing; arguments are
+        # still compared by id to ensure the same method on different instances
+        # are not equal
+        return (
+            (self.function.__name__ == other.function.__name__)
+            and (self.function.__code__ == other.function.__code__)
+            and (self.function.__module__ == other.function.__module__)
+            and (self.function.__globals__ == other.function.__globals__)
+            and (self.function.__closure__ == other.function.__closure__)
+            and self.arguments == other.arguments
+        )
+
+    def __hash__(self):
+        return hash((self.function.__name__, self.function.__code__, self.arguments))
 
 
 class Mode(Enum):

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ REQUIRED_MAJOR = 3
 REQUIRED_MINOR = 6
 
 
-TEST_REQUIRES = ["pytest", "pytest-cov", "gpytorch"]
+TEST_REQUIRES = ["pytest", "pytest-cov"]
 DEV_REQUIRES = TEST_REQUIRES + [
     "black==19.3b0",
     "isort",
@@ -83,15 +83,16 @@ setup(
     long_description_content_type="text/markdown",
     python_requires=">=3.6",
     install_requires=[
-        "torch>=1.4.0",
+        "astor>=0.7.1",
         "dataclasses>=0.6",
+        "gpytorch>=1.1.1",
         "pandas>=0.24.2",
+        "pathos>=0.2.4",
         "plotly>=2.2.1",
         "scipy>=0.16",
         "statsmodels>=0.8.0",
+        "torch>=1.5",
         "tqdm>=4.40.2",
-        "astor>=0.7.1",
-        "black>=19.3b0",
     ],
     packages=find_packages(),
     ext_modules=[


### PR DESCRIPTION
Summary:
Introduces `__eq__` and `__hash__` on `RVIdentifier` which uses the id of `arguments` but the `__name__` of `function` (previously we were using id-based equality on both, and function id is not stable after deserialization).

Note that the same instance method on different instances will not be equal (as expected) because the first argument (`self`) will fail the id check for `arguments`.

Adds dependency/test case using dill to SerDe `MonteCarloSamples`. (dep is on pathos because it will be needed for replacing multiprocessing, which uses pickle internally)

See https://medium.com/emlynoregan/serialising-all-the-functions-in-python-cd880a63b591 for details on why we need dill.

Differential Revision: D21958354

