### PR TITLE
Ensure TO_REAL operator works on negative reals

### DIFF
--- a/src/beanmachine/graph/tests/operator_test.py
+++ b/src/beanmachine/graph/tests/operator_test.py
@@ -19,6 +19,7 @@ class TestOperators(unittest.TestCase):
         c5 = g.add_constant_probability(0.7)
         c6 = g.add_constant(23)  # NATURAL
         c7 = g.add_constant(False)
+        c8 = g.add_constant_neg_real(-1.25)
         # add const matrices, operators on matrix to be added
         g.add_constant_matrix(np.array([[True, False], [False, True]]))
         g.add_constant_matrix(np.array([[-0.1, 0.0], [2.0, -1.0]]))
@@ -37,6 +38,7 @@ class TestOperators(unittest.TestCase):
             g.add_operator(bmg.OperatorType.TO_REAL, [])
         g.add_operator(bmg.OperatorType.TO_REAL, [c4])
         g.add_operator(bmg.OperatorType.TO_REAL, [c6])
+        g.add_operator(bmg.OperatorType.TO_REAL, [c8])
         with self.assertRaises(ValueError):
             g.add_operator(bmg.OperatorType.TO_REAL, [c4, c5])
         # test EXP


### PR DESCRIPTION
Summary:
I'm gradually adding support for negative real numbers in the BMG type system; in this diff I just make sure that negative real nodes can be inputs to TO_REAL.

UPDATE: Detian made the *exact* same change in a different diff and won the race to land; however, I'm still going to land this diff because it makes some minor changes to test cases that I will build on in later diffs in this stack.

Reviewed By: nimar

Differential Revision: D24179549

