### PR TITLE
Remove node embedding from IC proposer param net

### DIFF
--- a/src/beanmachine/ppl/experimental/inference_compilation/ic_infer.py
+++ b/src/beanmachine/ppl/experimental/inference_compilation/ic_infer.py
@@ -351,10 +351,7 @@ class ICInference(AbstractMHInference):
         return NodeEmbedding(node_id_embedding, node_embedding_net)
 
     def _build_node_proposal_param_network(self, node: RVIdentifier) -> nn.Module:
-        in_features = (
-            self._MB_EMBEDDING_DIM
-            + self._OBS_EMBEDDING_DIM
-        )
+        in_features = self._MB_EMBEDDING_DIM + self._OBS_EMBEDDING_DIM
         layers = []
         for _ in range(self._NODE_PROPOSAL_NUM_LAYERS):
             # TODO: bottlenecking?


### PR DESCRIPTION
### Motivation

Including node embeddings to IC's proposer parameter FFW NN results in a trivial identity embedding. Removing it forces IC to learn to invert the observation -> latent behavior.

### Changes proposed

Removes `node_embedding` input to `proposer_param_nets`

### Test Plan

Before:
![image](https://user-images.githubusercontent.com/990069/89588685-00e41e80-d7f9-11ea-8739-b8764e2bf759.png)


After:
![image](https://user-images.githubusercontent.com/990069/89588577-c67a8180-d7f8-11ea-83a6-78d86cb63439.png)


### Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](https://github.com/facebookincubator/BeanMachine/blob/master/CONTRIBUTING.md)** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] The title of my pull request is a short description of the requested changes.
