### PR TITLE
Drop warmup samples for posterior predictive.

### DIFF
--- a/src/beanmachine/ppl/inference/monte_carlo_samples.py
+++ b/src/beanmachine/ppl/inference/monte_carlo_samples.py
@@ -77,9 +77,10 @@ class MonteCarloSamples(object):
         :returns: samples drawn during inference for the specified variable
         """
 
-        steps_start = self.num_adaptive_samples
         if include_adapt_steps:
             steps_start = 0
+        else:
+            steps_start = self.num_adaptive_samples
 
         if self.chain is None:
             return self.data.rv_dict[rv][:, steps_start:]
@@ -98,8 +99,11 @@ class MonteCarloSamples(object):
         """
         return self.data.num_chains
 
-    def get_num_samples(self) -> int:
+    def get_num_samples(self, include_adapt_steps=False) -> int:
         """
         :returns: the number of samples run during inference
         """
-        return next(iter(self.data.rv_dict.values())).shape[-1]
+        total = next(iter(self.data.rv_dict.values())).shape[-1]
+        if include_adapt_steps:
+            return total
+        return total - self.num_adaptive_samples

--- a/src/beanmachine/ppl/inference/predictive.py
+++ b/src/beanmachine/ppl/inference/predictive.py
@@ -58,7 +58,10 @@ class Predictive(object):
         ) == 1, "Only one of posterior or num_samples should be set."
         sampler = SingleSiteAncestralMetropolisHastings()
         if posterior:
-            obs = posterior.data.rv_dict
+            n_warmup = posterior.num_adaptive_samples
+            post_dict = posterior.data.rv_dict
+            # drop the warm up samples
+            obs = {k: v[:, n_warmup:] for k, v in post_dict.items()}
             if vectorized:
                 # predictives are jointly sampled
                 sampler.queries_ = queries
@@ -132,7 +135,9 @@ class Predictive(object):
             (num_samples,)
         )
         for q in queries:
-            rv_dict[q] = samples.data.rv_dict[q][chain_indices, sample_indices]
+            rv_dict[q] = samples.get_variable(q, include_adapt_steps=False)[
+                chain_indices, sample_indices
+            ]
         return MonteCarloSamples([rv_dict])
 
 


### PR DESCRIPTION
Summary: This PR drops the warmup samples when using  posterior predictive and empirical.

Differential Revision: D23125318

