### PR TITLE
Start adding support for BMG complement node

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/bmg_nodes_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_nodes_test.py
@@ -9,6 +9,7 @@ from beanmachine.ppl.compiler.bmg_nodes import (
     BinomialNode,
     BooleanNode,
     Chi2Node,
+    ComplementNode,
     ExpNode,
     FlatNode,
     GammaNode,
@@ -294,6 +295,13 @@ class ASTToolsTest(unittest.TestCase):
         self.assertEqual(NegateNode(bino).inf_type, Real)
         self.assertEqual(NegateNode(half).inf_type, Real)
         self.assertEqual(NegateNode(norm).inf_type, Real)
+
+        # Complement
+        # - Boolean -> Boolean
+        # - Probability -> Probability
+        # Everything else is illegal
+        self.assertEqual(ComplementNode(bern).inf_type, Boolean)
+        self.assertEqual(ComplementNode(beta).inf_type, Probability)
 
         # Exp
         # exp Boolean -> PositiveReal
@@ -741,6 +749,10 @@ class ASTToolsTest(unittest.TestCase):
         self.assertEqual(NegateNode(bino).requirements, [Real])
         self.assertEqual(NegateNode(half).requirements, [Real])
         self.assertEqual(NegateNode(norm).requirements, [Real])
+
+        # Complement requires that its operand be probability or Boolean
+        self.assertEqual(ComplementNode(bern).requirements, [Boolean])
+        self.assertEqual(ComplementNode(beta).requirements, [Probability])
 
         # Exp requires that its operand be positive real or real.
 


### PR DESCRIPTION
Summary:
BMG supports two kinds of negation: unary minus, which operates on reals, and complement, which has the semantics of "not b" for a Boolean operand and "1-p" for a probability operand. (Though the keen-eyed reviewer will notice that "1-b" and "not b" are the same thing in Python if b is a bool.)

My plan is to transform a Python model's uses of "not b" and "1-p" to the complement node, so we'll add such a node to the node hierarchy in the compiler. We do not make use of it yet; I will add the transformations in a later diff.

Reviewed By: wtaha

Differential Revision: D23328794

