### PR TITLE
Fix bad observations

### DIFF
--- a/src/beanmachine/ppl/compiler/bmg_nodes.py
+++ b/src/beanmachine/ppl/compiler/bmg_nodes.py
@@ -2825,11 +2825,11 @@ should no loger be uniform."""
 
     @property
     def inf_type(self) -> BMGLatticeType:
-        # TODO: Since an observation node is never consumed, it's not actually
-        # meaningful to compute its type, but we can potentially use this
-        # to check for errors; for example, if we have an observation with
-        # value 0.5 on an operation known to be of type Natural then we can
-        # flag that as a likely error.
+        # Since an observation node is never consumed it is not actually
+        # meaningful to compute its type. However, we can use this to check for
+        # errors; for example, if we have an observation with value 0.5 on
+        # an operation known to be of type Natural then we flag that as an
+        # error.
         return self.observed.inf_type
 
     @property

--- a/src/beanmachine/ppl/compiler/error_report.py
+++ b/src/beanmachine/ppl/compiler/error_report.py
@@ -6,7 +6,7 @@ when compiling Bean Machine models to Bean Machine Graph."""
 from abc import ABC
 from typing import List
 
-from beanmachine.ppl.compiler.bmg_nodes import BMGNode
+from beanmachine.ppl.compiler.bmg_nodes import BMGNode, Observation
 from beanmachine.ppl.compiler.bmg_types import BMGLatticeType, Requirement, UpperBound
 
 
@@ -36,6 +36,23 @@ class Violation(BMGError):
             f"The {self.edge} of a {self.consumer.label} "
             + f"is required to be a {t.long_name} "
             + f"but is a {self.node.inf_type.long_name}."
+        )
+        return msg
+
+
+class ImpossibleObservation(BMGError):
+    node: Observation
+
+    def __init__(self, node: Observation) -> None:
+        self.node = node
+
+    def __str__(self) -> str:
+        v = self.node.value
+        d = self.node.operand.operand.label
+        t = self.node.inf_type.long_name
+        msg = (
+            f"A {d} distribution is observed to have value {v} "
+            + f"but only produces samples of type {t}."
         )
         return msg
 

--- a/src/beanmachine/ppl/utils/bm_graph_builder.py
+++ b/src/beanmachine/ppl/utils/bm_graph_builder.py
@@ -1223,3 +1223,9 @@ the "right"."""
         for r in roots:
             visit(r)
         return result
+
+    def all_observations(self) -> List[Observation]:
+        return sorted(
+            (n for n in self.nodes if isinstance(n, Observation)),
+            key=lambda n: self.nodes[n],
+        )


### PR DESCRIPTION
Summary: The observed value of a sample must be a value that the distribution can actually produce. Here we add a pass to the problem fixer which looks for observations that do not match the distribution type; those that can be fixed are fixed, and those that cannot produce an error.

Reviewed By: wtaha

Differential Revision: D23697546

