### PR TITLE
Fix warning in test files

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,3 +9,7 @@ exclude =
 [tool:pytest]
 # any ignore= commands can be added here if needed
 addopts = "--ignore-glob=tutorials/*.py"
+filterwarnings =
+    error
+    # patsy is a statsmodels dependency which currently triggers a DeprecationWarning
+    default::DeprecationWarning:patsy.constraint

--- a/setup.py
+++ b/setup.py
@@ -135,7 +135,7 @@ setup(
         "plotly>=2.2.1",
         "scipy>=0.16",
         "statsmodels>=0.8.0",
-        "tqdm>=4.40.2",
+        "tqdm>=4.46.0",
         "astor>=0.7.1",
         "black>=19.3b0",
     ],

--- a/src/beanmachine/graph/tests/nmc_test.py
+++ b/src/beanmachine/graph/tests/nmc_test.py
@@ -145,10 +145,10 @@ class TestNMC(unittest.TestCase):
         g.query(phi_x_sq)
         means = g.infer_mean(10000, graph.InferenceType.NMC)
         post_var = means[1] - means[0] ** 2
-        self.assertAlmostEquals(
+        self.assertAlmostEqual(
             means[0], 2 / (2 + 1), 2, f"posterior mean {means[0]} is not accurate"
         )
-        self.assertAlmostEquals(
+        self.assertAlmostEqual(
             post_var,
             2 * 1 / (2 + 1) ** 2 / (2 + 1 + 1),
             2,

--- a/src/beanmachine/graph/tests/operator_test.py
+++ b/src/beanmachine/graph/tests/operator_test.py
@@ -107,7 +107,7 @@ class TestOperators(unittest.TestCase):
         g.query(o2)
         samples = g.infer(2)
         self.assertTrue(type(samples[0][0]), float)
-        self.assertAlmostEquals(samples[0][0], 0.14, 3)
+        self.assertAlmostEqual(samples[0][0], 0.14, 3)
 
     def test_sample(self) -> None:
         # negative test we can't exponentiate the sample from a Bernoulli

--- a/src/beanmachine/ppl/diagnostics/tests/diagnostics_test.py
+++ b/src/beanmachine/ppl/diagnostics/tests/diagnostics_test.py
@@ -115,7 +115,7 @@ class DiagnosticsTest(unittest.TestCase):
             for i in range(num_samples):
                 expected_acf = acf(
                     query_samples[:, i].detach().numpy(),
-                    unbiased=True,
+                    adjusted=True,
                     nlags=num_samples - 1,
                     fft=False,
                 )

--- a/src/beanmachine/ppl/experimental/tests/gp/inference_test.py
+++ b/src/beanmachine/ppl/experimental/tests/gp/inference_test.py
@@ -145,7 +145,7 @@ class InferenceTests(unittest.TestCase):
         likelihood = gpytorch.likelihoods.GaussianLikelihood()
         for i in range(n_samples):
             pred_gp = EvalRegression(
-                x, y, likelihood, lengthscale=torch.tensor(samples[i])
+                x, y, likelihood, lengthscale=samples[i].detach().clone()
             )
             pred_gp.eval()
             pred_mean = pred_gp.likelihood(pred_gp(test_x)).mean

--- a/src/beanmachine/ppl/inference/proposer/tests/single_site_no_u_turn_sampler_proposer_test.py
+++ b/src/beanmachine/ppl/inference/proposer/tests/single_site_no_u_turn_sampler_proposer_test.py
@@ -165,8 +165,8 @@ class SingleSiteNoUTurnSamplerProposerTest(unittest.TestCase):
         h0 = d.log_prob(theta0) - (r0 * r0).sum() / 2
         dH = h1 - h0
 
-        n1 = tensor(u <= dH)
-        s1 = tensor(u < proposer.delta_max + dH)
+        n1 = (u <= dH).detach().clone()
+        s1 = (u < proposer.delta_max + dH).detach().clone()
         accept_ratio = torch.min(tensor(1.0), torch.exp(dH))
 
         self.assertAlmostEqual(output[0], theta1)
@@ -229,7 +229,7 @@ class SingleSiteNoUTurnSamplerProposerTest(unittest.TestCase):
         h1 = d.log_prob(theta1) - (r1 * r1).sum() / 2
         h0 = d.log_prob(theta0) - (r0 * r0).sum() / 2
         dH = h1 - h0
-        n1 = tensor(u <= dH)
+        n1 = (u <= dH).detach().clone()
         accept_ratio_1 = torch.min(tensor(1.0), torch.exp(dH)).detach()
 
         # right subtree
@@ -241,8 +241,8 @@ class SingleSiteNoUTurnSamplerProposerTest(unittest.TestCase):
         r2 = r1_next - step_size * grad_U / 2
         h1 = d.log_prob(theta2) - (r2 * r2).sum() / 2
         dH = h1 - h0
-        n2 = tensor(u <= dH)
-        s2 = tensor(u < proposer.delta_max + dH)
+        n2 = (u <= dH).detach().clone()
+        s2 = (u < proposer.delta_max + dH).detach().clone()
         accept_ratio_2 = torch.min(tensor(1.0), torch.exp(dH)).detach()
 
         neg_turn = ((theta2 - theta1) * r1).sum() >= 0

--- a/src/beanmachine/ppl/inference/tests/single_site_random_walk_test.py
+++ b/src/beanmachine/ppl/inference/tests/single_site_random_walk_test.py
@@ -196,7 +196,7 @@ class SingleSiteRandomWalkTest(unittest.TestCase):
             mh = bm.SingleSiteRandomWalk()
             p_key = model.p()
             queries = [p_key]
-            observations = {model.q(): torch.tensor(evidence)}
+            observations = {model.q(): evidence.detach().clone()}
             predictions = mh.infer(queries, observations, 20)
             predictions = predictions.get_chain()[p_key]
             """

--- a/src/beanmachine/ppl/utils/tests/rules_test.py
+++ b/src/beanmachine/ppl/utils/tests/rules_test.py
@@ -471,7 +471,7 @@ def toss(i):
         self.maxDiff = None
 
         d = ignore_div_zero(PatternRule([int, int], lambda l: l[0] / l[1]))
-        self.assertEquals(d([10, 5]).expect_success(), 2)
+        self.assertEqual(d([10, 5]).expect_success(), 2)
         self.assertTrue(d([10, 0]).is_fail())
 
         n = ignore_runtime_error(PatternRule(int, always_throws))


### PR DESCRIPTION
Summary:
Even though currently there is no failure in the testing suite, we do see a lot of warnings at the end ([example here](https://app.circleci.com/pipelines/github/facebookincubator/beanmachine/1360/workflows/13da74af-1f24-4bf5-8fc2-4b9b1b752038/jobs/2647)), which could be distracting and could potentially break the tests in the future. Below are the list of issues addressed by this diff

- **Change path of testdata in `TestBMA`**
    - Fix: `DeprecationWarning: Use of .. or absolute path in a resource path is not allowed and will raise exceptions in a future release`
    - Because tests directory is not part of the package, we can no longer use `pkg_resources` to find the location of current file. Hence, `pathlib` is used instead.
- **Use `adjusted` instead of `unbiased` in `stattools.acf`**
    - Fix: `FutureWarning: the 'unbiased'' keyword is deprecated, use 'adjusted' instead`
- **Use `assertAlmostEqual`/`assertEqual` instead of  `assertAlmostEquals`/`assertEquals`**
    - Fix: `DeprecationWarning: Please use assertAlmostEqual/assertEqual instead.`
- **Use `x.detach().clone()` instead of `torch.tensor(x)` when `x` is a tensor**
    - Fix: `UserWarning: To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).`
- **Requires `tqdm` version to be greater than 4.46.0**
    - This is the version where [exception handling issue](https://github.com/tqdm/tqdm/releases/tag/v4.46.0) was fixed.

Differential Revision: D23400875

