### PR TITLE
Implement graph transformation to eliminate division nodes

### DIFF
--- a/beanmachine/ppl/compiler/fix_problems.py
+++ b/beanmachine/ppl/compiler/fix_problems.py
@@ -13,6 +13,7 @@ from beanmachine.ppl.compiler.bmg_nodes import (
     BMGNode,
     ConstantNode,
     DistributionNode,
+    DivisionNode,
     IndexNode,
     MapNode,
     MultiplicationNode,
@@ -297,8 +298,13 @@ requirement is given; the name of this edge is provided for error reporting."""
         # Chi2 -> Gamma
         # Not -> Complement
         # Index/Map -> IfThenElse
-        # Division -> Multiplication
         # Power -> Multiplication
+        if isinstance(node, DivisionNode):
+            r = node.right
+            if isinstance(r, ConstantNode):
+                return self.bmg.add_multiplication(
+                    node.left, self.bmg.add_constant(1.0 / r.value)
+                )
         return None
 
     def _fix_unsupported_nodes(self) -> None:


### PR DESCRIPTION
Summary:
BMG does not support a node representing division; if we have a model that contains a division by a constant, we rewrite it as a multiplication.

The test case illustrates how we start with a graph containing a division node:

{F243938573}

 and then orphan that division node (and some constants) to produce a graph where the distributions depend only on the multiplication:

{F243938580}

The unused division and constants will not be emitted into the BMG.

Reviewed By: wtaha

Differential Revision: D22490752

