### PR TITLE
modularize accept and reject code

### DIFF
--- a/beanmachine/ppl/inference/rejection_sampling_infer.py
+++ b/beanmachine/ppl/inference/rejection_sampling_infer.py
@@ -30,6 +30,36 @@ class RejectionSampling(AbstractInference, metaclass=ABCMeta):
         self.max_attempts_per_sample = int(max_attempts_per_sample)
         self.tolerance = torch.tensor(tolerance)
 
+    def _accept_sample(self):
+        for query in self.queries_:
+            # unsqueeze the sampled value tensor, which adds an extra dimension
+            # along which we'll be adding samples generated at each iteration
+            if query not in self.queries_sample:
+                self.queries_sample[query] = (
+                    query.function._wrapper(*query.arguments).unsqueeze(0).clone()
+                )
+            else:
+                self.queries_sample[query] = torch.cat(
+                    [
+                        self.queries_sample[query],
+                        query.function._wrapper(*query.arguments).unsqueeze(0).clone(),
+                    ],
+                    dim=0,
+                )
+        self.num_accepted_samples += 1
+        self.attempts_per_sample = 0
+
+    def _reject_sample(self, node_key):
+        self.attempts_per_sample += 1
+        LOGGER_UPDATES.log(
+            LogLevel.DEBUG_UPDATES.value,
+            f"sample {self.num_accepted_samples}, attempt {self.attempts_per_sample}"
+            + f" failed\n rejected node: {node_key}",
+        )
+        # check if number of attempts per sample exceeds the max allowed, report error and exit
+        if self.attempts_per_sample >= self.max_attempts_per_sample:
+            raise RuntimeError("max_attempts_per_sample exceeded")
+
     def _single_inference_step(self):
         """
         Single inference step of the rejection sampling algorithm which attempts to obtain a sample.
@@ -64,33 +94,10 @@ class RejectionSampling(AbstractInference, metaclass=ABCMeta):
                 self.tolerance,
             )
             if samples_dont_match.any():
-                self.attempts_per_sample += 1
-                LOGGER_UPDATES.log(
-                    LogLevel.DEBUG_UPDATES.value,
-                    f"sample {self.num_accepted_samples}, attempt {self.attempts_per_sample}"
-                    + f" failed\n rejected node: {node_key}",
-                )
-                # check if number of attempts per sample exceeds the max allowed, report error and exit
-                if self.attempts_per_sample >= self.max_attempts_per_sample:
-                    raise RuntimeError("max_attempts_per_sample exceeded")
+                self._reject_sample(node_key)
                 return 0
-        for query in self.queries_:
-            # unsqueeze the sampled value tensor, which adds an extra dimension
-            # along which we'll be adding samples generated at each iteration
-            if query not in self.queries_sample:
-                self.queries_sample[query] = (
-                    query.function._wrapper(*query.arguments).unsqueeze(0).clone()
-                )
-            else:
-                self.queries_sample[query] = torch.cat(
-                    [
-                        self.queries_sample[query],
-                        query.function._wrapper(*query.arguments).unsqueeze(0).clone(),
-                    ],
-                    dim=0,
-                )
-        self.num_accepted_samples += 1
-        self.attempts_per_sample = 0
+
+        self._accept_sample()
         return 1
 
     def _infer(


### PR DESCRIPTION
Summary:
After coding up ABC, it was clear that code that processed the samples after accept or reject did not change. So this code was modularized into thier own methods
`_accept_sample()` and `_reject_sample()`

Differential Revision: D22261674

