### PR TITLE
Wrapper functions handle bounded methods.

### DIFF
--- a/src/beanmachine/ppl/inference/compositional_infer.py
+++ b/src/beanmachine/ppl/inference/compositional_infer.py
@@ -13,7 +13,7 @@ from beanmachine.ppl.inference.proposer.single_site_newtonian_monte_carlo_propos
 from beanmachine.ppl.inference.proposer.single_site_uniform_proposer import (
     SingleSiteUniformProposer,
 )
-from beanmachine.ppl.model.utils import RVIdentifier
+from beanmachine.ppl.model.utils import RVIdentifier, get_wrapper
 
 
 class CompositionalInference(AbstractMHInference):
@@ -71,8 +71,9 @@ class CompositionalInference(AbstractMHInference):
         if node in self.proposers_per_rv_:
             return self.proposers_per_rv_[node]
 
-        if node.function._wrapper in self.proposers_per_family_:
-            proposer_inst = self.proposers_per_family_[node.function._wrapper]
+        wrapped_fn = get_wrapper(node.function)
+        if wrapped_fn in self.proposers_per_family_:
+            proposer_inst = self.proposers_per_family_[wrapped_fn]
             self.proposers_per_rv_[node] = copy.deepcopy(proposer_inst)
             return self.proposers_per_rv_[node]
 

--- a/src/beanmachine/ppl/model/statistical_model.py
+++ b/src/beanmachine/ppl/model/statistical_model.py
@@ -103,6 +103,7 @@ class StatisticalModel(object):
         Decorator to be used for every stochastic random variable defined in
         all statistical models.
         """
+        import inspect
 
         @wraps(f)
         def wrapper(*args):
@@ -112,7 +113,11 @@ class StatisticalModel(object):
             world = StatisticalModel.__world_
             return world.update_graph(func_key)
 
-        f._wrapper = wrapper
+        if inspect.ismethod(f):
+            meth_name = f.__name__ + "_wrapper"
+            setattr(f.__self__, meth_name, wrapper)
+        else:
+            f._wrapper = wrapper
         return wrapper
 
     @staticmethod
@@ -127,6 +132,7 @@ class StatisticalModel(object):
         """
         Decorator to be used for every query defined in statistical model.
         """
+        import inspect
 
         @wraps(f)
         def wrapper(*args):
@@ -137,7 +143,11 @@ class StatisticalModel(object):
                 return world.update_cached_functionals(f, *args)
             return f(*args)
 
-        f._wrapper = wrapper
+        if inspect.ismethod(f):
+            meth_name = f.__name__ + "_wrapper"
+            setattr(f.__self__, meth_name, wrapper)
+        else:
+            f._wrapper = wrapper
         return wrapper
 
 

--- a/src/beanmachine/ppl/model/utils.py
+++ b/src/beanmachine/ppl/model/utils.py
@@ -1,10 +1,20 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
+import inspect
 import logging
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any
 
 import torch
+
+
+def get_wrapper(f):
+    """
+    Gets wrapped function given a Python callable
+    """
+    if inspect.ismethod(f):
+        return getattr(f.__self__, f.__name__ + "_wrapper")
+    return f._wrapper
 
 
 @dataclass(eq=True, frozen=True)

--- a/src/beanmachine/ppl/utils/memoize.py
+++ b/src/beanmachine/ppl/utils/memoize.py
@@ -23,6 +23,7 @@ def memoize(f):
     """
     Decorator to be used to memoize arbitrary functions.
     """
+    import inspect
 
     cache: Dict[Any, Any] = {}
     # TODO: Can we use a more efficient type than a list? We don't know
@@ -44,5 +45,9 @@ def memoize(f):
                 in_flight.pop()
         return cache[key]
 
-    f._wrapper = wrapper
+    if inspect.ismethod(f):
+        meth_name = f.__name__ + "_wrapper"
+        setattr(f.__self__, meth_name, wrapper)
+    else:
+        f._wrapper = wrapper
     return wrapper

--- a/src/beanmachine/ppl/utils/probabilistic.py
+++ b/src/beanmachine/ppl/utils/probabilistic.py
@@ -8,6 +8,7 @@ def probabilistic(bmg: BMGraphBuilder):
     """
     Decorator to be used to make sample function probabilistic
     """
+    import inspect
 
     def inner(f):
         @wraps(f)
@@ -28,7 +29,11 @@ def probabilistic(bmg: BMGraphBuilder):
             # If we got here, there were no distribution arguments.
             return f(*args)
 
-        f._wrapper = wrapper
+        if inspect.ismethod(f):
+            meth_name = f.__name__ + "_wrapper"
+            setattr(f.__self__, meth_name, wrapper)
+        else:
+            f._wrapper = wrapper
         return wrapper
 
     return inner

--- a/src/beanmachine/ppl/world/world.py
+++ b/src/beanmachine/ppl/world/world.py
@@ -3,7 +3,7 @@ import copy
 from collections import defaultdict
 from typing import Dict, List, Optional, Set, Tuple
 
-from beanmachine.ppl.model.utils import RVIdentifier
+from beanmachine.ppl.model.utils import RVIdentifier, get_wrapper
 from beanmachine.ppl.utils.dotbuilder import print_graph
 from beanmachine.ppl.world.diff import Diff
 from beanmachine.ppl.world.diff_stack import DiffStack
@@ -163,7 +163,7 @@ class World(object):
         :param node: the node to look up
         :returns: whether the node has transform enabled or not
         """
-        return self.transforms_[node.function._wrapper]
+        return self.transforms_[get_wrapper(node.function)]
 
     def set_proposer(self, func_wrapper, proposer):
         """
@@ -201,7 +201,7 @@ class World(object):
         :param node: the node to look up
         :returns: the associate proposer
         """
-        return self.proposer_[node.function._wrapper]
+        return self.proposer_[get_wrapper(node.function)]
 
     def __str__(self) -> str:
         return (

--- a/src/beanmachine/ppl/world/world_vars.py
+++ b/src/beanmachine/ppl/world/world_vars.py
@@ -2,7 +2,7 @@
 from collections import defaultdict
 from typing import Dict, Optional
 
-from beanmachine.ppl.model.utils import RVIdentifier
+from beanmachine.ppl.model.utils import RVIdentifier, get_wrapper
 from beanmachine.ppl.world.variable import Variable
 from torch import Tensor, tensor
 
@@ -29,7 +29,7 @@ class WorldVars(object):
         """
         self.data_[node] = value
         if hasattr(node, "function"):
-            self.var_funcs_[node.function._wrapper].add(node)
+            self.var_funcs_[get_wrapper(node.function)].add(node)
 
     def contains_node_by_func(self, node_func: str) -> bool:
         """
@@ -96,7 +96,7 @@ class WorldVars(object):
         :param node: the node to delete
         """
         del self.data_[node]
-        self.var_funcs_[node.function._wrapper].remove(node)
+        self.var_funcs_[get_wrapper(node.function)].remove(node)
 
     def len(self) -> int:
         """


### PR DESCRIPTION
Summary:
### Motivation
Pytorch nn's are callables that invoke the `.forward()` method. We'd like to support nn outputs as random variables:
```
class A(nn.Module):
    def __init__(self):
        ...

    bm.random_variable
    def forward(self):
        return Normal(mu, sigma)
```

This will also make models jittable when we support that.

### Change
In python, unlike functions, methods don't have attributes so you can't do something like:
```
a = A()
a.forward._wrapper = f
```
which is used in `random_variable()` and elsewhere. This PR saves wrapped methods as instance methods named `'{function name}_wrapper'`.  This change does not break any existing functionality.

Differential Revision: D23722873

