### PR TITLE
Start adding negative real type to Beanstalk compiler

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/bmg_types_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_types_test.py
@@ -7,6 +7,7 @@ from beanmachine.ppl.compiler.bmg_types import (
     BooleanMatrix,
     Natural,
     NaturalMatrix,
+    NegativeReal,
     One,
     OneHotMatrix,
     PositiveReal,
@@ -17,6 +18,7 @@ from beanmachine.ppl.compiler.bmg_types import (
     RealMatrix,
     SimplexMatrix,
     Tensor,
+    Zero,
     bottom,
     meets_requirement,
     supremum,
@@ -43,6 +45,8 @@ class BMGTypesTest(unittest.TestCase):
         self.assertEqual(PositiveReal, supremum(Probability, Natural))
         self.assertEqual(Real, supremum(Natural, Probability, Real))
         self.assertEqual(Tensor, supremum(Real, Tensor, Natural, Boolean))
+        self.assertEqual(Real, supremum(NegativeReal, PositiveReal))
+        self.assertEqual(Boolean, supremum(One, Zero))
 
         # Supremum of any two types with different matrix dimensions is Tensor
         self.assertEqual(Tensor, supremum(RealMatrix(1, 2), RealMatrix(2, 1)))


### PR DESCRIPTION
Summary:
We're experimenting with adding a negative real type to BMG, which means we'll need it in Beanstalk as well.

We organize types in Beanstalk into a lattice, where every node constructed during graph accumulation has an "infimum type" -- a unique "smallest" type that indicates what it is convertible to in the lattice.  Adding a negative real type immediately raises the question "what is the infimum type of zero?"  Previously the infimum type of zero was "bool", because it can be interpreted as "false", and bool is the smallest type with a zero value.

But if we add a negative real type to the matrix, then zero could be both bool and negative real. (Remember, "positive real" actually means "non-negative" and similarly "negative real" means "non-positive"). However, bool is not a subtype or supertype of negative reals.

Therefore we need to add a type to the matrix that contains only zero.

In this diff I just add the negative real and zero types to the matrix. I've also rewritten the "what's the supremum of these two types?" logic to use a lookup table because the if-then logic was getting a little hard to follow.

Reviewed By: wtaha

Differential Revision: D24096806

