### PR TITLE
Start implementing chi2 distribution in BM->BMG compiler

### DIFF
--- a/beanmachine/ppl/compiler/bmg_nodes.py
+++ b/beanmachine/ppl/compiler/bmg_nodes.py
@@ -884,6 +884,60 @@ we generate a different node in BMG."""
         return (tensor(i).view(sr) for i in itertools.product(*([r] * prod(sr))))
 
 
+class Chi2Node(DistributionNode):
+    """The chi2 distribution is a distribution of positive
+real numbers; it is a special case of the gamma distribution."""
+
+    edges = ["df"]
+
+    def __init__(self, df: BMGNode):
+        DistributionNode.__init__(self, [df])
+
+    @property
+    def df(self) -> BMGNode:
+        return self.children[0]
+
+    @df.setter
+    def df(self, p: BMGNode) -> None:
+        self.children[0] = p
+
+    @property
+    def graph_type(self) -> type:
+        return PositiveReal
+
+    @property
+    def inf_type(self) -> type:
+        return PositiveReal
+
+    @property
+    def requirements(self) -> List[Requirement]:
+        return [PositiveReal]
+
+    @property
+    def size(self) -> torch.Size:
+        return self.df.size
+
+    @property
+    def label(self) -> str:
+        return "Chi2"
+
+    def __str__(self) -> str:
+        return f"Chi2({str(self.df)})"
+
+    def _supported_in_bmg(self) -> bool:
+        # Not supported directly; we replace it with a gamma, which is supported.
+        return False
+
+    def support(self) -> Iterator[Any]:
+        # TODO: Make a better exception type.
+        # TODO: Catch this error during graph generation and produce a better
+        # TODO: error message that diagnoses the problem more exactly for
+        # TODO: the user.  This would happen if we did something like
+        # TODO: x(n()) where x() is a sample that takes a finite index but
+        # TODO: n() is a sample that returns a Chi2.
+        raise ValueError("Chi2 distribution does not have finite support.")
+
+
 class DirichletNode(DistributionNode):
     """The Dirichlet distribution generates simplexs -- vectors
 whose members are probabilities that add to 1.0, and

--- a/beanmachine/ppl/compiler/bmg_nodes_test.py
+++ b/beanmachine/ppl/compiler/bmg_nodes_test.py
@@ -8,6 +8,7 @@ from beanmachine.ppl.compiler.bmg_nodes import (
     BetaNode,
     BinomialNode,
     BooleanNode,
+    Chi2Node,
     ExpNode,
     FlatNode,
     GammaNode,
@@ -81,6 +82,7 @@ class ASTToolsTest(unittest.TestCase):
         bino = SampleNode(BinomialNode(nat, prob))
         flat = SampleNode(FlatNode())
         gamm = SampleNode(GammaNode(pos, pos))
+        chi2 = SampleNode(Chi2Node(pos))
         half = SampleNode(HalfCauchyNode(pos))
         norm = SampleNode(NormalNode(real, pos))
         stut = SampleNode(StudentTNode(pos, pos, pos))
@@ -89,6 +91,7 @@ class ASTToolsTest(unittest.TestCase):
         self.assertEqual(beta.inf_type, Probability)
         self.assertEqual(bino.inf_type, Natural)
         self.assertEqual(flat.inf_type, Probability)
+        self.assertEqual(chi2.inf_type, PositiveReal)
         self.assertEqual(gamm.inf_type, PositiveReal)
         self.assertEqual(half.inf_type, PositiveReal)
         self.assertEqual(norm.inf_type, Real)
@@ -438,6 +441,7 @@ class ASTToolsTest(unittest.TestCase):
         self.assertEqual(BetaNode(pos, pos).requirements, [PositiveReal, PositiveReal])
         self.assertEqual(BinomialNode(nat, prob).requirements, [Natural, Probability])
         self.assertEqual(GammaNode(pos, pos).requirements, [PositiveReal, PositiveReal])
+        self.assertEqual(Chi2Node(pos).requirements, [PositiveReal])
         self.assertEqual(HalfCauchyNode(pos).requirements, [PositiveReal])
         self.assertEqual(NormalNode(real, pos).requirements, [Real, PositiveReal])
         self.assertEqual(


### PR DESCRIPTION
Summary:
We already have partial support for the chi2 distribution because it is literally a subtype of the gamma distribution, but we do not yet support all scenarios in which a chi2 distribution is used in a model that is then compiled to BMG.

The first step in supporting that is to make a node type specifically for this distribution; in a later diff I will add support to (1) the graph builder, and (2) the problem fixer.  The problem fixer will rewrite instances of chi2 into the equivalent gamma, which is supported in BMG.

Reviewed By: wtaha

Differential Revision: D22558421

