### PR TITLE
Changing naming convention for consistency across models and externally

### DIFF
--- a/src/beanmachine/ppl/examples/conjugate_models/beta_binomial.py
+++ b/src/beanmachine/ppl/examples/conjugate_models/beta_binomial.py
@@ -5,15 +5,26 @@ from torch import Tensor
 
 
 class BetaBinomialModel(object):
-    def __init__(self, alpha: Tensor, beta: Tensor, trials: Tensor):
+    """ This Bean Machine model is an example of conjugacy, where
+    the prior and the likelihood are the Beta and the Binomial
+    distributions respectively. Conjugacy means the posterior
+    will also be in the same family as the prior, Beta.
+    The random variable names theta and x follow the
+    typical presentation of the conjugate prior relation in the
+    form of p(theta|x) = p(x|theta) * p(theta)/p(x).
+    Note: Variable names here follow those used on:
+    https://en.wikipedia.org/wiki/Conjugate_prior
+    """
+
+    def __init__(self, alpha: Tensor, beta: Tensor, n: Tensor):
         self.alpha_ = alpha
         self.beta_ = beta
-        self.trials_ = trials
+        self.n_ = n
 
     @bm.random_variable
-    def beta(self):
+    def theta(self):
         return dist.Beta(self.alpha_, self.beta_)
 
     @bm.random_variable
-    def binomial(self):
-        return dist.Binomial(self.trials_, self.beta())
+    def x(self):
+        return dist.Binomial(self.n_, self.theta())

--- a/src/beanmachine/ppl/inference/tests/single_site_random_walk_test.py
+++ b/src/beanmachine/ppl/inference/tests/single_site_random_walk_test.py
@@ -285,12 +285,12 @@ class SingleSiteRandomWalkTest(unittest.TestCase):
 
     def test_single_site_random_walk_interval_support_rate(self):
         model = BetaBinomialModel(
-            alpha=torch.ones(1) * 2.0, beta=torch.ones(1), trials=torch.ones(1) * 10.0
+            alpha=torch.ones(1) * 2.0, beta=torch.ones(1), n=torch.ones(1) * 10.0
         )
         mh = bm.SingleSiteRandomWalk(step_size=0.3)
-        p_key = model.beta()
+        p_key = model.theta()
         queries = [p_key]
-        observations = {model.binomial(): torch.tensor([10.0])}
+        observations = {model.x(): torch.tensor([10.0])}
         predictions = mh.infer(queries, observations, 50)
         predictions = predictions.get_chain()[p_key]
         """

--- a/src/beanmachine/ppl/testlib/abstract_conjugate.py
+++ b/src/beanmachine/ppl/testlib/abstract_conjugate.py
@@ -21,6 +21,8 @@ class AbstractConjugateTests(metaclass=ABCMeta):
      Computes the posterior mean and standard deviation of some of the conjugate
      distributions included below.
      https://en.wikipedia.org/wiki/Conjugate_prior#Table_of_conjugate_distributions
+
+     Note: Whenever possible, we will use same variable names as on that page.
     """
 
     def compute_statistics(self, predictions: Tensor) -> Tuple[Tensor, Tensor]:
@@ -43,19 +45,20 @@ class AbstractConjugateTests(metaclass=ABCMeta):
         """
         alpha = tensor([2.0, 2.0])
         beta = tensor([1.0, 1.0])
-        trials = tensor([1.0, 1.0])
+        n = tensor([1.0, 1.0])
         obs = tensor([1.0, 0.0])
-        model = BetaBinomialModel(alpha, beta, trials)
-        queries = [model.beta()]
-        observations = {model.binomial(): obs}
-        alpha = alpha + obs
-        beta = beta - obs + trials
-        expected_mean = alpha / (alpha + beta)
-        expected_std = (
-            (alpha * beta) / ((alpha + beta).pow(2.0) * (alpha + beta + 1.0))
+        model = BetaBinomialModel(alpha, beta, n)
+        queries = [model.theta()]
+        observations = {model.x(): obs}
+        alpha_prime = alpha + obs
+        beta_prime = beta - obs + n
+        mean_prime = alpha_prime / (alpha_prime + beta_prime)
+        std_prime = (
+            (alpha_prime * beta_prime)
+            / ((alpha_prime + beta_prime).pow(2.0) * (alpha_prime + beta + 1.0))
         ).pow(0.5)
 
-        return (expected_mean, expected_std, queries, observations)
+        return (mean_prime, std_prime, queries, observations)
 
     def compute_gamma_gamma_moments(
         self,


### PR DESCRIPTION
Summary: This diff is a template for a name change that we are considering for all Bean Machine models that are examples of conjugate priors.

Reviewed By: nimar

Differential Revision: D23915726

