### PR TITLE
Fix test failures in opt mode due to Operactor refactoring

### DIFF
--- a/src/beanmachine/graph/operator/operator.cpp
+++ b/src/beanmachine/graph/operator/operator.cpp
@@ -57,7 +57,9 @@ std::unique_ptr<Operator> OperatorFactory::create_op(
     const std::vector<graph::Node*>& in_nodes) {
   int op_id = static_cast<int>(op_type);
   auto iter = OperatorFactory::op_map().find(op_id);
-  if (iter != OperatorFactory::op_map().end()) {
+  // Check Sample::is_registered here to deactivate compiler optimization on
+  // unused static is_registered variables.
+  if (iter != OperatorFactory::op_map().end() and Sample::is_registered) {
     return iter->second(in_nodes);
   }
   throw std::runtime_error(

--- a/src/beanmachine/graph/operator/stochasticop.h
+++ b/src/beanmachine/graph/operator/stochasticop.h
@@ -44,7 +44,6 @@ class Sample : public oper::StochasticOperator {
     return std::make_unique<Sample>(in_nodes);
   }
 
- private:
   static bool is_registered;
 };
 


### PR DESCRIPTION
Summary: check ```is_register``` in ```create_op()``` to avoid compiler optimization error

Reviewed By: wtaha

Differential Revision: D23717490

