### PR TITLE
Add a negative-real-constant node to Beanstalk

### DIFF
--- a/src/beanmachine/ppl/compiler/bmg_nodes.py
+++ b/src/beanmachine/ppl/compiler/bmg_nodes.py
@@ -15,6 +15,7 @@ from beanmachine.ppl.compiler.bmg_types import (
     Boolean,
     Malformed,
     Natural,
+    NegativeReal,
     One,
     PositiveReal,
     Probability,
@@ -361,6 +362,47 @@ class PositiveRealNode(ConstantNode):
         n = d[self]
         v = self._value_to_python()
         return f"n{n} = g.add_constant_pos_real({v})"
+
+
+class NegativeRealNode(ConstantNode):
+    """A real constant restricted to non-positive values"""
+
+    value: float
+
+    def __init__(self, value: float):
+        ConstantNode.__init__(self)
+        self.value = value
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+    @property
+    def graph_type(self) -> BMGLatticeType:
+        return NegativeReal
+
+    @property
+    def size(self) -> torch.Size:
+        return torch.Size([])
+
+    @property
+    def label(self) -> str:
+        return str(self.value)
+
+    def _add_to_graph(self, g: Graph, d: Dict[BMGNode, int]) -> int:
+        return g.add_constant_neg_real(float(self.value))
+
+    def _value_to_python(self) -> str:
+        return str(float(self.value))
+
+    def _to_cpp(self, d: Dict["BMGNode", int]) -> str:
+        n = d[self]
+        v = _value_to_cpp(self.value)
+        return f"uint n{n} = g.add_constant_neg_real({v});"
+
+    def _to_python(self, d: Dict["BMGNode", int]) -> str:
+        n = d[self]
+        v = self._value_to_python()
+        return f"n{n} = g.add_constant_neg_real({v})"
 
 
 class ProbabilityNode(ConstantNode):

--- a/src/beanmachine/ppl/compiler/tests/bmg_nodes_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_nodes_test.py
@@ -12,6 +12,7 @@ from beanmachine.ppl.compiler.bmg_nodes import (
     GammaNode,
     HalfCauchyNode,
     NaturalNode,
+    NegativeRealNode,
     NormalNode,
     PositiveRealNode,
     ProbabilityNode,
@@ -44,6 +45,7 @@ class BMGNodesTest(unittest.TestCase):
         bf = BooleanNode(False)
         prob = ProbabilityNode(0.5)
         pos = PositiveRealNode(1.5)
+        neg = NegativeRealNode(-1.5)
         real = RealNode(-1.5)
         nat = NaturalNode(2)
 
@@ -51,6 +53,7 @@ class BMGNodesTest(unittest.TestCase):
         self.assertEqual(bf.inf_type, Zero)
         self.assertEqual(prob.inf_type, Probability)
         self.assertEqual(pos.inf_type, PositiveReal)
+        self.assertEqual(neg.inf_type, NegativeReal)
         self.assertEqual(real.inf_type, NegativeReal)
         self.assertEqual(nat.inf_type, Natural)
 
@@ -104,12 +107,14 @@ class BMGNodesTest(unittest.TestCase):
         b = BooleanNode(True)
         prob = ProbabilityNode(0.5)
         pos = PositiveRealNode(1.5)
+        neg = NegativeRealNode(-1.5)
         real = RealNode(-1.5)
         nat = NaturalNode(2)
 
         self.assertEqual(b.requirements, [])
         self.assertEqual(prob.requirements, [])
         self.assertEqual(pos.requirements, [])
+        self.assertEqual(neg.requirements, [])
         self.assertEqual(real.requirements, [])
         self.assertEqual(nat.requirements, [])
 
@@ -121,6 +126,7 @@ class BMGNodesTest(unittest.TestCase):
         self.assertEqual(GammaNode(pos, pos).requirements, [PositiveReal, PositiveReal])
         self.assertEqual(Chi2Node(pos).requirements, [PositiveReal])
         self.assertEqual(HalfCauchyNode(pos).requirements, [PositiveReal])
+        self.assertEqual(NormalNode(neg, pos).requirements, [Real, PositiveReal])
         self.assertEqual(NormalNode(real, pos).requirements, [Real, PositiveReal])
         self.assertEqual(
             StudentTNode(pos, pos, pos).requirements, [PositiveReal, Real, PositiveReal]


### PR DESCRIPTION
Summary: As we continue to add support for negative reals, I've added a node type for negative real constants in the beanstalk compiler.  So far I've just created the class and defined a few simple tests; we will add support in the graph builder later on.

Reviewed By: wtaha

Differential Revision: D24174347

