### PR TITLE
Continue adding negative real type to Beanstalk

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/bmg_nodes_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_nodes_test.py
@@ -22,10 +22,12 @@ from beanmachine.ppl.compiler.bmg_nodes import (
 from beanmachine.ppl.compiler.bmg_types import (
     Boolean,
     Natural,
+    NegativeReal,
     One,
     PositiveReal,
     Probability,
     Real,
+    Zero,
 )
 
 
@@ -46,10 +48,10 @@ class BMGNodesTest(unittest.TestCase):
         nat = NaturalNode(2)
 
         self.assertEqual(b.inf_type, One)
-        self.assertEqual(bf.inf_type, Boolean)
+        self.assertEqual(bf.inf_type, Zero)
         self.assertEqual(prob.inf_type, Probability)
         self.assertEqual(pos.inf_type, PositiveReal)
-        self.assertEqual(real.inf_type, Real)
+        self.assertEqual(real.inf_type, NegativeReal)
         self.assertEqual(nat.inf_type, Natural)
 
         # Constant infimum type depends on the value,

--- a/src/beanmachine/ppl/compiler/tests/bmg_types_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_types_test.py
@@ -8,6 +8,7 @@ from beanmachine.ppl.compiler.bmg_types import (
     Natural,
     NaturalMatrix,
     NegativeReal,
+    NegativeRealMatrix,
     One,
     OneHotMatrix,
     PositiveReal,
@@ -19,6 +20,7 @@ from beanmachine.ppl.compiler.bmg_types import (
     SimplexMatrix,
     Tensor,
     Zero,
+    ZeroMatrix,
     bottom,
     meets_requirement,
     supremum,
@@ -65,21 +67,21 @@ class BMGTypesTest(unittest.TestCase):
         """test_type_of_value"""
 
         self.assertEqual(One, type_of_value(True))
-        self.assertEqual(Boolean, type_of_value(False))
-        self.assertEqual(Boolean, type_of_value(0))
+        self.assertEqual(Zero, type_of_value(False))
+        self.assertEqual(Zero, type_of_value(0))
         self.assertEqual(One, type_of_value(1))
-        self.assertEqual(Boolean, type_of_value(0.0))
+        self.assertEqual(Zero, type_of_value(0.0))
         self.assertEqual(One, type_of_value(1.0))
-        self.assertEqual(Boolean, type_of_value(tensor(False)))
-        self.assertEqual(Boolean, type_of_value(tensor(0)))
+        self.assertEqual(Zero, type_of_value(tensor(False)))
+        self.assertEqual(Zero, type_of_value(tensor(0)))
         self.assertEqual(One, type_of_value(tensor(1)))
-        self.assertEqual(Boolean, type_of_value(tensor(0.0)))
+        self.assertEqual(Zero, type_of_value(tensor(0.0)))
         self.assertEqual(One, type_of_value(tensor(1.0)))
         self.assertEqual(One, type_of_value(tensor([[True]])))
-        self.assertEqual(Boolean, type_of_value(tensor([[False]])))
-        self.assertEqual(Boolean, type_of_value(tensor([[0]])))
+        self.assertEqual(Zero, type_of_value(tensor([[False]])))
+        self.assertEqual(Zero, type_of_value(tensor([[0]])))
         self.assertEqual(One, type_of_value(tensor([[1]])))
-        self.assertEqual(Boolean, type_of_value(tensor([[0.0]])))
+        self.assertEqual(Zero, type_of_value(tensor([[0.0]])))
         self.assertEqual(One, type_of_value(tensor([[1.0]])))
         self.assertEqual(Natural, type_of_value(2))
         self.assertEqual(Natural, type_of_value(2.0))
@@ -93,11 +95,13 @@ class BMGTypesTest(unittest.TestCase):
         self.assertEqual(PositiveReal, type_of_value(1.5))
         self.assertEqual(PositiveReal, type_of_value(tensor(1.5)))
         self.assertEqual(PositiveReal, type_of_value(tensor([[1.5]])))
-        self.assertEqual(Real, type_of_value(-1.5))
-        self.assertEqual(Real, type_of_value(tensor(-1.5)))
-        self.assertEqual(Real, type_of_value(tensor([[-1.5]])))
+        self.assertEqual(NegativeReal, type_of_value(-1.5))
+        self.assertEqual(NegativeReal, type_of_value(tensor(-1.5)))
+        self.assertEqual(NegativeReal, type_of_value(tensor([[-1.5]])))
         # 1-d tensor is matrix
-        self.assertEqual(BooleanMatrix(1, 2), type_of_value(tensor([0, 0])))
+        self.assertEqual(ZeroMatrix(1, 2), type_of_value(tensor([0, 0])))
+        self.assertEqual(BooleanMatrix(1, 3), type_of_value(tensor([0, 1, 1])))
+        self.assertEqual(BooleanMatrix(1, 2), type_of_value(tensor([1, 1])))
         # 2-d tensor is matrix
         self.assertEqual(OneHotMatrix(2, 2), type_of_value(tensor([[1, 0], [1, 0]])))
         self.assertEqual(BooleanMatrix(2, 2), type_of_value(tensor([[1, 1], [1, 0]])))
@@ -113,6 +117,10 @@ class BMGTypesTest(unittest.TestCase):
         )
         self.assertEqual(
             RealMatrix(2, 2), type_of_value(tensor([[1.75, 0.5], [0.5, -0.5]]))
+        )
+        self.assertEqual(
+            NegativeRealMatrix(2, 2),
+            type_of_value(tensor([[-1.75, -0.5], [-0.5, -0.5]])),
         )
         # 3-d tensor is Tensor
         self.assertEqual(

--- a/src/beanmachine/ppl/compiler/tests/error_report_test.py
+++ b/src/beanmachine/ppl/compiler/tests/error_report_test.py
@@ -16,5 +16,5 @@ class ErrorReportTest(unittest.TestCase):
         e = ErrorReport()
         e.add_error(v)
         expected = """
-The probability of a Bernoulli is required to be a probability but is a real."""
+The probability of a Bernoulli is required to be a probability but is a negative real."""
         self.assertEqual(expected.strip(), str(e).strip())

--- a/src/beanmachine/ppl/compiler/tests/fix_problems_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_problems_test.py
@@ -238,7 +238,7 @@ digraph "graph" {
 The count of a Binomial is required to be a natural but is a positive real.
 The probability of a Bernoulli is required to be a probability but is a 1 x 2 simplex matrix.
 The probability of a Binomial is required to be a probability but is a positive real.
-The sigma of a Normal is required to be a positive real but is a real.
+The sigma of a Normal is required to be a positive real but is a negative real.
         """
         self.assertEqual(observed.strip(), expected.strip())
 
@@ -319,7 +319,7 @@ digraph "graph" {
   N06[label="*:M>=N"];
   N07[label="Binomial:N>=N"];
   N08[label="Sample:N>=N"];
-  N09[label="0:N>=B"];
+  N09[label="0:N>=Z"];
   N10[label="if:N>=N"];
   N00 -> N04[label="count:N"];
   N01 -> N02[label="probability:P"];
@@ -387,7 +387,7 @@ digraph "graph" {
   N07[label="Log:R>=R"];
   N08[label="Normal:R>=R"];
   N09[label="Sample:R>=R"];
-  N10[label="-1.0:R>=R"];
+  N10[label="-1.0:R>=R-"];
   N11[label="**:R+>=R+"];
   N12[label="*:R+>=R+"];
   N13[label="1.0:R+>=OH"];
@@ -968,7 +968,7 @@ A Binomial distribution is observed to have value 5.25 but only produces samples
         # The observations have been converted to the correct types:
         expected = """
 digraph "graph" {
-  N00[label="0.0:R>=B"];
+  N00[label="0.0:R>=Z"];
   N01[label="1.0:R>=OH"];
   N02[label="2.0:R>=N"];
   N03[label="0.5:R>=P"];

--- a/src/beanmachine/ppl/utils/bm_graph_builder.py
+++ b/src/beanmachine/ppl/utils/bm_graph_builder.py
@@ -114,6 +114,7 @@ from beanmachine.ppl.compiler.bmg_types import (
     PositiveReal,
     Probability,
     Real,
+    Zero,
 )
 from beanmachine.ppl.utils.beanstalk_common import allowed_functions
 from beanmachine.ppl.utils.dotbuilder import DotBuilder
@@ -644,11 +645,10 @@ constant graph node of the stated type for it, and adds it to the builder"""
         if isinstance(left, ConstantNode):
             if isinstance(right, ConstantNode):
                 return self.add_constant(left.value + right.value)
-            if left.inf_type == Boolean:
-                # Must be a zero; otherwise we'd return One.
+            if left.inf_type == Zero:
                 return right
         if isinstance(right, ConstantNode):
-            if right.inf_type == Boolean:
+            if right.inf_type == Zero:
                 return left
 
         node = AdditionNode(left, right)
@@ -674,14 +674,13 @@ constant graph node of the stated type for it, and adds it to the builder"""
             t = left.inf_type
             if t == One:
                 return right
-            if t == Boolean:
-                # It must be a zero.
+            if t == Zero:
                 return left
         if isinstance(right, ConstantNode):
             t = right.inf_type
             if t == One:
                 return left
-            if t == Boolean:
+            if t == Zero:
                 return right
         node = MultiplicationNode(left, right)
         self.add_node(node)


### PR DESCRIPTION
Summary:
In the previous diff we added zero and negative real types to the beanstalk type lattice. In this diff we start classifying constant values as zero or negative real.

The idea here is that we need to know whether a given node can be used in a context where a particular type is required; the easiest nodes to analyze are constants so we start with them. A node that is the constant zero can be used in a context that requires a bool, but can also be used in a context that requires a negative real, so we need the zero type to represent "I could be either".  (This is analogous to how we are already using the "one" type to represent "I could be a bool or a simplex")

A nice property of this change is that previously, we would classify real constants as either "positive real" if positive, or "real" if negative, which seems a little odd. We now classify positives as positives and negatives as negatives.  Similarly, we would classify true as "one" and false as "bool"; we now classify true as "one" and false as "zero", which makes a little more sense.

Reviewed By: wtaha

Differential Revision: D24171008

