### PR TITLE
add maintain_graph and cache_functional to world

### DIFF
--- a/beanmachine/ppl/experimental/abc/abc_infer.py
+++ b/beanmachine/ppl/experimental/abc/abc_infer.py
@@ -49,6 +49,8 @@ class ApproximateBayesianComputation(RejectionSampling, metaclass=ABCMeta):
         """
         self.world_ = StatisticalModel.reset()
         self.world_.set_initialize_from_prior(True)
+        self.world_.set_maintain_graph(False)
+        self.world_.set_cache_functionals(True)
         StatisticalModel.set_mode(Mode.INFERENCE)
         # if a distance function was not passed, instantiate default distance
 

--- a/beanmachine/ppl/inference/rejection_sampling_infer.py
+++ b/beanmachine/ppl/inference/rejection_sampling_infer.py
@@ -82,6 +82,8 @@ class RejectionSampling(AbstractInference, metaclass=ABCMeta):
         """
         self.world_ = StatisticalModel.reset()
         self.world_.set_initialize_from_prior(True)
+        self.world_.set_maintain_graph(False)
+        self.world_.set_cache_functionals(True)
         StatisticalModel.set_mode(Mode.INFERENCE)
         for node_key, node_observation in self.observations_.items():
             temp_sample = node_key.function._wrapper(*node_key.arguments)

--- a/beanmachine/ppl/model/statistical_model.py
+++ b/beanmachine/ppl/model/statistical_model.py
@@ -122,7 +122,9 @@ class StatisticalModel(object):
         def wrapper(*args):
             if StatisticalModel.__mode_ == Mode.INITIALIZE:
                 return StatisticalModel.get_func_key(f, args)
-
+            world = StatisticalModel.__world_
+            if world.get_cache_functionals():
+                return world.update_cached_functionals(f, *args)
             return f(*args)
 
         f._wrapper = wrapper


### PR DESCRIPTION
Summary:
This diff adds to mutually exclusive flags to `world.py`:
- `maintain_graph` : True by default, this lets the world know that the inference method required log probs and Markov blanket based data from the world. If set to False, the world will not compute these values which gives a performance gain for inference methods that do not require the data
- `cache_functionals`: False by default, this lets `StatisticalModel` to cache the functionals computed during INFERNCE mode. In time series models, it is often useful to cache functionals computed at each time step to avoid wasteful repetition in computation, but it could present difficulties in single site MCMC methods as a functional could be evaluated to different values. Hence to use this feature, `maintain_graph` has to be set to False

along with `world.py`, `variable.py`, `statistical_model.py` have been updated to support this functionality

the inference methods that benefit from the non-default state have been so updated and their tests now explicitly test the new changes to code.

Differential Revision: D22438948

