### PR TITLE
Automatically eliminate identity multiplication and addition

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/logistic_regression_test.py
+++ b/src/beanmachine/ppl/compiler/tests/logistic_regression_test.py
@@ -60,75 +60,73 @@ expected_bmg = """
 Node 0 type 1 parents [ ] children [ 2 ] real 0
 Node 1 type 1 parents [ ] children [ 2 ] positive real 1
 Node 2 type 2 parents [ 0 1 ] children [ 3 4 5 ] unknown
-Node 3 type 3 parents [ 2 ] children [ 7 ] real 0
-Node 4 type 3 parents [ 2 ] children [ 9 17 25 33 41 49 57 65 ] real 0
-Node 5 type 3 parents [ 2 ] children [ 12 20 28 36 44 52 60 68 ] real 0
-Node 6 type 1 parents [ ] children [ 7 ] real 1
-Node 7 type 3 parents [ 6 3 ] children [ 10 18 26 34 42 50 58 66 ] real 0
-Node 8 type 1 parents [ ] children [ 9 ] real 7.6483
-Node 9 type 3 parents [ 8 4 ] children [ 10 ] real 0
-Node 10 type 3 parents [ 7 9 ] children [ 13 ] real 0
-Node 11 type 1 parents [ ] children [ 12 ] real 5.6988
-Node 12 type 3 parents [ 11 5 ] children [ 13 ] real 0
-Node 13 type 3 parents [ 10 12 ] children [ 14 ] real 0
-Node 14 type 2 parents [ 13 ] children [ 15 ] unknown
-Node 15 type 3 parents [ 14 ] children [ ] boolean 0
-Node 16 type 1 parents [ ] children [ 17 ] real -6.2928
-Node 17 type 3 parents [ 16 4 ] children [ 18 ] real 0
-Node 18 type 3 parents [ 7 17 ] children [ 21 ] real 0
-Node 19 type 1 parents [ ] children [ 20 ] real 1.1692
-Node 20 type 3 parents [ 19 5 ] children [ 21 ] real 0
-Node 21 type 3 parents [ 18 20 ] children [ 22 ] real 0
-Node 22 type 2 parents [ 21 ] children [ 23 ] unknown
-Node 23 type 3 parents [ 22 ] children [ ] boolean 0
-Node 24 type 1 parents [ ] children [ 25 ] real 1.6583
-Node 25 type 3 parents [ 24 4 ] children [ 26 ] real 0
-Node 26 type 3 parents [ 7 25 ] children [ 29 ] real 0
-Node 27 type 1 parents [ ] children [ 28 ] real -4.7142
-Node 28 type 3 parents [ 27 5 ] children [ 29 ] real 0
-Node 29 type 3 parents [ 26 28 ] children [ 30 ] real 0
-Node 30 type 2 parents [ 29 ] children [ 31 ] unknown
-Node 31 type 3 parents [ 30 ] children [ ] boolean 0
-Node 32 type 1 parents [ ] children [ 33 ] real -7.7588
-Node 33 type 3 parents [ 32 4 ] children [ 34 ] real 0
-Node 34 type 3 parents [ 7 33 ] children [ 37 ] real 0
-Node 35 type 1 parents [ ] children [ 36 ] real 7.9859
-Node 36 type 3 parents [ 35 5 ] children [ 37 ] real 0
-Node 37 type 3 parents [ 34 36 ] children [ 38 ] real 0
-Node 38 type 2 parents [ 37 ] children [ 39 ] unknown
-Node 39 type 3 parents [ 38 ] children [ ] boolean 0
-Node 40 type 1 parents [ ] children [ 41 ] real -1.2421
-Node 41 type 3 parents [ 40 4 ] children [ 42 ] real 0
-Node 42 type 3 parents [ 7 41 ] children [ 45 ] real 0
-Node 43 type 1 parents [ ] children [ 44 ] real 5.4628
-Node 44 type 3 parents [ 43 5 ] children [ 45 ] real 0
-Node 45 type 3 parents [ 42 44 ] children [ 46 ] real 0
-Node 46 type 2 parents [ 45 ] children [ 47 ] unknown
-Node 47 type 3 parents [ 46 ] children [ ] boolean 0
-Node 48 type 1 parents [ ] children [ 49 ] real 6.4529
-Node 49 type 3 parents [ 48 4 ] children [ 50 ] real 0
-Node 50 type 3 parents [ 7 49 ] children [ 53 ] real 0
-Node 51 type 1 parents [ ] children [ 52 ] real 2.3994
-Node 52 type 3 parents [ 51 5 ] children [ 53 ] real 0
-Node 53 type 3 parents [ 50 52 ] children [ 54 ] real 0
-Node 54 type 2 parents [ 53 ] children [ 55 ] unknown
-Node 55 type 3 parents [ 54 ] children [ ] boolean 0
-Node 56 type 1 parents [ ] children [ 57 ] real -4.9269
-Node 57 type 3 parents [ 56 4 ] children [ 58 ] real 0
-Node 58 type 3 parents [ 7 57 ] children [ 61 ] real 0
-Node 59 type 1 parents [ ] children [ 60 ] real 7.8679
-Node 60 type 3 parents [ 59 5 ] children [ 61 ] real 0
-Node 61 type 3 parents [ 58 60 ] children [ 62 ] real 0
-Node 62 type 2 parents [ 61 ] children [ 63 ] unknown
-Node 63 type 3 parents [ 62 ] children [ ] boolean 0
-Node 64 type 1 parents [ ] children [ 65 ] real 4.213
-Node 65 type 3 parents [ 64 4 ] children [ 66 ] real 0
-Node 66 type 3 parents [ 7 65 ] children [ 69 ] real 0
-Node 67 type 1 parents [ ] children [ 68 ] real 2.6175
-Node 68 type 3 parents [ 67 5 ] children [ 69 ] real 0
-Node 69 type 3 parents [ 66 68 ] children [ 70 ] real 0
-Node 70 type 2 parents [ 69 ] children [ 71 ] unknown
-Node 71 type 3 parents [ 70 ] children [ ] boolean 0
+Node 3 type 3 parents [ 2 ] children [ 8 16 24 32 40 48 56 64 ] real 0
+Node 4 type 3 parents [ 2 ] children [ 7 15 23 31 39 47 55 63 ] real 0
+Node 5 type 3 parents [ 2 ] children [ 10 18 26 34 42 50 58 66 ] real 0
+Node 6 type 1 parents [ ] children [ 7 ] real 7.6483
+Node 7 type 3 parents [ 6 4 ] children [ 8 ] real 0
+Node 8 type 3 parents [ 3 7 ] children [ 11 ] real 0
+Node 9 type 1 parents [ ] children [ 10 ] real 5.6988
+Node 10 type 3 parents [ 9 5 ] children [ 11 ] real 0
+Node 11 type 3 parents [ 8 10 ] children [ 12 ] real 0
+Node 12 type 2 parents [ 11 ] children [ 13 ] unknown
+Node 13 type 3 parents [ 12 ] children [ ] boolean 0
+Node 14 type 1 parents [ ] children [ 15 ] real -6.2928
+Node 15 type 3 parents [ 14 4 ] children [ 16 ] real 0
+Node 16 type 3 parents [ 3 15 ] children [ 19 ] real 0
+Node 17 type 1 parents [ ] children [ 18 ] real 1.1692
+Node 18 type 3 parents [ 17 5 ] children [ 19 ] real 0
+Node 19 type 3 parents [ 16 18 ] children [ 20 ] real 0
+Node 20 type 2 parents [ 19 ] children [ 21 ] unknown
+Node 21 type 3 parents [ 20 ] children [ ] boolean 0
+Node 22 type 1 parents [ ] children [ 23 ] real 1.6583
+Node 23 type 3 parents [ 22 4 ] children [ 24 ] real 0
+Node 24 type 3 parents [ 3 23 ] children [ 27 ] real 0
+Node 25 type 1 parents [ ] children [ 26 ] real -4.7142
+Node 26 type 3 parents [ 25 5 ] children [ 27 ] real 0
+Node 27 type 3 parents [ 24 26 ] children [ 28 ] real 0
+Node 28 type 2 parents [ 27 ] children [ 29 ] unknown
+Node 29 type 3 parents [ 28 ] children [ ] boolean 0
+Node 30 type 1 parents [ ] children [ 31 ] real -7.7588
+Node 31 type 3 parents [ 30 4 ] children [ 32 ] real 0
+Node 32 type 3 parents [ 3 31 ] children [ 35 ] real 0
+Node 33 type 1 parents [ ] children [ 34 ] real 7.9859
+Node 34 type 3 parents [ 33 5 ] children [ 35 ] real 0
+Node 35 type 3 parents [ 32 34 ] children [ 36 ] real 0
+Node 36 type 2 parents [ 35 ] children [ 37 ] unknown
+Node 37 type 3 parents [ 36 ] children [ ] boolean 0
+Node 38 type 1 parents [ ] children [ 39 ] real -1.2421
+Node 39 type 3 parents [ 38 4 ] children [ 40 ] real 0
+Node 40 type 3 parents [ 3 39 ] children [ 43 ] real 0
+Node 41 type 1 parents [ ] children [ 42 ] real 5.4628
+Node 42 type 3 parents [ 41 5 ] children [ 43 ] real 0
+Node 43 type 3 parents [ 40 42 ] children [ 44 ] real 0
+Node 44 type 2 parents [ 43 ] children [ 45 ] unknown
+Node 45 type 3 parents [ 44 ] children [ ] boolean 0
+Node 46 type 1 parents [ ] children [ 47 ] real 6.4529
+Node 47 type 3 parents [ 46 4 ] children [ 48 ] real 0
+Node 48 type 3 parents [ 3 47 ] children [ 51 ] real 0
+Node 49 type 1 parents [ ] children [ 50 ] real 2.3994
+Node 50 type 3 parents [ 49 5 ] children [ 51 ] real 0
+Node 51 type 3 parents [ 48 50 ] children [ 52 ] real 0
+Node 52 type 2 parents [ 51 ] children [ 53 ] unknown
+Node 53 type 3 parents [ 52 ] children [ ] boolean 0
+Node 54 type 1 parents [ ] children [ 55 ] real -4.9269
+Node 55 type 3 parents [ 54 4 ] children [ 56 ] real 0
+Node 56 type 3 parents [ 3 55 ] children [ 59 ] real 0
+Node 57 type 1 parents [ ] children [ 58 ] real 7.8679
+Node 58 type 3 parents [ 57 5 ] children [ 59 ] real 0
+Node 59 type 3 parents [ 56 58 ] children [ 60 ] real 0
+Node 60 type 2 parents [ 59 ] children [ 61 ] unknown
+Node 61 type 3 parents [ 60 ] children [ ] boolean 0
+Node 62 type 1 parents [ ] children [ 63 ] real 4.213
+Node 63 type 3 parents [ 62 4 ] children [ 64 ] real 0
+Node 64 type 3 parents [ 3 63 ] children [ 67 ] real 0
+Node 65 type 1 parents [ ] children [ 66 ] real 2.6175
+Node 66 type 3 parents [ 65 5 ] children [ 67 ] real 0
+Node 67 type 3 parents [ 64 66 ] children [ 68 ] real 0
+Node 68 type 2 parents [ 67 ] children [ 69 ] unknown
+Node 69 type 3 parents [ 68 ] children [ ] boolean 0
 """
 
 
