### PR TITLE
Start implementing type lattice logic

### DIFF
--- a/beanmachine/ppl/compiler/bmg_types.py
+++ b/beanmachine/ppl/compiler/bmg_types.py
@@ -1,5 +1,8 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
+from torch import Tensor
+
+
 """This module contains type definitions used as markers
 for BMG types not represented in the Python type system.
 
@@ -46,3 +49,91 @@ class Natural:
 
 class Malformed:
     pass
+
+
+"""
+When converting from an accumulated graph that uses Python types, we
+can express the rules concisely by defining a *type lattice*. A type
+lattice is a DAG which meets these conditions:
+
+* Nodes are types
+* Edges are directed from "larger" types to "smaller" types.
+  (Note that there is no requirement for a total order.)
+* There is a function called "supremum" which takes two types
+  and returns the unique type that is the smallest type that
+  is bigger than both arguments.
+* There is a function called "infimum" which similarly is
+  the unique largest type smaller than both arguments.
+  (Right now we do not actually need this function in our
+  type analysis so it is not implemented.)
+
+The type lattice of the BMG type system is:
+
+          tensor
+            |
+          real
+            |
+         posreal
+         |     |
+        nat   prob
+          |   |
+          bool
+
+where bool is the smallest type and tensor is the largest.
+"""
+
+# There are only 36 pairs; we can just list them.
+_lookup = {
+    (bool, bool): bool,
+    (bool, Natural): Natural,
+    (bool, Probability): Probability,
+    (bool, PositiveReal): PositiveReal,
+    (bool, float): float,
+    (bool, Tensor): Tensor,
+    (Natural, bool): Natural,
+    (Natural, Natural): Natural,
+    (Natural, Probability): PositiveReal,
+    (Natural, PositiveReal): PositiveReal,
+    (Natural, float): float,
+    (Natural, Tensor): Tensor,
+    (Probability, bool): Probability,
+    (Probability, Natural): PositiveReal,
+    (Probability, Probability): Probability,
+    (Probability, PositiveReal): PositiveReal,
+    (Probability, float): float,
+    (Probability, Tensor): Tensor,
+    (PositiveReal, bool): PositiveReal,
+    (PositiveReal, Natural): PositiveReal,
+    (PositiveReal, Probability): PositiveReal,
+    (PositiveReal, PositiveReal): PositiveReal,
+    (PositiveReal, float): float,
+    (PositiveReal, Tensor): Tensor,
+    (float, bool): float,
+    (float, Natural): float,
+    (float, Probability): float,
+    (float, PositiveReal): float,
+    (float, float): float,
+    (float, Tensor): Tensor,
+    (Tensor, bool): Tensor,
+    (Tensor, Natural): Tensor,
+    (Tensor, Probability): Tensor,
+    (Tensor, PositiveReal): Tensor,
+    (Tensor, float): Tensor,
+    (Tensor, Tensor): Tensor,
+}
+
+
+def _supremum(t: type, u: type) -> type:
+    """Takes two BMG types; returns the smallest type that is
+greater than or equal to both."""
+    if (t, u) in _lookup:
+        return _lookup[(t, u)]
+    raise ValueError("Invalid arguments to _supremum")
+
+
+# We can extend the two-argument supremum function to any number of arguments:
+def supremum(*ts: type) -> type:
+    result = bool
+    for t in ts:
+        result = _supremum(result, t)
+    return result

--- a/beanmachine/ppl/compiler/bmg_types_test.py
+++ b/beanmachine/ppl/compiler/bmg_types_test.py
@@ -1,0 +1,22 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+"""Tests for bmg_types.py"""
+import unittest
+
+from beanmachine.ppl.compiler.bmg_types import (
+    Natural,
+    PositiveReal,
+    Probability,
+    supremum,
+)
+from torch import Tensor
+
+
+class BMGTypesTest(unittest.TestCase):
+    def test_supremum(self) -> None:
+        """test_supremum"""
+
+        self.assertEqual(bool, supremum())
+        self.assertEqual(Probability, supremum(Probability))
+        self.assertEqual(PositiveReal, supremum(Probability, Natural))
+        self.assertEqual(float, supremum(Natural, Probability, float))
+        self.assertEqual(Tensor, supremum(float, Tensor, Natural, bool))


### PR DESCRIPTION
Summary:
After much thought I have arrived at an algorithm which should be able to convert a graph typed with "python" tensor types into an equivalent graph typed with Bean Machine Graph "semantic" types, like "probability" and "positive real".

The algorithm is most concisely expressed by describing the BMG type system as a *lattice*; that is a special kind of DAG which allows us to answer questions like "what is the most specific type that is more general than these two types?"

In lattice theory that function -- find the most specific thing more general than two other things -- is called "supremum", and I will need an implementation of it in my upcoming work.  This diff implements that function and a few tests.

Differential Revision: D22105249

