### PR TITLE
Load posterior samples into kernels

### DIFF
--- a/src/beanmachine/ppl/experimental/gp/kernels.py
+++ b/src/beanmachine/ppl/experimental/gp/kernels.py
@@ -1,8 +1,11 @@
+import copy
+
 import gpytorch.kernels as kernels
+import torch
 from beanmachine.ppl.model.utils import RVIdentifier
 
 
-class KernelMixin(object):
+class KernelMixin(torch.nn.Module):
     """
     Wrapper for Gpytorch kernels that overrides the parameter attributes
     with invocations of a Bean Machine `random_variable`::
@@ -21,7 +24,7 @@ class KernelMixin(object):
         assert isinstance(prior(), RVIdentifier)
         "Prior should be None or a random variable but was: {}".format(type(prior))
 
-    def __init__(self, **kwargs):
+    def __init__(self, *args, **kwargs):
         self.priors = {}
         for k, v in kwargs.copy().items():
             if "prior" not in k:
@@ -33,7 +36,33 @@ class KernelMixin(object):
             # remove the prior for GPytorch
             kwargs.pop(k)
 
-        super().__init__(**kwargs)
+        super().__init__(*args, **kwargs)
+
+    def __call__(self, *args, **kwargs):
+        # eagerly call priors so BM can track them
+        if self.training:
+            [p() for p in self.priors.values()]
+            if hasattr(self, "base_kernel"):
+                self.base_kernel(*args, **kwargs)
+        return super().__call__(*args, **kwargs)
+
+    def train(self, mode=True):
+        if mode:
+            # loads bm priors
+            self._strict(True)
+            if hasattr(self, "_priors"):
+                self.priors = self._priors
+            if hasattr(self, "base_kernel"):
+                self.base_kernel.train()
+            return super().train()
+        else:
+            # eval mode is a gpytorch kernel
+            self._strict(False)
+            self._priors = copy.deepcopy(self.priors)
+            self.priors = {}
+            if hasattr(self, "base_kernel"):
+                self.base_kernel.eval()
+            return super().train(False)
 
     @property
     def lengthscale(self):
@@ -41,11 +70,19 @@ class KernelMixin(object):
             return self.priors["lengthscale_prior"]()
         return super().lengthscale
 
+    @lengthscale.setter
+    def lengthscale(self, val):
+        super()._set_lengthscale(val)
+
     @property
     def outputscale(self):
         if "outputscale_prior" in self.priors:
             return self.priors["outputscale_prior"]()
         return super().outputscale
+
+    @outputscale.setter
+    def outputscale(self, val):
+        super()._set_outputscale(val)
 
     @property
     def variance(self):
@@ -53,11 +90,19 @@ class KernelMixin(object):
             return self.priors["variance_prior"]()
         return super().variance
 
+    @variance.setter
+    def variance(self, val):
+        super()._set_variance(val)
+
     @property
     def offset(self):
         if "offset_prior" in self.priors:
             return self.priors["offset_prior"]()
         return super().offset
+
+    @offset.setter
+    def offset(self, val):
+        self._set_offset(val)
 
     @property
     def angular_weights(self):
@@ -65,11 +110,27 @@ class KernelMixin(object):
             return self.priors["angular_weights_prior"]()
         return super().angular_weights
 
+    @angular_weights.setter
+    def angular_weights(self, value):
+        if not torch.is_tensor(value):
+            value = torch.tensor(value)
+        super().initialize(
+            raw_angular_weights=self.raw_angular_weights_constraint.inverse_transform(
+                value
+            )
+        )
+
     @property
     def alpha(self):
         if "alpha_prior" in self.priors:
             return self.priors["alpha_prior"]()
         return super().alpha
+
+    @alpha.setter
+    def alpha(self, value):
+        if not torch.is_tensor(value):
+            value = torch.tensor(value)
+        super().initialize(raw_alpha=self.raw_alpha_constraint.inverse_transform(value))
 
     @property
     def beta(self):
@@ -77,11 +138,21 @@ class KernelMixin(object):
             return self.priors["beta_prior"]()
         return super().beta
 
+    @beta.setter
+    def beta(self, value):
+        if not torch.is_tensor(value):
+            value = torch.tensor(value)
+        super().initialize(raw_beta=self.raw_beta_constraint.inverse_transform(value))
+
     @property
     def mixture_means(self):
         if "mixture_means_prior" in self.priors:
             return self.priors["mixture_means_prior"]()
         return super().mixture_means
+
+    @mixture_means.setter
+    def mixture_means(self, value):
+        super()._set_mixture_means(value)
 
     @property
     def mixture_scales(self):
@@ -89,23 +160,39 @@ class KernelMixin(object):
             return self.priors["mixture_scales_prior"]()
         return super().mixture_scales
 
+    @mixture_scales.setter
+    def mixture_scales(self, value):
+        super()._set_mixture_scales(value)
+
     @property
     def mixture_weights(self):
         if "mixture_weights_prior" in self.priors:
             return self.priors["mixture_weights_prior"]()
         return super().mixture_weights
 
-    @property
-    def task_covar(self):
-        if "task_covar_prior" in self.priors:
-            return self.priors["task_covar_prior"]()
-        return super().task_covar
+    @mixture_weights.setter
+    def mixture_weights(self, value):
+        super()._set_mixture_weights(value)
 
     @property
     def period_length(self):
         if "period_length_prior" in self.priors:
             return self.priors["period_length_prior"]()
         return super().period_length
+
+    @period_length.setter
+    def period_length(self, value):
+        super()._set_period_length(value)
+
+    @property
+    def var(self):
+        if "var" in self.priors:
+            return self.priors["var"]()
+        return super().var
+
+    @var.setter
+    def var(self, val):
+        super()._set_var(val)
 
 
 all_kernels = []

--- a/src/beanmachine/ppl/experimental/tests/gp/kernel_test.py
+++ b/src/beanmachine/ppl/experimental/tests/gp/kernel_test.py
@@ -25,9 +25,9 @@ class KernelTests(unittest.TestCase):
         assert not kernel.has_lengthscale
         kernel = kernels.RBFKernel()
         assert kernel.has_lengthscale
-        assert isinstance(kernel.lengthscale, torch.Tensor), type(kernel.lengthscale)
+        assert isinstance(kernel.lengthscale, torch.Tensor)
         kernel = kernels.RBFKernel(lengthscale_prior=normal)
-        assert isinstance(kernel.lengthscale, RVIdentifier), type(kernel.lengthscale)
+        assert isinstance(kernel.lengthscale, RVIdentifier)
 
     def test_covar(self):
         @bm.random_variable
@@ -38,3 +38,24 @@ class KernelTests(unittest.TestCase):
         lazy_covar = kernel(torch.zeros(1))
         # kernel.evaluate() can only be called within inference
         self.assertRaises(AttributeError, lazy_covar.evaluate)
+
+    def test_setter(self):
+        @bm.random_variable
+        def normal():
+            return dist.base_distributions.Normal(0.0, 1.0)
+
+        kernel = kernels.MaternKernel(lengthscale_prior=normal)
+        assert isinstance(kernel.lengthscale, RVIdentifier)
+        # Convert to gpytorch kernel
+        kernel.eval()
+        kernel.lengthscale = torch.ones(1)
+        assert isinstance(kernel.lengthscale, torch.Tensor)
+        kernel.train()
+        assert isinstance(kernel.lengthscale, RVIdentifier)
+
+        kernel = kernels.CylindricalKernel(5, kernel, alpha_prior=normal)
+        assert isinstance(kernel.alpha, RVIdentifier)
+        # Convert to gpytorch kernel
+        kernel.eval()
+        kernel.alpha = torch.ones(1)
+        assert isinstance(kernel.alpha, torch.Tensor)


### PR DESCRIPTION
Summary: Uses gpytorch prediction strategies instead of custom ones by allowing kernels to be converted to gpytorch base kernels post-inference.

Differential Revision: D23571755

