### PR TITLE
Support sampling element-wise iid random matrix & Add natural_t matrix in AtomicValue.

### DIFF
--- a/src/beanmachine/graph/distribution/distribution.cpp
+++ b/src/beanmachine/graph/distribution/distribution.cpp
@@ -107,10 +107,11 @@ void Distribution::sample(std::mt19937& gen, graph::AtomicValue& sample_value)
     return;
   }
   // iid sample SCALARs
-  if (sample_value.type.variable_type ==
-          graph::VariableType::BROADCAST_MATRIX and
-      sample_value.type.cols == 1 and sample_value.type.rows > 1) {
-    uint size = sample_value.type.rows;
+  if (sample_type.variable_type == graph::VariableType::SCALAR and
+      sample_value.type.variable_type ==
+          graph::VariableType::BROADCAST_MATRIX) {
+    uint size = sample_value.type.cols * sample_value.type.rows;
+    assert(size > 1);
     switch (sample_value.type.atomic_type) {
       case graph::AtomicType::BOOLEAN:
         for (uint i = 0; i < size; i++) {
@@ -122,6 +123,11 @@ void Distribution::sample(std::mt19937& gen, graph::AtomicValue& sample_value)
       case graph::AtomicType::PROBABILITY:
         for (uint i = 0; i < size; i++) {
           *(sample_value._matrix.data() + i) = _double_sampler(gen);
+        }
+        break;
+      case graph::AtomicType::NATURAL:
+        for (uint i = 0; i < size; i++) {
+          *(sample_value._nmatrix.data() + i) = _natural_sampler(gen);
         }
         break;
       default:

--- a/src/beanmachine/graph/graph.cpp
+++ b/src/beanmachine/graph/graph.cpp
@@ -106,6 +106,9 @@ AtomicValue::AtomicValue(ValueType type) : type(type) {
       case AtomicType::PROBABILITY:
         _matrix = Eigen::MatrixXd::Constant(type.rows, type.cols, PRECISION);
         break;
+      case AtomicType::NATURAL:
+        _nmatrix = Eigen::MatrixXn::Constant(type.rows, type.cols, (natural_t)0);
+        break;
       default:
         throw std::invalid_argument(
             "Unsupported types for BROADCAST_MATRIX.");
@@ -415,6 +418,10 @@ uint Graph::add_constant_matrix(Eigen::MatrixXd& value) {
   return add_constant(AtomicValue(value));
 }
 
+uint Graph::add_constant_matrix(Eigen::MatrixXn& value) {
+  return add_constant(AtomicValue(value));
+}
+
 uint Graph::add_constant_pos_matrix(Eigen::MatrixXd& value) {
   if ((value.array() < 0).any()) {
     throw std::invalid_argument("All elements in pos_matrix must be >=0");
@@ -512,6 +519,11 @@ void Graph::observe(uint node_id, Eigen::MatrixXd& val) {
 }
 
 void Graph::observe(uint node_id, Eigen::MatrixXb& val) {
+  Node* node = check_node(node_id, NodeType::OPERATOR);
+  observe(node_id, AtomicValue(node->value.type, val));
+}
+
+void Graph::observe(uint node_id, Eigen::MatrixXn& val) {
   Node* node = check_node(node_id, NodeType::OPERATOR);
   observe(node_id, AtomicValue(node->value.type, val));
 }

--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -10,8 +10,11 @@
 #include <vector>
 #include <Eigen/Dense>
 
+#define NATURAL_TYPE unsigned long long int
+
 namespace Eigen {
   typedef Matrix<bool, Dynamic, Dynamic> MatrixXb;
+  typedef Matrix<NATURAL_TYPE, Dynamic, Dynamic> MatrixXn;
 }
 
 namespace beanmachine {
@@ -102,7 +105,7 @@ struct ValueType {
   std::string to_string() const;
 };
 
-typedef unsigned long long int natural_t;
+typedef NATURAL_TYPE natural_t;
 
 class AtomicValue {
  public:
@@ -114,6 +117,7 @@ class AtomicValue {
   };
   Eigen::MatrixXd _matrix;
   Eigen::MatrixXb _bmatrix;
+  Eigen::MatrixXn _nmatrix;
 
   AtomicValue() : type(AtomicType::UNKNOWN) {}
   explicit AtomicValue(AtomicType type);
@@ -136,6 +140,13 @@ class AtomicValue {
             value.rows(),
             value.cols())),
         _bmatrix(value) {}
+  explicit AtomicValue(Eigen::MatrixXn& value)
+      : type(ValueType(
+            VariableType::BROADCAST_MATRIX,
+            AtomicType::NATURAL,
+            value.rows(),
+            value.cols())),
+        _nmatrix(value) {}
 
   AtomicValue(AtomicType type, bool value) : type(type), _bool(value) {
     assert(type == AtomicType::BOOLEAN);
@@ -154,14 +165,11 @@ class AtomicValue {
         type == AtomicType::REAL or type == AtomicType::POS_REAL or
         type == AtomicType::PROBABILITY);
   }
-  AtomicValue(AtomicType type, Eigen::MatrixXb& value)
-      : type(ValueType(
-            VariableType::BROADCAST_MATRIX,
-            type,
-            value.rows(),
-            value.cols())),
-        _bmatrix(value) {
+  AtomicValue(AtomicType /* type */, Eigen::MatrixXb& value) : AtomicValue(value) {
     assert(type == AtomicType::BOOLEAN);
+  }
+  AtomicValue(AtomicType /* type */, Eigen::MatrixXn& value) : AtomicValue(value) {
+    assert(type == AtomicType::NATURAL);
   }
   AtomicValue(ValueType type, Eigen::MatrixXd& value) : type(type), _matrix(value) {
     assert(
@@ -175,6 +183,11 @@ class AtomicValue {
   AtomicValue(ValueType type, Eigen::MatrixXb& value) : type(type), _bmatrix(value) {
     assert(type.variable_type == VariableType::BROADCAST_MATRIX);
     assert(type.atomic_type == AtomicType::BOOLEAN);
+    assert(type.rows == value.rows() and type.cols == value.cols());
+  }
+  AtomicValue(ValueType type, Eigen::MatrixXn& value) : type(type), _nmatrix(value) {
+    assert(type.variable_type == VariableType::BROADCAST_MATRIX);
+    assert(type.atomic_type == AtomicType::NATURAL);
     assert(type.rows == value.rows() and type.cols == value.cols());
   }
   AtomicValue(AtomicType type, double value);
@@ -206,10 +219,12 @@ class AtomicValue {
           break;
         case AtomicType::REAL:
         case AtomicType::POS_REAL:
-        case AtomicType::PROBABILITY: {
+        case AtomicType::PROBABILITY:
           _matrix = other._matrix;
           break;
-        }
+        case AtomicType::NATURAL:
+          _nmatrix = other._nmatrix;
+          break;
         default: {
           throw std::invalid_argument(
               "Trying to copy a MATRIX AtomicValue of unsupported type.");
@@ -237,6 +252,9 @@ class AtomicValue {
          (type.variable_type == VariableType::BROADCAST_MATRIX and
           type.atomic_type == AtomicType::BOOLEAN and
           _bmatrix == other._bmatrix) or
+         (type.variable_type == VariableType::BROADCAST_MATRIX and
+          type.atomic_type == AtomicType::NATURAL and
+          _nmatrix == other._nmatrix) or
          (type.variable_type == VariableType::COL_SIMPLEX_MATRIX and
           _matrix.isApprox(other._matrix)));
   }
@@ -371,6 +389,7 @@ struct Graph {
   uint add_constant_pos_real(double value);
   uint add_constant_matrix(Eigen::MatrixXb& value);
   uint add_constant_matrix(Eigen::MatrixXd& value);
+  uint add_constant_matrix(Eigen::MatrixXn& value);
   uint add_constant_pos_matrix(Eigen::MatrixXd& value);
   uint add_constant_probability_matrix(Eigen::MatrixXd& value);
   uint add_constant_col_simplex_matrix(Eigen::MatrixXd& value);
@@ -390,6 +409,7 @@ struct Graph {
   void observe(uint var, natural_t val);
   void observe(uint var, Eigen::MatrixXb& val);
   void observe(uint var, Eigen::MatrixXd& val);
+  void observe(uint var, Eigen::MatrixXn& val);
   void observe(uint var, AtomicValue val);
   uint query(uint var); // returns the index of the query in the samples
   /*

--- a/src/beanmachine/graph/operator/stochasticop.cpp
+++ b/src/beanmachine/graph/operator/stochasticop.cpp
@@ -21,9 +21,10 @@ Sample::Sample(const std::vector<graph::Node*>& in_nodes)
 
 IIdSample::IIdSample(const std::vector<graph::Node*>& in_nodes)
     : StochasticOperator(graph::OperatorType::IID_SAMPLE) {
-  if (in_nodes.size() != 2 ) {
+  uint in_degree = in_nodes.size();
+  if (in_degree != 2 and in_degree != 3) {
     throw std::invalid_argument(
-        "iid sample operator requires exactly 2 parent nodes");
+        "iid sample operator requires 2 or 3 parent nodes");
   }
   if (in_nodes[0]->node_type != graph::NodeType::DISTRIBUTION) {
     throw std::invalid_argument(
@@ -34,15 +35,23 @@ IIdSample::IIdSample(const std::vector<graph::Node*>& in_nodes)
     throw std::invalid_argument(
       "for iid sample, the 2nd parent must be a constant natural-valued node");
   }
-  if (in_nodes[1]->value._natural < 2) {
+  if (in_degree == 3 and
+      (in_nodes[2]->node_type != graph::NodeType::CONSTANT or
+       in_nodes[2]->value.type != graph::AtomicType::NATURAL)) {
     throw std::invalid_argument(
-      "for iid sample, the 2nd parent must have value >= 2");
+        "for iid sample, the 3rd parent must be a constant natural-valued node");
+  }
+  if (in_degree == 2 and in_nodes[1]->value._natural < 2) {
+    throw std::invalid_argument(
+      "for iid sample with two parents, the 2nd parent must have value >= 2");
+  }
+  if (in_degree == 3 and
+      (in_nodes[1]->value._natural * in_nodes[2]->value._natural) < 2) {
+    throw std::invalid_argument(
+        "for iid sample with three parents, the product of the 2nd and 3rd parents must be >= 2");
   }
   const auto dist = static_cast<distribution::Distribution*>(in_nodes[0]);
-  if (dist->dist_type != graph::DistributionType::BETA) {
-    throw std::invalid_argument(
-      "currently iid sample only supports Beta distribution");
-  }
+
   // determine the value type
   graph::ValueType vtype;
   switch (dist->sample_type.variable_type) {
@@ -51,11 +60,11 @@ IIdSample::IIdSample(const std::vector<graph::Node*>& in_nodes)
           graph::VariableType::BROADCAST_MATRIX,
           dist->sample_type.atomic_type,
           in_nodes[1]->value._natural,
-          1);
+          in_degree == 2 ? 1: in_nodes[2]->value._natural);
       break;
     case graph::VariableType::BROADCAST_MATRIX:
     case graph::VariableType::COL_SIMPLEX_MATRIX:
-      //TODO(ddeng): add IID_SAMPLE_COL after refactoring Operator class
+      //TODO(ddeng): add IID_SAMPLE_COL after first multivariate distrib added
       throw std::invalid_argument(
           "For matrix sample types, use IID_SAMPLE_COL. ");
     default:

--- a/src/beanmachine/graph/tests/operator_test.py
+++ b/src/beanmachine/graph/tests/operator_test.py
@@ -22,6 +22,7 @@ class TestOperators(unittest.TestCase):
         # add const matrices, operators on matrix to be added
         g.add_constant_matrix(np.array([[True, False], [False, True]]))
         g.add_constant_matrix(np.array([[-0.1, 0.0], [2.0, -1.0]]))
+        g.add_constant_matrix(np.array([[1, 2], [0, 999]]))
         g.add_constant_pos_matrix(np.array([[0.1, 0.0], [2.0, 1.0]]))
         g.add_constant_probability_matrix(np.array([0.1, 0.9]))
         g.add_constant_col_simplex_matrix(np.array([[0.1, 1.0], [0.9, 0.0]]))


### PR DESCRIPTION
Summary:
- updated ```Sample``` constructor and ```Distribution::sample()``` method to support sampling element-wise iid random matrix from univariate distributions
- add a natural_t type matrix to support iid sampling from ```Binomial``` distribution

Differential Revision: D23753376

