### PR TITLE
change pyre-fixme to inline pyre-ignore

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ commands:
           command: sudo pip install --progress-bar off --upgrade pip
       - run:
           name: "Install lint packages"
-          command: sudo pip install --progress-bar off black==19.3b0 isort flake8
+          command: sudo pip install --progress-bar off black==19.3b0 isort==4.3.21 flake8
 
   lint_flake8:
     description: "Lint with flake8"

--- a/beanmachine/ppl/experimental/abc/abc_smc_infer.py
+++ b/beanmachine/ppl/experimental/abc/abc_smc_infer.py
@@ -14,9 +14,7 @@ from beanmachine.ppl.inference.proposer.single_site_random_walk_proposer import 
 from beanmachine.ppl.model.statistical_model import StatisticalModel
 from beanmachine.ppl.model.utils import LogLevel, Mode, RVIdentifier
 from torch import Tensor
-
-# pyre-fixme[21]: Could not find name `tqdm` in `tqdm.auto`.
-from tqdm.auto import tqdm
+from tqdm.auto import tqdm  # pyre-ignore
 
 
 LOGGER_UPDATES = logging.getLogger("beanmachine.debug.updates")

--- a/beanmachine/ppl/experimental/inference_compilation/ic_infer.py
+++ b/beanmachine/ppl/experimental/inference_compilation/ic_infer.py
@@ -9,9 +9,7 @@ import torch.distributions as dist
 import torch.nn as nn
 import torch.optim as optim
 from torch import Tensor, tensor
-
-# pyre-fixme[21]: Could not find name `tqdm` in `tqdm.auto`.
-from tqdm.auto import tqdm
+from tqdm.auto import tqdm  # pyre-ignore
 
 from ...inference.abstract_infer import AbstractInference
 from ...inference.abstract_mh_infer import AbstractMHInference

--- a/beanmachine/ppl/inference/abstract_mh_infer.py
+++ b/beanmachine/ppl/inference/abstract_mh_infer.py
@@ -14,9 +14,7 @@ from beanmachine.ppl.model.statistical_model import StatisticalModel
 from beanmachine.ppl.model.utils import LogLevel, Mode, RVIdentifier
 from beanmachine.ppl.world.variable import TransformType
 from torch import Tensor
-
-# pyre-fixme[21]: Could not find name `tqdm` in `tqdm.auto`.
-from tqdm.auto import tqdm
+from tqdm.auto import tqdm  # pyre-ignore
 
 
 LOGGER_UPDATES = logging.getLogger("beanmachine.debug.updates")

--- a/beanmachine/ppl/inference/proposer/newtonian_monte_carlo_utils.py
+++ b/beanmachine/ppl/inference/proposer/newtonian_monte_carlo_utils.py
@@ -1,9 +1,7 @@
 from typing import Optional, Tuple, Union
 
 import torch
-
-# pyre-fixme[21]: Could not find name `tensorops` in `beanmachine.ppl.utils`.
-from beanmachine.ppl.utils import tensorops
+from beanmachine.ppl.utils import tensorops  # pyre-ignore
 from torch import Tensor, tensor
 from torch.autograd import grad
 

--- a/beanmachine/ppl/inference/proposer/single_site_half_space_newtonian_monte_carlo_proposer.py
+++ b/beanmachine/ppl/inference/proposer/single_site_half_space_newtonian_monte_carlo_proposer.py
@@ -13,9 +13,7 @@ from beanmachine.ppl.inference.proposer.single_site_ancestral_proposer import (
     SingleSiteAncestralProposer,
 )
 from beanmachine.ppl.model.utils import RVIdentifier
-
-# pyre-fixme[21]: Could not find name `tensorops` in `beanmachine.ppl.utils`.
-from beanmachine.ppl.utils import tensorops
+from beanmachine.ppl.utils import tensorops  # pyre-ignore
 from beanmachine.ppl.world import ProposalDistribution, Variable, World
 from torch import Tensor
 

--- a/beanmachine/ppl/inference/proposer/single_site_real_space_newtonian_monte_carlo_proposer.py
+++ b/beanmachine/ppl/inference/proposer/single_site_real_space_newtonian_monte_carlo_proposer.py
@@ -16,9 +16,7 @@ from beanmachine.ppl.inference.proposer.single_site_ancestral_proposer import (
     SingleSiteAncestralProposer,
 )
 from beanmachine.ppl.model.utils import LogLevel, RVIdentifier
-
-# pyre-fixme[21]: Could not find name `tensorops` in `beanmachine.ppl.utils`.
-from beanmachine.ppl.utils import tensorops
+from beanmachine.ppl.utils import tensorops  # pyre-ignore
 from beanmachine.ppl.world import ProposalDistribution, Variable, World
 from torch import Tensor, tensor
 

--- a/beanmachine/ppl/inference/proposer/single_site_simplex_newtonian_monte_carlo_proposer.py
+++ b/beanmachine/ppl/inference/proposer/single_site_simplex_newtonian_monte_carlo_proposer.py
@@ -13,9 +13,7 @@ from beanmachine.ppl.inference.proposer.single_site_ancestral_proposer import (
     SingleSiteAncestralProposer,
 )
 from beanmachine.ppl.model.utils import RVIdentifier
-
-# pyre-fixme[21]: Could not find name `tensorops` in `beanmachine.ppl.utils`.
-from beanmachine.ppl.utils import tensorops
+from beanmachine.ppl.utils import tensorops  # pyre-ignore
 from beanmachine.ppl.world import ProposalDistribution, Variable, World
 from torch import Tensor
 

--- a/beanmachine/ppl/inference/rejection_sampling_infer.py
+++ b/beanmachine/ppl/inference/rejection_sampling_infer.py
@@ -9,9 +9,7 @@ from beanmachine.ppl.inference.abstract_infer import AbstractInference, VerboseL
 from beanmachine.ppl.model.statistical_model import StatisticalModel
 from beanmachine.ppl.model.utils import LogLevel, Mode, RVIdentifier
 from torch import Tensor
-
-# pyre-fixme[21]: Could not find name `tqdm` in `tqdm.auto`.
-from tqdm.auto import tqdm
+from tqdm.auto import tqdm  # pyre-ignore
 
 
 LOGGER_UPDATES = logging.getLogger("beanmachine.debug.updates")


### PR DESCRIPTION
Summary: Changed all pyre-fixme to inline pyre-ignore to avoid incompatibility between isort and black in handling of comments within import blocks. Also reverted isort to 4.3.21 on CircleCI to match version on fbcode.

Differential Revision: D22876229

