### PR TITLE
Reinstate sequential predictive as an togglable flag

### DIFF
--- a/beanmachine/ppl/inference/monte_carlo_samples.py
+++ b/beanmachine/ppl/inference/monte_carlo_samples.py
@@ -102,4 +102,4 @@ class MonteCarloSamples(object):
         """
         :returns: the number of samples run during inference
         """
-        return len(next(iter(self.data.rv_dict.values())))
+        return next(iter(self.data.rv_dict.values())).shape[-1]

--- a/beanmachine/ppl/inference/predictive_test.py
+++ b/beanmachine/ppl/inference/predictive_test.py
@@ -28,6 +28,13 @@ class PredictiveTest(unittest.TestCase):
         return dist.Bernoulli(self.prior_1())
 
     @bm.random_variable
+    def likelihood_dynamic(self, i):
+        if self.likelihood_i(i).item() > 0:
+            return dist.Normal(torch.zeros(1), torch.ones(1))
+        else:
+            return dist.Normal(5.0 * torch.ones(1), torch.ones(1))
+
+    @bm.random_variable
     def prior_2(self):
         return dist.Uniform(torch.zeros(1, 2), torch.ones(1, 2))
 
@@ -38,6 +45,10 @@ class PredictiveTest(unittest.TestCase):
     @bm.random_variable
     def likelihood_2_vec(self, i):
         return dist.Bernoulli(self.prior_2())
+
+    @bm.random_variable
+    def likelihood_reg(self, x):
+        return dist.Normal(self.prior() * x, torch.tensor(1.0))
 
     def test_prior_predictive(self):
         queries = [self.prior(), self.likelihood()]
@@ -54,9 +65,50 @@ class PredictiveTest(unittest.TestCase):
             [self.prior()], obs, num_samples=10, num_chains=2
         )
         assert post_samples[self.prior()].shape == (2, 10)
-        predictives = bm.simulate(list(obs.keys()), post_samples)
+        predictives = bm.simulate(list(obs.keys()), post_samples, vectorized=True)
         predictives[self.likelihood_i(0)].shape == (2, 10)
         assert predictives[self.likelihood_i(1)].shape == (2, 10)
+
+    def test_posterior_predictive_seq(self):
+        obs = {
+            self.likelihood_i(0): torch.tensor(1.0),
+            self.likelihood_i(1): torch.tensor(0.0),
+        }
+        post_samples = bm.SingleSiteAncestralMetropolisHastings().infer(
+            [self.prior()], obs, num_samples=10, num_chains=2
+        )
+        assert post_samples[self.prior()].shape == (2, 10)
+        predictives = bm.simulate(list(obs.keys()), post_samples, vectorized=True)
+        predictives[self.likelihood_i(0)].shape == (2, 10)
+        assert predictives[self.likelihood_i(1)].shape == (2, 10)
+
+    def test_predictive_dynamic(self):
+        obs = {
+            self.likelihood_dynamic(0): torch.tensor([0.9]),
+            self.likelihood_dynamic(1): torch.tensor([4.9]),
+        }
+        # only query one of the variables
+        post_samples = bm.SingleSiteAncestralMetropolisHastings().infer(
+            [self.prior()], obs, num_samples=10, num_chains=2
+        )
+        assert post_samples[self.prior()].shape == (2, 10)
+        predictives = bm.simulate(list(obs.keys()), post_samples, vectorized=False)
+        assert predictives[self.likelihood_dynamic(0)].shape == (2, 10)
+        assert predictives[self.likelihood_dynamic(1)].shape == (2, 10)
+
+    @unittest.skip("Automatic broadcasting not yet implemented.")
+    def test_predictive_data(self):
+        x = torch.randn(4)
+        y = torch.randn(4) + 2.0
+        obs = {self.likelihood_reg(x): y}
+        post_samples = bm.SingleSiteAncestralMetropolisHastings().infer(
+            [self.prior()], obs, num_samples=10, num_chains=2, vectorized=True
+        )
+        assert post_samples[self.prior()].shape == (2, 10)
+        test_x = torch.randn(4)
+        test_query = self.likelihood_reg(test_x)
+        predictives = bm.simulate([test_query], post_samples)
+        assert predictives[test_query].shape == (2, 10, 4)
 
     def test_posterior_predictive_1d(self):
         obs = {self.likelihood_1(): torch.tensor([1.0])}
@@ -64,7 +116,7 @@ class PredictiveTest(unittest.TestCase):
             [self.prior_1()], obs, num_samples=10, num_chains=1
         )
         assert post_samples[self.prior_1()].shape == (1, 10, 1)
-        predictives = bm.simulate(list(obs.keys()), post_samples)
+        predictives = bm.simulate(list(obs.keys()), post_samples, vectorized=True)
         y = predictives[self.likelihood_1()].shape
         assert y == (1, 10, 1)
 
@@ -79,7 +131,7 @@ class PredictiveTest(unittest.TestCase):
         )
 
         assert post_samples[self.prior_2()].shape == (2, 10, 1, 2)
-        predictives = bm.simulate(list(obs.keys()), post_samples)
+        predictives = bm.simulate(list(obs.keys()), post_samples, vectorized=True)
         predictive_0 = predictives[self.likelihood_2(0)]
         predictive_1 = predictives[self.likelihood_2(1)]
         assert predictive_0.shape == (2, 10, 1, 2)
@@ -97,7 +149,7 @@ class PredictiveTest(unittest.TestCase):
         )
         empirical = bm.empirical([self.prior()], post_samples, num_samples=26)
         assert empirical[self.prior()].shape == (1, 26)
-        predictives = bm.simulate(list(obs.keys()), post_samples)
+        predictives = bm.simulate(list(obs.keys()), post_samples, vectorized=True)
         empirical = bm.empirical(list(obs.keys()), predictives, num_samples=27)
         assert len(empirical.data.rv_dict.keys()) == 3
         assert empirical[self.likelihood_i(0)].shape == (1, 27)


### PR DESCRIPTION
Summary:
This PR does a few things:
1. implement sequential predictive for dynamic models
2. fixes a bug in `MonteCarloSamples.get_num_variables`
3. adds a failing test for automatic broadcasting

Differential Revision: D22722195

