### PR TITLE
Add matrix types to AtomicValue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,9 @@ commands:
       - run:
           name: "Install Boost"
           command: sudo apt-get install libboost-all-dev
+      - run:
+          name: "Install Eigen"
+          command: sudo apt-get install libeigen3-dev
 
   setup_py_install:
     description: "Install beanmachine as an ordinary user would via setup.py install"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Bean Machine is a probabilistic programming language for inference over statisti
     git clone https://github.com/facebookincubator/BeanMachine.git
     cd BeanMachine
     apt-get install libboost-all-dev
+    apt-get install libeigen3-dev
     pip install numpy torch
     python setup.py install
 

--- a/beanmachine/graph/distribution/tabular.cpp
+++ b/beanmachine/graph/distribution/tabular.cpp
@@ -97,7 +97,7 @@ double Tabular::log_prob(const graph::AtomicValue& value) const {
     throw std::runtime_error(
         "expecting boolean value in child of Tabular node_id " +
         std::to_string(index) + " got type " +
-        std::to_string(static_cast<int>(value.type)));
+        value.type.to_string());
   }
   return value._bool ? std::log(prob_true) : std::log(1 - prob_true);
 }

--- a/beanmachine/graph/operator/binaryop.cpp
+++ b/beanmachine/graph/operator/binaryop.cpp
@@ -27,7 +27,7 @@ void multiply(graph::Node* node) {
     }
   } else {
     throw std::runtime_error(
-        "invalid type " + std::to_string(static_cast<int>(parent0.type)) +
+        "invalid type " + parent0.type.to_string() +
         " for MULTIPLY operator at node_id " + std::to_string(node->index));
   }
 }
@@ -52,7 +52,7 @@ void add(graph::Node* node) {
     }
   } else {
     throw std::runtime_error(
-        "invalid type " + std::to_string(static_cast<int>(parent0.type)) +
+        "invalid type " + parent0.type.to_string() +
         " for ADD operator at node_id " + std::to_string(node->index));
   }
 }
@@ -76,7 +76,7 @@ void logsumexp(graph::Node* node) {
     node->value._double = std::log(expsum) + max_val;
   } else {
     throw std::runtime_error(
-        "invalid type " + std::to_string(static_cast<int>(parent0.type)) +
+        "invalid type " + parent0.type.to_string() +
         " for LOGSUMEXP operator at node_id " + std::to_string(node->index));
   }
 }

--- a/beanmachine/graph/operator/operator.cpp
+++ b/beanmachine/graph/operator/operator.cpp
@@ -38,7 +38,7 @@ static void check_multiary_op(
         std::to_string(static_cast<int>(op_type)));
   }
   // all parent nodes should have the same value type
