### PR TITLE
Relaxed delta in tests that broke due to correct definition of norm

### DIFF
--- a/src/beanmachine/ppl/experimental/neutra/tests/iaf_conjugate_test_nightly.py
+++ b/src/beanmachine/ppl/experimental/neutra/tests/iaf_conjugate_test_nightly.py
@@ -119,8 +119,9 @@ class SingleSiteIAFConjugateTest(unittest.TestCase, AbstractConjugateTests):
             True,
             [],
         )
+        # TODO: The delta in the following needs to be reduced
         self.normal_normal_conjugate_run(
-            iaf, num_samples=100, delta=0.3, num_adaptive_samples=500
+            iaf, num_samples=100, delta=0.33, num_adaptive_samples=500
         )
 
     def test_distant_normal_normal_conjugate_run(self):
@@ -149,6 +150,7 @@ class SingleSiteIAFConjugateTest(unittest.TestCase, AbstractConjugateTests):
             True,
             [],
         )
+        # TODO: The delta in the following needs to be reduced
         self.dirichlet_categorical_conjugate_run(
-            iaf, num_samples=200, delta=0.05, num_adaptive_samples=100
+            iaf, num_samples=200, delta=0.364, num_adaptive_samples=100
         )

--- a/src/beanmachine/ppl/inference/tests/single_site_hamiltonian_monte_carlo_adaptive_conjugate_test_nightly.py
+++ b/src/beanmachine/ppl/inference/tests/single_site_hamiltonian_monte_carlo_adaptive_conjugate_test_nightly.py
@@ -34,4 +34,5 @@ class SingleSiteAdaptiveHamiltonianMonteCarloConjugateTest(
 
     def test_dirichlet_categorical_conjugate_run(self):
         hmc = bm.SingleSiteHamiltonianMonteCarlo(0.1)
-        self.dirichlet_categorical_conjugate_run(hmc, num_samples=200, delta=0.15)
+        # TODO: The delta in the following needs to be reduced
+        self.dirichlet_categorical_conjugate_run(hmc, num_samples=200, delta=0.384)

--- a/src/beanmachine/ppl/inference/tests/single_site_no_u_turn_conjugate_test_nightly.py
+++ b/src/beanmachine/ppl/inference/tests/single_site_no_u_turn_conjugate_test_nightly.py
@@ -25,14 +25,16 @@ class SingleSiteNoUTurnConjugateTest(unittest.TestCase, AbstractConjugateTests):
 
     def test_gamma_normal_conjugate_run(self):
         nuts = SingleSiteNoUTurnSampler()
+        # TODO: The delta in the following needs to be reduced
         self.gamma_normal_conjugate_run(
-            nuts, num_samples=150, delta=0.1, num_adaptive_samples=50
+            nuts, num_samples=150, delta=0.16, num_adaptive_samples=50
         )
 
     def test_normal_normal_conjugate_run(self):
         nuts = SingleSiteNoUTurnSampler()
+        # TODO: The delta in the following needs to be reduced
         self.normal_normal_conjugate_run(
-            nuts, num_samples=200, delta=0.05, num_adaptive_samples=100
+            nuts, num_samples=200, delta=0.06, num_adaptive_samples=100
         )
 
     def test_distant_normal_normal_conjugate_run(self):

--- a/src/beanmachine/ppl/inference/tests/single_site_random_walk_adaptive_conjugate_test_nightly.py
+++ b/src/beanmachine/ppl/inference/tests/single_site_random_walk_adaptive_conjugate_test_nightly.py
@@ -36,8 +36,9 @@ class SingleSiteAdaptiveRandomWalkConjugateTest(
         )
 
     def test_distant_normal_normal_conjugate_run(self):
+        # TODO: The delta in the following needs to be reduced
         self.normal_normal_conjugate_run(
-            self.mh, num_samples=4000, num_adaptive_samples=500, delta=0.1
+            self.mh, num_samples=4000, num_adaptive_samples=500, delta=0.13
         )
 
     def test_dirichlet_categorical_conjugate_run(self):

--- a/src/beanmachine/ppl/inference/tests/single_site_random_walk_conjugate_test_nightly.py
+++ b/src/beanmachine/ppl/inference/tests/single_site_random_walk_conjugate_test_nightly.py
@@ -28,4 +28,5 @@ class SingleSiteRandomWalkConjugateTest(unittest.TestCase, AbstractConjugateTest
         self.normal_normal_conjugate_run(mh, num_samples=5000, delta=1.0)
 
     def test_dirichlet_categorical_conjugate_run(self):
-        self.dirichlet_categorical_conjugate_run(self.mh, num_samples=2000, delta=0.2)
+        # TODO: The delta in the following should be reduced
+        self.dirichlet_categorical_conjugate_run(self.mh, num_samples=2000, delta=0.29)


### PR DESCRIPTION
Summary: In a previous diff, a typo in the definition of the L_1 norm was fixed (D23840917 (https://github.com/facebookincubator/beanmachine/commit/e53b02fbeccf98b14b42e01ec556dfad65e92be0)). This led to several existing tests breaking. This diff temporarily fixes those tests by relaxing the delta that they use for comparing the resulting average. The plan is to rewrite tests to use p-values, and to introduce this in upcoming diffs.

Reviewed By: nimar

Differential Revision: D23933801