@@ -140,159 +138,155 @@ digraph "graph" {
   N03[label="Sample:R"];
   N04[label="Sample:R"];
   N05[label="Sample:R"];
-  N06[label="1.0:R"];
+  N06[label="7.6483:R"];
   N07[label="*:R"];
-  N08[label="7.6483:R"];
-  N09[label="*:R"];
-  N10[label="+:R"];
-  N11[label="5.6988:R"];
-  N12[label="*:R"];
-  N13[label="+:R"];
-  N14[label="Bernoulli(logits):B"];
-  N15[label="Sample:B"];
-  N16[label="-6.2928:R"];
-  N17[label="*:R"];
-  N18[label="+:R"];
-  N19[label="1.1692:R"];
-  N20[label="*:R"];
-  N21[label="+:R"];
-  N22[label="Bernoulli(logits):B"];
-  N23[label="Sample:B"];
-  N24[label="1.6583:R"];
-  N25[label="*:R"];
-  N26[label="+:R"];
-  N27[label="-4.7142:R"];
-  N28[label="*:R"];
-  N29[label="+:R"];
-  N30[label="Bernoulli(logits):B"];
-  N31[label="Sample:B"];
-  N32[label="-7.7588:R"];
-  N33[label="*:R"];
-  N34[label="+:R"];
-  N35[label="7.9859:R"];
-  N36[label="*:R"];
-  N37[label="+:R"];
-  N38[label="Bernoulli(logits):B"];
-  N39[label="Sample:B"];
-  N40[label="-1.2421:R"];
-  N41[label="*:R"];
-  N42[label="+:R"];
-  N43[label="5.4628:R"];
-  N44[label="*:R"];
-  N45[label="+:R"];
-  N46[label="Bernoulli(logits):B"];
-  N47[label="Sample:B"];
-  N48[label="6.4529:R"];
-  N49[label="*:R"];
-  N50[label="+:R"];
-  N51[label="2.3994:R"];
-  N52[label="*:R"];
-  N53[label="+:R"];
-  N54[label="Bernoulli(logits):B"];
-  N55[label="Sample:B"];
-  N56[label="-4.9269:R"];
-  N57[label="*:R"];
-  N58[label="+:R"];
-  N59[label="7.8679:R"];
-  N60[label="*:R"];
-  N61[label="+:R"];
-  N62[label="Bernoulli(logits):B"];
-  N63[label="Sample:B"];
-  N64[label="4.213:R"];
-  N65[label="*:R"];
-  N66[label="+:R"];
-  N67[label="2.6175:R"];
-  N68[label="*:R"];
-  N69[label="+:R"];
-  N70[label="Bernoulli(logits):B"];
-  N71[label="Sample:B"];
+  N08[label="+:R"];
+  N09[label="5.6988:R"];
+  N10[label="*:R"];
+  N11[label="+:R"];
+  N12[label="Bernoulli(logits):B"];
+  N13[label="Sample:B"];
+  N14[label="-6.2928:R"];
+  N15[label="*:R"];
+  N16[label="+:R"];
+  N17[label="1.1692:R"];
+  N18[label="*:R"];
+  N19[label="+:R"];
+  N20[label="Bernoulli(logits):B"];
+  N21[label="Sample:B"];
+  N22[label="1.6583:R"];
+  N23[label="*:R"];
+  N24[label="+:R"];
+  N25[label="-4.7142:R"];
+  N26[label="*:R"];
+  N27[label="+:R"];
+  N28[label="Bernoulli(logits):B"];
+  N29[label="Sample:B"];
+  N30[label="-7.7588:R"];
+  N31[label="*:R"];
+  N32[label="+:R"];
+  N33[label="7.9859:R"];
+  N34[label="*:R"];
+  N35[label="+:R"];
+  N36[label="Bernoulli(logits):B"];
+  N37[label="Sample:B"];
+  N38[label="-1.2421:R"];
+  N39[label="*:R"];
+  N40[label="+:R"];
+  N41[label="5.4628:R"];
+  N42[label="*:R"];
+  N43[label="+:R"];
+  N44[label="Bernoulli(logits):B"];
+  N45[label="Sample:B"];
+  N46[label="6.4529:R"];
+  N47[label="*:R"];
+  N48[label="+:R"];
+  N49[label="2.3994:R"];
+  N50[label="*:R"];
+  N51[label="+:R"];
+  N52[label="Bernoulli(logits):B"];
+  N53[label="Sample:B"];
+  N54[label="-4.9269:R"];
+  N55[label="*:R"];
+  N56[label="+:R"];
+  N57[label="7.8679:R"];
+  N58[label="*:R"];
+  N59[label="+:R"];
+  N60[label="Bernoulli(logits):B"];
+  N61[label="Sample:B"];
+  N62[label="4.213:R"];
+  N63[label="*:R"];
+  N64[label="+:R"];
+  N65[label="2.6175:R"];
+  N66[label="*:R"];
+  N67[label="+:R"];
+  N68[label="Bernoulli(logits):B"];
+  N69[label="Sample:B"];
   N00 -> N02[label=mu];
   N01 -> N02[label=sigma];
   N02 -> N03[label=operand];
   N02 -> N04[label=operand];
   N02 -> N05[label=operand];
-  N03 -> N07[label=right];
-  N04 -> N09[label=right];
-  N04 -> N17[label=right];
-  N04 -> N25[label=right];
-  N04 -> N33[label=right];
-  N04 -> N41[label=right];
-  N04 -> N49[label=right];
-  N04 -> N57[label=right];
-  N04 -> N65[label=right];
-  N05 -> N12[label=right];
-  N05 -> N20[label=right];
-  N05 -> N28[label=right];
-  N05 -> N36[label=right];
-  N05 -> N44[label=right];
-  N05 -> N52[label=right];
-  N05 -> N60[label=right];
-  N05 -> N68[label=right];
+  N03 -> N08[label=left];
+  N03 -> N16[label=left];
+  N03 -> N24[label=left];
+  N03 -> N32[label=left];
+  N03 -> N40[label=left];
+  N03 -> N48[label=left];
+  N03 -> N56[label=left];
+  N03 -> N64[label=left];
+  N04 -> N07[label=right];
+  N04 -> N15[label=right];
+  N04 -> N23[label=right];
+  N04 -> N31[label=right];
+  N04 -> N39[label=right];
+  N04 -> N47[label=right];
+  N04 -> N55[label=right];
+  N04 -> N63[label=right];
+  N05 -> N10[label=right];
+  N05 -> N18[label=right];
+  N05 -> N26[label=right];
+  N05 -> N34[label=right];
+  N05 -> N42[label=right];
+  N05 -> N50[label=right];
+  N05 -> N58[label=right];
+  N05 -> N66[label=right];
   N06 -> N07[label=left];
-  N07 -> N10[label=left];
-  N07 -> N18[label=left];
-  N07 -> N26[label=left];
-  N07 -> N34[label=left];
-  N07 -> N42[label=left];
-  N07 -> N50[label=left];
-  N07 -> N58[label=left];
-  N07 -> N66[label=left];
-  N08 -> N09[label=left];
-  N09 -> N10[label=right];
-  N10 -> N13[label=left];
-  N11 -> N12[label=left];
-  N12 -> N13[label=right];
-  N13 -> N14[label=probability];
-  N14 -> N15[label=operand];
-  N16 -> N17[label=left];
-  N17 -> N18[label=right];
-  N18 -> N21[label=left];
-  N19 -> N20[label=left];
-  N20 -> N21[label=right];
-  N21 -> N22[label=probability];
-  N22 -> N23[label=operand];
-  N24 -> N25[label=left];
-  N25 -> N26[label=right];
-  N26 -> N29[label=left];
-  N27 -> N28[label=left];
-  N28 -> N29[label=right];
-  N29 -> N30[label=probability];
-  N30 -> N31[label=operand];
-  N32 -> N33[label=left];
-  N33 -> N34[label=right];
-  N34 -> N37[label=left];
-  N35 -> N36[label=left];
-  N36 -> N37[label=right];
-  N37 -> N38[label=probability];
-  N38 -> N39[label=operand];
-  N40 -> N41[label=left];
-  N41 -> N42[label=right];
-  N42 -> N45[label=left];
-  N43 -> N44[label=left];
-  N44 -> N45[label=right];
-  N45 -> N46[label=probability];
-  N46 -> N47[label=operand];
-  N48 -> N49[label=left];
-  N49 -> N50[label=right];
-  N50 -> N53[label=left];
-  N51 -> N52[label=left];
-  N52 -> N53[label=right];
-  N53 -> N54[label=probability];
-  N54 -> N55[label=operand];
-  N56 -> N57[label=left];
-  N57 -> N58[label=right];
-  N58 -> N61[label=left];
-  N59 -> N60[label=left];
-  N60 -> N61[label=right];
-  N61 -> N62[label=probability];
-  N62 -> N63[label=operand];
-  N64 -> N65[label=left];
-  N65 -> N66[label=right];
-  N66 -> N69[label=left];
-  N67 -> N68[label=left];
-  N68 -> N69[label=right];
-  N69 -> N70[label=probability];
-  N70 -> N71[label=operand];
+  N07 -> N08[label=right];
+  N08 -> N11[label=left];
+  N09 -> N10[label=left];
+  N10 -> N11[label=right];
+  N11 -> N12[label=probability];
+  N12 -> N13[label=operand];
+  N14 -> N15[label=left];
+  N15 -> N16[label=right];
+  N16 -> N19[label=left];
+  N17 -> N18[label=left];
+  N18 -> N19[label=right];
+  N19 -> N20[label=probability];
+  N20 -> N21[label=operand];
+  N22 -> N23[label=left];
+  N23 -> N24[label=right];
+  N24 -> N27[label=left];
+  N25 -> N26[label=left];
+  N26 -> N27[label=right];
+  N27 -> N28[label=probability];
+  N28 -> N29[label=operand];
+  N30 -> N31[label=left];
+  N31 -> N32[label=right];
+  N32 -> N35[label=left];
+  N33 -> N34[label=left];
+  N34 -> N35[label=right];
+  N35 -> N36[label=probability];
+  N36 -> N37[label=operand];
+  N38 -> N39[label=left];
+  N39 -> N40[label=right];
+  N40 -> N43[label=left];
+  N41 -> N42[label=left];
+  N42 -> N43[label=right];
+  N43 -> N44[label=probability];
+  N44 -> N45[label=operand];
+  N46 -> N47[label=left];
+  N47 -> N48[label=right];
+  N48 -> N51[label=left];
+  N49 -> N50[label=left];
+  N50 -> N51[label=right];
+  N51 -> N52[label=probability];
+  N52 -> N53[label=operand];
+  N54 -> N55[label=left];
+  N55 -> N56[label=right];
+  N56 -> N59[label=left];
+  N57 -> N58[label=left];
+  N58 -> N59[label=right];
+  N59 -> N60[label=probability];
+  N60 -> N61[label=operand];
+  N62 -> N63[label=left];
+  N63 -> N64[label=right];
+  N64 -> N67[label=left];
+  N65 -> N66[label=left];
+  N66 -> N67[label=right];
+  N67 -> N68[label=probability];
+  N68 -> N69[label=operand];
 }
 """
 

--- a/src/beanmachine/ppl/utils/tests/bm_graph_builder_test.py
+++ b/src/beanmachine/ppl/utils/tests/bm_graph_builder_test.py
@@ -711,8 +711,10 @@ digraph "graph" {
         # Graph nodes
         gr1 = bmg.add_real(1.0)
         self.assertTrue(isinstance(gr1, RealNode))
+        gr2 = bmg.add_real(2.0)
         gt1 = bmg.add_tensor(t1)
         self.assertTrue(isinstance(gt1, TensorNode))
+        gt2 = bmg.add_tensor(t2)
 
         # torch defines a "static" mul method that takes two values.
         # Calling torch.mul(x, y) should be logically the same as x * y
@@ -731,6 +733,7 @@ digraph "graph" {
         self.assertEqual(bmg.handle_dot_get(t1, "mul"), ta1)
 
         gta1 = bmg.handle_dot_get(gt1, "mul")
+        gta2 = bmg.handle_dot_get(gt2, "mul")
 
         ta2 = torch.Tensor.mul
         self.assertEqual(bmg.handle_dot_get(torch.Tensor, "mul"), ta2)
@@ -810,26 +813,26 @@ digraph "graph" {
         self.assertTrue(isinstance(bmg.handle_function(ta, [t2, s]), n))
         self.assertTrue(isinstance(bmg.handle_function(sa, [2.0]), n))
         self.assertTrue(isinstance(bmg.handle_function(sa, [t2]), n))
-        self.assertTrue(isinstance(bmg.handle_function(gta1, [s]), n))
+        self.assertTrue(isinstance(bmg.handle_function(gta2, [s]), n))
         self.assertTrue(isinstance(bmg.handle_function(ta2, [s, 2.0]), n))
         self.assertTrue(isinstance(bmg.handle_function(ta2, [s, t2]), n))
         self.assertTrue(isinstance(bmg.handle_function(ta2, [t2, s]), n))
 
         # Sample times graph node produces node
-        self.assertTrue(isinstance(bmg.handle_multiplication(s, gr1), n))
-        self.assertTrue(isinstance(bmg.handle_multiplication(s, gt1), n))
-        self.assertTrue(isinstance(bmg.handle_multiplication(gr1, s), n))
-        self.assertTrue(isinstance(bmg.handle_multiplication(gt1, s), n))
-        self.assertTrue(isinstance(bmg.handle_function(ta, [s, gr1]), n))
-        self.assertTrue(isinstance(bmg.handle_function(ta, [s, gt1]), n))
-        self.assertTrue(isinstance(bmg.handle_function(ta, [gr1, s]), n))
-        self.assertTrue(isinstance(bmg.handle_function(ta, [gt1, s]), n))
-        self.assertTrue(isinstance(bmg.handle_function(sa, [gr1]), n))
-        self.assertTrue(isinstance(bmg.handle_function(sa, [gt1]), n))
-        self.assertTrue(isinstance(bmg.handle_function(ta2, [s, gr1]), n))
-        self.assertTrue(isinstance(bmg.handle_function(ta2, [s, gt1]), n))
-        self.assertTrue(isinstance(bmg.handle_function(ta2, [gt1, s]), n))
-        self.assertTrue(isinstance(bmg.handle_function(ta2, [gt1], {"other": s}), n))
+        self.assertTrue(isinstance(bmg.handle_multiplication(s, gr2), n))
+        self.assertTrue(isinstance(bmg.handle_multiplication(s, gt2), n))
+        self.assertTrue(isinstance(bmg.handle_multiplication(gr2, s), n))
+        self.assertTrue(isinstance(bmg.handle_multiplication(gt2, s), n))
+        self.assertTrue(isinstance(bmg.handle_function(ta, [s, gr2]), n))
+        self.assertTrue(isinstance(bmg.handle_function(ta, [s, gt2]), n))
+        self.assertTrue(isinstance(bmg.handle_function(ta, [gr2, s]), n))
+        self.assertTrue(isinstance(bmg.handle_function(ta, [gt2, s]), n))
+        self.assertTrue(isinstance(bmg.handle_function(sa, [gr2]), n))
+        self.assertTrue(isinstance(bmg.handle_function(sa, [gt2]), n))
+        self.assertTrue(isinstance(bmg.handle_function(ta2, [s, gr2]), n))
+        self.assertTrue(isinstance(bmg.handle_function(ta2, [s, gt2]), n))
+        self.assertTrue(isinstance(bmg.handle_function(ta2, [gt2, s]), n))
+        self.assertTrue(isinstance(bmg.handle_function(ta2, [gt2], {"other": s}), n))
 
     def test_matrix_multiplication(self) -> None:
         """Test matrix_multiplication"""


### PR DESCRIPTION
Summary:
If during graph accumulation we have an addition of zero to something, or a multiplication by one, or a multiplication by zero, we can optimize it away immediately. This saves having to deal with type analysis, later optimization passes, and so on.

The logistic regression model that I recently added as a test case has multiplication by 1.0 in it, and so its generated graph became smaller as a result.

The multiplication node unit test was using multiplication by 1.0 as a test case, so I updated parts of it to multiply by 2.0 instead, so that the multiplication would not be optimized away for the test.

Reviewed By: wtaha

Differential Revision: D23831426

