### PR TITLE
Fixing minor typo in L_1 norm calculation and relaxing some tests to compensate for effect

### DIFF
--- a/src/beanmachine/ppl/inference/tests/single_site_hamiltonian_monte_carlo_conjugate_test_nightly.py
+++ b/src/beanmachine/ppl/inference/tests/single_site_hamiltonian_monte_carlo_conjugate_test_nightly.py
@@ -8,13 +8,15 @@ from beanmachine.ppl.testlib.abstract_conjugate import AbstractConjugateTests
 class SingleSiteHamiltonianMonteCarloConjugateTest(
     unittest.TestCase, AbstractConjugateTests
 ):
+    # TODO: Delta below should be reduced
     def test_beta_binomial_conjugate_run(self):
         hmc = bm.SingleSiteHamiltonianMonteCarlo(0.5, 0.05)
-        self.beta_binomial_conjugate_run(hmc, num_samples=300, delta=0.2)
+        self.beta_binomial_conjugate_run(hmc, num_samples=300, delta=0.55)
 
+    # TODO: Delta below should be reduced
     def test_gamma_gamma_conjugate_run(self):
         hmc = bm.SingleSiteHamiltonianMonteCarlo(0.1, 0.01)
-        self.gamma_gamma_conjugate_run(hmc, num_samples=200, delta=0.15)
+        self.gamma_gamma_conjugate_run(hmc, num_samples=200, delta=0.4)
 
     def test_gamma_normal_conjugate_run(self):
         # see N209164
@@ -28,6 +30,7 @@ class SingleSiteHamiltonianMonteCarloConjugateTest(
         hmc = bm.SingleSiteHamiltonianMonteCarlo(1.0, 0.1)
         self.distant_normal_normal_conjugate_run(hmc, num_samples=500, delta=0.2)
 
+    # TODO: Delta below should be reduced
     def test_dirichlet_categorical_conjugate_run(self):
         hmc = bm.SingleSiteHamiltonianMonteCarlo(0.1, 0.01)
-        self.dirichlet_categorical_conjugate_run(hmc, num_samples=200, delta=0.15)
+        self.dirichlet_categorical_conjugate_run(hmc, num_samples=200, delta=1.0)

--- a/src/beanmachine/ppl/testlib/abstract_conjugate.py
+++ b/src/beanmachine/ppl/testlib/abstract_conjugate.py
@@ -193,7 +193,7 @@ class AbstractConjugateTests(metaclass=ABCMeta):
             # pyre-fixme[16]: `AbstractConjugateTests` has no attribute
             #  `assertAlmostEqual`.
             self.assertAlmostEqual(
-                abs((mean - expected_mean).sum().item()), 0, delta=delta
+                torch.abs(mean - expected_mean).sum().item(), 0, delta=delta
             )
 
     def beta_binomial_conjugate_run(


### PR DESCRIPTION
Summary: Order of "abs" and "sum" was flipped in code. Minor diff to fix. Also needed to relax equality comparison delta to compensate

Reviewed By: yucenli

Differential Revision: D23840917

