### PR TITLE
Add entropy regularization to IC

### DIFF
--- a/src/beanmachine/applications/clara/nmc.py
+++ b/src/beanmachine/applications/clara/nmc.py
@@ -155,7 +155,7 @@ class State:
             * true_one_hot,
         )
         ssum = score.sum()
-        grad, = torch.autograd.grad(
+        (grad,) = torch.autograd.grad(
             ssum, confusion, retain_graph=True, create_graph=True
         )
         # simulate the cost of computing a vector Hessian
@@ -169,7 +169,7 @@ class State:
     def propose_prevalence(self, prior, prevalence, labels):
         prevalence = prevalence.clone().requires_grad_(True)
         score = prior.log_prob(prevalence) + prevalence[labels].log().sum()
-        grad, = torch.autograd.grad(
+        (grad,) = torch.autograd.grad(
             score, prevalence, retain_graph=True, create_graph=True
         )
         # simulate the cost of computing a vector Hessian

--- a/src/beanmachine/ppl/experimental/inference_compilation/ic_infer.py
+++ b/src/beanmachine/ppl/experimental/inference_compilation/ic_infer.py
@@ -197,7 +197,9 @@ class ICInference(AbstractMHInference):
         if node_proposal_num_layers:
             self._NODE_PROPOSAL_NUM_LAYERS = node_proposal_num_layers
         if entropy_regularization_coefficient:
-            self._ENTROPY_REGULARIZATION_COEFFICIENT = entropy_regularization_coefficient
+            self._ENTROPY_REGULARIZATION_COEFFICIENT = (
+                entropy_regularization_coefficient
+            )
 
         random_seed = torch.randint(AbstractInference._rand_int_max, (1,)).int().item()
         AbstractInference.set_seed_for_chain(random_seed, 0)
@@ -312,11 +314,7 @@ class ICInference(AbstractMHInference):
                 .get_proposal_distribution(node, node_var, world, {})[0]
                 .proposal_distribution
             )
-            loss -= (
-                proposal_distribution
-                .log_prob(node_var.value)
-                .sum()
-            )
+            loss -= proposal_distribution.log_prob(node_var.value).sum()
             if self._ENTROPY_REGULARIZATION_COEFFICIENT > 0.0:
                 loss += (
                     self._ENTROPY_REGULARIZATION_COEFFICIENT


### PR DESCRIPTION
### Motivation

Entropy regularization helps mitigate exploding variance in IC.

### Changes proposed

Adds `entropy_regularization_coefficient` optional argument to `compile()` arguments.

### Test Plan

Call `ic.compile(entropy_regularization_coefficient=1.0)`.

### Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](https://github.com/facebookincubator/BeanMachine/blob/master/CONTRIBUTING.md)** document.
- [ ] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [x] The title of my pull request is a short description of the requested changes.
