### PR TITLE
Rewrite for list comprehensions into SSA form

### DIFF
--- a/src/beanmachine/ppl/utils/ast_patterns.py
+++ b/src/beanmachine/ppl/utils/ast_patterns.py
@@ -175,6 +175,10 @@ def ast_while(
     )
 
 
+def ast_listComp(elt: Pattern = _any, generators: Pattern = _any) -> Pattern:
+    return type_and_attributes(ast.ListComp, {"elt": elt, "generators": generators})
+
+
 def ast_boolop(op: Pattern = _any, values: Pattern = _any) -> Pattern:
     return type_and_attributes(ast.BoolOp, {"op": op, "values": values})
 

--- a/src/beanmachine/ppl/utils/single_assignment_test.py
+++ b/src/beanmachine/ppl/utils/single_assignment_test.py
@@ -1175,3 +1175,166 @@ def flip_logit_constant():
         self.check_rewrite(source, expected)
 
         self.check_rewrite_ast(source, expected)
+
+    def test_single_assignment_listComp(self) -> None:
+        """Test the assign rule for desugaring listComps"""
+
+        source = """
+x = [i for i in range(0,j) if even(i+j)]
+"""
+        expected = """
+def p1():
+    r2 = []
+    for i in range(0, j):
+        if even(i + j):r2.append(i)
+    return r2
+
+
+x = p1()
+"""
+
+        self.check_rewrite(
+            source, expected, _some_top_down(self.s._handle_assign_listComp())
+        )
+
+        self.check_rewrite(
+            source, expected, many(_some_top_down(self.s._handle_assign_listComp()))
+        )
+
+        expected = """
+def p1():
+    r2 = []
+    a12 = 0
+    a10 = [a12]
+    a13 = [j]
+    r8 = a10 + a13
+    r14 = {}
+    f3 = range(*r8, **r14)
+    for i in f3:
+        a9 = i + j
+        r6 = [a9]
+        r11 = {}
+        r4 = even(*r6, **r11)
+        if r4:r2.append(i)
+    return r2
+
+
+r5 = []
+r7 = {}
+x = p1(*r5, **r7)
+"""
+        self.check_rewrite(source, expected)
+
+        source = """
+y = [(x,y) for x in range(0,10) for y in range (x,10) if y == 2*x]
+"""
+        expected = """
+def p1():
+    r2 = []
+    for x in range(0, 10):
+        for y in range(x, 10):
+            if y == 2 * x:r2.append((x, y))
+    return r2
+
+
+y = p1()
+"""
+
+        self.check_rewrite(
+            source, expected, _some_top_down(self.s._handle_assign_listComp())
+        )
+
+        self.check_rewrite(
+            source, expected, many(_some_top_down(self.s._handle_assign_listComp()))
+        )
+
+        expected = """
+def p1():
+    r2 = []
+    a13 = 0
+    a11 = [a13]
+    a17 = 10
+    a14 = [a17]
+    r9 = a11 + a14
+    r15 = {}
+    f3 = range(*r9, **r15)
+    for x in f3:
+        a16 = [x]
+        a20 = 10
+        a18 = [a20]
+        r12 = a16 + a18
+        r19 = {}
+        f4 = range(*r12, **r19)
+        for y in f4:
+            a10 = 2
+            a7 = a10 * x
+            r6 = y == a7
+            if r6:r2.append((x, y))
+    return r2
+
+
+r5 = []
+r8 = {}
+y = p1(*r5, **r8)
+"""
+
+        self.check_rewrite(source, expected)
+
+        source = """
+y = [(x,y) for x in range(0,10) if x>0 for y in range (x,10) if y == 2*x]
+"""
+        expected = """
+def p1():
+    r2 = []
+    for x in range(0, 10):
+        if x > 0:
+            for y in range(x, 10):
+                if y == 2 * x:r2.append((x, y))
+    return r2
+
+
+y = p1()
+"""
+
+        self.check_rewrite(
+            source, expected, _some_top_down(self.s._handle_assign_listComp())
+        )
+
+        self.check_rewrite(
+            source, expected, many(_some_top_down(self.s._handle_assign_listComp()))
+        )
+
+        expected = """
+def p1():
+    r2 = []
+    a14 = 0
+    a12 = [a14]
+    a18 = 10
+    a15 = [a18]
+    r10 = a12 + a15
+    r16 = {}
+    f3 = range(*r10, **r16)
+    for x in f3:
+        a6 = 0
+        r4 = x > a6
+        if r4:
+            a19 = [x]
+            a22 = 10
+            a20 = [a22]
+            r17 = a19 + a20
+            r21 = {}
+            f7 = range(*r17, **r21)
+            for y in f7:
+                a13 = 2
+                a11 = a13 * x
+                r8 = y == a11
+                if r8:r2.append((x, y))
+    return r2
+
+
+r5 = []
+r9 = {}
+y = p1(*r5, **r9)
+"""
+
+        self.check_rewrite(source, expected)


### PR DESCRIPTION
Summary:
List comprehensions are expressions like

   y = [c for v_i in e_i if b_i].

The key insight in this diff is that such expressions can be desugared
into expressions that use operators for which we already have
rewrites. In particular, an expression such as the above would be
translated into one with the following form:

   def p():
      r = []
      for v_i in e_i
         if b_i:r.append(c)
      return r
   y=p()

From then on, existing rewrites handle the rest of SSA conversion.

We use a new function definition in the rewriten term to address
scoping issues, of which there are two. First, we do not want v_i to
be visible outside the scope of the lhs of the assignment we started
off with (actually, not even outside the comprehension brackets within
that lhs). Second, we do not want any interference between the names
v_i and the name y, which can in principle overlap. Both issues are
addressed with the use of the new function definition. Note also that
p and r are fresh names.

While adding this rewrite, a couple of incidental additions were
made. First, some comments were added to existing functions. Second, a
new function freshName was introduced to make it more convenient to
introduced fresh names (such as p and r) while building a new term.

Differential Revision: D23247448

