### PR TITLE
Beanstalk negate operator now supports negative, positive reals

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/fix_problems_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_problems_test.py
@@ -712,12 +712,12 @@ digraph "graph" {
     def test_fix_problems_10(self) -> None:
         """test_fix_problems_10"""
 
-        # Demonstrate that we can rewrite 1 - p for probability p into
+        # Demonstrate that we can rewrite 1-p for probability p into
         # complement(p) -- which is of type P -- instead of
         # add(1, negate(p)) which is of type R.
 
-        # TODO: Also demonstrate that this works for 1 b
-        # TODO: Get this working for the "not" operator, since 1 b
+        # TODO: Also demonstrate that this works for 1-b
+        # TODO: Get this working for the "not" operator, since 1-b
         # and "not b" are the same thing for bool b.
 
         self.maxDiff = None
@@ -750,16 +750,16 @@ digraph "graph" {
   N1[label="2.0:R>=N"];
   N2[label="Beta:P>=P"];
   N3[label="Sample:P>=P"];
-  N4[label="-:R>=R"];
-  N5[label="+:R>=P"];
+  N4[label="-:M>=R-"];
+  N5[label="+:M>=P"];
   N6[label="Bernoulli:B>=B"];
   N7[label="Sample:B>=B"];
   N0 -> N5[label="left:OH"];
   N1 -> N2[label="alpha:R+"];
   N1 -> N2[label="beta:R+"];
   N2 -> N3[label="operand:P"];
-  N3 -> N4[label="operand:R"];
-  N4 -> N5[label="right:R"];
+  N3 -> N4[label="operand:R+"];
+  N4 -> N5[label="right:R-"];
   N5 -> N6[label="probability:P"];
   N6 -> N7[label="operand:B"];
 }
@@ -784,17 +784,17 @@ digraph "graph" {
   N1[label="2.0:R>=N"];
   N2[label="Beta:P>=P"];
   N3[label="Sample:P>=P"];
-  N4[label="-:R>=R"];
-  N5[label="+:R>=P"];
+  N4[label="-:M>=R-"];
+  N5[label="+:M>=P"];
   N6[label="Bernoulli:B>=B"];
   N7[label="Sample:B>=B"];
   N8[label="complement:P>=P"];
   N9[label="2.0:R+>=N"];
   N0 -> N5[label="left:OH"];
   N2 -> N3[label="operand:P"];
-  N3 -> N4[label="operand:R"];
+  N3 -> N4[label="operand:R+"];
   N3 -> N8[label="operand:P"];
-  N4 -> N5[label="right:R"];
+  N4 -> N5[label="right:R-"];
   N6 -> N7[label="operand:B"];
   N8 -> N6[label="probability:P"];
   N9 -> N2[label="alpha:R+"];

--- a/src/beanmachine/ppl/compiler/tests/unary_nodes_test.py
+++ b/src/beanmachine/ppl/compiler/tests/unary_nodes_test.py
@@ -58,14 +58,15 @@ class UnaryNodesTest(unittest.TestCase):
 
         # Negate
         # - Boolean -> Real
-        # - Probability -> Real
-        # - Natural -> Real
-        # - PositiveReal -> Real
+        # - Probability -> NegativeReal
+        # - Natural -> NegativeReal
+        # - PositiveReal -> NegativeReal
+        # - TODO: Add a test for NegativeReal -> PositiveReal
         # - Real -> Real
-        self.assertEqual(NegateNode(bern).inf_type, Real)
-        self.assertEqual(NegateNode(beta).inf_type, Real)
-        self.assertEqual(NegateNode(bino).inf_type, Real)
-        self.assertEqual(NegateNode(half).inf_type, Real)
+        self.assertEqual(NegateNode(bern).inf_type, NegativeReal)
+        self.assertEqual(NegateNode(beta).inf_type, NegativeReal)
+        self.assertEqual(NegateNode(bino).inf_type, NegativeReal)
+        self.assertEqual(NegateNode(half).inf_type, NegativeReal)
         self.assertEqual(NegateNode(norm).inf_type, Real)
 
         # Complement
@@ -140,16 +141,11 @@ class UnaryNodesTest(unittest.TestCase):
         half = SampleNode(HalfCauchyNode(pos))
         norm = SampleNode(NormalNode(real, pos))
 
-        # Negate
-        # - Boolean -> Real
-        # - Probability -> Real
-        # - Natural -> Real
-        # - PositiveReal -> Real
-        # - Real -> Real
-        self.assertEqual(NegateNode(bern).requirements, [Real])
-        self.assertEqual(NegateNode(beta).requirements, [Real])
-        self.assertEqual(NegateNode(bino).requirements, [Real])
-        self.assertEqual(NegateNode(half).requirements, [Real])
+        # Negate requires its operand be positive real, negative real or real.
+        self.assertEqual(NegateNode(bern).requirements, [PositiveReal])
+        self.assertEqual(NegateNode(beta).requirements, [PositiveReal])
+        self.assertEqual(NegateNode(bino).requirements, [PositiveReal])
+        self.assertEqual(NegateNode(half).requirements, [PositiveReal])
         self.assertEqual(NegateNode(norm).requirements, [Real])
 
         # Complement requires that its operand be probability or Boolean


### PR DESCRIPTION
Summary:
In the previous diff we made the BMG negation operator support real, negative real and positive real operands. In this diff we do the same to the beanstalk type analyzer. Note that this causes some minor test changes in the test which verifies that (1 + (-prob)) is correctly turned into a complement operator, since the type analysis of the -prob is now different.

We now have enough gear in place that we can remove the NEG_LOG operator from Beanstalk and BMG. That will be the next few diffs.

Reviewed By: wtaha

Differential Revision: D24207146

