### PR TITLE
Make a type for lattice types

### DIFF
--- a/src/beanmachine/ppl/compiler/bmg_nodes.py
+++ b/src/beanmachine/ppl/compiler/bmg_nodes.py
@@ -19,6 +19,7 @@ from beanmachine.ppl.compiler.bmg_types import (
     Probability,
     Real,
     Requirement,
+    Tensor as BMGTensor,
     supremum,
     type_of_value,
     upper_bound,
@@ -27,6 +28,8 @@ from beanmachine.ppl.compiler.internal_error import InternalError
 from torch import Tensor, tensor
 from torch.distributions.utils import broadcast_all
 
+
+# TODO: BMGTensor will be eliminated soon in favor of matrix types.
 
 # TODO: For reasons unknown, Pyre is unable to find type information about
 # TODO: beanmachine.graph from beanmachine.ppl.  I'll figure out why later;
@@ -460,7 +463,7 @@ class TensorNode(ConstantNode):
 
     @property
     def graph_type(self) -> BMGLatticeType:
-        return Tensor
+        return BMGTensor
 
     @property
     def size(self) -> torch.Size:
@@ -866,7 +869,7 @@ we generate a different node in BMG."""
         # TODO: We do not yet support categoricals in BMG and when we do,
         # we will likely need to implement a simplex type rather than
         # a tensor. Fix this up when categoricals are implemented.
-        return [Tensor]
+        return [BMGTensor]
 
     @property
     def size(self) -> torch.Size:
@@ -963,11 +966,11 @@ distribution."""
 
     @property
     def graph_type(self) -> BMGLatticeType:
-        return Tensor
+        return BMGTensor
 
     @property
     def inf_type(self) -> BMGLatticeType:
-        return Tensor
+        return BMGTensor
 
     @property
     def requirements(self) -> List[Requirement]:
@@ -975,7 +978,7 @@ distribution."""
         # TODO: We do not yet support Dirichlet in BMG; when we do
         # verify that this is correct. Also, we may wish at that
         # time to also note that the sample type is a simplex.
-        return [Tensor]
+        return [BMGTensor]
 
     @property
     def size(self) -> torch.Size:
@@ -1753,7 +1756,7 @@ class DivisionNode(BinaryOperatorNode):
         lgt = self.left.graph_type
         if lgt != self.right.graph_type:
             return Malformed
-        if lgt != PositiveReal and lgt != Real and lgt != Tensor:
+        if lgt != PositiveReal and lgt != Real and lgt != BMGTensor:
             return Malformed
         return lgt
 
@@ -1856,7 +1859,7 @@ multiple control flows based on the value of a stochastic node."""
         it = self.inf_type
         # TODO: This isn't quite right; when we support this kind of node
         # in BMG, fix this.
-        return [upper_bound(Tensor), it] * (len(self.children) // 2)
+        return [upper_bound(BMGTensor), it] * (len(self.children) // 2)
 
     @property
     def size(self) -> torch.Size:
@@ -1916,7 +1919,7 @@ choose an element from the map."""
         it = self.inf_type
         # TODO: This isn't quite right; when we support this kind of node
         # in BMG, fix this.
-        return [upper_bound(Tensor), it]
+        return [upper_bound(BMGTensor), it]
 
     @property
     def size(self) -> torch.Size:

--- a/src/beanmachine/ppl/compiler/bmg_nodes_test.py
+++ b/src/beanmachine/ppl/compiler/bmg_nodes_test.py
@@ -415,7 +415,7 @@ class ASTToolsTest(unittest.TestCase):
         # Probability x PositiveReal -> PositiveReal
         # Probability x Real -> Real
         self.assertEqual(
-            MultiplicationNode(beta, bern).requirements, [Probability, bool]
+            MultiplicationNode(beta, bern).requirements, [Probability, Boolean]
         )
         self.assertEqual(
             MultiplicationNode(beta, beta).requirements, [Probability, Probability]

--- a/src/beanmachine/ppl/compiler/bmg_types_test.py
+++ b/src/beanmachine/ppl/compiler/bmg_types_test.py
@@ -8,13 +8,17 @@ from beanmachine.ppl.compiler.bmg_types import (
     PositiveReal,
     Probability,
     Real,
+    Tensor,
     meets_requirement,
     supremum,
     type_of_value,
     upper_bound,
 )
 from beanmachine.ppl.utils.bm_graph_builder import BMGraphBuilder
-from torch import Tensor, tensor
+from torch import tensor
+
+
+# TODO: Tensor type will be removed in favor of matrix types soon.
 
 
 class BMGTypesTest(unittest.TestCase):

--- a/src/beanmachine/ppl/compiler/error_report.py
+++ b/src/beanmachine/ppl/compiler/error_report.py
@@ -7,7 +7,12 @@ from abc import ABC
 from typing import List
 
 from beanmachine.ppl.compiler.bmg_nodes import BMGNode
-from beanmachine.ppl.compiler.bmg_types import Requirement, UpperBound, name_of_type
+from beanmachine.ppl.compiler.bmg_types import (
+    BMGLatticeType,
+    Requirement,
+    UpperBound,
+    name_of_type,
+)
 
 
 class BMGError(ABC):
@@ -29,12 +34,9 @@ class Violation(BMGError):
         self.edge = edge
 
     def __str__(self) -> str:
-        t = (
-            self.requirement.bound
-            if isinstance(self.requirement, UpperBound)
-            else self.requirement
-        )
-        assert isinstance(t, type)
+        r = self.requirement
+        t = r.bound if isinstance(r, UpperBound) else r
+        assert isinstance(t, BMGLatticeType)
         msg = (
             f"The {self.edge} of a {self.consumer.label} "
             + f"is required to be a {name_of_type(t)} "

--- a/src/beanmachine/ppl/compiler/fix_problems.py
+++ b/src/beanmachine/ppl/compiler/fix_problems.py
@@ -272,7 +272,7 @@ error is added to the error report."""
         # * The requirement is an upper-bound requirement, and the inf type
         #   meets it. Convert the node to the inf type.
 
-        if isinstance(requirement, type):
+        if isinstance(requirement, BMGLatticeType):
             result = self._convert_node(node, requirement, consumer, edge)
         else:
             result = self._convert_node(node, it, consumer, edge)


### PR DESCRIPTION
Summary: The BMG type system now has complex types such as 2x2-matrix-of-reals, and so on; we will need a proper class for representing instances of BMG types. In this diff I create a base type, but we are still only handling "scalar" types. I will gradually add support for matrix types in subsequent diffs

Reviewed By: wtaha

Differential Revision: D23116114

