### PR TITLE
add Adaptive-ABC-SMC to Bean Machine

### DIFF
--- a/src/beanmachine/ppl/experimental/abc/adaptive_abc_smc_infer.py
+++ b/src/beanmachine/ppl/experimental/abc/adaptive_abc_smc_infer.py
@@ -1,0 +1,264 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import logging
+from abc import ABCMeta
+from collections import defaultdict
+from typing import Callable, Dict, Union
+
+import torch
+import torch.distributions as dist
+import torch.tensor as tensor
+from beanmachine.ppl.experimental.abc.abc_infer import ApproximateBayesianComputation
+from beanmachine.ppl.inference.abstract_infer import VerboseLevel
+from beanmachine.ppl.inference.proposer.single_site_random_walk_proposer import (
+    SingleSiteRandomWalkProposer,
+)
+from beanmachine.ppl.inference.utils import safe_log_prob_sum
+from beanmachine.ppl.model.statistical_model import StatisticalModel
+from beanmachine.ppl.model.utils import LogLevel, Mode, RVIdentifier
+from torch import Tensor
+from tqdm.auto import tqdm  # pyre-ignore
+
+
+LOGGER_UPDATES = logging.getLogger("beanmachine.debug.updates")
+LOGGER_ERROR = logging.getLogger("beanmachine.error")
+
+
+class AdaptiveApproximateBayesianComputationSequentialMonteCarlo(
+    ApproximateBayesianComputation, metaclass=ABCMeta
+):
+    """
+    Inference object for adaptive ABC-SMC inference.
+    This implemenation follows from the paper: https://pubmed.ncbi.nlm.nih.gov/19880371/
+    """
+
+    def __init__(
+        self,
+        initial_tolerance: float,
+        target_tolerance: float,
+        perturb_kernel: Union[Callable, None] = None,
+        distance_function: Union[Dict, Callable] = torch.dist,
+        max_attempts_per_sample: int = 10000,
+        survival_rate: float = 0.5,
+    ):
+        """
+        :param perturb_kernel: The pertrubation kernel which takes previously accepted sample
+        and performs perturbation to it
+        :param distance_function: This can be a single Callable method which will be applied to all
+        summay statistics, or a dict which would have the summary statistics as keys and the specific
+        distance functions as values
+        :param target tolreance: The inference process stops when this tolrance value is attained
+        :param max_attempts_per_sample: number of attempts to make per sample before inference stops
+        :param survival_rate: the fraction of samples to pass to the next stage
+        """
+        super().__init__()
+        self.max_attempts_per_sample = max_attempts_per_sample
+        if perturb_kernel is None:
+            self.perturb_kernel = self.gaussian_random_walk_with_mh_steps
+        else:
+            self.perturb_kernel = perturb_kernel
+        self.distance_function = distance_function
+        self.tolerance = initial_tolerance
+        self.target_tolerance = target_tolerance
+        self.survival_rate = survival_rate
+        self.queries_sample_weights = []
+        self.previous_stage_queries_sample_weights = []
+        self.previous_stage_queries_sample = defaultdict()
+        self.step_size = 0.01
+        self.num_adaptive_samples = 0
+
+    def weighted_sample_draw(self) -> Dict:
+        """
+        performs a weighted draw from samples of previous stage
+        """
+        weighted_sample_draw = {}
+        draw = dist.Categorical(
+            self.tolerance - self.previous_stage_queries_sample_weights
+        ).sample()
+
+        for sample, value in self.previous_stage_queries_sample.items():
+            weighted_sample_draw[sample] = value[draw]
+        return weighted_sample_draw
+
+    def gaussian_random_walk_with_mh_steps(self, sample: Dict, stage: int) -> Dict:
+        """
+        Default perturb kernel. Performs a sigle step gaussian random walk. Variance decays with stage
+        :returns: perturbed sample
+        """
+        proposer = SingleSiteRandomWalkProposer(step_size=self.step_size)
+        for key, value in sample.items():
+            key.function._wrapper(*key.arguments)
+
+            node_var = self.world_.get_node_in_world(key)
+            # pyre-fixme
+            node_var.update_value(value)
+            is_accepted = False
+            (
+                proposed_value,
+                negative_proposal_log_update,
+                auxiliary_variables,
+            ) = proposer.propose(key, self.world_)
+            node_var.update_value(proposed_value)
+            proposal_distribution, _ = proposer.get_proposal_distribution(
+                key,
+                # pyre-fixme
+                node_var,
+                self.world_,
+                auxiliary_variables,
+            )
+            positive_proposal_log_update = safe_log_prob_sum(
+                proposal_distribution.proposal_distribution, value
+            )
+            proposal_log_update = (
+                positive_proposal_log_update + negative_proposal_log_update
+            )
+            node_var.update_value(value)
+            if proposal_log_update >= tensor(0.0):
+                is_accepted = True
+            else:
+                alpha = dist.Uniform(tensor(0.0), tensor(1.0)).sample().log()
+                if proposal_log_update > alpha:
+                    is_accepted = True
+                else:
+                    is_accepted = False
+            acceptance_prob = torch.min(
+                tensor(1.0, dtype=proposal_log_update.dtype),
+                torch.exp(proposal_log_update),
+            )
+            if self.num_accepted_samples <= self.num_adaptive_samples:
+                # do adaptation in each stage
+                # pyre-fixme
+                if node_var.value.reshape([-1]).shape[0] == 1:
+                    target_acc_rate = tensor(0.44)
+                    c = torch.reciprocal(target_acc_rate)
+                else:
+                    target_acc_rate = tensor(0.234)
+                    c = torch.reciprocal(1.0 - target_acc_rate)
+                new_step_size = self.step_size * torch.exp(
+                    (acceptance_prob - target_acc_rate)
+                    * c
+                    / (self.num_accepted_samples + 1.0)
+                )
+                self.step_size = new_step_size.item()
+            # pyre-fixme
+            node_var.update_value(proposed_value if is_accepted else value)
+
+    def _single_inference_step(self, stage: int) -> int:
+        """
+        Single inference step of the adaptive ABC-SMC algorithm which attempts to obtain a sample.
+        In the first stage, samples are generated from the prior of the node to be observed, and their
+        summary statistic is compared with summary statistic of provided observations. If distance is
+        within provided tolerence values, the sample is accepted. In concequent stages, the samples are
+        drawn from accepted samples of the last stage, perturbed using a perturbation kernel and
+        then the summray statistic is computed and compared for accept/reject. Each stage has a different
+        tolerance value which is computed from the max distance of accepted sample from last stage.
+        :param stage: the stage of Adaptive ABC-SMC inference used to choose from the tolerance schedule
+        :returns: 1 if sample is accepted and 0 if sample is rejected (used to update the tqdm iterator)
+        """
+        self.world_ = StatisticalModel.reset()
+        self.world_.set_initialize_from_prior(True)
+        self.world_.set_maintain_graph(False)
+        self.world_.set_cache_functionals(True)
+        StatisticalModel.set_mode(Mode.INFERENCE)
+        if not stage == 0:
+            # do a weighted sample draw and perturb step
+            weighted_sample = self.weighted_sample_draw()
+            self.perturb_kernel(weighted_sample, stage)
+
+        weights = []
+        for summary_statistic, observed_summary in self.observations_.items():
+            # makes the call for the summary statistic node, which will run sample(node())
+            # that results in adding its corresponding Variable and its dependent
+            # Variable to the world, as well as computing it's value
+            computed_summary = summary_statistic.function._wrapper(
+                *summary_statistic.arguments
+            )
+            # check if passed observation is a tensor, if not, cast it
+            if not torch.is_tensor(observed_summary):
+                observed_summary = torch.tensor(observed_summary)
+            # check if the shapes of computed and provided summary matches
+            if computed_summary.shape != observed_summary.shape:
+                raise ValueError(
+                    f"Shape mismatch in random variable {summary_statistic}"
+                    + "\nshape does not match with observation\n"
+                    + f"Expected observation shape: {computed_summary.shape};"
+                    + f"Provided observation shape{observed_summary.shape}"
+                )
+
+            # if user passed a dict for distance functions, load from it, else load default
+            if isinstance(self.distance_function, dict):
+                # pyre-fixme
+                distance_function = self.distance_function[summary_statistic]
+            else:
+                distance_function = self.distance_function
+
+            # perform rejection
+            distance = distance_function(
+                computed_summary.float(), observed_summary.float()
+            )
+            reject = torch.gt(distance, self.tolerance)
+            if reject:
+                self._reject_sample(node_key=summary_statistic)
+                return 0
+            weights.append(distance)
+        self.queries_sample_weights.append(torch.mean(torch.stack(weights)))
+        self._accept_sample()
+        return 1
+
+    def prepare_next_stage(self, num_samples: int, stage: int):
+        """
+        select the top (survival_rate * num_samples) samples with min distance for next stage
+        """
+        self.previous_stage_queries_sample_weights, indices = torch.topk(
+            torch.stack(self.queries_sample_weights),
+            int(num_samples * self.survival_rate),
+            largest=False,
+        )
+        self.tolerance = torch.max(self.previous_stage_queries_sample_weights).item()
+        if self.tolerance <= self.target_tolerance:
+            return
+        self.previous_stage_queries_sample = defaultdict()
+        for key in self.queries_sample:
+            self.previous_stage_queries_sample[key] = self.queries_sample[key][indices]
+        self.queries_sample = defaultdict()
+        self.num_accepted_samples = 0
+        self.queries_sample_weights = []
+
+    def _infer(
+        self,
+        num_samples: int,
+        num_adaptive_samples: int = 0,
+        verbose: VerboseLevel = VerboseLevel.LOAD_BAR,
+        initialize_from_prior: bool = True,
+    ) -> Dict[RVIdentifier, Tensor]:
+        """
+            Run adaptive ABC-SMC inference algorithm
+
+            :param num_samples: number of samples excluding adaptation.
+            :param num_adapt_steps: not used in rejection sampling
+            :param verbose: Integer indicating how much output to print to stdio
+            :param initialize_from_prior: boolean to initialize samples from prior
+            :returns: samples for the query
+            """
+        stage = 0
+        self.num_adaptive_samples = num_adaptive_samples
+        while self.tolerance >= self.target_tolerance:
+            total_attempted_samples = 0
+            # pyre-fixme
+            pbar = tqdm(
+                desc=f"Stage {stage + 1} with tolerance {self.tolerance}",
+                total=num_samples,
+                disable=not bool(verbose == VerboseLevel.LOAD_BAR),
+            )
+            while self.num_accepted_samples < num_samples:
+                pbar.update(self._single_inference_step(stage))
+                total_attempted_samples += 1
+            pbar.close()
+            LOGGER_UPDATES.log(
+                LogLevel.DEBUG_UPDATES.value,
+                f"Inference stage {stage} completed; accepted {num_samples} from \
+                    {total_attempted_samples} attempted samples. \
+                    \nAcceptance rate: {float(num_samples/total_attempted_samples)}",
+            )
+            self.prepare_next_stage(num_samples, stage)
+            stage += 1
+        return self.queries_sample

