### PR TITLE
Add ABC inference to Bean Machine

### DIFF
--- a/beanmachine/ppl/experimental/abc/abc_infer.py
+++ b/beanmachine/ppl/experimental/abc/abc_infer.py
@@ -1,0 +1,96 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import logging
+from abc import ABCMeta
+from typing import Callable, Dict, Union
+
+import torch
+from beanmachine.ppl.inference.rejection_sampling_infer import RejectionSampling
+from beanmachine.ppl.model.statistical_model import StatisticalModel
+from beanmachine.ppl.model.utils import Mode
+
+
+LOGGER_UPDATES = logging.getLogger("beanmachine.debug.updates")
+
+
+class ApproximateBayesianComputation(RejectionSampling, metaclass=ABCMeta):
+    """
+    Inference object for vanilla ABC inference. Other ABC inference types will inherit from this class.
+    For details refer to this paper: https://doi.org/10.1371/journal.pcbi.1002803
+    """
+
+    def __init__(
+        self,
+        distance_function: Union[Dict, Callable] = torch.dist,
+        tolerance: Union[Dict, float] = 0.0,
+        max_attempts_per_sample: int = 10000,
+    ):
+        """
+        :param distance_function: This can be a single Callable method which will be applied to all
+        summay statistics, or a dict which would have the summary statistics as keys and the specific
+        distance functions as values
+        :param tolerance: This can be a single float value which will be applied to all
+        summay statistics, or a dict which would have the summary statistics as keys and the specific
+        tolerances as values
+        :param max_attempts_per_sample: number of attempts to make per sample before inference stops
+        """
+        super().__init__()
+        self.distance_function = distance_function
+        self.tolerance = tolerance
+        self.max_attempts_per_sample = max_attempts_per_sample
+
+    def _single_inference_step(self) -> int:
+        """
+        Single inference step of the vanilla ABC algorithm which attempts to obtain a sample.
+        Samples are generated from the prior of the node to be observed, and their summary statistic is
+        compared with summary statistic of provided observations. If distance is within provided
+        tolerence values, the sample is accepted.
+
+        :returns: 1 if sample is accepted and 0 if sample is rejected (used to update the tqdm iterator)
+        """
+        self.world_ = StatisticalModel.reset()
+        self.world_.set_initialize_from_prior(True)
+        StatisticalModel.set_mode(Mode.INFERENCE)
+        # if a distance function was not passed, instantiate default distance
+
+        for summary_statistic, observed_summary in self.observations_.items():
+            # makes the call for the summary statistic node, which will run sample(node())
+            # that results in adding its corresponding Variable and its dependent
+            # Variable to the world, as well as computing it's value
+            computed_summary = summary_statistic.function._wrapper(
+                *summary_statistic.arguments
+            )
+            # check if passed observation is a tensor, if not, cast it
+            if not torch.is_tensor(observed_summary):
+                observed_summary = torch.tensor(observed_summary)
+            # check if the shapes of computed and provided summary matches
+            if computed_summary.shape != observed_summary.shape:
+                raise ValueError(
+                    f"Shape mismatch in random variable {summary_statistic}"
+                    + "\nshape does not match with observation\n"
+                    + f"Expected observation shape: {computed_summary.shape};"
+                    + f"Provided observation shape{observed_summary.shape}"
+                )
+
+            # if user passed a dict for distance functions, load from it, else load default
+            if isinstance(self.distance_function, dict):
+                # pyre-fixme
+                distance_function = self.distance_function[summary_statistic]
+            else:
+                distance_function = self.distance_function
+            # we allow users to pass either a dict or a single value for tolerance
+            if isinstance(self.tolerance, dict):
+                # pyre-fixme
+                tolerance = self.tolerance[summary_statistic]
+            else:
+                tolerance = self.tolerance
+
+            # perform rejection
+            reject = torch.gt(
+                distance_function(computed_summary.float(), observed_summary.float()),
+                tolerance,
+            )
+            if reject:
+                self._reject_sample(node_key=summary_statistic)
+                return 0
+        self._accept_sample()
+        return 1

