### PR TITLE
Enable new "fix problems" tool in end-to-end building of graph

### DIFF
--- a/beanmachine/ppl/utils/bm_graph_builder.py
+++ b/beanmachine/ppl/utils/bm_graph_builder.py
@@ -1070,9 +1070,11 @@ they were created."""
     def to_bmg(self) -> Graph:
         """This transforms the accumulated graph into a BMG type system compliant
 graph and then creates the graph nodes in memory."""
+        from beanmachine.ppl.compiler.fix_problems import fix_problems
+
+        fix_problems(self).raise_errors()
         g = Graph()
         d: Dict[BMGNode, int] = {}
-        self._fix_types()
         for node in self._traverse_from_roots():
             d[node] = node._add_to_graph(g, d)
         return g
@@ -1088,8 +1090,10 @@ it returns a dictionary mapping nodes to integers."""
     def to_python(self) -> str:
         """This transforms the accumulatled graph into a BMG type system compliant
 graph and then creates a Python program which creates the graph."""
+        from beanmachine.ppl.compiler.fix_problems import fix_problems
 
-        self._fix_types()
+        fix_problems(self).raise_errors()
+
         header = """from beanmachine import graph
 from torch import tensor
 g = graph.Graph()
@@ -1100,7 +1104,10 @@ g = graph.Graph()
     def to_cpp(self) -> str:
         """This transforms the accumulatled graph into a BMG type system compliant
 graph and then creates a C++ program which creates the graph."""
-        self._fix_types()
+
+        from beanmachine.ppl.compiler.fix_problems import fix_problems
+
+        fix_problems(self).raise_errors()
         sorted_nodes = self._resort_nodes()
         return "graph::Graph g;\n" + "\n".join(
             n._to_cpp(sorted_nodes) for n in sorted_nodes

--- a/beanmachine/ppl/utils/end_to_end_test.py
+++ b/beanmachine/ppl/utils/end_to_end_test.py
@@ -244,60 +244,50 @@ uint n1 = g.add_distribution(
   std::vector<uint>({n0}));
 uint n2 = g.add_operator(
   graph::OperatorType::SAMPLE, std::vector<uint>({n1}));
-uint n3 = g.add_constant(1.0);
-uint n4 = g.add_constant(0.0);
-n5 = g.add_operator(
-  graph::OperatorType::IF_THEN_ELSE,
-  std::vector<uint>({n2, n3, n4}));
-uint n6 = g.add_constant_pos_real(1.0);
-uint n7 = g.add_constant_pos_real(0.0);
-n8 = g.add_operator(
-  graph::OperatorType::IF_THEN_ELSE,
-  std::vector<uint>({n2, n6, n7}));
-uint n9 = g.add_distribution(
+uint n3 = g.add_operator(
+  graph::OperatorType::TO_REAL, std::vector<uint>({n2}));
+uint n4 = g.add_operator(
+  graph::OperatorType::TO_POS_REAL, std::vector<uint>({n2}));
+uint n5 = g.add_distribution(
   graph::DistributionType::NORMAL,
   graph::AtomicType::REAL,
-  std::vector<uint>({n5, n8}));
-uint n10 = g.add_operator(
-  graph::OperatorType::SAMPLE, std::vector<uint>({n9}));
-uint n11 = g.add_constant(1);
-uint n12 = g.add_constant(0);
-n13 = g.add_operator(
+  std::vector<uint>({n3, n4}));
+uint n6 = g.add_operator(
+  graph::OperatorType::SAMPLE, std::vector<uint>({n5}));
+uint n7 = g.add_constant(1);
+uint n8 = g.add_constant(0);
+n9 = g.add_operator(
   graph::OperatorType::IF_THEN_ELSE,
-  std::vector<uint>({n2, n11, n12}));
-uint n14 = g.add_constant_probability(1.0);
-uint n15 = g.add_constant_probability(0.0);
-n16 = g.add_operator(
+  std::vector<uint>({n2, n7, n8}));
+uint n10 = g.add_constant_probability(1.0);
+uint n11 = g.add_constant_probability(0.0);
+n12 = g.add_operator(
   graph::OperatorType::IF_THEN_ELSE,
-  std::vector<uint>({n2, n14, n15}));
-uint n17 = g.add_distribution(
+  std::vector<uint>({n2, n10, n11}));
+uint n13 = g.add_distribution(
   graph::DistributionType::BINOMIAL,
   graph::AtomicType::NATURAL,
-  std::vector<uint>({n13, n16}));
-uint n18 = g.add_operator(
-  graph::OperatorType::SAMPLE, std::vector<uint>({n17}));
+  std::vector<uint>({n9, n12}));
+uint n14 = g.add_operator(
+  graph::OperatorType::SAMPLE, std::vector<uint>({n13}));
 """
 
 expected_bmg_2 = """
 Node 0 type 1 parents [ ] children [ 1 ] probability value 0.5
 Node 1 type 2 parents [ 0 ] children [ 2 ] unknown value
-Node 2 type 3 parents [ 1 ] children [ 5 8 13 16 ] boolean value 0
-Node 3 type 1 parents [ ] children [ 5 ] real value 1
-Node 4 type 1 parents [ ] children [ 5 ] real value 0
-Node 5 type 3 parents [ 2 3 4 ] children [ 9 ] real value 0
-Node 6 type 1 parents [ ] children [ 8 ] pos real value 1
-Node 7 type 1 parents [ ] children [ 8 ] pos real value 1e-10
-Node 8 type 3 parents [ 2 6 7 ] children [ 9 ] pos real value 0
-Node 9 type 2 parents [ 5 8 ] children [ 10 ] unknown value
-Node 10 type 3 parents [ 9 ] children [ ] real value 0
-Node 11 type 1 parents [ ] children [ 13 ] natural value 1
-Node 12 type 1 parents [ ] children [ 13 ] natural value 0
-Node 13 type 3 parents [ 2 11 12 ] children [ 17 ] natural value 0
-Node 14 type 1 parents [ ] children [ 16 ] probability value 1
-Node 15 type 1 parents [ ] children [ 16 ] probability value 1e-10
-Node 16 type 3 parents [ 2 14 15 ] children [ 17 ] probability value 0
-Node 17 type 2 parents [ 13 16 ] children [ 18 ] unknown value
-Node 18 type 3 parents [ 17 ] children [ ] natural value 0
+Node 2 type 3 parents [ 1 ] children [ 3 4 9 12 ] boolean value 0
+Node 3 type 3 parents [ 2 ] children [ 5 ] real value 0
+Node 4 type 3 parents [ 2 ] children [ 5 ] pos real value 0
+Node 5 type 2 parents [ 3 4 ] children [ 6 ] unknown value
+Node 6 type 3 parents [ 5 ] children [ ] real value 0
+Node 7 type 1 parents [ ] children [ 9 ] natural value 1
+Node 8 type 1 parents [ ] children [ 9 ] natural value 0
+Node 9 type 3 parents [ 2 7 8 ] children [ 13 ] natural value 0
+Node 10 type 1 parents [ ] children [ 12 ] probability value 1
+Node 11 type 1 parents [ ] children [ 12 ] probability value 1e-10
+Node 12 type 3 parents [ 2 10 11 ] children [ 13 ] probability value 0
+Node 13 type 2 parents [ 9 12 ] children [ 14 ] unknown value
+Node 14 type 3 parents [ 13 ] children [ ] natural value 0
 """
 
 expected_python_2 = """
@@ -310,36 +300,28 @@ n1 = g.add_distribution(
   graph.AtomicType.BOOLEAN,
   [n0])
 n2 = g.add_operator(graph.OperatorType.SAMPLE, [n1])
-n3 = g.add_constant(1.0)
-n4 = g.add_constant(0.0)
-n5 = g.add_operator(
-  graph.OperatorType.IF_THEN_ELSE,
-  [n2, n3, n4])
-n6 = g.add_constant_pos_real(1.0)
-n7 = g.add_constant_pos_real(0.0)
-n8 = g.add_operator(
-  graph.OperatorType.IF_THEN_ELSE,
-  [n2, n6, n7])
-n9 = g.add_distribution(
+n3 = g.add_operator(graph.OperatorType.TO_REAL, [n2])
+n4 = g.add_operator(graph.OperatorType.TO_POS_REAL, [n2])
+n5 = g.add_distribution(
   graph.DistributionType.NORMAL,
   graph.AtomicType.REAL,
-  [n5, n8])
-n10 = g.add_operator(graph.OperatorType.SAMPLE, [n9])
-n11 = g.add_constant(1)
-n12 = g.add_constant(0)
-n13 = g.add_operator(
+  [n3, n4])
+n6 = g.add_operator(graph.OperatorType.SAMPLE, [n5])
+n7 = g.add_constant(1)
+n8 = g.add_constant(0)
+n9 = g.add_operator(
   graph.OperatorType.IF_THEN_ELSE,
-  [n2, n11, n12])
-n14 = g.add_constant_probability(1.0)
-n15 = g.add_constant_probability(0.0)
-n16 = g.add_operator(
+  [n2, n7, n8])
+n10 = g.add_constant_probability(1.0)
+n11 = g.add_constant_probability(0.0)
+n12 = g.add_operator(
   graph.OperatorType.IF_THEN_ELSE,
-  [n2, n14, n15])
-n17 = g.add_distribution(
+  [n2, n10, n11])
+n13 = g.add_distribution(
   graph.DistributionType.BINOMIAL,
   graph.AtomicType.NATURAL,
-  [n13, n16])
-n18 = g.add_operator(graph.OperatorType.SAMPLE, [n17])
+  [n9, n12])
+n14 = g.add_operator(graph.OperatorType.SAMPLE, [n13])
 """
 
 


### PR DESCRIPTION
Summary:
I've put my new "problem fixer" step in place before we attempt to generate a BMG graph. This replaces the previous prototype code for fixing type problems; it will be deleted in the next diff.

The new code does a better job than the old code; as you can see in the updated tests, it generates smaller graphs in some cases.

Right now if a problem is encountered, we throw an exception containing the error report. As we continue to evolve the compiler, this will be replaced with a more principled error reporting mechanism.

Differential Revision: D22416411

