### PR TITLE
Add a to-positive-real node to graph builder

### DIFF
--- a/beanmachine/ppl/compiler/bmg_nodes.py
+++ b/beanmachine/ppl/compiler/bmg_nodes.py
@@ -2072,9 +2072,6 @@ values."""
         return self.operand.support()
 
 
-# TODO: Describe the situations in which we generate this.
-
-
 class ToRealNode(UnaryOperatorNode):
     operator_type = OperatorType.TO_REAL
 
@@ -2104,10 +2101,33 @@ class ToRealNode(UnaryOperatorNode):
         return SetOfTensors(float(o) for o in self.operand.support())
 
 
-# TODO: Add ToPositiveReal
+class ToPositiveRealNode(UnaryOperatorNode):
+    operator_type = OperatorType.TO_POS_REAL
 
+    def __init__(self, operand: BMGNode):
+        UnaryOperatorNode.__init__(self, operand)
 
-# TODO: Describe the situations in which we generate this.
+    @property
+    def node_type(self) -> Any:
+        return PositiveReal
+
+    @property
+    def inf_type(self) -> type:
+        return PositiveReal
+
+    @property
+    def label(self) -> str:
+        return "ToPosReal"
+
+    @property
+    def size(self) -> torch.Size:
+        return torch.Size([])
+
+    def __str__(self) -> str:
+        return "ToPosReal(" + str(self.operand) + ")"
+
+    def support(self) -> Iterator[Any]:
+        return SetOfTensors(float(o) for o in self.operand.support())
 
 
 class ToTensorNode(UnaryOperatorNode):

--- a/beanmachine/ppl/compiler/bmg_nodes_test.py
+++ b/beanmachine/ppl/compiler/bmg_nodes_test.py
@@ -21,6 +21,7 @@ from beanmachine.ppl.compiler.bmg_nodes import (
     SampleNode,
     StudentTNode,
     TensorNode,
+    ToPositiveRealNode,
     ToRealNode,
     ToTensorNode,
 )
@@ -352,6 +353,7 @@ class ASTToolsTest(unittest.TestCase):
         self.assertEqual(ToRealNode(bino).inf_type, float)
         self.assertEqual(ToRealNode(half).inf_type, float)
         self.assertEqual(ToRealNode(norm).inf_type, float)
+        # To Real is illegal on tensors
 
         # To Tensor
         self.assertEqual(ToTensorNode(bern).inf_type, Tensor)
@@ -361,4 +363,9 @@ class ASTToolsTest(unittest.TestCase):
         self.assertEqual(ToTensorNode(norm).inf_type, Tensor)
         self.assertEqual(ToTensorNode(t).inf_type, Tensor)
 
-        # TODO: To Pos Real
+        # To Positive Real
+        self.assertEqual(ToPositiveRealNode(bern).inf_type, PositiveReal)
+        self.assertEqual(ToPositiveRealNode(beta).inf_type, PositiveReal)
+        self.assertEqual(ToPositiveRealNode(bino).inf_type, PositiveReal)
+        self.assertEqual(ToPositiveRealNode(half).inf_type, PositiveReal)
+        # To Positive Real is illegal on reals and tensors


### PR DESCRIPTION
Summary:
The BMG type system does not permit "implicit" conversions. For example, suppose we have a node with output, say "probability" and a different node with an input that requires a positive real -- say, the standard deviation of a normal.  We cannot use the probability node as an input, because a probability is not considered to be a kind of positive real. Rather, we must insert an explicit "to positive real" node.

This implements that node; the infimum type of "to positive real" is always a positive real.

Differential Revision: D22140430

