### PR TITLE
Update the Tabular distribution with new matrix type

### DIFF
--- a/beanmachine/graph/cavi_test.py
+++ b/beanmachine/graph/cavi_test.py
@@ -2,6 +2,7 @@
 import math
 import unittest
 
+import numpy as np
 import torch
 from beanmachine import graph
 
@@ -40,8 +41,8 @@ class TestCAVI(unittest.TestCase):
             graph.DistributionType.BERNOULLI, graph.AtomicType.BOOLEAN, [c1]
         )
         o1 = g.add_operator(graph.OperatorType.SAMPLE, [d1])
-        c2 = g.add_constant(
-            torch.Tensor([[0.0, 1.0], [1 - math.exp(-1), math.exp(-1)]])
+        c2 = g.add_constant_row_simplex_matrix(
+            np.array([[0.0, 1.0], [1 - math.exp(-1), math.exp(-1)]])
         )
         d2 = g.add_distribution(
             graph.DistributionType.TABULAR, graph.AtomicType.BOOLEAN, [c2, o1]
@@ -103,8 +104,8 @@ class TestCAVI(unittest.TestCase):
         y = g.add_operator(graph.OperatorType.SAMPLE, [d_prior])
         pos_x = g.add_operator(graph.OperatorType.TO_POS_REAL, [x])
         pos_y = g.add_operator(graph.OperatorType.TO_POS_REAL, [y])
-        c_m_log_pt01 = g.add_constant_pos_real(-math.log(0.01))
-        c_m_log_pt99 = g.add_constant_pos_real(-math.log(0.99))
+        c_m_log_pt01 = g.add_constant_pos_real(-(math.log(0.01)))
+        c_m_log_pt99 = g.add_constant_pos_real(-(math.log(0.99)))
         param = g.add_operator(
             graph.OperatorType.ADD,
             [

--- a/beanmachine/graph/distribution/distribution_test.cpp
+++ b/beanmachine/graph/distribution/distribution_test.cpp
@@ -1,8 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-#include <array>
-
 #include <gtest/gtest.h>
-#include <torch/torch.h>
 
 #include "beanmachine/graph/distribution/bernoulli.h"
 #include "beanmachine/graph/distribution/bernoulli_noisy_or.h"
@@ -81,13 +78,14 @@ TEST(testdistrib, bernoulli_noisy_or) {
 }
 
 TEST(testdistrib, tabular) {
-  // clang-format off
-  std::array<float, 4> mat_arr = {
-      0.9, 0.1,
-      0.1, 0.9};
-  // clang-format on
-  torch::Tensor mat = torch::from_blob(mat_arr.data(), {2, 2});
-  graph::ConstNode cnode1(graph::AtomicValue{mat});
+  Eigen::MatrixXd matrix(2, 2);
+  matrix << 0.9, 0.1,
+            0.1, 0.9;
+  graph::ConstNode cnode1(graph::AtomicValue(
+      graph::ValueType(
+          graph::VariableType::ROW_SIMPLEX_MATRIX,
+          graph::AtomicType::PROBABILITY),
+      matrix));
   graph::ConstNode cnode2(graph::AtomicValue{true});
   distribution::Tabular dnode1(
       graph::AtomicType::BOOLEAN, std::vector<graph::Node*>{&cnode1, &cnode2});

--- a/beanmachine/graph/util.cpp
+++ b/beanmachine/graph/util.cpp
@@ -12,37 +12,6 @@ namespace util {
 // see https://core.ac.uk/download/pdf/41787448.pdf
 const double PHI_APPROX_GAMMA = 1.702;
 
-bool is_boolean_scalar(const torch::Tensor& value) {
-  if (value.dim() != 0 or value.scalar_type() != torch::ScalarType::Byte or
-      value.item<uint8_t>() > 1) {
-    return false;
-  } else {
-    return true;
-  }
-}
-
-bool is_boolean_tensor(const torch::Tensor& value) {
-  return (
-      value.scalar_type() == torch::ScalarType::Byte and
-      value.le(1).all().item<uint8_t>());
-}
-
-bool is_real_tensor(const torch::Tensor& value) {
-  torch::ScalarType sctype = value.scalar_type();
-  return (
-      sctype == torch::ScalarType::Half or sctype == torch::ScalarType::Float or
-      sctype == torch::ScalarType::Double);
-}
-
-bool is_real_scalar(const torch::Tensor& value) {
-  torch::ScalarType sctype = value.scalar_type();
-  return (
-      value.dim() == 0 and
-      (sctype == torch::ScalarType::Half or
-       sctype == torch::ScalarType::Float or
-       sctype == torch::ScalarType::Double));
-}
-
 bool sample_logodds(std::mt19937& gen, double logodds) {
   if (logodds < 0) {
     double wt = exp(logodds);

--- a/beanmachine/graph/util.h
+++ b/beanmachine/graph/util.h
@@ -11,14 +11,6 @@
 namespace beanmachine {
 namespace util {
 
-bool is_boolean_scalar(const torch::Tensor& value);
-
-bool is_boolean_tensor(const torch::Tensor& value);
-
-bool is_real_scalar(const torch::Tensor& value);
-
-bool is_real_tensor(const torch::Tensor& value);
-
 // sample with probability 1 / (1 + exp(-logodds))
 bool sample_logodds(std::mt19937& gen, double logodds);
 


### PR DESCRIPTION
Summary:
- Represent the conditional probabiliy matrix of Tabular distribution with ROW_SIMPLEX_MATRIX, deprecate the use of torch::Tensor
- Update relevant tests.
- Next step: deprecate torch in BMGraph

Differential Revision: D22590263

