### PR TITLE
Update docker image to Python 3.7 on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,9 +93,9 @@ commands:
 
 jobs:
 
-  dev_install_test_py36_pip:
+  dev_install_test_py37_pip:
     docker:
-      - image: circleci/python:3.6.9
+      - image: circleci/python:3.7
     steps:
       - apt_get_install_deps
       - pip_install_deps
@@ -103,9 +103,9 @@ jobs:
       - dev_install
       - dev_unit_tests
 
-  user_install_test_py36_pip:
+  user_install_test_py37_pip:
     docker:
-      - image: circleci/python:3.6.9
+      - image: circleci/python:3.7
     steps:
       - apt_get_install_deps
       - pip_install_deps
@@ -113,9 +113,9 @@ jobs:
       - user_install
       - user_unit_tests
 
-  lint_py36_pip:
+  lint_py37_pip:
     docker:
-      - image: circleci/python:3.6.9
+      - image: circleci/python:3.7
     steps:
       - checkout
       - pip_lint_install
@@ -137,11 +137,11 @@ workflows:
 
   lint_and_test:
     jobs:
-      - lint_py36_pip:
+      - lint_py37_pip:
           filters: *exclude_ghpages_fbconfig
 
-      - dev_install_test_py36_pip:
+      - dev_install_test_py37_pip:
           filters: *exclude_ghpages_fbconfig
 
-      - user_install_test_py36_pip:
+      - user_install_test_py37_pip:
           filters: *exclude_ghpages_fbconfig

--- a/setup.py
+++ b/setup.py
@@ -128,10 +128,9 @@ setup(
     ],
     long_description=long_description,
     long_description_content_type="text/markdown",
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=[
         "torch>=1.6.0",
-        "dataclasses>=0.6",
         "pandas>=0.24.2",
         "plotly>=2.2.1",
         "scipy>=0.16",


### PR DESCRIPTION
Summary: Update docker image to use Python 3.7, which allows us to take advantage of some features available in the newer version of Python (e.g., avoid circular import issue).

Differential Revision: D23355029

