### PR TITLE
Infer posteriors from Python models using BMG

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/coin_flip_test.py
+++ b/src/beanmachine/ppl/compiler/tests/coin_flip_test.py
@@ -1,0 +1,56 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+"""End-to-end test of realistic coin flip model"""
+import unittest
+
+from beanmachine.ppl.utils.bm_to_bmg import infer
+
+
+source = """
+import beanmachine.ppl as bm
+import torch
+from torch.distributions import Bernoulli, Beta
+
+@bm.random_variable
+def beta():
+    return Beta(2.0, 2.0)
+
+@bm.random_variable
+def flip(n):
+    return Bernoulli(beta())
+
+queries = [beta()]
+observations = {
+    flip(0): 0.0,
+    flip(1): 0.0,
+    flip(2): 1.0,
+    flip(3): 0.0,
+}
+"""
+
+expected = 0.37
+
+
+class CoinFlipTest(unittest.TestCase):
+    def test_inference(self) -> None:
+        """test_inference from coin_flip_test.py"""
+
+        # We've got a prior on the coin of Beta(2,2), so it is most
+        # likely to be actually fair, but still with some probability
+        # of being unfair in either direction.
+        #
+        # We flip the coin four times and get heads 25% of the time,
+        # so this is some evidence that the true fairness of the coin is
+        # closer to 25% than 50%.
+        #
+        # We sample 1000 times from the posterior and take the average;
+        # it should come out that the true fairness is now most likely
+        # to be around 37%.
+
+        self.maxDiff = None
+        observed = infer(source)
+        # We get [[0.12], [0.34], ...]; turn that into
+        # [0.12, 0.34, ...]
+        observed = [x[0] for x in observed]
+        # and take the average
+        observed = sum(observed) / len(observed)
+        self.assertAlmostEqual(first=observed, second=expected, delta=0.05)


### PR DESCRIPTION
Summary:
At long last, we can actually do a true end-to-end test where we have a model expressed in Python source code, and we get inferred samples from BMG.

The mechanisms I've created to do this have some pretty rough edges, but this proof-of-concept shows that we can make it work; we can decide later how best to expose this ability to actual users.

Right now it works like this:

* Write your model in Python in a single module
* At the bottom of your model, create two global variables "queries" and "observations" -- just as you would in a regular Python model; the difference is that they must be in variables with those names.
* Pass the whole model as a string to my new "infer" method.
* The infer method passes back a list of samples for the queried stochastic quantities.

The implementation details of the infer method are:

* The string is parsed as a Python program and transformed such that when it executes, it accumulates nodes into a graph builder
* Once execution has finished, we add observations and queries to the graph
* The graph is then transformed into a legal BMG graph which is created via Python-to-native bindings
* We call infer() on the BMG graph and return the result.

The test case is the standard "hello world" model where we create a coin with a prior on its fairness, observe some coin flips, and then get a posterior on the fairness. In this case the prior fairness is Beta(2,2), so it is most likely to be 50% fair. We observe three tails and one head, which is evidence that the coin is really 25% fair. The posterior should then be in the middle; the average of the samples from the posterior is around 37% fair.

Reviewed By: wtaha

Differential Revision: D23695270

