### PR TITLE
Fix uninitialized memory bug in BMG

### DIFF
--- a/src/beanmachine/graph/operator/unaryop.cpp
+++ b/src/beanmachine/graph/operator/unaryop.cpp
@@ -159,7 +159,7 @@ Phi::Phi(const std::vector<graph::Node*>& in_nodes)
   if (type0 != graph::AtomicType::REAL) {
     throw std::invalid_argument("Phi require a real-valued parent");
   }
-  value.type = graph::AtomicType::PROBABILITY;
+  value = graph::AtomicValue(graph::AtomicType::PROBABILITY);
 }
 
 void Phi::eval(std::mt19937& /* gen */) {
@@ -179,7 +179,7 @@ Logistic::Logistic(const std::vector<graph::Node*>& in_nodes)
   if (type0 != graph::AtomicType::REAL) {
     throw std::invalid_argument("logistic require a real-valued parent");
   }
-  value.type = graph::AtomicType::PROBABILITY;
+  value = graph::AtomicValue(graph::AtomicType::PROBABILITY);
 }
 
 void Logistic::eval(std::mt19937& /* gen */) {


### PR DESCRIPTION
Summary:
The constructors for graph nodes in BMG need to initialize both the type and the value of a graph upon construction; two of the nodes were initializing only the type.

The reason we must initialize the value is because the default zero value needs to be shown when the graph is created and then represented as a string; the values are output then. If we do not initialize the values then test cases which check the string form of the graph can fail unexpectedly.

Reviewed By: dengdetian0603

Differential Revision: D23966395

