### PR TITLE
Continue adding negative real type to beanstalk compiler

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/fix_problems_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_problems_test.py
@@ -998,3 +998,44 @@ digraph "graph" {
 }
 """
         self.assertEqual(observed.strip(), expected.strip())
+
+    def test_fix_problems_14(self) -> None:
+        """test_fix_problems_14"""
+
+        # Fixes for problems involving negative reals.
+
+        self.maxDiff = None
+        bmg = BMGraphBuilder()
+
+        # Right now the only node we have of type negative real is
+        # a constant; if we force a scenario where a negative real
+        # constant is used in a context where a real is needed,
+        # we generate a new real constant.
+
+        m = bmg.add_neg_real(-1.0)
+        s = bmg.add_pos_real(1.0)
+        norm = bmg.add_normal(m, s)
+        bmg.add_sample(norm)
+
+        error_report = fix_problems(bmg)
+        self.assertEqual(str(error_report).strip(), "")
+        observed = bmg.to_dot(
+            graph_types=True,
+            inf_types=False,
+            edge_requirements=True,
+            point_at_input=True,
+        )
+
+        expected = """
+digraph "graph" {
+  N0[label="-1.0:R-"];
+  N1[label="1.0:R+"];
+  N2[label="Normal:R"];
+  N3[label="Sample:R"];
+  N4[label="-1.0:R"];
+  N1 -> N2[label="sigma:R+"];
+  N2 -> N3[label="operand:R"];
+  N4 -> N2[label="mu:R"];
+}
+"""
+        self.assertEqual(observed.strip(), expected.strip())

--- a/src/beanmachine/ppl/utils/bm_graph_builder.py
+++ b/src/beanmachine/ppl/utils/bm_graph_builder.py
@@ -89,6 +89,7 @@ from beanmachine.ppl.compiler.bmg_nodes import (
     NaturalNode,
     NegateNode,
     NegativeLogNode,
+    NegativeRealNode,
     NormalNode,
     NotNode,
     Observation,
@@ -110,6 +111,7 @@ from beanmachine.ppl.compiler.bmg_types import (
     BMGLatticeType,
     Boolean,
     Natural,
+    NegativeReal,
     One,
     PositiveReal,
     Probability,
@@ -396,6 +398,8 @@ constant graph node of the stated type for it, and adds it to the builder"""
             return self.add_natural(int(value))
         if node_type == PositiveReal:
             return self.add_pos_real(float(value))
+        if node_type == NegativeReal:
+            return self.add_neg_real(float(value))
         if node_type == Real:
             return self.add_real(float(value))
         if node_type == Tensor:
@@ -419,6 +423,12 @@ constant graph node of the stated type for it, and adds it to the builder"""
     @memoize
     def add_pos_real(self, value: float) -> PositiveRealNode:
         node = PositiveRealNode(value)
+        self.add_node(node)
+        return node
+
+    @memoize
+    def add_neg_real(self, value: float) -> NegativeRealNode:
+        node = NegativeRealNode(value)
         self.add_node(node)
         return node
 


### PR DESCRIPTION
Summary:
We can now add negative real constant nodes to the graph builder.

I've also verified that we can automatically convert a negative real constant to a real constant when necessary. More complex manipulations of negative reals will come later, as we add support in the type system for more operators to handle negative reals.

Reviewed By: wtaha

Differential Revision: D24182827

