### PR TITLE
Start replacing uses of bool type with proper marker type

### DIFF
--- a/src/beanmachine/ppl/compiler/bmg_types.py
+++ b/src/beanmachine/ppl/compiler/bmg_types.py
@@ -55,6 +55,7 @@ class Malformed:
 
 
 Real = float
+Boolean = bool
 
 BMGLatticeType = Union[type]
 # Union is necessary to work around aliasing bugs in Pyre.
@@ -169,37 +170,37 @@ could possibly be: PositiveReal.
 
 # There are only 36 pairs; we can just list them.
 _lookup = {
-    (bool, bool): bool,
-    (bool, Natural): Natural,
-    (bool, Probability): Probability,
-    (bool, PositiveReal): PositiveReal,
-    (bool, Real): Real,
-    (bool, Tensor): Tensor,
-    (Natural, bool): Natural,
+    (Boolean, Boolean): Boolean,
+    (Boolean, Natural): Natural,
+    (Boolean, Probability): Probability,
+    (Boolean, PositiveReal): PositiveReal,
+    (Boolean, Real): Real,
+    (Boolean, Tensor): Tensor,
+    (Natural, Boolean): Natural,
     (Natural, Natural): Natural,
     (Natural, Probability): PositiveReal,
     (Natural, PositiveReal): PositiveReal,
     (Natural, Real): Real,
     (Natural, Tensor): Tensor,
-    (Probability, bool): Probability,
+    (Probability, Boolean): Probability,
     (Probability, Natural): PositiveReal,
     (Probability, Probability): Probability,
     (Probability, PositiveReal): PositiveReal,
     (Probability, Real): Real,
     (Probability, Tensor): Tensor,
-    (PositiveReal, bool): PositiveReal,
+    (PositiveReal, Boolean): PositiveReal,
     (PositiveReal, Natural): PositiveReal,
     (PositiveReal, Probability): PositiveReal,
     (PositiveReal, PositiveReal): PositiveReal,
     (PositiveReal, Real): Real,
     (PositiveReal, Tensor): Tensor,
-    (Real, bool): Real,
+    (Real, Boolean): Real,
     (Real, Natural): Real,
     (Real, Probability): Real,
     (Real, PositiveReal): Real,
     (Real, Real): Real,
     (Real, Tensor): Tensor,
-    (Tensor, bool): Tensor,
+    (Tensor, Boolean): Tensor,
     (Tensor, Natural): Tensor,
     (Tensor, Probability): Tensor,
     (Tensor, PositiveReal): Tensor,
@@ -220,7 +221,7 @@ greater than or equal to both."""
 def supremum(*ts: BMGLatticeType) -> BMGLatticeType:
     """Takes any number of BMG types; returns the smallest type that is
 greater than or equal to all of them."""
-    result = bool
+    result = Boolean
     for t in ts:
         result = _supremum(result, t)
     return result
@@ -233,10 +234,10 @@ def type_of_value(v: Any) -> BMGLatticeType:
             return type_of_value(float(v))  # pyre-fixme
         return Tensor
     if isinstance(v, bool):
-        return bool
+        return Boolean
     if isinstance(v, int):
         if v == 0 or v == 1:
-            return bool
+            return Boolean
         if v >= 2:
             return Natural
         return Real
@@ -299,7 +300,7 @@ def meets_requirement(t: BMGLatticeType, r: Requirement) -> bool:
 
 
 _type_names = {
-    bool: "bool",
+    Boolean: "bool",
     Malformed: "malformed",
     Natural: "natural",
     PositiveReal: "positive real",
@@ -309,7 +310,7 @@ _type_names = {
 }
 
 _short_type_names = {
-    bool: "B",
+    Boolean: "B",
     Malformed: "M",
     Natural: "N",
     PositiveReal: "R+",

--- a/src/beanmachine/ppl/compiler/bmg_types_test.py
+++ b/src/beanmachine/ppl/compiler/bmg_types_test.py
@@ -3,6 +3,7 @@
 import unittest
 
 from beanmachine.ppl.compiler.bmg_types import (
+    Boolean,
     Natural,
     PositiveReal,
     Probability,
@@ -20,33 +21,32 @@ class BMGTypesTest(unittest.TestCase):
     def test_supremum(self) -> None:
         """test_supremum"""
 
-        self.assertEqual(bool, supremum())
+        self.assertEqual(Boolean, supremum())
         self.assertEqual(Probability, supremum(Probability))
         self.assertEqual(PositiveReal, supremum(Probability, Natural))
         self.assertEqual(Real, supremum(Natural, Probability, Real))
-        self.assertEqual(Tensor, supremum(Real, Tensor, Natural, bool))
+        self.assertEqual(Tensor, supremum(Real, Tensor, Natural, Boolean))
 
     def test_type_of_value(self) -> None:
         """test_type_of_value"""
 
-        self.assertEqual(bool, type_of_value(True))
-        self.assertEqual(bool, type_of_value(False))
-        self.assertEqual(bool, type_of_value(0))
-        self.assertEqual(bool, type_of_value(1))
-        self.assertEqual(bool, type_of_value(0.0))
-        self.assertEqual(bool, type_of_value(1.0))
-        self.assertEqual(bool, type_of_value(tensor(True)))
-        self.assertEqual(bool, type_of_value(tensor(False)))
-        self.assertEqual(bool, type_of_value(tensor(0)))
-        self.assertEqual(bool, type_of_value(tensor(1)))
-        self.assertEqual(bool, type_of_value(tensor(0.0)))
-        self.assertEqual(bool, type_of_value(tensor(1.0)))
-        self.assertEqual(bool, type_of_value(tensor([[True]])))
-        self.assertEqual(bool, type_of_value(tensor([[False]])))
-        self.assertEqual(bool, type_of_value(tensor([[0]])))
-        self.assertEqual(bool, type_of_value(tensor([[1]])))
-        self.assertEqual(bool, type_of_value(tensor([[0.0]])))
-        self.assertEqual(bool, type_of_value(tensor([[1.0]])))
+        self.assertEqual(Boolean, type_of_value(True))
+        self.assertEqual(Boolean, type_of_value(False))
+        self.assertEqual(Boolean, type_of_value(0))
+        self.assertEqual(Boolean, type_of_value(1))
+        self.assertEqual(Boolean, type_of_value(0.0))
+        self.assertEqual(Boolean, type_of_value(1.0))
+        self.assertEqual(Boolean, type_of_value(tensor(False)))
+        self.assertEqual(Boolean, type_of_value(tensor(0)))
+        self.assertEqual(Boolean, type_of_value(tensor(1)))
+        self.assertEqual(Boolean, type_of_value(tensor(0.0)))
+        self.assertEqual(Boolean, type_of_value(tensor(1.0)))
+        self.assertEqual(Boolean, type_of_value(tensor([[True]])))
+        self.assertEqual(Boolean, type_of_value(tensor([[False]])))
+        self.assertEqual(Boolean, type_of_value(tensor([[0]])))
+        self.assertEqual(Boolean, type_of_value(tensor([[1]])))
+        self.assertEqual(Boolean, type_of_value(tensor([[0.0]])))
+        self.assertEqual(Boolean, type_of_value(tensor([[1.0]])))
         self.assertEqual(Natural, type_of_value(2))
         self.assertEqual(Natural, type_of_value(2.0))
         self.assertEqual(Natural, type_of_value(tensor(2)))
@@ -66,9 +66,9 @@ class BMGTypesTest(unittest.TestCase):
 
     def test_meets_requirement(self) -> None:
         """test_meets_requirement"""
-        self.assertFalse(meets_requirement(Natural, bool))
+        self.assertFalse(meets_requirement(Natural, Boolean))
         self.assertTrue(meets_requirement(Natural, Natural))
-        self.assertTrue(meets_requirement(bool, upper_bound(Natural)))
+        self.assertTrue(meets_requirement(Boolean, upper_bound(Natural)))
         self.assertTrue(meets_requirement(Natural, upper_bound(Natural)))
         self.assertFalse(meets_requirement(PositiveReal, upper_bound(Natural)))
 


### PR DESCRIPTION
Summary:
As noted in previous diffs in this stack, the current Beanstalk type analyzer uses real Python types like float and bool as markers for the types of graph nodes. We are going to need to abandon this practice as we start to support matrix types. The first step to make this happen is I am replacing usages of "bool" with an alias Boolean, that will soon be a proper object representing a particular lattice type.

So far I am just updating the type definition and its tests. I'll make this update throughout the rest of the system in later diffs, along with also adding the BMGLatticeType annotation mentioned earlier.

Differential Revision: D23015620

