### PR TITLE
Bump black linter's version to 20.8b1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ commands:
           command: sudo pip install --progress-bar off --upgrade pip
       - run:
           name: "Install lint packages"
-          command: sudo pip install --progress-bar off black==19.3b0 isort==4.3.21 flake8
+          command: sudo pip install --progress-bar off black==20.8b1 isort==4.3.21 flake8
 
   lint_flake8:
     description: "Lint with flake8"

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ REQUIRED_MINOR = 6
 
 TEST_REQUIRES = ["pytest", "pytest-cov", "botorch"]
 DEV_REQUIRES = TEST_REQUIRES + [
-    "black==19.3b0",
+    "black==20.8b1",
     "isort",
     "flake8",
     "sphinx",


### PR DESCRIPTION
Summary: Beanmachine's [CircleCI linter workflow](https://app.circleci.com/pipelines/github/facebookincubator/beanmachine/1582/workflows/0093a28a-227d-44c9-8e43-6f5475964380/jobs/3238) has been failing since the codemod that bump the internal version of black linter to 20.8b1 (D24325133 (https://github.com/facebookincubator/beanmachine/commit/f1ee58b6ef037bfd6ab0583a41c917f8906f7482)). So I guess it's time to upgrade the black linter's version on CircleCI as well. ;)

Differential Revision: D24431864

