### PR TITLE
Start tracking "one-hot" scalars in type system

### DIFF
--- a/src/beanmachine/ppl/compiler/bmg_nodes_test.py
+++ b/src/beanmachine/ppl/compiler/bmg_nodes_test.py
@@ -29,6 +29,7 @@ from beanmachine.ppl.compiler.bmg_nodes import (
 from beanmachine.ppl.compiler.bmg_types import (
     Boolean,
     Natural,
+    One,
     PositiveReal,
     Probability,
     Real,
@@ -51,12 +52,14 @@ class ASTToolsTest(unittest.TestCase):
         # Constants
 
         b = BooleanNode(True)
+        bf = BooleanNode(False)
         prob = ProbabilityNode(0.5)
         pos = PositiveRealNode(1.5)
         real = RealNode(-1.5)
         nat = NaturalNode(2)
 
-        self.assertEqual(b.inf_type, Boolean)
+        self.assertEqual(b.inf_type, One)
+        self.assertEqual(bf.inf_type, Boolean)
         self.assertEqual(prob.inf_type, Probability)
         self.assertEqual(pos.inf_type, PositiveReal)
         self.assertEqual(real.inf_type, Real)
@@ -65,8 +68,8 @@ class ASTToolsTest(unittest.TestCase):
         # Constant infimum type depends on the value,
         # not the type of the container.
 
-        self.assertEqual(ProbabilityNode(1.0).inf_type, Boolean)
-        self.assertEqual(NaturalNode(1).inf_type, Boolean)
+        self.assertEqual(ProbabilityNode(1.0).inf_type, One)
+        self.assertEqual(NaturalNode(1).inf_type, One)
         self.assertEqual(PositiveRealNode(2.0).inf_type, Natural)
         self.assertEqual(RealNode(2.5).inf_type, PositiveReal)
 

--- a/src/beanmachine/ppl/compiler/bmg_types.py
+++ b/src/beanmachine/ppl/compiler/bmg_types.py
@@ -201,20 +201,20 @@ class SimplexMatrix(BMGMatrixType):
 @memoize
 class OneHotMatrix(BMGMatrixType):
     def __init__(self, rows: int, columns: int) -> None:
-        BMGMatrixType.__init__(
-            self,
-            bool_element,
-            f"OH[{rows},{columns}]",
-            f"{rows} x {columns} one-hot matrix",
-            rows,
-            columns,
+        short_name = "OH" if rows == 1 and columns == 1 else f"OH[{rows},{columns}]"
+        long_name = (
+            "one-hot"
+            if rows == 1 and columns == 1
+            else f"{rows} x {columns} one-hot matrix"
         )
+        BMGMatrixType.__init__(self, bool_element, short_name, long_name, rows, columns)
 
     def with_dimensions(self, rows: int, columns: int) -> BMGMatrixType:
         return OneHotMatrix(rows, columns)
 
 
 bottom = BMGLatticeType("bottom", "bottom")
+One = OneHotMatrix(1, 1)
 Boolean = BooleanMatrix(1, 1)
 Natural = NaturalMatrix(1, 1)
 Probability = ProbabilityMatrix(1, 1)
@@ -432,20 +432,20 @@ greater than or equal to all of them."""
     return result
 
 
-# TODO: Update this algorithm
-
-
 def type_of_value(v: Any) -> BMGLatticeType:
     """This computes the smallest BMG type that a given value fits into."""
     if isinstance(v, torch.Tensor):
+        # TODO: Update this algorithm to support 2-dimensional matrices
         if v.numel() == 1:
             return type_of_value(float(v))  # pyre-fixme
         return Tensor
     if isinstance(v, bool):
-        return Boolean
+        return One if v else Boolean
     if isinstance(v, int):
-        if v == 0 or v == 1:
+        if v == 0:
             return Boolean
+        if v == 1:
+            return One
         if v >= 2:
             return Natural
         return Real

--- a/src/beanmachine/ppl/compiler/bmg_types_test.py
+++ b/src/beanmachine/ppl/compiler/bmg_types_test.py
@@ -7,6 +7,7 @@ from beanmachine.ppl.compiler.bmg_types import (
     BooleanMatrix,
     Natural,
     NaturalMatrix,
+    One,
     PositiveReal,
     PositiveRealMatrix,
     Probability,
@@ -58,23 +59,23 @@ class BMGTypesTest(unittest.TestCase):
     def test_type_of_value(self) -> None:
         """test_type_of_value"""
 
-        self.assertEqual(Boolean, type_of_value(True))
+        self.assertEqual(One, type_of_value(True))
         self.assertEqual(Boolean, type_of_value(False))
         self.assertEqual(Boolean, type_of_value(0))
-        self.assertEqual(Boolean, type_of_value(1))
+        self.assertEqual(One, type_of_value(1))
         self.assertEqual(Boolean, type_of_value(0.0))
-        self.assertEqual(Boolean, type_of_value(1.0))
+        self.assertEqual(One, type_of_value(1.0))
         self.assertEqual(Boolean, type_of_value(tensor(False)))
         self.assertEqual(Boolean, type_of_value(tensor(0)))
-        self.assertEqual(Boolean, type_of_value(tensor(1)))
+        self.assertEqual(One, type_of_value(tensor(1)))
         self.assertEqual(Boolean, type_of_value(tensor(0.0)))
-        self.assertEqual(Boolean, type_of_value(tensor(1.0)))
-        self.assertEqual(Boolean, type_of_value(tensor([[True]])))
+        self.assertEqual(One, type_of_value(tensor(1.0)))
+        self.assertEqual(One, type_of_value(tensor([[True]])))
         self.assertEqual(Boolean, type_of_value(tensor([[False]])))
         self.assertEqual(Boolean, type_of_value(tensor([[0]])))
-        self.assertEqual(Boolean, type_of_value(tensor([[1]])))
+        self.assertEqual(One, type_of_value(tensor([[1]])))
         self.assertEqual(Boolean, type_of_value(tensor([[0.0]])))
-        self.assertEqual(Boolean, type_of_value(tensor([[1.0]])))
+        self.assertEqual(One, type_of_value(tensor([[1.0]])))
         self.assertEqual(Natural, type_of_value(2))
         self.assertEqual(Natural, type_of_value(2.0))
         self.assertEqual(Natural, type_of_value(tensor(2)))
@@ -119,7 +120,7 @@ class BMGTypesTest(unittest.TestCase):
         observed = bmg.to_dot(True, True, True, True)
         expected = """
 digraph "graph" {
-  N00[label="1.0:T>=B"];
+  N00[label="1.0:T>=OH"];
   N01[label="2.0:T>=N"];
   N02[label="0.5:T>=P"];
   N03[label="Beta:P>=P"];

--- a/src/beanmachine/ppl/compiler/fix_problems_test.py
+++ b/src/beanmachine/ppl/compiler/fix_problems_test.py
@@ -399,11 +399,16 @@ The unsupported node is the mu of a Normal.
         norm = bmg.add_normal(q, one)
         bmg.add_sample(norm)
 
-        observed = bmg.to_dot(True, True, True, True)
+        observed = bmg.to_dot(
+            graph_types=True,
+            inf_types=True,
+            edge_requirements=True,
+            point_at_input=True,
+        )
 
         expected = """
 digraph "graph" {
-  N0[label="1.0:R>=B"];
+  N0[label="1.0:R>=OH"];
   N1[label="2.5:R>=R+"];
   N2[label="HalfCauchy:R+>=R+"];
   N3[label="Sample:R+>=R+"];
@@ -430,7 +435,7 @@ digraph "graph" {
 
         expected = """
 digraph "graph" {
-  N00[label="1.0:R>=B"];
+  N00[label="1.0:R>=OH"];
   N01[label="2.5:R>=R+"];
   N02[label="HalfCauchy:R+>=R+"];
   N03[label="Sample:R+>=R+"];
@@ -439,7 +444,7 @@ digraph "graph" {
   N06[label="Sample:R>=R"];
   N07[label="0.4:R>=P"];
   N08[label="*:R+>=R+"];
-  N09[label="1.0:R+>=B"];
+  N09[label="1.0:R+>=OH"];
   N10[label="0.4:R+>=P"];
   N11[label="ToReal:R>=R"];
   N01 -> N04[label="right:R+"];
@@ -522,7 +527,7 @@ The unsupported node is the operand of a Sample.
 
         expected = """
 digraph "graph" {
-  N0[label="1.0:R>=B"];
+  N0[label="1.0:R>=OH"];
   N1[label="HalfCauchy:R+>=R+"];
   N2[label="Sample:R+>=R+"];
   N3[label="Chi2:R+>=R+"];
@@ -549,7 +554,7 @@ digraph "graph" {
 
         expected = """
 digraph "graph" {
-  N0[label="1.0:R>=B"];
+  N0[label="1.0:R>=OH"];
   N1[label="HalfCauchy:R+>=R+"];
   N2[label="Sample:R+>=R+"];
   N3[label="Chi2:R+>=R+"];
@@ -557,7 +562,7 @@ digraph "graph" {
   N5[label="0.5:R+>=P"];
   N6[label="*:R+>=R+"];
   N7[label="Gamma:R+>=R+"];
-  N8[label="1.0:R+>=B"];
+  N8[label="1.0:R+>=OH"];
   N1 -> N2[label="operand:R+"];
   N2 -> N3[label="df:R+"];
   N2 -> N6[label="left:R+"];


### PR DESCRIPTION
Summary:
The addition of both Boolean and row-simplex matrices to the type system presents a problem.

A "one-hot" matrix has every row all 0 except for a single 1. But that is clearly usable as both a Boolean matrix -- since every element is 0 or 1 -- or as a row-simplex matrix -- since every row's values are between 0 and 1, and they add to 1.

The solution is to add "one-hot matrix" as a lattice type smaller than both Boolean matrix and simplex matrix.  This lattice type only shows up in type analysis, and only in cases where we have a constant value; it is not an actual type in the BMG type system proper.

Since we are treating scalars the same as 1x1 matrices, we can start testing support of one-hot by treating any constant 1, 1.0, or True, or any tensor containing a single element of those values, as having the infimum type "One" which I will make a synonym for "1x1 one-hot matrix".

As we add support in the analysis for larger matrix types we will add tests for larger one-hot matrices.

Reviewed By: wtaha

Differential Revision: D23193024

