### PR TITLE
Implement constant value classification for BMG type system

### DIFF
--- a/beanmachine/ppl/compiler/bmg_types.py
+++ b/beanmachine/ppl/compiler/bmg_types.py
@@ -1,5 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
+from typing import Any
+
 from torch import Tensor
 
 
@@ -133,7 +135,34 @@ greater than or equal to both."""
 
 # We can extend the two-argument supremum function to any number of arguments:
 def supremum(*ts: type) -> type:
+    """Takes any number of BMG types; returns the smallest type that is
+greater than or equal to all of them."""
     result = bool
     for t in ts:
         result = _supremum(result, t)
     return result
+
+
+def type_of_value(v: Any) -> type:
+    """This computes the smallest BMG type that a given value fits into."""
+    if isinstance(v, Tensor):
+        if v.numel() == 1:
+            return type_of_value(float(v))  # pyre-fixme
+        return Tensor
+    if isinstance(v, bool):
+        return bool
+    if isinstance(v, int):
+        if v == 0 or v == 1:
+            return bool
+        if v >= 2:
+            return Natural
+        return float
+    if isinstance(v, float):
+        if v == int(v):
+            return type_of_value(int(v))
+        if 0.0 <= v:
+            if v <= 1.0:
+                return Probability
+            return PositiveReal
+        return float
+    raise ValueError("Unexpected value passed to type_of_value")

--- a/beanmachine/ppl/compiler/bmg_types_test.py
+++ b/beanmachine/ppl/compiler/bmg_types_test.py
@@ -7,8 +7,9 @@ from beanmachine.ppl.compiler.bmg_types import (
     PositiveReal,
     Probability,
     supremum,
+    type_of_value,
 )
-from torch import Tensor
+from torch import Tensor, tensor
 
 
 class BMGTypesTest(unittest.TestCase):
@@ -20,3 +21,41 @@ class BMGTypesTest(unittest.TestCase):
         self.assertEqual(PositiveReal, supremum(Probability, Natural))
         self.assertEqual(float, supremum(Natural, Probability, float))
         self.assertEqual(Tensor, supremum(float, Tensor, Natural, bool))
+
+    def test_type_of_value(self) -> None:
+        """test_type_of_value"""
+
+        self.assertEqual(bool, type_of_value(True))
+        self.assertEqual(bool, type_of_value(False))
+        self.assertEqual(bool, type_of_value(0))
+        self.assertEqual(bool, type_of_value(1))
+        self.assertEqual(bool, type_of_value(0.0))
+        self.assertEqual(bool, type_of_value(1.0))
+        self.assertEqual(bool, type_of_value(tensor(True)))
+        self.assertEqual(bool, type_of_value(tensor(False)))
+        self.assertEqual(bool, type_of_value(tensor(0)))
+        self.assertEqual(bool, type_of_value(tensor(1)))
+        self.assertEqual(bool, type_of_value(tensor(0.0)))
+        self.assertEqual(bool, type_of_value(tensor(1.0)))
+        self.assertEqual(bool, type_of_value(tensor([[True]])))
+        self.assertEqual(bool, type_of_value(tensor([[False]])))
+        self.assertEqual(bool, type_of_value(tensor([[0]])))
+        self.assertEqual(bool, type_of_value(tensor([[1]])))
+        self.assertEqual(bool, type_of_value(tensor([[0.0]])))
+        self.assertEqual(bool, type_of_value(tensor([[1.0]])))
+        self.assertEqual(Natural, type_of_value(2))
+        self.assertEqual(Natural, type_of_value(2.0))
+        self.assertEqual(Natural, type_of_value(tensor(2)))
+        self.assertEqual(Natural, type_of_value(tensor(2.0)))
+        self.assertEqual(Natural, type_of_value(tensor([[2]])))
+        self.assertEqual(Natural, type_of_value(tensor([[2.0]])))
+        self.assertEqual(Probability, type_of_value(0.5))
+        self.assertEqual(Probability, type_of_value(tensor(0.5)))
+        self.assertEqual(Probability, type_of_value(tensor([[0.5]])))
+        self.assertEqual(PositiveReal, type_of_value(1.5))
+        self.assertEqual(PositiveReal, type_of_value(tensor(1.5)))
+        self.assertEqual(PositiveReal, type_of_value(tensor([[1.5]])))
+        self.assertEqual(float, type_of_value(-1.5))
+        self.assertEqual(float, type_of_value(tensor(-1.5)))
+        self.assertEqual(float, type_of_value(tensor([[-1.5]])))
+        self.assertEqual(Tensor, type_of_value(tensor([[0, 0]])))


### PR DESCRIPTION
Summary:
To implement my type inferencing engine for converting graphs to BMG typed graphs, one of the tools I need is a function that classifies a value based on the smallest BMG type that can hold it, based on the rules:

* one-element tensors are treated as if they were scalars
* other tensors are Tensor
* 0, 0.0, 1 and 1.0 are treated the same as True and False -- they are treated as bools
* Non-negative integers are Natural
* Reals between 0.0 and 1.0 are Probability
* other positive reals are PositiveReal
* negative reals are reals

Differential Revision: D22107506

