### PR TITLE
BMG LOG operator now supports probability operand

### DIFF
--- a/src/beanmachine/graph/operator/tests/operator_test.cpp
+++ b/src/beanmachine/graph/operator/tests/operator_test.cpp
@@ -361,12 +361,15 @@ TEST(testoperator, logsumexp) {
 TEST(testoperator, log) {
   Graph g;
   // negative tests: exactly one pos_real should be the input
+  // or one probability should be the input.
   EXPECT_THROW(
       g.add_operator(OperatorType::LOG, std::vector<uint>{}),
       std::invalid_argument);
   auto prob1 = g.add_constant_probability(0.5);
+  g.add_operator(OperatorType::LOG, std::vector<uint>{prob1});
+  auto real1 = g.add_constant(-0.5);
   EXPECT_THROW(
-      g.add_operator(OperatorType::LOG, std::vector<uint>{prob1}),
+      g.add_operator(OperatorType::LOG, std::vector<uint>{real1}),
       std::invalid_argument);
   auto pos1 = g.add_constant_pos_real(1.0);
   EXPECT_THROW(

--- a/src/beanmachine/graph/operator/unaryop.cpp
+++ b/src/beanmachine/graph/operator/unaryop.cpp
@@ -237,16 +237,21 @@ void Log1pExp::eval(std::mt19937& /* gen */) {
 Log::Log(const std::vector<graph::Node*>& in_nodes)
     : UnaryOperator(graph::OperatorType::LOG, in_nodes) {
   graph::ValueType type0 = in_nodes[0]->value.type;
-  if (type0 != graph::AtomicType::POS_REAL) {
-    throw std::invalid_argument("operator LOG requires a pos_real parent");
+  if (type0 == graph::AtomicType::POS_REAL) {
+    value = graph::AtomicValue(graph::AtomicType::REAL);
+  } else if (type0 == graph::AtomicType::PROBABILITY) {
+    value = graph::AtomicValue(graph::AtomicType::NEG_REAL);
+  } else {
+    throw std::invalid_argument(
+        "operator LOG requires a pos_real or probability parent");
   }
-  value = graph::AtomicValue(graph::AtomicType::REAL);
 }
 
 void Log::eval(std::mt19937& /* gen */) {
   assert(in_nodes.size() == 1);
   const graph::AtomicValue& parent = in_nodes[0]->value;
-  if (parent.type == graph::AtomicType::POS_REAL) {
+  if (parent.type == graph::AtomicType::POS_REAL or
+      parent.type == graph::AtomicType::PROBABILITY) {
     value._double = std::log(parent._double);
   } else {
     throw std::runtime_error(
@@ -256,6 +261,8 @@ void Log::eval(std::mt19937& /* gen */) {
   }
 }
 
+// TODO: Once we have more complete implementation of the NEG_REAL type,
+// TODO: we can remove this operator entirely.
 NegativeLog::NegativeLog(const std::vector<graph::Node*>& in_nodes)
     : UnaryOperator(graph::OperatorType::NEGATIVE_LOG, in_nodes) {
   graph::ValueType type0 = in_nodes[0]->value.type;

--- a/src/beanmachine/graph/tests/operator_test.py
+++ b/src/beanmachine/graph/tests/operator_test.py
@@ -48,10 +48,21 @@ class TestOperators(unittest.TestCase):
         with self.assertRaises(ValueError):
             g.add_operator(bmg.OperatorType.EXP, [c4, c5])
         # test LOG
+        # Log needs exactly one operand:
         with self.assertRaises(ValueError):
             g.add_operator(bmg.OperatorType.LOG, [])
         with self.assertRaises(ValueError):
             g.add_operator(bmg.OperatorType.LOG, [c1, c2])
+        # That operand must be positive real or probability:
+        with self.assertRaises(ValueError):
+            g.add_operator(bmg.OperatorType.LOG, [c2])
+        with self.assertRaises(ValueError):
+            g.add_operator(bmg.OperatorType.LOG, [c6])
+        with self.assertRaises(ValueError):
+            g.add_operator(bmg.OperatorType.LOG, [c7])
+        with self.assertRaises(ValueError):
+            g.add_operator(bmg.OperatorType.LOG, [c8])
+        g.add_operator(bmg.OperatorType.LOG, [c3])
         # test NEGATE
         with self.assertRaises(ValueError):
             g.add_operator(bmg.OperatorType.NEGATE, [])


### PR DESCRIPTION
Summary:
The BMG LOG operator previously supported only taking an input of type positive real and producing an output of type real.

We now also support taking an input of type probability and producing an output of type negative real.

I will add support for this to the beanstalk compiler in the next diff.

Reviewed By: wtaha

Differential Revision: D24203997

