### PR TITLE
BMG type problem fixer now handles multiplication by bool

### DIFF
--- a/beanmachine/ppl/utils/bm_to_bmg.py
+++ b/beanmachine/ppl/utils/bm_to_bmg.py
@@ -393,8 +393,16 @@ def to_cpp(source: str) -> str:
     return to_graph_builder(source).to_cpp()
 
 
-def to_dot(source: str) -> str:
-    return to_graph_builder(source).to_dot()
+def to_dot(
+    source: str,
+    graph_types: bool = False,
+    inf_types: bool = False,
+    edge_requirements: bool = False,
+    point_at_input: bool = False,
+) -> str:
+    return to_graph_builder(source).to_dot(
+        graph_types, inf_types, edge_requirements, point_at_input
+    )
 
 
 def to_bmg(source: str):


### PR DESCRIPTION
Summary:
The BMG multiplication node has requirements:

* left and right inputs must be same type
* input type must be probability, positive real, real or tensor

This means that a multiplication of a natural by a bool requires that we promote the natural and the bool to positive real -- the smallest type that they are both convertible to on that list -- and then do the multiplication in positive reals.

But a natural times a bool can be a natural if we turn the multiplication into an if-then-else that takes the bool and chooses between the natural and natural zero.

Similarly a multiplication of bool by anything else, including another bool, can be realized as an if-then-else.

This diff has several changes to implement this feature.

* Recall that the *graph type* of a node is the type that this node actually would be in BMG, or "Malformed" if the node, as it stands now, would not be legal in BMG.  We now correctly compute the malformed-ness of a multiplication node. It must have its input graph types the same, and they must be probability or larger.

* Recall that the *infimum type* of a node is *the smallest type that we know this node or a semantically equivalent node could output*.  Before this diff the inf type of a multiplication of natural and bool was positive real, but now it can be natural, since we know how to convert the multiplication to an if-then-else; that's a smaller type.

* Recall that every edge in the graph has a *requirement*. When given a multiplication of natural and bool, we used to compute that both edges from the multiplication to the operands had a "positive real" requirement, but now we simply put a bool requirement on the bool and a natural requirement on the natural, guaranteeing that the requirements will be met.

* When the problem fixer sees a malformed multiplication where one of the operands is a bool, it fixes the problem by orphaning the malformed multiplication and replacing it with a well-formed if-then-else.

Let's work an example. Here is a graph where every node is indicated with "name : graph type >= inf type". P is probability, N is natural, B is bool, M is malformed.  Every edge is decorated with the requirement; the requirement is the type that the pointed-from node must have.

Every requirement is met except for the multiplication, because it is malformed. We have a bool and a natural coming in, and we require a natural to come out:

{F243484738}

The problem fixer solves the problem by orphaning the invalid multiplication node; since it is no longer outputting anything, it will be trimmed from the graph in a later pass. The node is replaced by a well-formed if-then-else, and now every requirement is met:

{F243485304}

Differential Revision: D22425659

