### PR TITLE
Support natural to power of bool in BM->BMG compiler

### DIFF
--- a/src/beanmachine/ppl/compiler/fix_problems.py
+++ b/src/beanmachine/ppl/compiler/fix_problems.py
@@ -20,6 +20,7 @@ from beanmachine.ppl.compiler.bmg_nodes import (
     MultiplicationNode,
     Observation,
     OperatorNode,
+    PowerNode,
     Query,
     SampleNode,
     UniformNode,
@@ -191,6 +192,45 @@ error is added to the error report."""
 
         return self.meet_requirement(if_then_else, requirement, consumer, edge)
 
+    def _convert_malformed_power(
+        self, node: PowerNode, requirement: BMGLatticeType, consumer: BMGNode, edge: str
+    ) -> BMGNode:
+        # We are given a malformed power node which can be converted
+        # to a semantically equivalent node that meets the given requirement.
+        # Verify these preconditions.
+
+        assert node.graph_type == Malformed
+        assert supremum(node.inf_type, requirement) == requirement
+
+        # The only condition in which a power node can be malformed is
+        # if the exponent is bool; since we visit the nodes in topological
+        # order, we have already converted the operands to well-formed
+        # nodes.
+
+        lgt = node.left.graph_type
+        rgt = node.right.graph_type
+
+        assert lgt != Malformed
+        assert rgt == bool
+
+        # Therefore this can be made an if-then-else.
+        # x ** b --> if b then x else 1
+
+        one = self.bmg.add_constant_of_type(1.0, lgt)
+        if_then_else = self.bmg.add_if_then_else(node.right, node.left, one)
+
+        assert if_then_else.graph_type == lgt
+
+        # We have met the requirements of the if-then-else; the condition
+        # is bool and the consequence and alternative are of the same type.
+        # However, we might not yet have met the original requirement, which
+        # we have not yet used in this method. We might need to put a to_real
+        # on top of it, for instance.
+        #
+        # Recurse to ensure that is met.
+
+        return self.meet_requirement(if_then_else, requirement, consumer, edge)
+
     def _convert_node(
         self,
         node: OperatorNode,
@@ -208,6 +248,9 @@ error is added to the error report."""
             return self._convert_malformed_multiplication(
                 node, requirement, consumer, edge
             )
+
+        if isinstance(node, PowerNode) and node.graph_type == Malformed:
+            return self._convert_malformed_power(node, requirement, consumer, edge)
 
         # Converting anything to tensor, real or positive real is easy;
         # there's already a node for that so just insert it on the edge
@@ -342,14 +385,12 @@ requirement is given; the name of this edge is provided for error reporting."""
         # TODO:
         # Not -> Complement
         # Index/Map -> IfThenElse
-        # Power -> Multiplication
         if isinstance(node, Chi2Node):
             return self._replace_chi2(node)
         if isinstance(node, DivisionNode):
             return self._replace_division(node)
         if isinstance(node, UniformNode):
             return self._replace_uniform(node)
-
         return None
 
     def _fix_unsupported_nodes(self) -> None:

--- a/src/beanmachine/ppl/compiler/tests/bmg_nodes_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_nodes_test.py
@@ -325,11 +325,9 @@ class ASTToolsTest(unittest.TestCase):
         # * If the base is P or B and the exponent is R, the output is R+.
         # * If the base is B the output is P.
         # * If the base is N the output is R+.
-        # TODO: We can do a slightly better job than this; see comments
-        # in bmg_nodes.py for details.
 
         # Base is B
-        self.assertEqual(PowerNode(bern, bern).inf_type, Probability)
+        self.assertEqual(PowerNode(bern, bern).inf_type, Boolean)
         self.assertEqual(PowerNode(bern, beta).inf_type, Probability)
         self.assertEqual(PowerNode(bern, bino).inf_type, Probability)
         self.assertEqual(PowerNode(bern, half).inf_type, Probability)
@@ -343,7 +341,7 @@ class ASTToolsTest(unittest.TestCase):
         self.assertEqual(PowerNode(beta, norm).inf_type, PositiveReal)
 
         # Base is N
-        self.assertEqual(PowerNode(bino, bern).inf_type, PositiveReal)
+        self.assertEqual(PowerNode(bino, bern).inf_type, Natural)
         self.assertEqual(PowerNode(bino, beta).inf_type, PositiveReal)
         self.assertEqual(PowerNode(bino, bino).inf_type, PositiveReal)
         self.assertEqual(PowerNode(bino, half).inf_type, PositiveReal)
@@ -776,15 +774,11 @@ class ASTToolsTest(unittest.TestCase):
 
         # Power
         #
-        # For non-tensor cases we require that the base be P, R+, R and the
-        # exponent be R+ or R.
-        #
-        # TODO: We can do a slightly better job than this; see comments
-        # in bmg_nodes.py for details.
+        # We require that the base be P, R+, R and the exponent be R+ or R.
+        # However, if the exponent is bool then the base can be any type
+        # because we can rewrite the whole thing into an if-then-else.
 
-        self.assertEqual(
-            PowerNode(bern, bern).requirements, [Probability, PositiveReal]
-        )
+        self.assertEqual(PowerNode(bino, bern).requirements, [Natural, Boolean])
         self.assertEqual(
             PowerNode(beta, beta).requirements, [Probability, PositiveReal]
         )

--- a/src/beanmachine/ppl/compiler/tests/fix_problems_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_problems_test.py
@@ -569,3 +569,104 @@ digraph "graph" {
 """
 
         self.assertEqual(observed.strip(), expected.strip())
+
+    def test_fix_problems_9(self) -> None:
+        """test_fix_problems_9"""
+
+        # The problem we have here is that natural raised to bool
+        # is not supported in BMG without converting both to
+        # positive real, but natural raised to bool is plainly
+        # natural. We generate an if-then-else.
+
+        # @rv def berns():
+        #   return Bernoulli(0.5)
+        # @rv def nats():
+        #   return Binomial(2, 0.5)
+        # @rv def bino():
+        #   return Binomial(nats() ** berns(), 0.5)
+
+        self.maxDiff = None
+        bmg = BMGraphBuilder()
+
+        two = bmg.add_natural(2)
+        half = bmg.add_probability(0.5)
+        bern = bmg.add_bernoulli(half)
+        berns = bmg.add_sample(bern)
+        nat = bmg.add_binomial(two, half)
+        nats = bmg.add_sample(nat)
+        powr = bmg.add_power(nats, berns)
+        bino = bmg.add_binomial(powr, half)
+        bmg.add_sample(bino)
+
+        observed = bmg.to_dot(
+            graph_types=True,
+            inf_types=True,
+            edge_requirements=True,
+            point_at_input=True,
+        )
+
+        expected = """
+digraph "graph" {
+  N0[label="2:N>=N"];
+  N1[label="0.5:P>=P"];
+  N2[label="Bernoulli:B>=B"];
+  N3[label="Sample:B>=B"];
+  N4[label="Binomial:N>=N"];
+  N5[label="Sample:N>=N"];
+  N6[label="**:M>=N"];
+  N7[label="Binomial:N>=N"];
+  N8[label="Sample:N>=N"];
+  N0 -> N4[label="count:N"];
+  N1 -> N2[label="probability:P"];
+  N1 -> N4[label="probability:P"];
+  N1 -> N7[label="probability:P"];
+  N2 -> N3[label="operand:B"];
+  N3 -> N6[label="right:B"];
+  N4 -> N5[label="operand:N"];
+  N5 -> N6[label="left:N"];
+  N6 -> N7[label="count:N"];
+  N7 -> N8[label="operand:N"];
+}"""
+
+        self.assertEqual(observed.strip(), expected.strip())
+
+        error_report = fix_problems(bmg)
+
+        self.assertEqual("", str(error_report).strip())
+
+        observed = bmg.to_dot(
+            graph_types=True,
+            inf_types=True,
+            edge_requirements=True,
+            point_at_input=True,
+        )
+
+        expected = """
+digraph "graph" {
+  N00[label="2:N>=N"];
+  N01[label="0.5:P>=P"];
+  N02[label="Bernoulli:B>=B"];
+  N03[label="Sample:B>=B"];
+  N04[label="Binomial:N>=N"];
+  N05[label="Sample:N>=N"];
+  N06[label="**:M>=N"];
+  N07[label="Binomial:N>=N"];
+  N08[label="Sample:N>=N"];
+  N09[label="1:N>=B"];
+  N10[label="if:N>=N"];
+  N00 -> N04[label="count:N"];
+  N01 -> N02[label="probability:P"];
+  N01 -> N04[label="probability:P"];
+  N01 -> N07[label="probability:P"];
+  N02 -> N03[label="operand:B"];
+  N03 -> N06[label="right:B"];
+  N03 -> N10[label="condition:B"];
+  N04 -> N05[label="operand:N"];
+  N05 -> N06[label="left:N"];
+  N05 -> N10[label="consequence:N"];
+  N07 -> N08[label="operand:N"];
+  N09 -> N10[label="alternative:N"];
+  N10 -> N07[label="count:N"];
+}"""
+
+        self.assertEqual(observed.strip(), expected.strip())


### PR DESCRIPTION
Summary:
BMG's power node requires that both its operands be real numbers -- either probabilities, positive reals, or reals -- or tensors. However, we could represent natural raised to power of bool as being of type natural.

In this diff, we do so by turning `x**b` into `if b then x else 1`.

Reviewed By: wtaha

Differential Revision: D22825853

