### PR TITLE
Fix likelihood.forward

### DIFF
--- a/src/beanmachine/ppl/experimental/gp/likelihoods.py
+++ b/src/beanmachine/ppl/experimental/gp/likelihoods.py
@@ -1,6 +1,4 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
-from functools import partial
-
 import beanmachine.ppl as bm
 import gpytorch.likelihoods as likelihoods
 
@@ -14,16 +12,9 @@ class GpytorchMixin(object):
     @bm.random_variable
     def forward(self, prior_sample, *args, **kwargs):
         """
-        A `random_variable` annotated callable. Returns a pointer to the callable
-        that returns a torch distribution
+        Returns a sample from the likelihood given a prior random variable.
         """
-        fn = partial(super().forward, prior_sample())
-        return fn(*args, **kwargs)
-
-    @bm.random_variable
-    def marginal(self, *args, **kwargs):
-        # TODO this will work after predictive sampling is implemented
-        return super().marginal(*args, **kwargs)
+        return super().forward(prior_sample())
 
 
 all_likelihoods = []

--- a/src/beanmachine/ppl/experimental/tests/gp/likelihood_test.py
+++ b/src/beanmachine/ppl/experimental/tests/gp/likelihood_test.py
@@ -17,6 +17,7 @@ class LikelihoodTest(unittest.TestCase):
 
     def test_forward_smoke(self):
         n = gpytorch.distributions.MultivariateNormal(torch.zeros(2), torch.eye(2))
-        assert isinstance(likelihoods.GaussianLikelihood().marginal(n), RVIdentifier)
         assert isinstance(likelihoods.GaussianLikelihood().forward(n), RVIdentifier)
-        assert isinstance(likelihoods.GaussianLikelihood()(n), RVIdentifier)
+        assert isinstance(
+            likelihoods.GaussianLikelihood().forward(torch.zeros(2)), RVIdentifier
+        )


### PR DESCRIPTION
Summary:
Using partial messes up the markov blanket parsing.

I removed marginal since that can be done non-analytically via simulate, and it doesnt play well with gpytorch's `marginal` computations.

Differential Revision: D23363535

