### PR TITLE
Start using "Real" when referring to BMG type

### DIFF
--- a/beanmachine/ppl/compiler/bmg_nodes.py
+++ b/beanmachine/ppl/compiler/bmg_nodes.py
@@ -15,6 +15,7 @@ from beanmachine.ppl.compiler.bmg_types import (
     Natural,
     PositiveReal,
     Probability,
+    Real,
     Requirement,
     supremum,
     type_of_value,
@@ -567,7 +568,7 @@ we generate a different node in BMG."""
     def requirements(self) -> List[Requirement]:
         # The input to a Bernoulli must be exactly a real number if "logits",
         # and otherwise must be a Probability.
-        return [float if self.is_logits else Probability]
+        return [Real if self.is_logits else Probability]
 
     @property
     def size(self) -> torch.Size:
@@ -759,7 +760,7 @@ we generate a different node in BMG."""
         # The left input to a binomial must be a natural; the right
         # input must be a real number if "logits" and a Probability
         # otherwise.
-        return [Natural, float if self.is_logits else Probability]
+        return [Natural, Real if self.is_logits else Probability]
 
     @property
     def size(self) -> torch.Size:
@@ -1162,13 +1163,13 @@ a given mean and standard deviation."""
 
     @property
     def inf_type(self) -> type:
-        return float
+        return Real
 
     @property
     def requirements(self) -> List[Requirement]:
         # The mean of a normal must be a real; the standard deviation
         # must be a positive real.
-        return [float, PositiveReal]
+        return [Real, PositiveReal]
 
     @property
     def size(self) -> torch.Size:
@@ -1259,11 +1260,11 @@ and the true mean."""
 
     @property
     def inf_type(self) -> type:
-        return float
+        return Real
 
     @property
     def requirements(self) -> List[Requirement]:
-        return [PositiveReal, float, PositiveReal]
+        return [PositiveReal, Real, PositiveReal]
 
     def sample_type(self) -> Any:
         if self.types_fixed:
@@ -1351,7 +1352,7 @@ between 0.0 and 1.0."""
     def inf_type(self) -> type:
         # TODO: We will probably need to be smarter here
         # once this is implemented in BMG.
-        return float
+        return Real
 
     @property
     def requirements(self) -> List[Requirement]:
@@ -1359,7 +1360,7 @@ between 0.0 and 1.0."""
         # BMG; when we do, revisit this code.
         # TODO: If we know that a Uniform is bounded by constants 0.0 and 1.0,
         # we can generate a Flat distribution node for BMG.
-        return [float, float]
+        return [Real, Real]
 
     def sample_type(self) -> Any:
         return self.low.node_type
@@ -1684,7 +1685,7 @@ class DivisionNode(BinaryOperatorNode):
     def inf_type(self) -> type:
         # TODO: We do not support division in BMG yet; when we do, implement
         # this correctly.
-        return float
+        return Real
 
     @property
     def requirements(self) -> List[Requirement]:
@@ -1968,7 +1969,7 @@ class PowerNode(BinaryOperatorNode):
     def inf_type(self) -> type:
         # TODO: We do not yet support power nodes in BMG; when we
         # do, revisit this code.
-        return float
+        return Real
 
     @property
     def requirements(self) -> List[Requirement]:
@@ -2096,7 +2097,7 @@ a model contains calls to Tensor.log or math.log."""
     @property
     def inf_type(self) -> type:
         # TODO: When we support this node in BMG, revisit this code.
-        return supremum(self.operand.inf_type, float)
+        return supremum(self.operand.inf_type, Real)
 
     @property
     def requirements(self) -> List[Requirement]:
@@ -2137,7 +2138,7 @@ class NegateNode(UnaryOperatorNode):
 
     @property
     def inf_type(self) -> type:
-        return supremum(self.operand.inf_type, float)
+        return supremum(self.operand.inf_type, Real)
 
     @property
     def requirements(self) -> List[Requirement]:
@@ -2262,12 +2263,12 @@ class ToRealNode(UnaryOperatorNode):
     @property
     def inf_type(self) -> type:
         # A ToRealNode's output is always real
-        return float
+        return Real
 
     @property
     def requirements(self) -> List[Requirement]:
         # A ToRealNode's input must be real or smaller.
-        return [upper_bound(float)]
+        return [upper_bound(Real)]
 
     @property
     def label(self) -> str:

--- a/beanmachine/ppl/compiler/bmg_nodes_test.py
+++ b/beanmachine/ppl/compiler/bmg_nodes_test.py
@@ -29,6 +29,7 @@ from beanmachine.ppl.compiler.bmg_types import (
     Natural,
     PositiveReal,
     Probability,
+    Real,
     upper_bound,
 )
 from torch import Tensor, tensor
@@ -58,7 +59,7 @@ class ASTToolsTest(unittest.TestCase):
         self.assertEqual(b.inf_type, bool)
         self.assertEqual(prob.inf_type, Probability)
         self.assertEqual(pos.inf_type, PositiveReal)
-        self.assertEqual(real.inf_type, float)
+        self.assertEqual(real.inf_type, Real)
         self.assertEqual(nat.inf_type, Natural)
         self.assertEqual(t.inf_type, Tensor)
 
@@ -84,8 +85,8 @@ class ASTToolsTest(unittest.TestCase):
         self.assertEqual(beta.inf_type, Probability)
         self.assertEqual(bino.inf_type, Natural)
         self.assertEqual(half.inf_type, PositiveReal)
-        self.assertEqual(norm.inf_type, float)
-        self.assertEqual(stut.inf_type, float)
+        self.assertEqual(norm.inf_type, Real)
+        self.assertEqual(stut.inf_type, Real)
 
         # Multiplication
 
@@ -105,72 +106,72 @@ class ASTToolsTest(unittest.TestCase):
         # bool x Probability -> Probability
         # bool x Natural -> PositiveReal
         # bool x PositiveReal -> PositiveReal
-        # bool x float -> float
+        # bool x Real -> Real
         # bool x Tensor -> Tensor
         self.assertEqual(MultiplicationNode(bern, bern).inf_type, Probability)
         self.assertEqual(MultiplicationNode(bern, beta).inf_type, Probability)
         self.assertEqual(MultiplicationNode(bern, bino).inf_type, PositiveReal)
         self.assertEqual(MultiplicationNode(bern, half).inf_type, PositiveReal)
-        self.assertEqual(MultiplicationNode(bern, norm).inf_type, float)
+        self.assertEqual(MultiplicationNode(bern, norm).inf_type, Real)
         self.assertEqual(MultiplicationNode(bern, t).inf_type, Tensor)
 
         # Probability x bool -> Probability
         # Probability x Probability -> Probability
         # Probability x Natural -> PositiveReal
         # Probability x PositiveReal -> PositiveReal
-        # Probability x float -> float
+        # Probability x Real -> Real
         # Probability x Tensor -> Tensor
         self.assertEqual(MultiplicationNode(beta, bern).inf_type, Probability)
         self.assertEqual(MultiplicationNode(beta, beta).inf_type, Probability)
         self.assertEqual(MultiplicationNode(beta, bino).inf_type, PositiveReal)
         self.assertEqual(MultiplicationNode(beta, half).inf_type, PositiveReal)
-        self.assertEqual(MultiplicationNode(beta, norm).inf_type, float)
+        self.assertEqual(MultiplicationNode(beta, norm).inf_type, Real)
         self.assertEqual(MultiplicationNode(beta, t).inf_type, Tensor)
 
         # Natural x bool -> PositiveReal
         # Natural x Probability -> PositiveReal
         # Natural x Natural -> PositiveReal
         # Natural x PositiveReal -> PositiveReal
-        # Natural x float -> float
+        # Natural x Real -> Real
         # Natural x Tensor -> Tensor
         self.assertEqual(MultiplicationNode(bino, bern).inf_type, PositiveReal)
         self.assertEqual(MultiplicationNode(bino, beta).inf_type, PositiveReal)
         self.assertEqual(MultiplicationNode(bino, bino).inf_type, PositiveReal)
         self.assertEqual(MultiplicationNode(bino, half).inf_type, PositiveReal)
-        self.assertEqual(MultiplicationNode(bino, norm).inf_type, float)
+        self.assertEqual(MultiplicationNode(bino, norm).inf_type, Real)
         self.assertEqual(MultiplicationNode(bino, t).inf_type, Tensor)
 
         # PositiveReal x bool -> PositiveReal
         # PositiveReal x Probability -> PositiveReal
         # PositiveReal x Natural -> PositiveReal
         # PositiveReal x PositiveReal -> PositiveReal
-        # PositiveReal x float -> float
+        # PositiveReal x Real -> Real
         # PositiveReal x Tensor -> Tensor
         self.assertEqual(MultiplicationNode(half, bern).inf_type, PositiveReal)
         self.assertEqual(MultiplicationNode(half, beta).inf_type, PositiveReal)
         self.assertEqual(MultiplicationNode(half, bino).inf_type, PositiveReal)
         self.assertEqual(MultiplicationNode(half, half).inf_type, PositiveReal)
-        self.assertEqual(MultiplicationNode(half, norm).inf_type, float)
+        self.assertEqual(MultiplicationNode(half, norm).inf_type, Real)
         self.assertEqual(MultiplicationNode(half, t).inf_type, Tensor)
 
-        # float x bool -> float
-        # float x Probability -> float
-        # float x Natural -> float
-        # float x PositiveReal -> float
-        # float x float -> float
-        # float x Tensor -> Tensor
-        self.assertEqual(MultiplicationNode(norm, bern).inf_type, float)
-        self.assertEqual(MultiplicationNode(norm, beta).inf_type, float)
-        self.assertEqual(MultiplicationNode(norm, bino).inf_type, float)
-        self.assertEqual(MultiplicationNode(norm, half).inf_type, float)
-        self.assertEqual(MultiplicationNode(norm, norm).inf_type, float)
+        # Real x bool -> Real
+        # Real x Probability -> Real
+        # Real x Natural -> Real
+        # Real x PositiveReal -> Real
+        # Real x Real -> Real
+        # Real x Tensor -> Tensor
+        self.assertEqual(MultiplicationNode(norm, bern).inf_type, Real)
+        self.assertEqual(MultiplicationNode(norm, beta).inf_type, Real)
+        self.assertEqual(MultiplicationNode(norm, bino).inf_type, Real)
+        self.assertEqual(MultiplicationNode(norm, half).inf_type, Real)
+        self.assertEqual(MultiplicationNode(norm, norm).inf_type, Real)
         self.assertEqual(MultiplicationNode(norm, t).inf_type, Tensor)
 
         # Tensor x bool -> Tensor
         # Tensor x Probability -> Tensor
         # Tensor x Natural -> Tensor
         # Tensor x PositiveReal -> Tensor
-        # Tensor x float -> Tensor
+        # Tensor x Real -> Tensor
         # Tensor x Tensor -> Tensor
         self.assertEqual(MultiplicationNode(t, bern).inf_type, Tensor)
         self.assertEqual(MultiplicationNode(t, beta).inf_type, Tensor)
@@ -185,72 +186,72 @@ class ASTToolsTest(unittest.TestCase):
         # bool + Probability -> PositiveReal
         # bool + Natural -> PositiveReal
         # bool + PositiveReal -> PositiveReal
-        # bool + float -> float
+        # bool + Real -> Real
         # bool + Tensor -> Tensor
         self.assertEqual(AdditionNode(bern, bern).inf_type, PositiveReal)
         self.assertEqual(AdditionNode(bern, beta).inf_type, PositiveReal)
         self.assertEqual(AdditionNode(bern, bino).inf_type, PositiveReal)
         self.assertEqual(AdditionNode(bern, half).inf_type, PositiveReal)
-        self.assertEqual(AdditionNode(bern, norm).inf_type, float)
+        self.assertEqual(AdditionNode(bern, norm).inf_type, Real)
         self.assertEqual(AdditionNode(bern, t).inf_type, Tensor)
 
         # Probability + bool -> PositiveReal
         # Probability + Probability -> PositiveReal
         # Probability + Natural -> PositiveReal
         # Probability + PositiveReal -> PositiveReal
-        # Probability + float -> float
+        # Probability + Real -> Real
         # Probability + Tensor -> Tensor
         self.assertEqual(AdditionNode(beta, bern).inf_type, PositiveReal)
         self.assertEqual(AdditionNode(beta, beta).inf_type, PositiveReal)
         self.assertEqual(AdditionNode(beta, bino).inf_type, PositiveReal)
         self.assertEqual(AdditionNode(beta, half).inf_type, PositiveReal)
-        self.assertEqual(AdditionNode(beta, norm).inf_type, float)
+        self.assertEqual(AdditionNode(beta, norm).inf_type, Real)
         self.assertEqual(AdditionNode(beta, t).inf_type, Tensor)
 
         # Natural + bool -> PositiveReal
         # Natural + Probability -> PositiveReal
         # Natural + Natural -> PositiveReal
         # Natural + PositiveReal -> PositiveReal
-        # Natural + float -> float
+        # Natural + Real -> Real
         # Natural + Tensor -> Tensor
         self.assertEqual(AdditionNode(bino, bern).inf_type, PositiveReal)
         self.assertEqual(AdditionNode(bino, beta).inf_type, PositiveReal)
         self.assertEqual(AdditionNode(bino, bino).inf_type, PositiveReal)
         self.assertEqual(AdditionNode(bino, half).inf_type, PositiveReal)
-        self.assertEqual(AdditionNode(bino, norm).inf_type, float)
+        self.assertEqual(AdditionNode(bino, norm).inf_type, Real)
         self.assertEqual(AdditionNode(bino, t).inf_type, Tensor)
 
         # PositiveReal + bool -> PositiveReal
         # PositiveReal + Probability -> PositiveReal
         # PositiveReal + Natural -> PositiveReal
         # PositiveReal + PositiveReal -> PositiveReal
-        # PositiveReal + float -> float
+        # PositiveReal + Real -> Real
         # PositiveReal + Tensor -> Tensor
         self.assertEqual(AdditionNode(half, bern).inf_type, PositiveReal)
         self.assertEqual(AdditionNode(half, beta).inf_type, PositiveReal)
         self.assertEqual(AdditionNode(half, bino).inf_type, PositiveReal)
         self.assertEqual(AdditionNode(half, half).inf_type, PositiveReal)
-        self.assertEqual(AdditionNode(half, norm).inf_type, float)
+        self.assertEqual(AdditionNode(half, norm).inf_type, Real)
         self.assertEqual(AdditionNode(half, t).inf_type, Tensor)
 
-        # float + bool -> float
-        # float + Probability -> float
-        # float + Natural -> float
-        # float + PositiveReal -> float
-        # float + float -> float
-        # float + Tensor -> Tensor
-        self.assertEqual(AdditionNode(norm, bern).inf_type, float)
-        self.assertEqual(AdditionNode(norm, beta).inf_type, float)
-        self.assertEqual(AdditionNode(norm, bino).inf_type, float)
-        self.assertEqual(AdditionNode(norm, half).inf_type, float)
-        self.assertEqual(AdditionNode(norm, norm).inf_type, float)
+        # Real + bool -> Real
+        # Real + Probability -> Real
+        # Real + Natural -> Real
+        # Real + PositiveReal -> Real
+        # Real + Real -> Real
+        # Real + Tensor -> Tensor
+        self.assertEqual(AdditionNode(norm, bern).inf_type, Real)
+        self.assertEqual(AdditionNode(norm, beta).inf_type, Real)
+        self.assertEqual(AdditionNode(norm, bino).inf_type, Real)
+        self.assertEqual(AdditionNode(norm, half).inf_type, Real)
+        self.assertEqual(AdditionNode(norm, norm).inf_type, Real)
         self.assertEqual(AdditionNode(norm, t).inf_type, Tensor)
 
         # Tensor + bool -> Tensor
         # Tensor + Probability -> Tensor
         # Tensor + Natural -> Tensor
         # Tensor + PositiveReal -> Tensor
-        # Tensor + float -> Tensor
+        # Tensor + Real -> Tensor
         # Tensor + Tensor -> Tensor
         self.assertEqual(AdditionNode(t, bern).inf_type, Tensor)
         self.assertEqual(AdditionNode(t, beta).inf_type, Tensor)
@@ -265,72 +266,72 @@ class ASTToolsTest(unittest.TestCase):
         # bool : Probability -> Probability
         # bool : Natural -> Natural
         # bool : PositiveReal -> PositiveReal
-        # bool : float -> float
+        # bool : Real -> Real
         # bool : Tensor -> Tensor
         self.assertEqual(IfThenElseNode(bern, bern, bern).inf_type, bool)
         self.assertEqual(IfThenElseNode(bern, bern, beta).inf_type, Probability)
         self.assertEqual(IfThenElseNode(bern, bern, bino).inf_type, Natural)
         self.assertEqual(IfThenElseNode(bern, bern, half).inf_type, PositiveReal)
-        self.assertEqual(IfThenElseNode(bern, bern, norm).inf_type, float)
+        self.assertEqual(IfThenElseNode(bern, bern, norm).inf_type, Real)
         self.assertEqual(IfThenElseNode(bern, bern, t).inf_type, Tensor)
 
         # Probability : bool -> Probability
         # Probability : Probability -> Probability
         # Probability : Natural -> PositiveReal
         # Probability : PositiveReal -> PositiveReal
-        # Probability : float -> float
+        # Probability : Real -> Real
         # Probability : Tensor -> Tensor
         self.assertEqual(IfThenElseNode(bern, beta, bern).inf_type, Probability)
         self.assertEqual(IfThenElseNode(bern, beta, beta).inf_type, Probability)
         self.assertEqual(IfThenElseNode(bern, beta, bino).inf_type, PositiveReal)
         self.assertEqual(IfThenElseNode(bern, beta, half).inf_type, PositiveReal)
-        self.assertEqual(IfThenElseNode(bern, beta, norm).inf_type, float)
+        self.assertEqual(IfThenElseNode(bern, beta, norm).inf_type, Real)
         self.assertEqual(IfThenElseNode(bern, beta, t).inf_type, Tensor)
 
         # Natural : bool -> Natural
         # Natural : Probability -> PositiveReal
         # Natural : Natural -> Natural
         # Natural : PositiveReal -> PositiveReal
-        # Natural : float -> float
+        # Natural : Real -> Real
         # Natural : Tensor -> Tensor
         self.assertEqual(IfThenElseNode(bern, bino, bern).inf_type, Natural)
         self.assertEqual(IfThenElseNode(bern, bino, beta).inf_type, PositiveReal)
         self.assertEqual(IfThenElseNode(bern, bino, bino).inf_type, Natural)
         self.assertEqual(IfThenElseNode(bern, bino, half).inf_type, PositiveReal)
-        self.assertEqual(IfThenElseNode(bern, bino, norm).inf_type, float)
+        self.assertEqual(IfThenElseNode(bern, bino, norm).inf_type, Real)
         self.assertEqual(IfThenElseNode(bern, bino, t).inf_type, Tensor)
 
         # PositiveReal : bool -> PositiveReal
         # PositiveReal : Probability -> PositiveReal
         # PositiveReal : Natural -> PositiveReal
         # PositiveReal : PositiveReal -> PositiveReal
-        # PositiveReal : float -> float
+        # PositiveReal : Real -> Real
         # PositiveReal : Tensor -> Tensor
         self.assertEqual(IfThenElseNode(bern, half, bern).inf_type, PositiveReal)
         self.assertEqual(IfThenElseNode(bern, half, beta).inf_type, PositiveReal)
         self.assertEqual(IfThenElseNode(bern, half, bino).inf_type, PositiveReal)
         self.assertEqual(IfThenElseNode(bern, half, half).inf_type, PositiveReal)
-        self.assertEqual(IfThenElseNode(bern, half, norm).inf_type, float)
+        self.assertEqual(IfThenElseNode(bern, half, norm).inf_type, Real)
         self.assertEqual(IfThenElseNode(bern, half, t).inf_type, Tensor)
 
-        # float : bool -> float
-        # float : Probability -> float
-        # float : Natural -> float
-        # float : PositiveReal -> float
-        # float : float -> float
-        # float : Tensor -> Tensor
-        self.assertEqual(IfThenElseNode(bern, norm, bern).inf_type, float)
-        self.assertEqual(IfThenElseNode(bern, norm, beta).inf_type, float)
-        self.assertEqual(IfThenElseNode(bern, norm, bino).inf_type, float)
-        self.assertEqual(IfThenElseNode(bern, norm, half).inf_type, float)
-        self.assertEqual(IfThenElseNode(bern, norm, norm).inf_type, float)
+        # Real : bool -> Real
+        # Real : Probability -> Real
+        # Real : Natural -> Real
+        # Real : PositiveReal -> Real
+        # Real : Real -> Real
+        # Real : Tensor -> Tensor
+        self.assertEqual(IfThenElseNode(bern, norm, bern).inf_type, Real)
+        self.assertEqual(IfThenElseNode(bern, norm, beta).inf_type, Real)
+        self.assertEqual(IfThenElseNode(bern, norm, bino).inf_type, Real)
+        self.assertEqual(IfThenElseNode(bern, norm, half).inf_type, Real)
+        self.assertEqual(IfThenElseNode(bern, norm, norm).inf_type, Real)
         self.assertEqual(IfThenElseNode(bern, norm, t).inf_type, Tensor)
 
         # Tensor : bool -> Tensor
         # Tensor : Probability -> Tensor
         # Tensor : Natural -> Tensor
         # Tensor : PositiveReal -> Tensor
-        # Tensor : float -> Tensor
+        # Tensor : Real -> Tensor
         # Tensor : Tensor -> Tensor
         self.assertEqual(IfThenElseNode(bern, t, bern).inf_type, Tensor)
         self.assertEqual(IfThenElseNode(bern, t, beta).inf_type, Tensor)
@@ -340,17 +341,17 @@ class ASTToolsTest(unittest.TestCase):
         self.assertEqual(IfThenElseNode(bern, t, t).inf_type, Tensor)
 
         # Negate
-        # - bool -> float
-        # - Probability -> float
-        # - Natural -> float
-        # - PositiveReal -> float
-        # - float -> float
+        # - bool -> Real
+        # - Probability -> Real
+        # - Natural -> Real
+        # - PositiveReal -> Real
+        # - Real -> Real
         # - Tensor -> Tensor
-        self.assertEqual(NegateNode(bern).inf_type, float)
-        self.assertEqual(NegateNode(beta).inf_type, float)
-        self.assertEqual(NegateNode(bino).inf_type, float)
-        self.assertEqual(NegateNode(half).inf_type, float)
-        self.assertEqual(NegateNode(norm).inf_type, float)
+        self.assertEqual(NegateNode(bern).inf_type, Real)
+        self.assertEqual(NegateNode(beta).inf_type, Real)
+        self.assertEqual(NegateNode(bino).inf_type, Real)
+        self.assertEqual(NegateNode(half).inf_type, Real)
+        self.assertEqual(NegateNode(norm).inf_type, Real)
         self.assertEqual(NegateNode(t).inf_type, Tensor)
 
         # Exp
@@ -358,21 +359,21 @@ class ASTToolsTest(unittest.TestCase):
         # exp Probability -> PositiveReal
         # exp Natural -> PositiveReal
         # exp PositiveReal -> PositiveReal
-        # exp float -> float
+        # exp Real -> Real
         # exp Tensor -> Tensor
         self.assertEqual(ExpNode(bern).inf_type, PositiveReal)
         self.assertEqual(ExpNode(beta).inf_type, PositiveReal)
         self.assertEqual(ExpNode(bino).inf_type, PositiveReal)
         self.assertEqual(ExpNode(half).inf_type, PositiveReal)
-        self.assertEqual(ExpNode(norm).inf_type, float)
+        self.assertEqual(ExpNode(norm).inf_type, Real)
         self.assertEqual(ExpNode(t).inf_type, Tensor)
 
         # To Real
-        self.assertEqual(ToRealNode(bern).inf_type, float)
-        self.assertEqual(ToRealNode(beta).inf_type, float)
-        self.assertEqual(ToRealNode(bino).inf_type, float)
-        self.assertEqual(ToRealNode(half).inf_type, float)
-        self.assertEqual(ToRealNode(norm).inf_type, float)
+        self.assertEqual(ToRealNode(bern).inf_type, Real)
+        self.assertEqual(ToRealNode(beta).inf_type, Real)
+        self.assertEqual(ToRealNode(bino).inf_type, Real)
+        self.assertEqual(ToRealNode(half).inf_type, Real)
+        self.assertEqual(ToRealNode(norm).inf_type, Real)
         # To Real is illegal on tensors
 
         # To Tensor
@@ -427,10 +428,9 @@ class ASTToolsTest(unittest.TestCase):
         self.assertEqual(BetaNode(pos, pos).requirements, [PositiveReal, PositiveReal])
         self.assertEqual(BinomialNode(nat, prob).requirements, [Natural, Probability])
         self.assertEqual(HalfCauchyNode(pos).requirements, [PositiveReal])
-        self.assertEqual(NormalNode(real, pos).requirements, [float, PositiveReal])
+        self.assertEqual(NormalNode(real, pos).requirements, [Real, PositiveReal])
         self.assertEqual(
-            StudentTNode(pos, pos, pos).requirements,
-            [PositiveReal, float, PositiveReal],
+            StudentTNode(pos, pos, pos).requirements, [PositiveReal, Real, PositiveReal]
         )
 
         bern = SampleNode(BernoulliNode(prob))
@@ -457,7 +457,7 @@ class ASTToolsTest(unittest.TestCase):
         # bool x Probability -> Probability
         # bool x Natural -> PositiveReal
         # bool x PositiveReal -> PositiveReal
-        # bool x float -> float
+        # bool x Real -> Real
         # bool x Tensor -> Tensor
         self.assertEqual(
             MultiplicationNode(bern, bern).requirements, [Probability, Probability]
@@ -471,14 +471,14 @@ class ASTToolsTest(unittest.TestCase):
         self.assertEqual(
             MultiplicationNode(bern, half).requirements, [PositiveReal, PositiveReal]
         )
-        self.assertEqual(MultiplicationNode(bern, norm).requirements, [float, float])
+        self.assertEqual(MultiplicationNode(bern, norm).requirements, [Real, Real])
         self.assertEqual(MultiplicationNode(bern, t).requirements, [Tensor, Tensor])
 
         # Probability x bool -> Probability
         # Probability x Probability -> Probability
         # Probability x Natural -> PositiveReal
         # Probability x PositiveReal -> PositiveReal
-        # Probability x float -> float
+        # Probability x Real -> Real
         # Probability x Tensor -> Tensor
         self.assertEqual(
             MultiplicationNode(beta, bern).requirements, [Probability, Probability]
@@ -492,14 +492,14 @@ class ASTToolsTest(unittest.TestCase):
         self.assertEqual(
             MultiplicationNode(beta, half).requirements, [PositiveReal, PositiveReal]
         )
-        self.assertEqual(MultiplicationNode(beta, norm).requirements, [float, float])
+        self.assertEqual(MultiplicationNode(beta, norm).requirements, [Real, Real])
         self.assertEqual(MultiplicationNode(beta, t).requirements, [Tensor, Tensor])
 
         # Natural x bool -> PositiveReal
         # Natural x Probability -> PositiveReal
         # Natural x Natural -> PositiveReal
         # Natural x PositiveReal -> PositiveReal
-        # Natural x float -> float
+        # Natural x Real -> Real
         # Natural x Tensor -> Tensor
         self.assertEqual(
             MultiplicationNode(bino, bern).requirements, [PositiveReal, PositiveReal]
@@ -513,14 +513,14 @@ class ASTToolsTest(unittest.TestCase):
         self.assertEqual(
             MultiplicationNode(bino, half).requirements, [PositiveReal, PositiveReal]
         )
-        self.assertEqual(MultiplicationNode(bino, norm).requirements, [float, float])
+        self.assertEqual(MultiplicationNode(bino, norm).requirements, [Real, Real])
         self.assertEqual(MultiplicationNode(bino, t).requirements, [Tensor, Tensor])
 
         # PositiveReal x bool -> PositiveReal
         # PositiveReal x Probability -> PositiveReal
         # PositiveReal x Natural -> PositiveReal
         # PositiveReal x PositiveReal -> PositiveReal
-        # PositiveReal x float -> float
+        # PositiveReal x Real -> Real
         # PositiveReal x Tensor -> Tensor
         self.assertEqual(
             MultiplicationNode(half, bern).requirements, [PositiveReal, PositiveReal]
@@ -534,27 +534,27 @@ class ASTToolsTest(unittest.TestCase):
         self.assertEqual(
             MultiplicationNode(half, half).requirements, [PositiveReal, PositiveReal]
         )
-        self.assertEqual(MultiplicationNode(half, norm).requirements, [float, float])
+        self.assertEqual(MultiplicationNode(half, norm).requirements, [Real, Real])
         self.assertEqual(MultiplicationNode(half, t).requirements, [Tensor, Tensor])
 
-        # float x bool -> float
-        # float x Probability -> float
-        # float x Natural -> float
-        # float x PositiveReal -> float
-        # float x float -> float
-        # float x Tensor -> Tensor
-        self.assertEqual(MultiplicationNode(norm, bern).requirements, [float, float])
-        self.assertEqual(MultiplicationNode(norm, beta).requirements, [float, float])
-        self.assertEqual(MultiplicationNode(norm, bino).requirements, [float, float])
-        self.assertEqual(MultiplicationNode(norm, half).requirements, [float, float])
-        self.assertEqual(MultiplicationNode(norm, norm).requirements, [float, float])
+        # Real x bool -> Real
+        # Real x Probability -> Real
+        # Real x Natural -> Real
+        # Real x PositiveReal -> Real
+        # Real x Real -> Real
+        # Real x Tensor -> Tensor
+        self.assertEqual(MultiplicationNode(norm, bern).requirements, [Real, Real])
+        self.assertEqual(MultiplicationNode(norm, beta).requirements, [Real, Real])
+        self.assertEqual(MultiplicationNode(norm, bino).requirements, [Real, Real])
+        self.assertEqual(MultiplicationNode(norm, half).requirements, [Real, Real])
+        self.assertEqual(MultiplicationNode(norm, norm).requirements, [Real, Real])
         self.assertEqual(MultiplicationNode(norm, t).requirements, [Tensor, Tensor])
 
         # Tensor x bool -> Tensor
         # Tensor x Probability -> Tensor
         # Tensor x Natural -> Tensor
         # Tensor x PositiveReal -> Tensor
-        # Tensor x float -> Tensor
+        # Tensor x Real -> Tensor
         # Tensor x Tensor -> Tensor
         self.assertEqual(MultiplicationNode(t, bern).requirements, [Tensor, Tensor])
         self.assertEqual(MultiplicationNode(t, beta).requirements, [Tensor, Tensor])
@@ -569,7 +569,7 @@ class ASTToolsTest(unittest.TestCase):
         # bool + Probability -> PositiveReal
         # bool + Natural -> PositiveReal
         # bool + PositiveReal -> PositiveReal
-        # bool + float -> float
+        # bool + Real -> Real
         # bool + Tensor -> Tensor
         self.assertEqual(
             AdditionNode(bern, bern).requirements, [PositiveReal, PositiveReal]
@@ -583,14 +583,14 @@ class ASTToolsTest(unittest.TestCase):
         self.assertEqual(
             AdditionNode(bern, half).requirements, [PositiveReal, PositiveReal]
         )
-        self.assertEqual(AdditionNode(bern, norm).requirements, [float, float])
+        self.assertEqual(AdditionNode(bern, norm).requirements, [Real, Real])
         self.assertEqual(AdditionNode(bern, t).requirements, [Tensor, Tensor])
 
         # Probability + bool -> PositiveReal
         # Probability + Probability -> PositiveReal
         # Probability + Natural -> PositiveReal
         # Probability + PositiveReal -> PositiveReal
-        # Probability + float -> float
+        # Probability + Real -> Real
         # Probability + Tensor -> Tensor
         self.assertEqual(
             AdditionNode(beta, bern).requirements, [PositiveReal, PositiveReal]
@@ -604,14 +604,14 @@ class ASTToolsTest(unittest.TestCase):
         self.assertEqual(
             AdditionNode(beta, half).requirements, [PositiveReal, PositiveReal]
         )
-        self.assertEqual(AdditionNode(beta, norm).requirements, [float, float])
+        self.assertEqual(AdditionNode(beta, norm).requirements, [Real, Real])
         self.assertEqual(AdditionNode(beta, t).requirements, [Tensor, Tensor])
 
         # Natural + bool -> PositiveReal
         # Natural + Probability -> PositiveReal
         # Natural + Natural -> PositiveReal
         # Natural + PositiveReal -> PositiveReal
-        # Natural + float -> float
+        # Natural + Real -> Real
         # Natural + Tensor -> Tensor
         self.assertEqual(
             AdditionNode(bino, bern).requirements, [PositiveReal, PositiveReal]
@@ -625,14 +625,14 @@ class ASTToolsTest(unittest.TestCase):
         self.assertEqual(
             AdditionNode(bino, half).requirements, [PositiveReal, PositiveReal]
         )
-        self.assertEqual(AdditionNode(bino, norm).requirements, [float, float])
+        self.assertEqual(AdditionNode(bino, norm).requirements, [Real, Real])
         self.assertEqual(AdditionNode(bino, t).requirements, [Tensor, Tensor])
 
         # PositiveReal + bool -> PositiveReal
         # PositiveReal + Probability -> PositiveReal
         # PositiveReal + Natural -> PositiveReal
         # PositiveReal + PositiveReal -> PositiveReal
-        # PositiveReal + float -> float
+        # PositiveReal + Real -> Real
         # PositiveReal + Tensor -> Tensor
         self.assertEqual(
             AdditionNode(half, bern).requirements, [PositiveReal, PositiveReal]
@@ -646,27 +646,27 @@ class ASTToolsTest(unittest.TestCase):
         self.assertEqual(
             AdditionNode(half, half).requirements, [PositiveReal, PositiveReal]
         )
-        self.assertEqual(AdditionNode(half, norm).requirements, [float, float])
+        self.assertEqual(AdditionNode(half, norm).requirements, [Real, Real])
         self.assertEqual(AdditionNode(half, t).requirements, [Tensor, Tensor])
 
-        # float + bool -> float
-        # float + Probability -> float
-        # float + Natural -> float
-        # float + PositiveReal -> float
-        # float + float -> float
-        # float + Tensor -> Tensor
-        self.assertEqual(AdditionNode(norm, bern).requirements, [float, float])
-        self.assertEqual(AdditionNode(norm, beta).requirements, [float, float])
-        self.assertEqual(AdditionNode(norm, bino).requirements, [float, float])
-        self.assertEqual(AdditionNode(norm, half).requirements, [float, float])
-        self.assertEqual(AdditionNode(norm, norm).requirements, [float, float])
+        # Real + bool -> Real
+        # Real + Probability -> Real
+        # Real + Natural -> Real
+        # Real + PositiveReal -> Real
+        # Real + Real -> Real
+        # Real + Tensor -> Tensor
+        self.assertEqual(AdditionNode(norm, bern).requirements, [Real, Real])
+        self.assertEqual(AdditionNode(norm, beta).requirements, [Real, Real])
+        self.assertEqual(AdditionNode(norm, bino).requirements, [Real, Real])
+        self.assertEqual(AdditionNode(norm, half).requirements, [Real, Real])
+        self.assertEqual(AdditionNode(norm, norm).requirements, [Real, Real])
         self.assertEqual(AdditionNode(norm, t).requirements, [Tensor, Tensor])
 
         # Tensor + bool -> Tensor
         # Tensor + Probability -> Tensor
         # Tensor + Natural -> Tensor
         # Tensor + PositiveReal -> Tensor
-        # Tensor + float -> Tensor
+        # Tensor + Real -> Tensor
         # Tensor + Tensor -> Tensor
         self.assertEqual(AdditionNode(t, bern).requirements, [Tensor, Tensor])
         self.assertEqual(AdditionNode(t, beta).requirements, [Tensor, Tensor])
@@ -681,7 +681,7 @@ class ASTToolsTest(unittest.TestCase):
         # bool : Probability -> Probability
         # bool : Natural -> Natural
         # bool : PositiveReal -> PositiveReal
-        # bool : float -> float
+        # bool : Real -> Real
         # bool : Tensor -> Tensor
         self.assertEqual(
             IfThenElseNode(bern, bern, bern).requirements, [bool, bool, bool]
@@ -698,7 +698,7 @@ class ASTToolsTest(unittest.TestCase):
             [bool, PositiveReal, PositiveReal],
         )
         self.assertEqual(
-            IfThenElseNode(bern, bern, norm).requirements, [bool, float, float]
+            IfThenElseNode(bern, bern, norm).requirements, [bool, Real, Real]
         )
         self.assertEqual(
             IfThenElseNode(bern, bern, t).requirements, [bool, Tensor, Tensor]
@@ -708,7 +708,7 @@ class ASTToolsTest(unittest.TestCase):
         # Probability : Probability -> Probability
         # Probability : Natural -> PositiveReal
         # Probability : PositiveReal -> PositiveReal
-        # Probability : float -> float
+        # Probability : Real -> Real
         # Probability : Tensor -> Tensor
         self.assertEqual(
             IfThenElseNode(bern, beta, bern).requirements,
@@ -727,7 +727,7 @@ class ASTToolsTest(unittest.TestCase):
             [bool, PositiveReal, PositiveReal],
         )
         self.assertEqual(
-            IfThenElseNode(bern, beta, norm).requirements, [bool, float, float]
+            IfThenElseNode(bern, beta, norm).requirements, [bool, Real, Real]
         )
         self.assertEqual(
             IfThenElseNode(bern, beta, t).requirements, [bool, Tensor, Tensor]
@@ -737,7 +737,7 @@ class ASTToolsTest(unittest.TestCase):
         # Natural : Probability -> PositiveReal
         # Natural : Natural -> Natural
         # Natural : PositiveReal -> PositiveReal
-        # Natural : float -> float
+        # Natural : Real -> Real
         # Natural : Tensor -> Tensor
         self.assertEqual(
             IfThenElseNode(bern, bino, bern).requirements, [bool, Natural, Natural]
@@ -754,7 +754,7 @@ class ASTToolsTest(unittest.TestCase):
             [bool, PositiveReal, PositiveReal],
         )
         self.assertEqual(
-            IfThenElseNode(bern, bino, norm).requirements, [bool, float, float]
+            IfThenElseNode(bern, bino, norm).requirements, [bool, Real, Real]
         )
         self.assertEqual(
             IfThenElseNode(bern, bino, t).requirements, [bool, Tensor, Tensor]
@@ -764,7 +764,7 @@ class ASTToolsTest(unittest.TestCase):
         # PositiveReal : Probability -> PositiveReal
         # PositiveReal : Natural -> PositiveReal
         # PositiveReal : PositiveReal -> PositiveReal
-        # PositiveReal : float -> float
+        # PositiveReal : Real -> Real
         # PositiveReal : Tensor -> Tensor
         self.assertEqual(
             IfThenElseNode(bern, half, bern).requirements,
@@ -783,32 +783,32 @@ class ASTToolsTest(unittest.TestCase):
             [bool, PositiveReal, PositiveReal],
         )
         self.assertEqual(
-            IfThenElseNode(bern, half, norm).requirements, [bool, float, float]
+            IfThenElseNode(bern, half, norm).requirements, [bool, Real, Real]
         )
         self.assertEqual(
             IfThenElseNode(bern, half, t).requirements, [bool, Tensor, Tensor]
         )
 
-        # float : bool -> float
-        # float : Probability -> float
-        # float : Natural -> float
-        # float : PositiveReal -> float
-        # float : float -> float
-        # float : Tensor -> Tensor
+        # Real : bool -> Real
+        # Real : Probability -> Real
+        # Real : Natural -> Real
+        # Real : PositiveReal -> Real
+        # Real : Real -> Real
+        # Real : Tensor -> Tensor
         self.assertEqual(
-            IfThenElseNode(bern, norm, bern).requirements, [bool, float, float]
+            IfThenElseNode(bern, norm, bern).requirements, [bool, Real, Real]
         )
         self.assertEqual(
-            IfThenElseNode(bern, norm, beta).requirements, [bool, float, float]
+            IfThenElseNode(bern, norm, beta).requirements, [bool, Real, Real]
         )
         self.assertEqual(
-            IfThenElseNode(bern, norm, bino).requirements, [bool, float, float]
+            IfThenElseNode(bern, norm, bino).requirements, [bool, Real, Real]
         )
         self.assertEqual(
-            IfThenElseNode(bern, norm, half).requirements, [bool, float, float]
+            IfThenElseNode(bern, norm, half).requirements, [bool, Real, Real]
         )
         self.assertEqual(
-            IfThenElseNode(bern, norm, norm).requirements, [bool, float, float]
+            IfThenElseNode(bern, norm, norm).requirements, [bool, Real, Real]
         )
         self.assertEqual(
             IfThenElseNode(bern, norm, t).requirements, [bool, Tensor, Tensor]
@@ -818,7 +818,7 @@ class ASTToolsTest(unittest.TestCase):
         # Tensor : Probability -> Tensor
         # Tensor : Natural -> Tensor
         # Tensor : PositiveReal -> Tensor
-        # Tensor : float -> Tensor
+        # Tensor : Real -> Tensor
         # Tensor : Tensor -> Tensor
         self.assertEqual(
             IfThenElseNode(bern, t, bern).requirements, [bool, Tensor, Tensor]
@@ -840,17 +840,17 @@ class ASTToolsTest(unittest.TestCase):
         )
 
         # Negate
-        # - bool -> float
-        # - Probability -> float
-        # - Natural -> float
-        # - PositiveReal -> float
-        # - float -> float
+        # - bool -> Real
+        # - Probability -> Real
+        # - Natural -> Real
+        # - PositiveReal -> Real
+        # - Real -> Real
         # - Tensor -> Tensor
-        self.assertEqual(NegateNode(bern).requirements, [float])
-        self.assertEqual(NegateNode(beta).requirements, [float])
-        self.assertEqual(NegateNode(bino).requirements, [float])
-        self.assertEqual(NegateNode(half).requirements, [float])
-        self.assertEqual(NegateNode(norm).requirements, [float])
+        self.assertEqual(NegateNode(bern).requirements, [Real])
+        self.assertEqual(NegateNode(beta).requirements, [Real])
+        self.assertEqual(NegateNode(bino).requirements, [Real])
+        self.assertEqual(NegateNode(half).requirements, [Real])
+        self.assertEqual(NegateNode(norm).requirements, [Real])
         self.assertEqual(NegateNode(t).requirements, [Tensor])
 
         # Exp
@@ -858,21 +858,21 @@ class ASTToolsTest(unittest.TestCase):
         # exp Probability -> PositiveReal
         # exp Natural -> PositiveReal
         # exp PositiveReal -> PositiveReal
-        # exp float -> float
+        # exp Real -> Real
         # exp Tensor -> Tensor
         self.assertEqual(ExpNode(bern).requirements, [PositiveReal])
         self.assertEqual(ExpNode(beta).requirements, [PositiveReal])
         self.assertEqual(ExpNode(bino).requirements, [PositiveReal])
         self.assertEqual(ExpNode(half).requirements, [PositiveReal])
-        self.assertEqual(ExpNode(norm).requirements, [float])
+        self.assertEqual(ExpNode(norm).requirements, [Real])
         self.assertEqual(ExpNode(t).requirements, [Tensor])
 
         # To Real
-        self.assertEqual(ToRealNode(bern).requirements, [upper_bound(float)])
-        self.assertEqual(ToRealNode(beta).requirements, [upper_bound(float)])
-        self.assertEqual(ToRealNode(bino).requirements, [upper_bound(float)])
-        self.assertEqual(ToRealNode(half).requirements, [upper_bound(float)])
-        self.assertEqual(ToRealNode(norm).requirements, [upper_bound(float)])
+        self.assertEqual(ToRealNode(bern).requirements, [upper_bound(Real)])
+        self.assertEqual(ToRealNode(beta).requirements, [upper_bound(Real)])
+        self.assertEqual(ToRealNode(bino).requirements, [upper_bound(Real)])
+        self.assertEqual(ToRealNode(half).requirements, [upper_bound(Real)])
+        self.assertEqual(ToRealNode(norm).requirements, [upper_bound(Real)])
         # To Real is illegal on tensors
 
         # To Tensor

--- a/beanmachine/ppl/compiler/bmg_types.py
+++ b/beanmachine/ppl/compiler/bmg_types.py
@@ -18,7 +18,7 @@ types in the BMG type system are:
 Unknown       -- we largely do not need to worry about this one,
                  and it is more "undefined" than "unknown"
 Boolean       -- we can just use bool
-Real          -- we can just use float
+Real          -- we can just use float, but we'll make an alias Real
 Tensor        -- we can just use Tensor
 Probability   -- a real between 0.0 and 1.0
 Positive Real -- what it says on the tin
@@ -170,37 +170,37 @@ _lookup = {
     (bool, Natural): Natural,
     (bool, Probability): Probability,
     (bool, PositiveReal): PositiveReal,
-    (bool, float): float,
+    (bool, Real): Real,
     (bool, Tensor): Tensor,
     (Natural, bool): Natural,
     (Natural, Natural): Natural,
     (Natural, Probability): PositiveReal,
     (Natural, PositiveReal): PositiveReal,
-    (Natural, float): float,
+    (Natural, Real): Real,
     (Natural, Tensor): Tensor,
     (Probability, bool): Probability,
     (Probability, Natural): PositiveReal,
     (Probability, Probability): Probability,
     (Probability, PositiveReal): PositiveReal,
-    (Probability, float): float,
+    (Probability, Real): Real,
     (Probability, Tensor): Tensor,
     (PositiveReal, bool): PositiveReal,
     (PositiveReal, Natural): PositiveReal,
     (PositiveReal, Probability): PositiveReal,
     (PositiveReal, PositiveReal): PositiveReal,
-    (PositiveReal, float): float,
+    (PositiveReal, Real): Real,
     (PositiveReal, Tensor): Tensor,
-    (float, bool): float,
-    (float, Natural): float,
-    (float, Probability): float,
-    (float, PositiveReal): float,
-    (float, float): float,
-    (float, Tensor): Tensor,
+    (Real, bool): Real,
+    (Real, Natural): Real,
+    (Real, Probability): Real,
+    (Real, PositiveReal): Real,
+    (Real, Real): Real,
+    (Real, Tensor): Tensor,
     (Tensor, bool): Tensor,
     (Tensor, Natural): Tensor,
     (Tensor, Probability): Tensor,
     (Tensor, PositiveReal): Tensor,
-    (Tensor, float): Tensor,
+    (Tensor, Real): Tensor,
     (Tensor, Tensor): Tensor,
 }
 
@@ -236,7 +236,7 @@ def type_of_value(v: Any) -> type:
             return bool
         if v >= 2:
             return Natural
-        return float
+        return Real
     if isinstance(v, float):
         if v == int(v):
             return type_of_value(int(v))
@@ -244,7 +244,7 @@ def type_of_value(v: Any) -> type:
             if v <= 1.0:
                 return Probability
             return PositiveReal
-        return float
+        return Real
     raise ValueError("Unexpected value passed to type_of_value")
 
 

--- a/beanmachine/ppl/compiler/bmg_types_test.py
+++ b/beanmachine/ppl/compiler/bmg_types_test.py
@@ -6,6 +6,7 @@ from beanmachine.ppl.compiler.bmg_types import (
     Natural,
     PositiveReal,
     Probability,
+    Real,
     meets_requirement,
     supremum,
     type_of_value,
@@ -22,8 +23,8 @@ class BMGTypesTest(unittest.TestCase):
         self.assertEqual(bool, supremum())
         self.assertEqual(Probability, supremum(Probability))
         self.assertEqual(PositiveReal, supremum(Probability, Natural))
-        self.assertEqual(float, supremum(Natural, Probability, float))
-        self.assertEqual(Tensor, supremum(float, Tensor, Natural, bool))
+        self.assertEqual(Real, supremum(Natural, Probability, Real))
+        self.assertEqual(Tensor, supremum(Real, Tensor, Natural, bool))
 
     def test_type_of_value(self) -> None:
         """test_type_of_value"""
@@ -58,9 +59,9 @@ class BMGTypesTest(unittest.TestCase):
         self.assertEqual(PositiveReal, type_of_value(1.5))
         self.assertEqual(PositiveReal, type_of_value(tensor(1.5)))
         self.assertEqual(PositiveReal, type_of_value(tensor([[1.5]])))
-        self.assertEqual(float, type_of_value(-1.5))
-        self.assertEqual(float, type_of_value(tensor(-1.5)))
-        self.assertEqual(float, type_of_value(tensor([[-1.5]])))
+        self.assertEqual(Real, type_of_value(-1.5))
+        self.assertEqual(Real, type_of_value(tensor(-1.5)))
+        self.assertEqual(Real, type_of_value(tensor([[-1.5]])))
         self.assertEqual(Tensor, type_of_value(tensor([[0, 0]])))
 
     def test_meets_requirement(self) -> None:


### PR DESCRIPTION
Summary:
We need objects to represent the types of the BMG type system (bool, natural, probability, positive real, real, tensor). I've been using "float" to represent "real" but it reads poorly. I've made an alias `Real` and started using that anywhere in the code where I am referring specifically to the BMG type, not the Python type.

Thanks to Walid for the suggestion.

Reviewed By: wtaha

Differential Revision: D22341483

