### PR TITLE
BMG NEGATE operator now supports negative and positive real operands

### DIFF
--- a/src/beanmachine/graph/operator/unaryop.cpp
+++ b/src/beanmachine/graph/operator/unaryop.cpp
@@ -101,7 +101,7 @@ Negate::Negate(const std::vector<graph::Node*>& in_nodes)
     new_type = graph::AtomicType::POS_REAL;
   } else {
     throw std::invalid_argument(
-        "operator NEGATE only supports real/pos_real/neg_real parent");
+        "operator NEGATE requires a real, pos_real or neg_real parent");
   }
   value = graph::AtomicValue(new_type);
 }
@@ -294,8 +294,7 @@ Log1mExp::Log1mExp(const std::vector<graph::Node*>& in_nodes)
     : UnaryOperator(graph::OperatorType::LOG1MEXP, in_nodes) {
   graph::ValueType type0 = in_nodes[0]->value.type;
   if (type0 != graph::AtomicType::NEG_REAL) {
-    throw std::invalid_argument(
-        "operator LOG1MEXP requires neg_real parent");
+    throw std::invalid_argument("operator LOG1MEXP requires a neg_real parent");
   }
   value = graph::AtomicValue(graph::AtomicType::NEG_REAL);
 }

--- a/src/beanmachine/graph/tests/operator_test.py
+++ b/src/beanmachine/graph/tests/operator_test.py
@@ -64,11 +64,21 @@ class TestOperators(unittest.TestCase):
             g.add_operator(bmg.OperatorType.LOG, [c8])
         g.add_operator(bmg.OperatorType.LOG, [c3])
         # test NEGATE
+        # Negate needs exactly one operand
         with self.assertRaises(ValueError):
             g.add_operator(bmg.OperatorType.NEGATE, [])
         g.add_operator(bmg.OperatorType.NEGATE, [c2])
         with self.assertRaises(ValueError):
             g.add_operator(bmg.OperatorType.NEGATE, [c1, c2])
+        # Negate can take a real, negative real or positive real.
+        with self.assertRaises(ValueError):
+            g.add_operator(bmg.OperatorType.NEGATE, [c3])
+        with self.assertRaises(ValueError):
+            g.add_operator(bmg.OperatorType.NEGATE, [c6])
+        with self.assertRaises(ValueError):
+            g.add_operator(bmg.OperatorType.NEGATE, [c7])
+        g.add_operator(bmg.OperatorType.NEGATE, [c1])
+        g.add_operator(bmg.OperatorType.NEGATE, [c8])
         # test COMPLEMENT
         with self.assertRaises(ValueError):
             g.add_operator(bmg.OperatorType.COMPLEMENT, [])


### PR DESCRIPTION
Summary:
This diff was originally supposed to add support for neg_real in the NEGATE operator, but Detian already did that in another diff.

I'm keeping this diff though because it adds a few test cases and tweaks the wording of some error messages to make them more consistent.

In an upcoming diff I will add negative real support for the negate operator to the beanstalk compiler's graph builder.

Reviewed By: wtaha

Differential Revision: D24206016

