### PR TITLE
Convert -log(x) nodes to negative_log(x)

### DIFF
--- a/src/beanmachine/ppl/compiler/bmg_nodes.py
+++ b/src/beanmachine/ppl/compiler/bmg_nodes.py
@@ -2511,18 +2511,22 @@ class NegateNode(UnaryOperatorNode):
 
     @property
     def inf_type(self) -> BMGLatticeType:
-        return supremum(self.operand.inf_type, Real)
+        # Special case: if the operand is log(P) then we can
+        # turn this into a NegativeLog which is R+. Otherwise,
+        # negate is R.
+        o = self.operand
+        if isinstance(o, LogNode):
+            if supremum(o.operand.inf_type, Probability) == Probability:
+                return PositiveReal
+        return Real
 
     @property
     def graph_type(self) -> BMGLatticeType:
-        return self.operand.graph_type
+        return Real
 
     @property
     def requirements(self) -> List[Requirement]:
-        # We require that the input type be identical to the output type,
-        # and the smallest possible output type is the infimum type of
-        # the input.
-        return [self.inf_type]
+        return [Real]
 
     @property
     def size(self) -> torch.Size:

--- a/src/beanmachine/ppl/compiler/fix_problems.py
+++ b/src/beanmachine/ppl/compiler/fix_problems.py
@@ -17,6 +17,7 @@ from beanmachine.ppl.compiler.bmg_nodes import (
     DistributionNode,
     DivisionNode,
     IndexNode,
+    LogNode,
     MapNode,
     MultiplicationNode,
     NegateNode,
@@ -479,7 +480,36 @@ requirement is given; the name of this edge is provided for error reporting."""
                 node.children[i] = replacement
                 replacements[c] = replacement
 
+    def _fix_negative_logs(self) -> None:
+        # This pass has to run before general requirement checking. Why?
+        # The requirement fixing pass runs from leaves to roots, inserting
+        # conversions as it goes. If we have negate(log(p)) for probability p
+        # then we need to turn that into negative_log(p), but if we process
+        # the negate *after* we process the log(p) then we will already have
+        # generated negate(log(to_pos_real(p)). It is better to get rid of
+        # the neg(log(p)) first, before introducing the to_pos_real.
+
+        replacements = {}
+        nodes = self.bmg._traverse_from_roots()
+        for node in nodes:
+            for i in range(len(node.children)):
+                c = node.children[i]
+                if not isinstance(c, NegateNode):
+                    continue
+                assert isinstance(c, NegateNode)
+                o = c.operand
+                if not isinstance(o, LogNode):
+                    continue
+                assert isinstance(o, LogNode)
+                if c in replacements:
+                    node.children[i] = replacements[c]
+                    continue
+                replacement = self.bmg.add_negative_log(o.operand)
+                node.children[i] = replacement
+                replacements[c] = replacement
+
     def fix_all_problems(self) -> None:
+        self._fix_negative_logs()
         self._additions_to_complements()
         self._fix_unsupported_nodes()
         if self.errors.any():

--- a/src/beanmachine/ppl/utils/bm_graph_builder.py
+++ b/src/beanmachine/ppl/utils/bm_graph_builder.py
@@ -88,6 +88,7 @@ from beanmachine.ppl.compiler.bmg_nodes import (
     MultiplicationNode,
     NaturalNode,
     NegateNode,
+    NegativeLogNode,
     NormalNode,
     NotNode,
     Observation,
@@ -822,7 +823,7 @@ constant graph node of the stated type for it, and adds it to the builder"""
         return node
 
     @memoize
-    def add_exp(self, operand: BMGNode) -> ExpNode:
+    def add_exp(self, operand: BMGNode) -> BMGNode:
         if isinstance(operand, TensorNode):
             return self.add_constant(torch.exp(operand.value))
         if isinstance(operand, ConstantNode):
@@ -843,12 +844,22 @@ constant graph node of the stated type for it, and adds it to the builder"""
         return self.add_exp(input)
 
     @memoize
-    def add_log(self, operand: BMGNode) -> ExpNode:
+    def add_log(self, operand: BMGNode) -> BMGNode:
         if isinstance(operand, TensorNode):
             return self.add_constant(torch.log(operand.value))
         if isinstance(operand, ConstantNode):
             return self.add_constant(math.log(operand.value))
         node = LogNode(operand)
+        self.add_node(node)
+        return node
+
+    @memoize
+    def add_negative_log(self, operand: BMGNode) -> BMGNode:
+        if isinstance(operand, TensorNode):
+            return self.add_constant(-(torch.log(operand.value)))
+        if isinstance(operand, ConstantNode):
+            return self.add_constant(-(math.log(operand.value)))
+        node = NegativeLogNode(operand)
         self.add_node(node)
         return node
 


### PR DESCRIPTION
Summary:
If we detect usages of -log(x) and compile them into the new "negative log" node, then we can get a tighter bound on types; specifically, if we know that x is a probability then we know that negative_log(x) is a positive real.

This diff implements the fixer that does the graph transformation and updates the test.

I'll add an end-to-end test demonstrating this in the next diff.

Reviewed By: wtaha

Differential Revision: D23485199

