### PR TITLE
Convert Uniform(0,1) distributions to flat BMG nodes

### DIFF
--- a/beanmachine/ppl/compiler/end_to_end_test.py
+++ b/beanmachine/ppl/compiler/end_to_end_test.py
@@ -29,6 +29,7 @@ from torch.distributions import (
     HalfCauchy,
     Normal,
     StudentT,
+    Uniform,
 )
 
 @bm.random_variable
@@ -71,6 +72,9 @@ def bin_constant():
 def gamma():
   return Gamma(1.0, 2.0)
 
+@bm.random_variable
+def flat():
+  return Uniform(0.0, 1.0)
 """
 
 expected_cpp_1 = """
@@ -143,6 +147,12 @@ uint n25 = g.add_distribution(
   std::vector<uint>({n7, n24}));
 uint n26 = g.add_operator(
   graph::OperatorType::SAMPLE, std::vector<uint>({n25}));
+uint n27 = g.add_distribution(
+  graph::DistributionType::FLAT,
+  graph::AtomicType::PROBABILITY,
+  std::vector<uint>({}));
+uint n28 = g.add_operator(
+  graph::OperatorType::SAMPLE, std::vector<uint>({n27}));
 """
 
 expected_bmg_1 = """
@@ -173,6 +183,8 @@ Node 23 type 3 parents [ 22 ] children [ ] natural value 0
 Node 24 type 1 parents [ ] children [ 25 ] pos real value 2
 Node 25 type 2 parents [ 7 24 ] children [ 26 ] unknown value
 Node 26 type 3 parents [ 25 ] children [ ] pos real value 0
+Node 27 type 2 parents [ ] children [ 28 ] unknown value
+Node 28 type 3 parents [ 27 ] children [ ] probability value 0
 """
 
 expected_python_1 = """
@@ -236,6 +248,11 @@ n25 = g.add_distribution(
   graph.AtomicType.POS_REAL,
   [n7, n24])
 n26 = g.add_operator(graph.OperatorType.SAMPLE, [n25])
+n27 = g.add_distribution(
+  graph.DistributionType.FLAT,
+  graph.AtomicType.PROBABILITY,
+  [])
+n28 = g.add_operator(graph.OperatorType.SAMPLE, [n27])
 """
 
 # These are cases where we have a type conversion on a sample.

--- a/beanmachine/ppl/compiler/fix_problems_test.py
+++ b/beanmachine/ppl/compiler/fix_problems_test.py
@@ -460,9 +460,9 @@ digraph "graph" {
     def test_fix_problems_7(self) -> None:
         """test_fix_problems_7"""
 
-        # This test has a problem that cannot be fixed yet, but
-        # will be fixable soon; when it is, update this test to
-        # show the fixed and unfixed problem.
+        # The problem here is that we have two uniform distributions that
+        # we cannot turn into a flat distribution, and one we can. We therefore
+        # expect that we will get two errors.
 
         self.maxDiff = None
         bmg = BMGraphBuilder()
@@ -487,8 +487,6 @@ digraph "graph" {
         error_report = fix_problems(bmg)
         observed = str(error_report)
         expected = """
-The model uses a Uniform operation unsupported by Bean Machine Graph.
-The unsupported node is the operand of a Sample.
 The model uses a Uniform operation unsupported by Bean Machine Graph.
 The unsupported node is the operand of a Sample.
 The model uses a Uniform operation unsupported by Bean Machine Graph.

--- a/beanmachine/ppl/utils/bm_graph_builder.py
+++ b/beanmachine/ppl/utils/bm_graph_builder.py
@@ -75,6 +75,7 @@ from beanmachine.ppl.compiler.bmg_nodes import (
     DistributionNode,
     DivisionNode,
     ExpNode,
+    FlatNode,
     GammaNode,
     HalfCauchyNode,
     IfThenElseNode,
@@ -580,6 +581,12 @@ constant graph node of the stated type for it, and adds it to the builder"""
         if not isinstance(concentration0, BMGNode):
             concentration0 = self.add_constant(concentration0)
         return self.add_beta(concentration1, concentration0)
+
+    @memoize
+    def add_flat(self) -> FlatNode:
+        node = FlatNode()
+        self.add_node(node)
+        return node
 
     # ####
     # #### Graph accumulation for operators


### PR DESCRIPTION
Summary:
A Python model can use a uniform distribution that is parameterized by arbitrary constants, tensors, or samples, but BMG only supports standard uniform distributions from 0.0 to 1.0 right now, which it calls a "flat" distribution on probabilities.

If we encounter a Uniform(0, 1) distribution, we now transform it into a flat distribution when compiling the model.

Reviewed By: wtaha

Differential Revision: D22553565

