### PR TITLE
Start adding support for negative log to compiler

### DIFF
--- a/src/beanmachine/ppl/compiler/bmg_nodes.py
+++ b/src/beanmachine/ppl/compiler/bmg_nodes.py
@@ -2356,9 +2356,6 @@ a model contains calls to Tensor.log or math.log."""
 
     # The log node only takes a positive real and only produces a real.
 
-    # TODO: We might consider adding a -log(x) node which takes a
-    # probability and produces a positive real.
-
     @property
     def inf_type(self) -> BMGLatticeType:
         return Real
@@ -2383,8 +2380,61 @@ a model contains calls to Tensor.log or math.log."""
         return "Log(" + str(self.operand) + ")"
 
     def support(self) -> Iterator[Any]:
-        # TODO: Not always a tensor.
         return SetOfTensors(torch.log(o) for o in self.operand.support())
+
+    def _supported_in_bmg(self) -> bool:
+        return True
+
+
+class NegativeLogNode(UnaryOperatorNode):
+    """BMG supports a node with the semantics of -log(x), so that we can
+take advantage in the type system that -log(P) for probability P is
+known to be a positive real."""
+
+    operator_type = OperatorType.NEGATIVE_LOG
+
+    def __init__(self, operand: BMGNode):
+        UnaryOperatorNode.__init__(self, operand)
+
+    # The typing rules are:
+    # * if input is P, output is R+
+    # * if input is R+, output is R
+    # Nothing else is legal
+
+    @property
+    def inf_type(self) -> BMGLatticeType:
+        if supremum(self.operand.inf_type, Probability) == Probability:
+            return PositiveReal
+        return Real
+
+    @property
+    def graph_type(self) -> BMGLatticeType:
+        t = self.operand.graph_type
+        if t == Probability:
+            return PositiveReal
+        if t == PositiveReal:
+            return Real
+        return Malformed
+
+    @property
+    def requirements(self) -> List[Requirement]:
+        if supremum(self.operand.inf_type, Probability) == Probability:
+            return [Probability]
+        return [PositiveReal]
+
+    @property
+    def label(self) -> str:
+        return "NegLog"
+
+    @property
+    def size(self) -> torch.Size:
+        return self.operand.size
+
+    def __str__(self) -> str:
+        return "NegLog(" + str(self.operand) + ")"
+
+    def support(self) -> Iterator[Any]:
+        return SetOfTensors(-(torch.log(o)) for o in self.operand.support())
 
     def _supported_in_bmg(self) -> bool:
         return True

--- a/src/beanmachine/ppl/compiler/tests/bmg_nodes_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_nodes_test.py
@@ -15,9 +15,11 @@ from beanmachine.ppl.compiler.bmg_nodes import (
     GammaNode,
     HalfCauchyNode,
     IfThenElseNode,
+    LogNode,
     MultiplicationNode,
     NaturalNode,
     NegateNode,
+    NegativeLogNode,
     NormalNode,
     PositiveRealNode,
     PowerNode,
@@ -326,6 +328,19 @@ class ASTToolsTest(unittest.TestCase):
         self.assertEqual(ExpNode(bino).inf_type, PositiveReal)
         self.assertEqual(ExpNode(half).inf_type, PositiveReal)
         self.assertEqual(ExpNode(norm).inf_type, PositiveReal)
+
+        # Log of anything is Real
+        self.assertEqual(LogNode(bern).inf_type, Real)
+        self.assertEqual(LogNode(beta).inf_type, Real)
+        self.assertEqual(LogNode(bino).inf_type, Real)
+        self.assertEqual(LogNode(half).inf_type, Real)
+
+        # Negative Log of probability or smaller is Positive Real;
+        # otherwise Real.
+        self.assertEqual(NegativeLogNode(bern).inf_type, PositiveReal)
+        self.assertEqual(NegativeLogNode(beta).inf_type, PositiveReal)
+        self.assertEqual(NegativeLogNode(bino).inf_type, Real)
+        self.assertEqual(NegativeLogNode(half).inf_type, Real)
 
         # To Real
         self.assertEqual(ToRealNode(bern).inf_type, Real)
@@ -773,6 +788,18 @@ class ASTToolsTest(unittest.TestCase):
         self.assertEqual(ExpNode(bino).requirements, [PositiveReal])
         self.assertEqual(ExpNode(half).requirements, [PositiveReal])
         self.assertEqual(ExpNode(norm).requirements, [Real])
+
+        # Log requires that its operand be positive real.
+        self.assertEqual(LogNode(bern).requirements, [PositiveReal])
+        self.assertEqual(LogNode(beta).requirements, [PositiveReal])
+        self.assertEqual(LogNode(bino).requirements, [PositiveReal])
+        self.assertEqual(LogNode(half).requirements, [PositiveReal])
+
+        # Negative Log requires that its operand be positive real or probability.
+        self.assertEqual(NegativeLogNode(bern).requirements, [Probability])
+        self.assertEqual(NegativeLogNode(beta).requirements, [Probability])
+        self.assertEqual(NegativeLogNode(bino).requirements, [PositiveReal])
+        self.assertEqual(NegativeLogNode(half).requirements, [PositiveReal])
 
         # To Real
         self.assertEqual(ToRealNode(bern).requirements, [upper_bound(Real)])


### PR DESCRIPTION
Summary:
BMG now supports a negative-log node; by generating such a node for -log(x), we can deduce that the value is a positive real if the operand is a probability.

So far I've just implemented the node and verified that its participation in the type system is as expected. In the next few diffs I will add the transformation.

Reviewed By: wtaha

Differential Revision: D23463817

