### PR TITLE
Fix type system so EXP returns positive real

### DIFF
--- a/src/beanmachine/graph/operator/operator.cpp
+++ b/src/beanmachine/graph/operator/operator.cpp
@@ -175,7 +175,8 @@ Operator::Operator(
       check_multiary_op(op_type, in_nodes);
       if (type0 != graph::AtomicType::REAL and
           type0 != graph::AtomicType::POS_REAL) {
-        throw std::invalid_argument("operator ADD requires real/pos_real parent");
+        throw std::invalid_argument(
+            "operator ADD requires real/pos_real parent");
       }
       value = graph::AtomicValue(type0);
       break;

--- a/src/beanmachine/graph/tests/nmc_test.cpp
+++ b/src/beanmachine/graph/tests/nmc_test.cpp
@@ -285,8 +285,8 @@ TEST(testnmc, infinite_grad) {
         g.add_operator(OperatorType::EXP, std::vector<uint>({fere}));
     uint yhat_pos_real =
         g.add_operator(OperatorType::TO_REAL, std::vector<uint>({yhat_pos}));
-    uint yhat_neg =
-        g.add_operator(OperatorType::NEGATE, std::vector<uint>({yhat_pos_real}));
+    uint yhat_neg = g.add_operator(
+        OperatorType::NEGATE, std::vector<uint>({yhat_pos_real}));
     uint yhat = g.add_operator(
         OperatorType::IF_THEN_ELSE,
         std::vector<uint>({sign, yhat_pos_real, yhat_neg}));

--- a/src/beanmachine/ppl/compiler/bmg_nodes.py
+++ b/src/beanmachine/ppl/compiler/bmg_nodes.py
@@ -2226,23 +2226,21 @@ a model contains calls to Tensor.exp or math.exp."""
 
     @property
     def inf_type(self) -> BMGLatticeType:
-        # TODO: In BMG the input type of exp is positive real, real or
-        # tensor, and the output type is the same as the input type.
-        # However, we could know that if the input type is real, then
-        # the output type is positive real. Consider fixing that in
-        # BMG, and then fix it here as well.
-        return supremum(self.operand.inf_type, PositiveReal)
+        return PositiveReal
 
     @property
     def graph_type(self) -> BMGLatticeType:
-        return self.operand.graph_type
+        ot = self.operand.graph_type
+        if ot == Real or ot == PositiveReal:
+            return PositiveReal
+        return Malformed
 
     @property
     def requirements(self) -> List[Requirement]:
-        # Exp requires that the input type be exactly the same as the
-        # output type; the smallest possible output type is therefore
-        # the smallest possible input type.
-        return [self.inf_type]
+        # If the operand is a tensor or real, the requirement
+        # has been met; if not, we require that it be converted
+        # to positive real.
+        return [supremum(self.operand.inf_type, PositiveReal)]
 
     @property
     def size(self) -> torch.Size:

--- a/src/beanmachine/ppl/compiler/tests/bmg_nodes_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_nodes_test.py
@@ -299,12 +299,12 @@ class ASTToolsTest(unittest.TestCase):
         # exp Probability -> PositiveReal
         # exp Natural -> PositiveReal
         # exp PositiveReal -> PositiveReal
-        # exp Real -> Real
+        # exp Real -> PositiveReal
         self.assertEqual(ExpNode(bern).inf_type, PositiveReal)
         self.assertEqual(ExpNode(beta).inf_type, PositiveReal)
         self.assertEqual(ExpNode(bino).inf_type, PositiveReal)
         self.assertEqual(ExpNode(half).inf_type, PositiveReal)
-        self.assertEqual(ExpNode(norm).inf_type, Real)
+        self.assertEqual(ExpNode(norm).inf_type, PositiveReal)
 
         # To Real
         self.assertEqual(ToRealNode(bern).inf_type, Real)
@@ -700,12 +700,8 @@ class ASTToolsTest(unittest.TestCase):
         self.assertEqual(NegateNode(half).requirements, [Real])
         self.assertEqual(NegateNode(norm).requirements, [Real])
 
-        # Exp
-        # exp Boolean -> PositiveReal
-        # exp Probability -> PositiveReal
-        # exp Natural -> PositiveReal
-        # exp PositiveReal -> PositiveReal
-        # exp Real -> Real
+        # Exp requires that its operand be positive real or real.
+
         self.assertEqual(ExpNode(bern).requirements, [PositiveReal])
         self.assertEqual(ExpNode(beta).requirements, [PositiveReal])
         self.assertEqual(ExpNode(bino).requirements, [PositiveReal])


### PR DESCRIPTION
Summary:
In BMG and in the Beanstalk compiler, we treated EXP nodes as taking positive real, real or tensor, and returning whatever the input type was. But that's not quite right; an EXP node that takes a real can be known to return a positive real.

BMG has been fixed so that EXP only returns positive real. I've updated Beanstalk to match.

Reviewed By: wtaha

Differential Revision: D22650796

