### PR TITLE
Bump CircleCI no-output timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,7 @@ commands:
       - run:
           name: "Run unit tests"
           command: pytest -ra --cov=. --cov-report term-missing
+          no_output_timeout: 30m
 
   user_unit_tests:
     description: "Run unit tests when as an ordinary user would"


### PR DESCRIPTION
Summary: Fixes https://app.circleci.com/pipelines/github/facebookincubator/beanmachine/1015/workflows/0d91a1b4-3c13-49fd-a26c-6436d277f8bf/jobs/1586, see https://support.circleci.com/hc/en-us/articles/360007188574-Build-has-hit-timeout-limit

Differential Revision: D22509348

