### PR TITLE
Create test case for multiplication of bool by natural

### DIFF
--- a/beanmachine/ppl/compiler/fix_problems_test.py
+++ b/beanmachine/ppl/compiler/fix_problems_test.py
@@ -227,3 +227,30 @@ The probability of a Binomial is required to be a probability but is a positive 
 The sigma of a Normal is required to be a positive real but is a real.
         """
         self.assertEqual(observed.strip(), expected.strip())
+
+    def test_fix_problems_4(self) -> None:
+        """test_fix_problems_4"""
+
+        # This test has some problems that cannot be fixed -- yet.
+        # We will add a rule to the type system that allows
+        # bool * bool and bool * natural to work by turning them
+        # into if-then-else, and we will update this test then.
+
+        self.maxDiff = None
+        bmg = BMGraphBuilder()
+
+        two = bmg.add_natural(2)
+        half = bmg.add_probability(0.5)
+        bern = bmg.add_bernoulli(half)
+        berns = bmg.add_sample(bern)
+        nat = bmg.add_binomial(two, half)
+        nats = bmg.add_sample(nat)
+        mult = bmg.add_multiplication(berns, nats)
+        bino = bmg.add_binomial(mult, half)
+        bmg.add_sample(bino)
+
+        error_report = fix_problems(bmg)
+        observed = str(error_report)
+        expected = """
+The count of a Binomial is required to be a natural but is a positive real."""
+        self.assertEqual(observed.strip(), expected.strip())

--- a/beanmachine/ppl/utils/end_to_end_test.py
+++ b/beanmachine/ppl/utils/end_to_end_test.py
@@ -352,6 +352,33 @@ n13 = g.add_distribution(
 n14 = g.add_operator(graph.OperatorType.SAMPLE, [n13])
 """
 
+# Here is a model which we at present cannot compile because
+# we do not support multiplication of a Boolean by a natural
+# to produce a natural. The test verifies that we do not
+# support it, but rather produce an exception when attempting
+# to compile it. When we do support multiplication of Boolean
+# by natural to produce natural, we will update the test
+# case accordingly.
+
+source_3 = """
+import beanmachine.ppl as bm
+import torch
+from torch import tensor
+from torch.distributions import Bernoulli, Binomial
+
+@bm.random_variable
+def flip():
+  return Bernoulli(0.5)
+
+@bm.random_variable
+def nat():
+  return Binomial(2, 0.5)
+
+@bm.random_variable
+def bin():
+  return Binomial(nat() * flip(), 0.5)
+"""
+
 
 class EndToEndTest(unittest.TestCase):
     def test_to_cpp_1(self) -> None:
@@ -389,3 +416,9 @@ class EndToEndTest(unittest.TestCase):
         self.maxDiff = None
         observed = to_python(source_2)
         self.assertEqual(observed.strip(), expected_python_2.strip())
+
+    def test_to_python_3(self) -> None:
+        """test_to_python_3 from end_to_end_test.py"""
+        self.maxDiff = None
+        with self.assertRaises(ValueError):
+            to_python(source_3)


### PR DESCRIPTION
Summary:
BMG does not permit multiplication of bool by natural to produce a natural; a multiplication must produce a probability, positive real, real or tensor.

However, we can construct models in which bools are multiplied by naturals and used as naturals, and there is a way to compile these models into a BMG that does meet the BMG rules: turn `bool * natural` into `if bool then natural else 0`, which is a legal natural in BMG.

I'm going to add this transformation to my problem fixer pass; when I do, this test case will stop throwing an exception.

Differential Revision: D22424087

