### PR TITLE
Add allowed list for safe functions in graph accumulation

### DIFF
--- a/beanmachine/ppl/utils/bm_graph_builder_test.py
+++ b/beanmachine/ppl/utils/bm_graph_builder_test.py
@@ -1575,3 +1575,11 @@ digraph "graph" {
 }
 """
         self.assertEqual(observed.strip(), expected.strip())
+
+    def test_allowed_functions(self) -> None:
+        bmg = BMGraphBuilder()
+        p = bmg.add_constant(0.5)
+        b = bmg.add_bernoulli(p)
+        s = bmg.add_sample(b)
+        d = bmg.handle_function(dict, [[(1, s)]])
+        self.assertEqual(d, {1: s})


### PR DESCRIPTION
Summary:
When accumulating the graph, we look for places where a function call is passed a graph node, so that for instance if we have a call to `exp`, we can intercept the call and rather than making it, generate a graph node.

We produce an error if an unsupported function is called with a graph node, but there are functions which we know are safe; for example, if someone is making a list, dictionary or set containing a graph node.

We now allow these; however, this will then introduce several new problems which have not yet been solved that we will have to consider:

* What if that list or dictionary is then in turn used as a "star argument" to one of our supported functions?
* What if the list or dictionary is passed as an argument to an unsupported function?
* What about predicates on lists like "is this element a member of this list?"

Reviewed By: wtaha

Differential Revision: D22313537

