### PR TITLE
Clean up after IAF tests

### DIFF
--- a/beanmachine/ppl/experimental/neutra/iafflow_model_test.py
+++ b/beanmachine/ppl/experimental/neutra/iafflow_model_test.py
@@ -14,6 +14,9 @@ from torch import nn
 
 
 class IAFTest(unittest.TestCase):
+    def tearDown(self):
+        StatisticalModel.reset()
+
     class SampleModel(object):
         @bm.random_variable
         def foo(self):


### PR DESCRIPTION
Summary:
CircleCI has been broken since https://github.com/facebookincubator/beanmachine/commit/492595133f3630500b616e8d280dca0fee0f2bce#diff-ac422c51cbb9c22842aa5ed9d5b80e57R65 (eg see https://l.workplace.com/l.php?u=https%3A%2F%2Fapp.circleci.com%2Fpipelines%2Fgithub%2Ffacebookincubator%2Fbeanmachine%2F1030%2Fworkflows%2F52eba7a5-3e07-4bc4-9a5c-681685d679bc%2Fjobs%2F1654&h=AT0UNJl40nzUX-r6Sxo-clePuXCY1PwVh-Kns4TkHLGULlIA5BOHpnbTvMVWF-ISbgae8dYd3jKBQVt2Klu-cNjf-AeaUEFumooGL4SNgu5QPqqIvvytL8fihyYD9072_qZGiqt4sWgJ2IS3E_ej0g).

The RC is that `IAFTest` does not reset the `StatisticalModel` global singleton.

Differential Revision: D22510474

