### PR TITLE
Remove redundant black dep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -137,7 +137,6 @@ setup(
         "statsmodels>=0.8.0",
         "tqdm>=4.40.2",
         "astor>=0.7.1",
-        "black>=19.3b0",
     ],
     packages=find_packages("src/"),
     package_dir={"beanmachine": "src/beanmachine"},


### PR DESCRIPTION
### Motivation

Black is in `DEV_REQUIRES`; presumably a non-developer does not care about Python code formatting.

### Changes proposed

Remove redundant listing of `black` in `INSTALL_REQUIRES`

### Test Plan

CircleCI

### Types of changes
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](https://github.com/facebookresearch/pplbench/blob/master/CONTRIBUTING.md)** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] The title of my pull request is a short description of the requested changes.
