### PR TITLE
remove unused `num_adapt_windows` flag from single site random walk

### DIFF
--- a/beanmachine/ppl/inference/proposer/single_site_random_walk_proposer.py
+++ b/beanmachine/ppl/inference/proposer/single_site_random_walk_proposer.py
@@ -25,7 +25,6 @@ class SingleSiteRandomWalkProposer(SingleSiteAncestralProposer):
     def __init__(
         self,
         step_size: float,
-        num_adapt_windows: int,
         transform_type: TransformType = TransformType.NONE,
         transforms: Optional[List] = None,
     ):

--- a/beanmachine/ppl/inference/single_site_random_walk.py
+++ b/beanmachine/ppl/inference/single_site_random_walk.py
@@ -17,11 +17,10 @@ class SingleSiteRandomWalk(AbstractMHInference):
     def __init__(
         self,
         step_size: float = 1.0,
-        num_adapt_windows: int = 5,
         transform_type: TransformType = TransformType.NONE,
         transforms: Optional[List] = None,
     ):
-        self.proposer_ = SingleSiteRandomWalkProposer(step_size, num_adapt_windows)
+        self.proposer_ = SingleSiteRandomWalkProposer(step_size)
         super().__init__(self.proposer_, transform_type, transforms)
 
     def find_best_single_site_proposer(self, node: RVIdentifier):


### PR DESCRIPTION
Summary: There is an unused flag `num_adapt_windows` in the `SingleSiteRandomWalkProposer` and `SingleSiteRandomWalk` Inference method. This diffs removes the flag.

Differential Revision: D22732255

