### PR TITLE
Minor change to header links in BMG

### DIFF
--- a/src/beanmachine/graph/pybindings.cpp
+++ b/src/beanmachine/graph/pybindings.cpp
@@ -2,7 +2,6 @@
 #include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
-#include "beanmachine/graph/graph.h"
 #include "beanmachine/graph/pybindings.h"
 
 namespace beanmachine {

--- a/src/beanmachine/graph/pybindings.h
+++ b/src/beanmachine/graph/pybindings.h
@@ -1,5 +1,6 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
 #pragma once
+#include "beanmachine/graph/graph.h"
 
 // to keep the linter happy this template specialization has been declared here
 // in a header file that is only meant to be included by pybindings.cpp
@@ -45,13 +46,15 @@ struct type_caster<AtomicValue> : public type_caster_base<AtomicValue> {
         }
       }
     } else if (src.type.variable_type == VariableType::BROADCAST_MATRIX) {
-      switch(src.type.atomic_type){
+      switch (src.type.atomic_type) {
         case AtomicType::BOOLEAN:
-          return type_caster<Eigen::MatrixXb>::cast(src._bmatrix, policy, parent);
+          return type_caster<Eigen::MatrixXb>::cast(
+              src._bmatrix, policy, parent);
         case AtomicType::REAL:
         case AtomicType::POS_REAL:
         case AtomicType::PROBABILITY:
-          return type_caster<Eigen::MatrixXd>::cast(src._matrix, policy, parent);
+          return type_caster<Eigen::MatrixXd>::cast(
+              src._matrix, policy, parent);
         default:
           throw std::runtime_error("unexpected type for AtomicValue");
       }


### PR DESCRIPTION
Summary:
While working on another diff I noticed that pybindings.h has a dependency on graph.h which requires that graph.h be included before pybindings.h.  A better practice is to have pybindings.h itself include the required header.

I also ran pybindings.cpp through a formatter to fix a few minor formatting problems.

Reviewed By: nimar

Differential Revision: D23439011

