### PR TITLE
Adding parenthesis to correct order of evaluation

### DIFF
--- a/src/beanmachine/ppl/testlib/abstract_conjugate.py
+++ b/src/beanmachine/ppl/testlib/abstract_conjugate.py
@@ -52,7 +52,7 @@ class AbstractConjugateTests(metaclass=ABCMeta):
         beta = beta - obs + trials
         expected_mean = alpha / (alpha + beta)
         expected_std = (
-            (alpha * beta) / (alpha + beta).pow(2.0) * (alpha + beta + 1.0)
+            (alpha * beta) / ((alpha + beta).pow(2.0) * (alpha + beta + 1.0))
         ).pow(0.5)
 
         return (expected_mean, expected_std, queries, observations)


### PR DESCRIPTION
Summary: The calculation of the standard deviation of the beta distribution required parenthesization. Basically, the code had  `a/b*c` when `a/(b*c)` was intended.

Differential Revision: D23882093

