### PR TITLE
add dependency on pybind11 and remove pytorch dep

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ commands:
           command: sudo pip install --progress-bar off torch==1.6.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
 
   dev_install:
-    description: "Install beanmachine[dev] via pip"
+    description: "Install beanmachine[dev] in editable mode via pip"
     steps:
       - run:
           name: "Install beanmachine[dev]"
@@ -36,8 +36,8 @@ commands:
           name: "Update package lists"
           command: sudo apt-get update
       - run:
-          name: "Install Boost and Eigen"
-          command: sudo apt-get install libboost-dev libeigen3-dev
+          name: "Install Boost, Eigen, and PyBind11"
+          command: sudo apt-get install libboost-dev libeigen3-dev pybind11-dev
 
   pip_lint_install:
     description: "Install lint packages via pip"

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,3 +16,5 @@ filterwarnings =
     error
     # patsy is a statsmodels dependency which currently triggers a DeprecationWarning
     default::DeprecationWarning:patsy.constraint
+    # pandas sometimes complains about binary compatibility with numpy
+    default:numpy.ufunc size changed, may indicate binary incompatibility.*:RuntimeWarning


### PR DESCRIPTION
Summary: bmgraph still had a dependency on pytorch through the CppExtension module. Remove this dependency but as a result needed to add pybind11 dependency which was added here.

Differential Revision: D23638362