-  graph::AtomicType type0 = in_nodes[0]->value.type;
+  graph::AtomicType type0 = in_nodes[0]->value.type.atomic_type;
   for (const graph::Node* node : in_nodes) {
     if (node->value.type != type0) {
       throw std::invalid_argument(
@@ -57,7 +57,7 @@ Operator::Operator(
   if (in_nodes.size() < 1) {
     throw std::invalid_argument("operator requires a parent");
   }
-  graph::AtomicType type0 = in_nodes[0]->value.type;
+  graph::AtomicType type0 = in_nodes[0]->value.type.atomic_type;
   // now perform operator-specific checks and set the value type
   switch (op_type) {
     case graph::OperatorType::SAMPLE: {
@@ -191,7 +191,7 @@ Operator::Operator(
         throw std::invalid_argument(
             "operator IF_THEN_ELSE requires 3 args and arg2.type == arg3.type");
       }
-      value = graph::AtomicValue(in_nodes[1]->value.type);
+      value = graph::AtomicValue(in_nodes[1]->value.type.atomic_type);
       break;
     }
     default: {

--- a/beanmachine/graph/operator/unaryop.cpp
+++ b/beanmachine/graph/operator/unaryop.cpp
@@ -16,7 +16,7 @@ void complement(graph::Node* node) {
     node->value._double = 1 - parent._double;
   } else {
     throw std::runtime_error(
-        "invalid parent type " + std::to_string(static_cast<int>(parent.type)) +
+        "invalid parent type " + parent.type.to_string() +
         " for COMPLEMENT operator at node_id " + std::to_string(node->index));
   }
 }
@@ -35,7 +35,7 @@ void to_real(graph::Node* node) {
     node->value._double = (double)parent._natural;
   } else {
     throw std::runtime_error(
-        "invalid parent type " + std::to_string(static_cast<int>(parent.type)) +
+        "invalid parent type " + parent.type.to_string() +
         " for TO_REAL operator at node_id " + std::to_string(node->index));
   }
 }
@@ -53,7 +53,7 @@ void to_pos_real(graph::Node* node) {
     node->value._double = (double)parent._natural;
   } else {
     throw std::runtime_error(
-        "invalid parent type " + std::to_string(static_cast<int>(parent.type)) +
+        "invalid parent type " + parent.type.to_string() +
         " for TO_POS_REAL operator at node_id " + std::to_string(node->index));
   }
 }
@@ -77,7 +77,7 @@ void to_tensor(graph::Node* node) {
     node->value._tensor = parent._tensor.toType(torch::kDouble);
   } else {
     throw std::runtime_error(
-        "invalid parent type " + std::to_string(static_cast<int>(parent.type)) +
+        "invalid parent type " + parent.type.to_string() +
         " for TO_TENSOR operator at node_id " + std::to_string(node->index));
   }
 }
@@ -91,7 +91,7 @@ void negate(graph::Node* node) {
     node->value._tensor = parent._tensor.neg();
   } else {
     throw std::runtime_error(
-        "invalid parent type " + std::to_string(static_cast<int>(parent.type)) +
+        "invalid parent type " + parent.type.to_string() +
         " for NEGATE operator at node_id " + std::to_string(node->index));
   }
 }
@@ -106,7 +106,7 @@ void exp(graph::Node* node) {
     node->value._tensor = parent._tensor.exp();
   } else {
     throw std::runtime_error(
-        "invalid parent type " + std::to_string(static_cast<int>(parent.type)) +
+        "invalid parent type " + parent.type.to_string() +
         " for EXP operator at node_id " + std::to_string(node->index));
   }
 }
@@ -121,7 +121,7 @@ void expm1(graph::Node* node) {
     node->value._tensor = parent._tensor.expm1();
   } else {
     throw std::runtime_error(
-        "invalid parent type " + std::to_string(static_cast<int>(parent.type)) +
+        "invalid parent type " + parent.type.to_string() +
         " for EXPM1 operator at node_id " + std::to_string(node->index));
   }
 }
@@ -158,7 +158,7 @@ void log1pexp(graph::Node* node) {
     node->value._tensor = parent._tensor.exp().log1p();
   } else {
     throw std::runtime_error(
-        "invalid parent type " + std::to_string(static_cast<int>(parent.type)) +
+        "invalid parent type " + parent.type.to_string() +
         " for LOG1PEXP operator at node_id " + std::to_string(node->index));
   }
 }

--- a/beanmachine/graph/operator_test.py
+++ b/beanmachine/graph/operator_test.py
@@ -4,6 +4,7 @@ import math
 import unittest
 
 import beanmachine.graph as bmg
+import numpy as np
 
 
 class TestOperators(unittest.TestCase):
@@ -19,6 +20,20 @@ class TestOperators(unittest.TestCase):
         c5 = g.add_constant_probability(0.7)
         c6 = g.add_constant(23)  # NATURAL
         c7 = g.add_constant(False)
+        # add const matrices, operators on matrix to be added
+        g.add_constant_matrix(np.array([[-0.1, 0.0], [2.0, -1.0]]))
+        g.add_constant_pos_matrix(np.array([[0.1, 0.0], [2.0, 1.0]]))
+        g.add_constant_probability_matrix(np.array([0.1, 0.9]))
+        g.add_constant_row_simplex_matrix(np.array([[0.1, 0.9], [1.0, 0.0]]))
+        with self.assertRaises(ValueError):
+            g.add_constant_pos_matrix(np.array([[0.1, 0.0], [2.0, -1.0]]))
+        with self.assertRaises(ValueError):
+            g.add_constant_row_simplex_matrix(np.array([[0.1, 0.0], [2.0, 1.0]]))
+        with self.assertRaises(ValueError):
+            # np.array([0.1, 0.9]) is by default a colum vector
+            g.add_constant_row_simplex_matrix(np.array([0.1, 0.9]))
+        with self.assertRaises(ValueError):
+            g.add_constant_probability_matrix(np.array([1.1, 0.9]))
         # test TO_REAL
         with self.assertRaises(ValueError):
             g.add_operator(bmg.OperatorType.TO_REAL, [])

