### PR TITLE
Add NEGATIVE_LOG operator to BMG

### DIFF
--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -266,6 +266,7 @@ enum class OperatorType {
   LOGSUMEXP,
   LOG,
   POW,
+  NEGATIVE_LOG,
 };
 
 enum class DistributionType {

--- a/src/beanmachine/graph/operator/gradient.cpp
+++ b/src/beanmachine/graph/operator/gradient.cpp
@@ -69,6 +69,18 @@ void Operator::compute_gradients() {
           f_grad * in_nodes[0]->grad2;
       break;
     }
+    case graph::OperatorType::NEGATIVE_LOG: {
+      // f(x) = -log(x)
+      // f'(x) = -1 / x
+      // f''(x) = 1 / (x^2) = f'(x) * f'(x)
+      double x = in_nodes[0]->value._double;
+      double f_grad = -1.0 / x;
+      double f_grad2 = f_grad * f_grad;
+      grad1 = f_grad * in_nodes[0]->grad1;
+      grad2 = f_grad2 * in_nodes[0]->grad1 * in_nodes[0]->grad1 +
+          f_grad * in_nodes[0]->grad2;
+      break;
+    }
     case graph::OperatorType::LOG1PEXP: {
       // f(x) = log (1 + exp(x))
       // f'(x) = exp(x) / (1 + exp(x)) = 1 - exp(-f)

--- a/src/beanmachine/graph/operator/operator.cpp
+++ b/src/beanmachine/graph/operator/operator.cpp
@@ -149,15 +149,23 @@ Operator::Operator(
       break;
     }
     case graph::OperatorType::LOG: {
-      // TODO: We could also add an operator NEG_LOG which has the
-      // TODO: semantics of -log(x), which accepts a probability or
-      // TODO: a positive real, and maps probability to positive
-      // TODO: real.
       check_unary_op(op_type, in_nodes);
       if (type0 != graph::AtomicType::POS_REAL) {
         throw std::invalid_argument("operator LOG requires a pos_real parent");
       }
       value = graph::AtomicValue(graph::AtomicType::REAL);
+      break;
+    }
+    case graph::OperatorType::NEGATIVE_LOG: {
+      check_unary_op(op_type, in_nodes);
+      if (type0 == graph::AtomicType::POS_REAL) {
+        value = graph::AtomicValue(graph::AtomicType::REAL);
+      } else if (type0 == graph::AtomicType::PROBABILITY) {
+        value = graph::AtomicValue(graph::AtomicType::POS_REAL);
+      } else {
+        throw std::invalid_argument(
+            "operator NEG_LOG requires a pos_real/probability parent");
+      }
       break;
     }
     case graph::OperatorType::MULTIPLY: {
@@ -301,6 +309,10 @@ void Operator::eval(std::mt19937& gen) {
     }
     case graph::OperatorType::LOG: {
       log(this);
+      break;
+    }
+    case graph::OperatorType::NEGATIVE_LOG: {
+      negative_log(this);
       break;
     }
     case graph::OperatorType::EXP: {

--- a/src/beanmachine/graph/operator/tests/operator_test.cpp
+++ b/src/beanmachine/graph/operator/tests/operator_test.cpp
@@ -347,6 +347,54 @@ TEST(testoperator, log) {
   EXPECT_NEAR(grad2, -27.0904, 1e-3);
 }
 
+TEST(testoperator, negative_log) {
+  Graph g;
+  // negative tests: exactly one pos_real or probability should be the input
+  EXPECT_THROW(
+      g.add_operator(OperatorType::NEGATIVE_LOG, std::vector<uint>{}),
+      std::invalid_argument);
+  auto neg_real = g.add_constant(-1.5);
+  EXPECT_THROW(
+      g.add_operator(OperatorType::NEGATIVE_LOG, std::vector<uint>{neg_real}),
+      std::invalid_argument);
+  auto pos1 = g.add_constant_pos_real(1.0);
+  EXPECT_THROW(
+      g.add_operator(OperatorType::NEGATIVE_LOG, std::vector<uint>{pos1, pos1}),
+      std::invalid_argument);
+  // y ~ Normal(-log(x^2), 1)
+  // If we observe x = 0.5 then the mean should be -log(0.25) = 1.386.
+  auto prior = g.add_distribution(
+      DistributionType::FLAT, AtomicType::POS_REAL, std::vector<uint>{});
+  auto x = g.add_operator(OperatorType::SAMPLE, std::vector<uint>{prior});
+  auto x_sq = g.add_operator(OperatorType::MULTIPLY, std::vector<uint>{x, x});
+  auto log_x_sq =
+      g.add_operator(OperatorType::NEGATIVE_LOG, std::vector<uint>{x_sq});
+  auto likelihood = g.add_distribution(
+      DistributionType::NORMAL,
+      AtomicType::REAL,
+      std::vector<uint>{log_x_sq, pos1});
+  auto y = g.add_operator(OperatorType::SAMPLE, std::vector<uint>{likelihood});
+  g.query(y);
+  g.observe(x, 0.5);
+  const auto& means = g.infer_mean(10000, InferenceType::NMC);
+  EXPECT_NEAR(means[0], 1.386, 0.01);
+  g.observe(y, 0.0);
+  // check gradient:
+  // Verified in pytorch using the following code:
+  //
+  // x = tensor(0.5, requires_grad=True)
+  // fx = Normal(-(x * x).log(), tensor(1.0)).log_prob(tensor(0.0))
+  // f1x = grad(fx, x, create_graph=True)
+  // f2x = grad(f1x, x)
+  //
+  // f1x -> 5.5452 and f2x -> -27.0904
+  double grad1 = 0;
+  double grad2 = 0;
+  g.gradient_log_prob(x, grad1, grad2);
+  EXPECT_NEAR(grad1, 5.5452, 1e-3);
+  EXPECT_NEAR(grad2, -27.0904, 1e-3);
+}
+
 TEST(testoperator, pow) {
   Graph g;
   // There must be exactly two operands.

--- a/src/beanmachine/graph/operator/unaryop.cpp
+++ b/src/beanmachine/graph/operator/unaryop.cpp
@@ -144,5 +144,19 @@ void log(graph::Node* node) {
   }
 }
 
+void negative_log(graph::Node* node) {
+  assert(node->in_nodes.size() == 1);
+  const graph::AtomicValue& parent = node->in_nodes[0]->value;
+  if (parent.type == graph::AtomicType::POS_REAL or
+      parent.type == graph::AtomicType::PROBABILITY) {
+    node->value._double = -std::log(parent._double);
+  } else {
+    throw std::runtime_error(
+        "invalid parent type " +
+        std::to_string(static_cast<int>(parent.type.atomic_type)) +
+        " for NEGATIVE_LOG operator at node_id " + std::to_string(node->index));
+  }
+}
+
 } // namespace oper
 } // namespace beanmachine

--- a/src/beanmachine/graph/operator/unaryop.h
+++ b/src/beanmachine/graph/operator/unaryop.h
@@ -16,6 +16,7 @@ void phi(graph::Node* node);
 void logistic(graph::Node* node);
 void log1pexp(graph::Node* node);
 void log(graph::Node* node);
+void negative_log(graph::Node* node);
 
 } // namespace oper
 } // namespace beanmachine

--- a/src/beanmachine/graph/pybindings.cpp
+++ b/src/beanmachine/graph/pybindings.cpp
@@ -4,6 +4,7 @@
 #include <pybind11/stl.h>
 #include "beanmachine/graph/pybindings.h"
 
+
 namespace beanmachine {
 namespace graph {
 
@@ -54,7 +55,8 @@ PYBIND11_MODULE(graph, module) {
       .value("LOGSUMEXP", OperatorType::LOGSUMEXP)
       .value("IF_THEN_ELSE", OperatorType::IF_THEN_ELSE)
       .value("LOG", OperatorType::LOG)
-      .value("POW", OperatorType::POW);
+      .value("POW", OperatorType::POW)
+      .value("NEGATIVE_LOG", OperatorType::NEGATIVE_LOG);
 
   py::enum_<DistributionType>(module, "DistributionType")
       .value("TABULAR", DistributionType::TABULAR)


### PR DESCRIPTION
Summary: Nim suggested to me a while back that we add a NEGATIVE_LOG operator to BMG; the benefit of such an operator is that we know that if given a probability, it will produce a positive real. This then means we get good type analysis without having to introduce the concept of "negative real".

Reviewed By: nimar

Differential Revision: D23437112