--- a/src/beanmachine/ppl/experimental/tests/adaptive_abc_smc_infer_test.py
+++ b/src/beanmachine/ppl/experimental/tests/adaptive_abc_smc_infer_test.py
@@ -1,0 +1,77 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import unittest
+
+import beanmachine.ppl as bm
+import torch
+import torch.distributions as dist
+from beanmachine.ppl.experimental.abc.adaptive_abc_smc_infer import (
+    AdaptiveApproximateBayesianComputationSequentialMonteCarlo,
+)
+
+
+class AdaptiveApproximateBayesianComputationSequentialMonteCarloTest(unittest.TestCase):
+    torch.manual_seed(42)
+
+    class CoinTossModel:
+        def __init__(self, observation_shape):
+            self.observation_shape = observation_shape
+
+        @bm.random_variable
+        def bias(self):
+            return dist.Beta(0.5, 0.5)
+
+        @bm.random_variable
+        def coin_toss(self):
+            return dist.Bernoulli(self.bias().repeat(self.observation_shape))
+
+        def toss_mean(self, toss_vals):
+            return torch.mean(toss_vals)
+
+        @bm.functional
+        def mean_value(self):
+            return self.toss_mean(self.coin_toss())
+
+    def test_adaptive_abc_smc_inference(self):
+        model = self.CoinTossModel(observation_shape=10)
+        COIN_TOSS_DATA = dist.Bernoulli(0.77).sample([10])
+        mean_value_key = model.mean_value()
+        adaptive_abc_smc = AdaptiveApproximateBayesianComputationSequentialMonteCarlo(
+            initial_tolerance=0.5, target_tolerance=0.1
+        )
+        observations = {mean_value_key: model.toss_mean(COIN_TOSS_DATA)}
+        queries = [model.bias()]
+        samples = adaptive_abc_smc.infer(
+            queries, observations, num_samples=100, num_chains=1
+        )
+        self.assertAlmostEqual(
+            torch.mean(samples[model.bias()][0]).item(), 0.77, delta=0.3
+        )
+        adaptive_abc_smc.reset()
+
+    def test_max_attempts(self):
+        model = self.CoinTossModel(observation_shape=100)
+        COIN_TOSS_DATA = dist.Bernoulli(0.9).sample([100])
+        mean_value_key = model.mean_value()
+        adaptive_abc_smc = AdaptiveApproximateBayesianComputationSequentialMonteCarlo(
+            initial_tolerance=0.5, target_tolerance=0.1, max_attempts_per_sample=2
+        )
+        observations = {mean_value_key: model.toss_mean(COIN_TOSS_DATA)}
+        queries = [model.bias()]
+        with self.assertRaises(RuntimeError):
+            adaptive_abc_smc.infer(
+                queries, observations, num_samples=100, num_chains=1, verbose=None
+            )
+        adaptive_abc_smc.reset()
+
+    def test_shape_mismatch(self):
+        model = self.CoinTossModel(observation_shape=100)
+        adaptive_abc_smc = AdaptiveApproximateBayesianComputationSequentialMonteCarlo(
+            initial_tolerance=0.5, target_tolerance=0.1
+        )
+        observations = {model.mean_value(): torch.tensor([3, 4])}
+        queries = [model.bias()]
+        with self.assertRaises(ValueError):
+            adaptive_abc_smc.infer(
+                queries, observations, num_samples=100, num_chains=1, verbose=None
+            )
+        adaptive_abc_smc.reset()


### PR DESCRIPTION
Summary:
This diff adds a new type of ABC-SMC infernece. In this method, the random walk steps are replaced with full MH steps. Also the tolreance value of each step is computed automatically from the selected samples of the last stage.

NOTE: Some elements of the HM step (acceptance rate, attempts per sample, etc) code are ad-hoc these will be updated once experimentation is complete. These may also be inputs from user.

Differential Revision: D23009862

