### PR TITLE
Add inf types and edge requirements to graph debug output

### DIFF
--- a/beanmachine/ppl/compiler/bmg_types.py
+++ b/beanmachine/ppl/compiler/bmg_types.py
@@ -54,6 +54,9 @@ class Malformed:
     pass
 
 
+Real = float
+
+
 """
 When converting from an accumulated graph that uses Python types, we
 can express the rules concisely by defining a *type lattice*. A type
@@ -287,3 +290,46 @@ def meets_requirement(t: type, r: Requirement) -> bool:
     if isinstance(r, UpperBound):
         return _supremum(t, r.bound) == r.bound
     return t == r
+
+
+_type_names = {
+    bool: "bool",
+    Malformed: "malformed",
+    Natural: "natural",
+    PositiveReal: "positive real",
+    Real: "real",
+    Probability: "probability",
+    Tensor: "tensor",
+}
+
+_short_type_names = {
+    bool: "B",
+    Malformed: "M",
+    Natural: "N",
+    PositiveReal: "R+",
+    Real: "R",
+    Probability: "P",
+    Tensor: "T",
+}
+
+
+def name_of_type(t: type) -> str:
+    return _type_names[t]
+
+
+def short_name_of_type(t: type) -> str:
+    return _short_type_names[t]
+
+
+def name_of_requirement(r: Requirement) -> str:
+    if isinstance(r, UpperBound):
+        return "<=" + name_of_requirement(r.bound)
+    assert isinstance(r, type)
+    return name_of_type(r)
+
+
+def short_name_of_requirement(r: Requirement) -> str:
+    if isinstance(r, UpperBound):
+        return "<=" + short_name_of_requirement(r.bound)
+    assert isinstance(r, type)
+    return short_name_of_type(r)


### PR DESCRIPTION
Summary:
The type analyzer I am working on computes two things: first, what is the "infimum type" of every node in the accumulated graph? That is the answer to the question "if we had to convert this node to the smallest possible type in the lattice, what would that type be?"  That is the *greatest lower bound*, or *infimum*, of all types in the lattice, hence then name.

Second, we compute a *requirement* on each edge that is either "the value passed along this edge must be exactly this type" or "must be smaller than this type".

To help visualize this, I've added code to my graph builder to optionally display this information.

The way to read the annotation on a node, say, ">=N" is "this node can be converted to any type that is larger than or equal to Natural". The annotations on edges are "this edge must point **from** something of the stated type" -- that is, it is a requirement of the *pointed to* node.

{F242233215}

I made a few other minor changes along the way:

* Walid suggested a while back that using `float` to mean "real number" is slightly jarring to read. I've added `Real` as a synonym and will gradually modify the code to use it consistently.

* We're going to need in a few diffs a "human readable" string for each type and type requirement; since I was adding the abbreviated name for the graph builder now, I figured I'd add the long name too; it will be used in a few diffs down the road.

* Historically I've drawn graphs using the conventions of abstract syntax trees; the multiplication node has two arrows going out that point to its operands. But this is the opposite of the convention for Bayesian networks, where the inputs to the multiplication point at the multiplication. I've added an option to the graph builder to draw the arrows the "right" way, and will gradually change over the other test cases to use it.

Differential Revision: D22325570

