### PR TITLE
Format according to black linter

### DIFF
--- a/src/beanmachine/ppl/utils/fold_constants.py
+++ b/src/beanmachine/ppl/utils/fold_constants.py
@@ -647,7 +647,9 @@ _fold_all_constants: Rule = many(
 
 _fold_unary_minus = _bottom_up(
     once(
-        PatternRule(unarysub(operand=constant_literal), lambda u: ast.Num(-u.operand.n))
+        PatternRule(
+            unarysub(operand=constant_literal), lambda u: ast.Num(-(u.operand.n))
+        )
     )
 )
 


### PR DESCRIPTION
Summary: Just noticed that the linter has been complaining about this particular line when I ran it at `beanmachine/ppl` so I am trying to silence it.

Differential Revision: D23062296

