### PR TITLE
Convert 1+(-p) to complement node

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/bmg_nodes_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_nodes_test.py
@@ -172,6 +172,18 @@ class ASTToolsTest(unittest.TestCase):
 
         # Addition
 
+        # Special case: 1 + (-P) -> P
+        # Special case: 1 + (-B) -> B
+        # Special case: (-P) + 1 -> P
+        # Special case: (-B) + 1 -> B
+        nb = NegateNode(bern)
+        np = NegateNode(beta)
+        one = RealNode(1.0)
+        self.assertEqual(AdditionNode(np, one).inf_type, Probability)
+        self.assertEqual(AdditionNode(nb, one).inf_type, Boolean)
+        self.assertEqual(AdditionNode(one, np).inf_type, Probability)
+        self.assertEqual(AdditionNode(one, nb).inf_type, Boolean)
+
         # Boolean + Boolean -> PositiveReal
         # Boolean + Probability -> PositiveReal
         # Boolean + Natural -> PositiveReal

--- a/src/beanmachine/ppl/utils/bm_graph_builder.py
+++ b/src/beanmachine/ppl/utils/bm_graph_builder.py
@@ -71,6 +71,7 @@ from beanmachine.ppl.compiler.bmg_nodes import (
     BooleanNode,
     CategoricalNode,
     Chi2Node,
+    ComplementNode,
     ConstantNode,
     DirichletNode,
     DistributionNode,
@@ -761,6 +762,14 @@ constant graph node of the stated type for it, and adds it to the builder"""
         if isinstance(input, ConstantNode):
             return -input.value
         return self.add_negate(input)
+
+    @memoize
+    def add_complement(self, operand: BMGNode) -> BMGNode:
+        if isinstance(operand, ConstantNode):
+            return self.add_constant(1 - operand.value)
+        node = ComplementNode(operand)
+        self.add_node(node)
+        return node
 
     # TODO: What should the result of NOT on a tensor be?
     # TODO: Should it be legal at all in the graph?


### PR DESCRIPTION
Summary:
In BMG there is no subtraction node but there is a "complement" node which takes as its input a probability between 0.0 and 1.0, and produces 1-p as its output.

Negation is defined as taking a real, so 1 + (-p) by default will be of type real if we transform it directly into BMG. But if we detect this scenario and turn it into a complement, we can keep the type as probability, a smaller type than real.

Here is the final graph showing both included and orphaned nodes after the problem fixing phase. As you can see, we orphan the 2.0 "real" constant in favor of a 2.0 "positive real" constant, and the original "1 + (-beta)" node is orphaned in favor of a complement(beta) node; since the 1+(-beta) node no longer flows into a sample or observation it will be omitted when we emit the BMG.  I'll show that in a test case in a later diff.

{F312524119}

Reviewed By: wtaha

Differential Revision: D23403717

