### PR TITLE
Convert all relative imports -> absolute imports

### DIFF
--- a/src/beanmachine/applications/clara/nmc_df.py
+++ b/src/beanmachine/applications/clara/nmc_df.py
@@ -3,8 +3,7 @@ from typing import NamedTuple
 
 import numpy as np
 import pandas as pd
-
-from .nmc import obtain_posterior
+from beanmachine.applications.clara.nmc import obtain_posterior
 
 
 logger = logging.getLogger(__name__)

--- a/src/beanmachine/ppl/__init__.py
+++ b/src/beanmachine/ppl/__init__.py
@@ -1,7 +1,11 @@
-from . import experimental
-from .diagnostics import Diagnostics
-from .diagnostics.common_statistics import effective_sample_size, r_hat, split_r_hat
-from .inference import (
+from beanmachine.ppl import experimental
+from beanmachine.ppl.diagnostics import Diagnostics
+from beanmachine.ppl.diagnostics.common_statistics import (
+    effective_sample_size,
+    r_hat,
+    split_r_hat,
+)
+from beanmachine.ppl.inference import (
     CompositionalInference,
     Predictive,
     RejectionSampling,
@@ -14,7 +18,7 @@ from .inference import (
     empirical,
     simulate,
 )
-from .model import functional, get_beanmachine_logger, random_variable
+from beanmachine.ppl.model import functional, get_beanmachine_logger, random_variable
 
 
 LOGGER = get_beanmachine_logger()

--- a/src/beanmachine/ppl/diagnostics/diagnostics.py
+++ b/src/beanmachine/ppl/diagnostics/diagnostics.py
@@ -8,12 +8,11 @@ from typing import Callable, Dict, List, Optional, Tuple
 import numpy as np
 import pandas as pd
 import plotly
+from beanmachine.ppl.diagnostics import common_plots, common_statistics as common_stats
 from beanmachine.ppl.inference.monte_carlo_samples import MonteCarloSamples
 from beanmachine.ppl.model.utils import RVIdentifier
 from plotly.subplots import make_subplots
 from torch import Tensor
-
-from . import common_plots, common_statistics as common_stats
 
 
 class BaseDiagnostics:

--- a/src/beanmachine/ppl/experimental/inference_compilation/ic_infer.py
+++ b/src/beanmachine/ppl/experimental/inference_compilation/ic_infer.py
@@ -8,20 +8,19 @@ import torch
 import torch.distributions as dist
 import torch.nn as nn
 import torch.optim as optim
-from torch import Tensor, tensor
-from tqdm.auto import tqdm  # pyre-ignore
-
-from ...inference.abstract_infer import AbstractInference
-from ...inference.abstract_mh_infer import AbstractMHInference
-from ...inference.proposer.abstract_single_site_single_step_proposer import (
+from beanmachine.ppl.experimental.inference_compilation import utils
+from beanmachine.ppl.inference.abstract_infer import AbstractInference
+from beanmachine.ppl.inference.abstract_mh_infer import AbstractMHInference
+from beanmachine.ppl.inference.proposer.abstract_single_site_single_step_proposer import (
     AbstractSingleSiteSingleStepProposer,
 )
-from ...inference.proposer.single_site_ancestral_proposer import (
+from beanmachine.ppl.inference.proposer.single_site_ancestral_proposer import (
     SingleSiteAncestralProposer,
 )
-from ...model.utils import RVIdentifier
-from ...world import ProposalDistribution, Variable, World
-from . import utils
+from beanmachine.ppl.model.utils import RVIdentifier
+from beanmachine.ppl.world import ProposalDistribution, Variable, World
+from torch import Tensor, tensor
+from tqdm.auto import tqdm  # pyre-ignore
 
 
 LOGGER_IC = logging.getLogger("beanmachine.debug.ic")

--- a/src/beanmachine/ppl/inference/__init__.py
+++ b/src/beanmachine/ppl/inference/__init__.py
@@ -11,12 +11,13 @@ from beanmachine.ppl.inference.single_site_hamiltonian_monte_carlo import (
 from beanmachine.ppl.inference.single_site_newtonian_monte_carlo import (
     SingleSiteNewtonianMonteCarlo,
 )
+from beanmachine.ppl.inference.single_site_no_u_turn_sampler import (
+    SingleSiteNoUTurnSampler,
+)
 from beanmachine.ppl.inference.single_site_random_walk import SingleSiteRandomWalk
 from beanmachine.ppl.inference.single_site_uniform_mh import (
     SingleSiteUniformMetropolisHastings,
 )
-
-from .single_site_no_u_turn_sampler import SingleSiteNoUTurnSampler
 
 
 __all__ = [

--- a/src/beanmachine/ppl/inference/abstract_infer.py
+++ b/src/beanmachine/ppl/inference/abstract_infer.py
@@ -7,13 +7,12 @@ from typing import ClassVar, Dict, List
 
 import torch
 import torch.multiprocessing as mp
+from beanmachine.ppl.inference.monte_carlo_samples import MonteCarloSamples
+from beanmachine.ppl.model.statistical_model import StatisticalModel
+from beanmachine.ppl.model.utils import LogLevel, RVIdentifier
+from beanmachine.ppl.world import World
 from torch import Tensor
 from torch.multiprocessing import Queue
-
-from ..model.statistical_model import StatisticalModel
-from ..model.utils import LogLevel, RVIdentifier
-from ..world import World
-from .monte_carlo_samples import MonteCarloSamples
 
 
 class VerboseLevel(Enum):

--- a/src/beanmachine/ppl/inference/predictive.py
+++ b/src/beanmachine/ppl/inference/predictive.py
@@ -4,10 +4,11 @@ from typing import Dict, List, Optional
 
 import torch
 from beanmachine.ppl.inference.monte_carlo_samples import MonteCarloSamples
+from beanmachine.ppl.inference.single_site_ancestral_mh import (
+    SingleSiteAncestralMetropolisHastings,
+)
 from beanmachine.ppl.model.utils import RVIdentifier
 from torch.distributions import Categorical
-
-from .single_site_ancestral_mh import SingleSiteAncestralMetropolisHastings
 
 
 def _concat_rv_dicts(rvdict: List) -> Dict:

--- a/src/beanmachine/ppl/inference/single_site_no_u_turn_sampler.py
+++ b/src/beanmachine/ppl/inference/single_site_no_u_turn_sampler.py
@@ -2,12 +2,11 @@
 from typing import List, Optional
 
 from beanmachine.ppl.inference.abstract_mh_infer import AbstractMHInference
-from beanmachine.ppl.model.utils import RVIdentifier
-from beanmachine.ppl.world.world import TransformType
-
-from .proposer.single_site_no_u_turn_sampler_proposer import (
+from beanmachine.ppl.inference.proposer.single_site_no_u_turn_sampler_proposer import (
     SingleSiteNoUTurnSamplerProposer,
 )
+from beanmachine.ppl.model.utils import RVIdentifier
+from beanmachine.ppl.world.world import TransformType
 
 
 class SingleSiteNoUTurnSampler(AbstractMHInference):


### PR DESCRIPTION
Summary:
Converting all relative imports in bean machine library to absolute imports (i.e. import via full package name).

The downside of relative imports, apart from being discouraged in [some style guides](https://google.github.io/styleguide/pyguide.html#224-decision), is that relative imports can break testing when they are not being run as part of the package.

I haven't find an easy way to mark relative imports as lint errors. The files that get updates here are selected by searching for "`from .`" and "`import .`" patterns from the root of project directory.

Once we update CircleCI, relative imports will likely lead to ImportError on `user_install`... this could serve as a reminder for us to not use relative imports in the future.

Differential Revision: D23331807