--- a/beanmachine/graph/proposer/proposer.h
+++ b/beanmachine/graph/proposer/proposer.h
@@ -42,7 +42,7 @@ Returns a value for the specified type uniformly at random.
 */
 graph::AtomicValue uniform_initializer(
     std::mt19937& gen,
-    graph::AtomicType type);
+    graph::ValueType type);
 
 } // namespace proposer
 } // namespace beanmachine

--- a/beanmachine/graph/proposer/uniform_initializer.cpp
+++ b/beanmachine/graph/proposer/uniform_initializer.cpp
@@ -7,7 +7,7 @@ namespace proposer {
 
 graph::AtomicValue uniform_initializer(
     std::mt19937& gen,
-    graph::AtomicType type) {
+    graph::ValueType type) {
   // The initialization rules here are based on Stan's default initialization
   // except for discrete variables which are sampled uniformly.
   // Note: Stan doesn't support discrete variables.

--- a/beanmachine/ppl/compiler/end_to_end_test.py
+++ b/beanmachine/ppl/compiler/end_to_end_test.py
@@ -156,35 +156,35 @@ uint n28 = g.add_operator(
 """
 
 expected_bmg_1 = """
-Node 0 type 1 parents [ ] children [ 1 22 ] probability value 0.5
-Node 1 type 2 parents [ 0 ] children [ 2 ] unknown value
-Node 2 type 3 parents [ 1 ] children [ ] boolean value 0
-Node 3 type 1 parents [ ] children [ 4 ] probability value 0.119203
-Node 4 type 2 parents [ 3 ] children [ 5 ] unknown value
-Node 5 type 3 parents [ 4 ] children [ ] boolean value 0
-Node 6 type 1 parents [ ] children [ 8 ] real value 0
-Node 7 type 1 parents [ ] children [ 8 12 12 14 25 ] pos real value 1
-Node 8 type 2 parents [ 6 7 ] children [ 9 ] unknown value
-Node 9 type 3 parents [ 8 ] children [ 10 19 ] real value 0
-Node 10 type 2 parents [ 9 ] children [ 11 ] unknown value
-Node 11 type 3 parents [ 10 ] children [ ] boolean value 0
-Node 12 type 2 parents [ 7 7 ] children [ 13 ] unknown value
-Node 13 type 3 parents [ 12 ] children [ ] probability value 0
-Node 14 type 2 parents [ 7 ] children [ 15 16 ] unknown value
-Node 15 type 3 parents [ 14 ] children [ 17 19 ] pos real value 0
-Node 16 type 3 parents [ 14 ] children [ 17 19 ] pos real value 0
-Node 17 type 2 parents [ 15 16 ] children [ 18 ] unknown value
-Node 18 type 3 parents [ 17 ] children [ ] probability value 0
-Node 19 type 2 parents [ 15 9 16 ] children [ 20 ] unknown value
-Node 20 type 3 parents [ 19 ] children [ ] real value 0
-Node 21 type 1 parents [ ] children [ 22 ] natural value 3
-Node 22 type 2 parents [ 21 0 ] children [ 23 ] unknown value
-Node 23 type 3 parents [ 22 ] children [ ] natural value 0
-Node 24 type 1 parents [ ] children [ 25 ] pos real value 2
-Node 25 type 2 parents [ 7 24 ] children [ 26 ] unknown value
-Node 26 type 3 parents [ 25 ] children [ ] pos real value 0
-Node 27 type 2 parents [ ] children [ 28 ] unknown value
-Node 28 type 3 parents [ 27 ] children [ ] probability value 0
+Node 0 type 1 parents [ ] children [ 1 22 ] probability 0.5
+Node 1 type 2 parents [ 0 ] children [ 2 ] unknown
+Node 2 type 3 parents [ 1 ] children [ ] boolean 0
+Node 3 type 1 parents [ ] children [ 4 ] probability 0.119203
+Node 4 type 2 parents [ 3 ] children [ 5 ] unknown
+Node 5 type 3 parents [ 4 ] children [ ] boolean 0
+Node 6 type 1 parents [ ] children [ 8 ] real 0
+Node 7 type 1 parents [ ] children [ 8 12 12 14 25 ] positive real 1
+Node 8 type 2 parents [ 6 7 ] children [ 9 ] unknown
+Node 9 type 3 parents [ 8 ] children [ 10 19 ] real 0
+Node 10 type 2 parents [ 9 ] children [ 11 ] unknown
+Node 11 type 3 parents [ 10 ] children [ ] boolean 0
+Node 12 type 2 parents [ 7 7 ] children [ 13 ] unknown
+Node 13 type 3 parents [ 12 ] children [ ] probability 0
+Node 14 type 2 parents [ 7 ] children [ 15 16 ] unknown
+Node 15 type 3 parents [ 14 ] children [ 17 19 ] positive real 0
+Node 16 type 3 parents [ 14 ] children [ 17 19 ] positive real 0
+Node 17 type 2 parents [ 15 16 ] children [ 18 ] unknown
+Node 18 type 3 parents [ 17 ] children [ ] probability 0
+Node 19 type 2 parents [ 15 9 16 ] children [ 20 ] unknown
+Node 20 type 3 parents [ 19 ] children [ ] real 0
+Node 21 type 1 parents [ ] children [ 22 ] natural 3
+Node 22 type 2 parents [ 21 0 ] children [ 23 ] unknown
+Node 23 type 3 parents [ 22 ] children [ ] natural 0
+Node 24 type 1 parents [ ] children [ 25 ] positive real 2
+Node 25 type 2 parents [ 7 24 ] children [ 26 ] unknown
+Node 26 type 3 parents [ 25 ] children [ ] positive real 0
+Node 27 type 2 parents [ ] children [ 28 ] unknown
+Node 28 type 3 parents [ 27 ] children [ ] probability 0
 """
 
 expected_python_1 = """
@@ -318,21 +318,21 @@ uint n14 = g.add_operator(
 """
 
 expected_bmg_2 = """
-Node 0 type 1 parents [ ] children [ 1 ] probability value 0.5
-Node 1 type 2 parents [ 0 ] children [ 2 ] unknown value
-Node 2 type 3 parents [ 1 ] children [ 3 4 9 12 ] boolean value 0
-Node 3 type 3 parents [ 2 ] children [ 5 ] real value 0
-Node 4 type 3 parents [ 2 ] children [ 5 ] pos real value 0
-Node 5 type 2 parents [ 3 4 ] children [ 6 ] unknown value
-Node 6 type 3 parents [ 5 ] children [ ] real value 0
-Node 7 type 1 parents [ ] children [ 9 ] natural value 1
-Node 8 type 1 parents [ ] children [ 9 ] natural value 0
-Node 9 type 3 parents [ 2 7 8 ] children [ 13 ] natural value 0
-Node 10 type 1 parents [ ] children [ 12 ] probability value 1
-Node 11 type 1 parents [ ] children [ 12 ] probability value 1e-10
-Node 12 type 3 parents [ 2 10 11 ] children [ 13 ] probability value 0
-Node 13 type 2 parents [ 9 12 ] children [ 14 ] unknown value
-Node 14 type 3 parents [ 13 ] children [ ] natural value 0
+Node 0 type 1 parents [ ] children [ 1 ] probability 0.5
+Node 1 type 2 parents [ 0 ] children [ 2 ] unknown
+Node 2 type 3 parents [ 1 ] children [ 3 4 9 12 ] boolean 0
+Node 3 type 3 parents [ 2 ] children [ 5 ] real 0
+Node 4 type 3 parents [ 2 ] children [ 5 ] positive real 0
+Node 5 type 2 parents [ 3 4 ] children [ 6 ] unknown
+Node 6 type 3 parents [ 5 ] children [ ] real 0
+Node 7 type 1 parents [ ] children [ 9 ] natural 1
+Node 8 type 1 parents [ ] children [ 9 ] natural 0
+Node 9 type 3 parents [ 2 7 8 ] children [ 13 ] natural 0
+Node 10 type 1 parents [ ] children [ 12 ] probability 1
+Node 11 type 1 parents [ ] children [ 12 ] probability 1e-10
+Node 12 type 3 parents [ 2 10 11 ] children [ 13 ] probability 0
+Node 13 type 2 parents [ 9 12 ] children [ 14 ] unknown
+Node 14 type 3 parents [ 13 ] children [ ] natural 0
 """
 
 expected_python_2 = """


### PR DESCRIPTION
Summary:
- added thrree matrix types: REAL_MATRIX, POS_MATRIX, ROW_SIMPLEX_MATRIX
- added methods for add const matrix to graph
- added pybindings of matrix type
- updated Tabular distribution
- updated relevant tests

Differential Revision: D22562606

