### PR TITLE
Add test case for fixable problem

### DIFF
--- a/beanmachine/ppl/compiler/bmg_nodes.py
+++ b/beanmachine/ppl/compiler/bmg_nodes.py
@@ -1627,14 +1627,21 @@ class DivisionNode(BinaryOperatorNode):
     @property
     def inf_type(self) -> type:
         # TODO: We do not support division in BMG yet; when we do, implement
-        # this correctly.
-        return Real
+        # this correctly. Best guess so far: division is defined only on
+        # positive reals, reals and tensors.
+        return supremum(self.left.inf_type, self.right.inf_type, PositiveReal)
 
     @property
     def graph_type(self) -> type:
-        if self.left.graph_type == self.right.graph_type:
-            return self.left.graph_type
-        return Malformed
+        # TODO: We do not support division in BMG yet; when we do, implement
+        # this correctly. Best guess so far: left, right and output types
+        # must be the same, and must be PositiveReal, Real or tensor.
+        lgt = self.left.graph_type
+        if lgt != self.right.graph_type:
+            return Malformed
+        if lgt != PositiveReal and lgt != Real and lgt != Tensor:
+            return Malformed
+        return lgt
 
     @property
     def requirements(self) -> List[Requirement]:


### PR DESCRIPTION
Summary: We do not support division nodes in BMG yet, but we can fix a model that contains a division by a constant by turning it into a multiplication in a post-processing pass.  I haven't done that, but in the spirit of test-driven development I've written a test case that demonstrates that we currently produce an error message for this scenario. When we stop producing an error I'll update the test.

Reviewed By: wtaha

Differential Revision: D22490087

