### PR TITLE
Finish adding support for chi2 distribution to BM->BMG compiler

### DIFF
--- a/beanmachine/ppl/compiler/end_to_end_test.py
+++ b/beanmachine/ppl/compiler/end_to_end_test.py
@@ -25,6 +25,7 @@ from torch.distributions import (
     Bernoulli,
     Beta,
     Binomial,
+    Chi2,
     Gamma,
     HalfCauchy,
     Normal,
@@ -75,6 +76,10 @@ def gamma():
 @bm.random_variable
 def flat():
   return Uniform(0.0, 1.0)
+
+@bm.random_variable
+def chi2():
+  return Chi2(8.0)
 """
 
 expected_cpp_1 = """
@@ -153,6 +158,14 @@ uint n27 = g.add_distribution(
   std::vector<uint>({}));
 uint n28 = g.add_operator(
   graph::OperatorType::SAMPLE, std::vector<uint>({n27}));
+uint n29 = g.add_constant_pos_real(4.0);
+uint n30 = g.add_constant_pos_real(0.5);
+uint n31 = g.add_distribution(
+  graph::DistributionType::GAMMA,
+  graph::AtomicType::POS_REAL,
+  std::vector<uint>({n29, n30}));
+uint n32 = g.add_operator(
+  graph::OperatorType::SAMPLE, std::vector<uint>({n31}));
 """
 
 expected_bmg_1 = """
@@ -185,6 +198,10 @@ Node 25 type 2 parents [ 7 24 ] children [ 26 ] unknown
 Node 26 type 3 parents [ 25 ] children [ ] positive real 0
 Node 27 type 2 parents [ ] children [ 28 ] unknown
 Node 28 type 3 parents [ 27 ] children [ ] probability 0
+Node 29 type 1 parents [ ] children [ 31 ] positive real 4
+Node 30 type 1 parents [ ] children [ 31 ] positive real 0.5
+Node 31 type 2 parents [ 29 30 ] children [ 32 ] unknown
+Node 32 type 3 parents [ 31 ] children [ ] positive real 0
 """
 
 expected_python_1 = """
@@ -253,6 +270,13 @@ n27 = g.add_distribution(
   graph.AtomicType.PROBABILITY,
   [])
 n28 = g.add_operator(graph.OperatorType.SAMPLE, [n27])
+n29 = g.add_constant_pos_real(4.0)
+n30 = g.add_constant_pos_real(0.5)
+n31 = g.add_distribution(
+  graph.DistributionType.GAMMA,
+  graph.AtomicType.POS_REAL,
+  [n29, n30])
+n32 = g.add_operator(graph.OperatorType.SAMPLE, [n31])
 """
 
 # These are cases where we have a type conversion on a sample.


### PR DESCRIPTION
Summary:
We now have end-to-end support for the chi2 distribution -- a special case of the gamma distribution -- in the BM->BMG compiler. If a model uses chi2, it is transformed into a gamma distribution when the final graph is created.

For example, suppose we start with this model:

        rv def hcs():
          return HalfCauchy(1.0)
        rv def chi2():
          return Chi2(hcs())

When we initially accumulate the graph we get:

{F244475089}

Which we cannot represent in BMG. But when we run the problem fixer, the constant real is replaced with a constant positive real, the chi2 is replaced with the equivalent gamma, and those original nodes become "orphans" that are not emitted into the final graph:

{F244475347}

Reviewed By: wtaha

Differential Revision: D22583490

