### PR TITLE
Bug fix for missing ast.Expr around an ast.Call in a previous diff

### DIFF
--- a/src/beanmachine/ppl/utils/single_assignment.py
+++ b/src/beanmachine/ppl/utils/single_assignment.py
@@ -784,7 +784,7 @@ class SingleAssignment:
             "handle_assign_dictionary_values",
         )
 
-    def _nested_ifs_of(self, conditions: List[ast.expr], call: ast.AST) -> ast.AST:
+    def _nested_ifs_of(self, conditions: List[ast.expr], call: ast.stmt) -> ast.stmt:
         # Turns a series of conditions into nested ifs
         if conditions == []:
             return call
@@ -794,8 +794,8 @@ class SingleAssignment:
             return ast.If(test=head, body=[rest], orelse=[])
 
     def _nested_fors_and_ifs_of(
-        self, generators: List[ast.comprehension], call: ast.AST
-    ) -> ast.AST:
+        self, generators: List[ast.comprehension], call: ast.stmt
+    ) -> ast.stmt:
         # Turns nested comprehension generators into a nesting for for+if statements
         # for example [... for i in range(1,2) if odd(i)] into
         # for i in range(1,2):
@@ -842,14 +842,16 @@ class SingleAssignment:
                                 ),
                                 self._nested_fors_and_ifs_of(
                                     term.value.generators,
-                                    ast.Call(
-                                        func=ast.Attribute(
-                                            value=new_name("r", "load"),
-                                            attr="append",
-                                            ctx=ast.Load(),
-                                        ),
-                                        args=[term.value.elt],
-                                        keywords=[],
+                                    ast.Expr(
+                                        ast.Call(
+                                            func=ast.Attribute(
+                                                value=new_name("r", "load"),
+                                                attr="append",
+                                                ctx=ast.Load(),
+                                            ),
+                                            args=[term.value.elt],
+                                            keywords=[],
+                                        )
                                     ),
                                 ),
                                 ast.Return(new_name("r", "load")),
@@ -902,14 +904,16 @@ class SingleAssignment:
                                 ),
                                 self._nested_fors_and_ifs_of(
                                     term.value.generators,
-                                    ast.Call(
-                                        func=ast.Attribute(
-                                            value=new_name("r", "load"),
-                                            attr="add",
-                                            ctx=ast.Load(),
-                                        ),
-                                        args=[term.value.elt],
-                                        keywords=[],
+                                    ast.Expr(
+                                        ast.Call(
+                                            func=ast.Attribute(
+                                                value=new_name("r", "load"),
+                                                attr="add",
+                                                ctx=ast.Load(),
+                                            ),
+                                            args=[term.value.elt],
+                                            keywords=[],
+                                        )
                                     ),
                                 ),
                                 ast.Return(new_name("r", "load")),
@@ -958,14 +962,16 @@ class SingleAssignment:
                                 ),
                                 self._nested_fors_and_ifs_of(
                                     term.value.generators,
-                                    ast.Call(
-                                        func=ast.Attribute(
-                                            value=new_name("r", "load"),
-                                            attr="__setitem__",
-                                            ctx=ast.Load(),
-                                        ),
-                                        args=[term.value.key, term.value.value],
-                                        keywords=[],
+                                    ast.Expr(
+                                        ast.Call(
+                                            func=ast.Attribute(
+                                                value=new_name("r", "load"),
+                                                attr="__setitem__",
+                                                ctx=ast.Load(),
+                                            ),
+                                            args=[term.value.key, term.value.value],
+                                            keywords=[],
+                                        )
                                     ),
                                 ),
                                 ast.Return(new_name("r", "load")),

--- a/src/beanmachine/ppl/utils/tests/single_assignment_test.py
+++ b/src/beanmachine/ppl/utils/tests/single_assignment_test.py
@@ -1181,6 +1181,8 @@ def flip_logit_constant():
         # TODO: We should add some tests to check that we
         # handle nested function definitions correctly
 
+        self.maxDiff = None
+
         source = """
 x = [i for i in range(0,j) if even(i+j)]
 """
@@ -1188,7 +1190,8 @@ x = [i for i in range(0,j) if even(i+j)]
 def p1():
     r2 = []
     for i in range(0, j):
-        if even(i + j):r2.append(i)
+        if even(i + j):
+            r2.append(i)
     return r2
 
 
@@ -1206,25 +1209,30 @@ x = p1()
         expected = """
 def p1():
     r2 = []
-    a12 = 0
-    a10 = [a12]
-    a13 = [j]
-    r8 = a10 + a13
-    r14 = {}
-    f3 = range(*r8, **r14)
+    a15 = 0
+    a12 = [a15]
+    a16 = [j]
+    r10 = a12 + a16
+    r17 = {}
+    f3 = range(*r10, **r17)
     for i in f3:
-        a9 = i + j
-        r6 = [a9]
-        r11 = {}
-        r4 = even(*r6, **r11)
-        if r4:r2.append(i)
+        a11 = i + j
+        r7 = [a11]
+        r13 = {}
+        r4 = even(*r7, **r13)
+        if r4:
+            a8 = r2.append
+            r14 = [i]
+            r18 = {}
+            u6 = a8(*r14, **r18)
     return r2
 
 
 r5 = []
-r7 = {}
-x = p1(*r5, **r7)
+r9 = {}
+x = p1(*r5, **r9)
 """
+
         self.check_rewrite(source, expected)
 
         source = """
@@ -1235,7 +1243,8 @@ def p1():
     r2 = []
     for x in range(0, 10):
         for y in range(x, 10):
-            if y == 2 * x:r2.append((x, y))
+            if y == 2 * x:
+                r2.append((x, y))
     return r2
 
 
@@ -1253,31 +1262,36 @@ y = p1()
         expected = """
 def p1():
     r2 = []
-    a13 = 0
-    a11 = [a13]
-    a17 = 10
-    a14 = [a17]
-    r9 = a11 + a14
-    r15 = {}
-    f3 = range(*r9, **r15)
+    a15 = 0
+    a13 = [a15]
+    a20 = 10
+    a16 = [a20]
+    r10 = a13 + a16
+    r17 = {}
+    f3 = range(*r10, **r17)
     for x in f3:
-        a16 = [x]
-        a20 = 10
-        a18 = [a20]
-        r12 = a16 + a18
-        r19 = {}
-        f4 = range(*r12, **r19)
+        a18 = [x]
+        a24 = 10
+        a21 = [a24]
+        r14 = a18 + a21
+        r22 = {}
+        f4 = range(*r14, **r22)
         for y in f4:
-            a10 = 2
-            a7 = a10 * x
+            a11 = 2
+            a7 = a11 * x
             r6 = y == a7
-            if r6:r2.append((x, y))
+            if r6:
+                a12 = r2.append
+                a23 = x, y
+                r19 = [a23]
+                r25 = {}
+                u8 = a12(*r19, **r25)
     return r2
 
 
 r5 = []
-r8 = {}
-y = p1(*r5, **r8)
+r9 = {}
+y = p1(*r5, **r9)
 """
 
         self.check_rewrite(source, expected)
@@ -1291,7 +1305,8 @@ def p1():
     for x in range(0, 10):
         if x > 0:
             for y in range(x, 10):
-                if y == 2 * x:r2.append((x, y))
+                if y == 2 * x:
+                    r2.append((x, y))
     return r2
 
 
@@ -1309,28 +1324,33 @@ y = p1()
         expected = """
 def p1():
     r2 = []
-    a14 = 0
-    a12 = [a14]
-    a18 = 10
-    a15 = [a18]
-    r10 = a12 + a15
-    r16 = {}
-    f3 = range(*r10, **r16)
+    a16 = 0
+    a13 = [a16]
+    a20 = 10
+    a17 = [a20]
+    r10 = a13 + a17
+    r18 = {}
+    f3 = range(*r10, **r18)
     for x in f3:
         a6 = 0
         r4 = x > a6
         if r4:
-            a19 = [x]
-            a22 = 10
-            a20 = [a22]
-            r17 = a19 + a20
-            r21 = {}
-            f7 = range(*r17, **r21)
+            a21 = [x]
+            a26 = 10
+            a23 = [a26]
+            r19 = a21 + a23
+            r24 = {}
+            f7 = range(*r19, **r24)
             for y in f7:
-                a13 = 2
-                a11 = a13 * x
+                a14 = 2
+                a11 = a14 * x
                 r8 = y == a11
-                if r8:r2.append((x, y))
+                if r8:
+                    a15 = r2.append
+                    a25 = x, y
+                    r22 = [a25]
+                    r27 = {}
+                    u12 = a15(*r22, **r27)
     return r2
 
 
@@ -1346,6 +1366,8 @@ y = p1(*r5, **r9)
         # TODO: We should add some tests to check that we
         # handle nested function definitions correctly
 
+        self.maxDiff = None
+
         source = """
 x = {i for i in range(0,j) if even(i+j)}
 """
@@ -1353,7 +1375,8 @@ x = {i for i in range(0,j) if even(i+j)}
 def p1():
     r2 = set()
     for i in range(0, j):
-        if even(i + j):r2.add(i)
+        if even(i + j):
+            r2.add(i)
     return r2
 
 
@@ -1371,25 +1394,30 @@ x = p1()
         expected = """
 def p1():
     r2 = set()
-    a12 = 0
-    a10 = [a12]
-    a13 = [j]
-    r8 = a10 + a13
-    r14 = {}
-    f3 = range(*r8, **r14)
+    a15 = 0
+    a12 = [a15]
+    a16 = [j]
+    r10 = a12 + a16
+    r17 = {}
+    f3 = range(*r10, **r17)
     for i in f3:
-        a9 = i + j
-        r6 = [a9]
-        r11 = {}
-        r4 = even(*r6, **r11)
-        if r4:r2.add(i)
+        a11 = i + j
+        r7 = [a11]
+        r13 = {}
+        r4 = even(*r7, **r13)
+        if r4:
+            a8 = r2.add
+            r14 = [i]
+            r18 = {}
+            u6 = a8(*r14, **r18)
     return r2
 
 
 r5 = []
-r7 = {}
-x = p1(*r5, **r7)
+r9 = {}
+x = p1(*r5, **r9)
 """
+
         self.check_rewrite(source, expected)
 
         source = """
@@ -1400,7 +1428,8 @@ def p1():
     r2 = set()
     for x in range(0, 10):
         for y in range(x, 10):
-            if y == 2 * x:r2.add((x, y))
+            if y == 2 * x:
+                r2.add((x, y))
     return r2
 
 
@@ -1418,31 +1447,36 @@ y = p1()
         expected = """
 def p1():
     r2 = set()
-    a13 = 0
-    a11 = [a13]
-    a17 = 10
-    a14 = [a17]
-    r9 = a11 + a14
-    r15 = {}
-    f3 = range(*r9, **r15)
+    a15 = 0
+    a13 = [a15]
+    a20 = 10
+    a16 = [a20]
+    r10 = a13 + a16
+    r17 = {}
+    f3 = range(*r10, **r17)
     for x in f3:
-        a16 = [x]
-        a20 = 10
-        a18 = [a20]
-        r12 = a16 + a18
-        r19 = {}
-        f4 = range(*r12, **r19)
+        a18 = [x]
+        a24 = 10
+        a21 = [a24]
+        r14 = a18 + a21
+        r22 = {}
+        f4 = range(*r14, **r22)
         for y in f4:
-            a10 = 2
-            a7 = a10 * x
+            a11 = 2
+            a7 = a11 * x
             r6 = y == a7
-            if r6:r2.add((x, y))
+            if r6:
+                a12 = r2.add
+                a23 = x, y
+                r19 = [a23]
+                r25 = {}
+                u8 = a12(*r19, **r25)
     return r2
 
 
 r5 = []
-r8 = {}
-y = p1(*r5, **r8)
+r9 = {}
+y = p1(*r5, **r9)
 """
 
         self.check_rewrite(source, expected)
@@ -1456,7 +1490,8 @@ def p1():
     for x in range(0, 10):
         if x > 0:
             for y in range(x, 10):
-                if y == 2 * x:r2.add((x, y))
+                if y == 2 * x:
+                    r2.add((x, y))
     return r2
 
 
@@ -1474,28 +1509,33 @@ y = p1()
         expected = """
 def p1():
     r2 = set()
-    a14 = 0
-    a12 = [a14]
-    a18 = 10
-    a15 = [a18]
-    r10 = a12 + a15
-    r16 = {}
-    f3 = range(*r10, **r16)
+    a16 = 0
+    a13 = [a16]
+    a20 = 10
+    a17 = [a20]
+    r10 = a13 + a17
+    r18 = {}
+    f3 = range(*r10, **r18)
     for x in f3:
         a6 = 0
         r4 = x > a6
         if r4:
-            a19 = [x]
-            a22 = 10
-            a20 = [a22]
-            r17 = a19 + a20
-            r21 = {}
-            f7 = range(*r17, **r21)
+            a21 = [x]
+            a26 = 10
+            a23 = [a26]
+            r19 = a21 + a23
+            r24 = {}
+            f7 = range(*r19, **r24)
             for y in f7:
-                a13 = 2
-                a11 = a13 * x
+                a14 = 2
+                a11 = a14 * x
                 r8 = y == a11
-                if r8:r2.add((x, y))
+                if r8:
+                    a15 = r2.add
+                    a25 = x, y
+                    r22 = [a25]
+                    r27 = {}
+                    u12 = a15(*r22, **r27)
     return r2
 
 
@@ -1511,6 +1551,8 @@ y = p1(*r5, **r9)
         # TODO: We should add some tests to check that we
         # handle nested function definitions correctly
 
+        self.maxDiff = None
+
         source = """
 x = {i:i for i in range(0,j) if even(i+j)}
 """
@@ -1518,7 +1560,8 @@ x = {i:i for i in range(0,j) if even(i+j)}
 def p1():
     r2 = {}
     for i in range(0, j):
-        if even(i + j):r2.__setitem__(i, i)
+        if even(i + j):
+            r2.__setitem__(i, i)
     return r2
 
 
@@ -1536,24 +1579,30 @@ x = p1()
         expected = """
 def p1():
     r2 = {}
-    a12 = 0
-    a10 = [a12]
-    a13 = [j]
-    r8 = a10 + a13
-    r14 = {}
-    f3 = range(*r8, **r14)
+    a14 = 0
+    a12 = [a14]
+    a15 = [j]
+    r10 = a12 + a15
+    r16 = {}
+    f3 = range(*r10, **r16)
     for i in f3:
-        a9 = i + j
-        r6 = [a9]
-        r11 = {}
-        r4 = even(*r6, **r11)
-        if r4:r2.__setitem__(i, i)
+        a11 = i + j
+        r7 = [a11]
+        r13 = {}
+        r4 = even(*r7, **r13)
+        if r4:
+            a8 = r2.__setitem__
+            a18 = [i]
+            a19 = [i]
+            r17 = a18 + a19
+            r20 = {}
+            u6 = a8(*r17, **r20)
     return r2
 
 
 r5 = []
-r7 = {}
-x = p1(*r5, **r7)
+r9 = {}
+x = p1(*r5, **r9)
 """
         self.check_rewrite(source, expected)
 
@@ -1565,7 +1614,8 @@ def p1():
     r2 = {}
     for x in range(0, 10):
         for y in range(x, 10):
-            if y == 2 * x:r2.__setitem__(x, y)
+            if y == 2 * x:
+                r2.__setitem__(x, y)
     return r2
 
 
@@ -1583,31 +1633,37 @@ y = p1()
         expected = """
 def p1():
     r2 = {}
-    a13 = 0
-    a11 = [a13]
-    a17 = 10
-    a14 = [a17]
-    r9 = a11 + a14
-    r15 = {}
-    f3 = range(*r9, **r15)
+    a15 = 0
+    a13 = [a15]
+    a19 = 10
+    a16 = [a19]
+    r10 = a13 + a16
+    r17 = {}
+    f3 = range(*r10, **r17)
     for x in f3:
-        a16 = [x]
-        a20 = 10
-        a18 = [a20]
-        r12 = a16 + a18
-        r19 = {}
-        f4 = range(*r12, **r19)
+        a18 = [x]
+        a22 = 10
+        a20 = [a22]
+        r14 = a18 + a20
+        r21 = {}
+        f4 = range(*r14, **r21)
         for y in f4:
-            a10 = 2
-            a7 = a10 * x
+            a11 = 2
+            a7 = a11 * x
             r6 = y == a7
-            if r6:r2.__setitem__(x, y)
+            if r6:
+                a12 = r2.__setitem__
+                a24 = [x]
+                a25 = [y]
+                r23 = a24 + a25
+                r26 = {}
+                u8 = a12(*r23, **r26)
     return r2
 
 
 r5 = []
-r8 = {}
-y = p1(*r5, **r8)
+r9 = {}
+y = p1(*r5, **r9)
 """
 
         self.check_rewrite(source, expected)
@@ -1621,7 +1677,8 @@ def p1():
     for x in range(0, 10):
         if x > 0:
             for y in range(x, 10):
-                if y == 2 * x:r2.__setitem__(x, y)
+                if y == 2 * x:
+                    r2.__setitem__(x, y)
     return r2
 
 
@@ -1639,28 +1696,34 @@ y = p1()
         expected = """
 def p1():
     r2 = {}
-    a14 = 0
-    a12 = [a14]
-    a18 = 10
-    a15 = [a18]
-    r10 = a12 + a15
-    r16 = {}
-    f3 = range(*r10, **r16)
+    a16 = 0
+    a13 = [a16]
+    a20 = 10
+    a17 = [a20]
+    r10 = a13 + a17
+    r18 = {}
+    f3 = range(*r10, **r18)
     for x in f3:
         a6 = 0
         r4 = x > a6
         if r4:
-            a19 = [x]
-            a22 = 10
-            a20 = [a22]
-            r17 = a19 + a20
-            r21 = {}
-            f7 = range(*r17, **r21)
+            a21 = [x]
+            a24 = 10
+            a22 = [a24]
+            r19 = a21 + a22
+            r23 = {}
+            f7 = range(*r19, **r23)
             for y in f7:
-                a13 = 2
-                a11 = a13 * x
+                a14 = 2
+                a11 = a14 * x
                 r8 = y == a11
-                if r8:r2.__setitem__(x, y)
+                if r8:
+                    a15 = r2.__setitem__
+                    a26 = [x]
+                    a27 = [y]
+                    r25 = a26 + a27
+                    r28 = {}
+                    u12 = a15(*r25, **r28)
     return r2
 
 


### PR DESCRIPTION
Summary: Eric kindly reported an issue with single-static assignment rewrite rules for comprehensions through a disabled diff (D23970806). This diff fixes the bug by adding this constructor. In addition, the types of the functions involved were refined to be more precise and to help avoid such problems in the future. The type refinements also helped in deciding on the best place to fix this problem. Finally, the old tests that this fix breaks are updated

Reviewed By: ericlippert

Differential Revision: D24031665