--- a/beanmachine/ppl/experimental/tests/abc/abc_infer_test.py
+++ b/beanmachine/ppl/experimental/tests/abc/abc_infer_test.py
@@ -1,0 +1,101 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import unittest
+
+import beanmachine.ppl as bm
+import torch
+import torch.distributions as dist
+from beanmachine.ppl.experimental.abc.abc_infer import ApproximateBayesianComputation
+
+
+class ApproximateBayesianComputationTest(unittest.TestCase):
+    class CoinTossModel:
+        def __init__(self, observation_shape):
+            self.observation_shape = observation_shape
+
+        @bm.random_variable
+        def bias(self):
+            return dist.Beta(0.5, 0.5)
+
+        @bm.random_variable
+        def coin_toss(self):
+            return dist.Bernoulli(self.bias().repeat(self.observation_shape))
+
+        def toss_head_count(self, toss_vals):
+            return torch.sum(toss_vals)
+
+        def toss_mean(self, toss_vals):
+            return torch.mean(toss_vals)
+
+        @bm.functional
+        def num_heads(self):
+            return self.toss_head_count(self.coin_toss())
+
+        @bm.functional
+        def mean_value(self):
+            return self.toss_mean(self.coin_toss())
+
+    def test_abc_inference(self):
+        model = self.CoinTossModel(observation_shape=100)
+        COIN_TOSS_DATA = dist.Bernoulli(0.9).sample([100])
+        abc = ApproximateBayesianComputation(
+            tolerance={model.num_heads(): 10, model.mean_value(): 0.1}
+        )
+        observations = {
+            model.num_heads(): model.toss_head_count(COIN_TOSS_DATA),
+            model.mean_value(): model.toss_mean(COIN_TOSS_DATA),
+        }
+        queries = [model.bias()]
+        samples = abc.infer(
+            queries, observations, num_samples=100, num_chains=1, verbose=None
+        )
+        mean = torch.mean(samples[model.bias()][0])
+        self.assertTrue(mean.item() > 0.75)
+
+    def test_abc_inference_with_singleton_arguments(self):
+        model = self.CoinTossModel(observation_shape=100)
+        COIN_TOSS_DATA = dist.Bernoulli(0.9).sample([100])
+        abc = ApproximateBayesianComputation(
+            distance_function=torch.dist, tolerance=10.0
+        )
+        observations = {
+            model.num_heads(): model.toss_head_count(COIN_TOSS_DATA),
+            model.mean_value(): model.toss_mean(COIN_TOSS_DATA),
+        }
+        queries = [model.bias()]
+        samples = abc.infer(
+            queries, observations, num_samples=100, num_chains=1, verbose=None
+        )
+        mean = torch.mean(samples[model.bias()][0])
+        self.assertTrue(mean.item() > 0.75)
+
+    def test_single_inference_step(self):
+        model = self.CoinTossModel(observation_shape=10)
+        abc = ApproximateBayesianComputation(tolerance={model.num_heads(): 0.1})
+        abc.observations_ = {model.num_heads(): torch.tensor(2)}
+        self.assertEqual(abc._single_inference_step(), 0)
+        abc.reset()
+
+    def test_max_attempts(self):
+        model = self.CoinTossModel(observation_shape=100)
+        COIN_TOSS_DATA = dist.Bernoulli(0.9).sample([100])
+        abc = ApproximateBayesianComputation(
+            tolerance={model.num_heads(): 0.1}, max_attempts_per_sample=2
+        )
+        observations = {model.num_heads(): model.toss_head_count(COIN_TOSS_DATA)}
+        queries = [model.bias()]
+        with self.assertRaises(RuntimeError):
+            abc.infer(
+                queries, observations, num_samples=100, num_chains=1, verbose=None
+            )
+        abc.reset()
+
+    def test_shape_mismatch(self):
+        model = self.CoinTossModel(observation_shape=100)
+        abc = ApproximateBayesianComputation(tolerance={model.num_heads(): 0.1})
+        observations = {model.num_heads(): torch.tensor([3, 4])}
+        queries = [model.bias()]
+        with self.assertRaises(ValueError):
+            abc.infer(
+                queries, observations, num_samples=100, num_chains=1, verbose=None
+            )
+        abc.reset()


### PR DESCRIPTION
Summary:
This diff adds ABC inference to Bean Machine.
Added 4 tests to check.
Notebook showing two examples of ABC: N290426

Differential Revision: D22261752

