### PR TITLE
Minor fix to BMG header files

### DIFF
--- a/src/beanmachine/graph/pybindings.cpp
+++ b/src/beanmachine/graph/pybindings.cpp
@@ -1,9 +1,7 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-#include <pybind11/eigen.h>
+#include "beanmachine/graph/pybindings.h"
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
-#include "beanmachine/graph/pybindings.h"
-
 
 namespace beanmachine {
 namespace graph {

--- a/src/beanmachine/graph/pybindings.h
+++ b/src/beanmachine/graph/pybindings.h
@@ -1,5 +1,7 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
 #pragma once
+#include <pybind11/eigen.h>
+
 #include "beanmachine/graph/graph.h"
 
 // to keep the linter happy this template specialization has been declared here


### PR DESCRIPTION
Summary: I noticed that header file pybindings.h requires that eigen.h be processed before it; rather than putting that requirement on the consumer of pybindings.h, better to have it include its own dependencies itself.

Reviewed By: wtaha

Differential Revision: D24341292

