### PR TITLE
update default perturb kernel step size decay

### DIFF
--- a/beanmachine/ppl/experimental/abc/abc_smc_infer.py
+++ b/beanmachine/ppl/experimental/abc/abc_smc_infer.py
@@ -75,7 +75,9 @@ class ApproximateBayesianComputationSequentialMonteCarlo(
         Default perturb kernel. Performs a sigle step gaussian random walk. Variance decays with stage
         :returns: perturbed sample
         """
-        proposer = SingleSiteRandomWalkProposer(step_size=10 ** (-stage))
+        proposer = SingleSiteRandomWalkProposer(
+            step_size=(0.01 * (torch.exp(-(torch.tensor(stage, dtype=torch.float32)))).item())
+        )
         perturbed_sample = {}
         for key, value in sample.items():
             key.function._wrapper(*key.arguments)


### PR DESCRIPTION
Summary: Changed random walk perturb kernel step size decay to exponent to `e` instead of `10`

Differential Revision: D22897810

