### PR TITLE
BMG EXP operator now supports negative reals

### DIFF
--- a/src/beanmachine/graph/operator/unaryop.cpp
+++ b/src/beanmachine/graph/operator/unaryop.cpp
@@ -123,19 +123,25 @@ void Negate::eval(std::mt19937& /* gen */) {
 Exp::Exp(const std::vector<graph::Node*>& in_nodes)
     : UnaryOperator(graph::OperatorType::EXP, in_nodes) {
   graph::ValueType type0 = in_nodes[0]->value.type;
-  if (type0 != graph::AtomicType::REAL and
-      type0 != graph::AtomicType::POS_REAL) {
+  graph::ValueType new_type;
+  if (type0 == graph::AtomicType::REAL or
+      type0 == graph::AtomicType::POS_REAL) {
+    new_type = graph::AtomicType::POS_REAL;
+  } else if (type0 == graph::AtomicType::NEG_REAL) {
+    new_type = graph::AtomicType::PROBABILITY;
+  } else {
     throw std::invalid_argument(
-        "operator EXP requires a real or pos_real parent");
+        "operator EXP requires a probability, real or pos_real parent");
   }
-  value = graph::NodeValue(graph::AtomicType::POS_REAL);
+  value = graph::AtomicValue(new_type);
 }
 
 void Exp::eval(std::mt19937& /* gen */) {
   assert(in_nodes.size() == 1);
   const graph::NodeValue& parent = in_nodes[0]->value;
   if (parent.type == graph::AtomicType::REAL or
-      parent.type == graph::AtomicType::POS_REAL) {
+      parent.type == graph::AtomicType::POS_REAL or
+      parent.type == graph::AtomicType::PROBABILITY) {
     value._double = std::exp(parent._double);
   } else {
     throw std::runtime_error(

--- a/src/beanmachine/graph/tests/operator_test.py
+++ b/src/beanmachine/graph/tests/operator_test.py
@@ -42,11 +42,20 @@ class TestOperators(unittest.TestCase):
         with self.assertRaises(ValueError):
             g.add_operator(bmg.OperatorType.TO_REAL, [c4, c5])
         # test EXP
+        # Exp needs exactly one operand
         with self.assertRaises(ValueError):
             g.add_operator(bmg.OperatorType.EXP, [])
-        g.add_operator(bmg.OperatorType.EXP, [c2])
         with self.assertRaises(ValueError):
-            g.add_operator(bmg.OperatorType.EXP, [c4, c5])
+            g.add_operator(bmg.OperatorType.EXP, [c2, c8])
+        # That operand must be real, negative real or positive real:
+        with self.assertRaises(ValueError):
+            g.add_operator(bmg.OperatorType.EXP, [c3])
+        with self.assertRaises(ValueError):
+            g.add_operator(bmg.OperatorType.EXP, [c6])
+        with self.assertRaises(ValueError):
+            g.add_operator(bmg.OperatorType.EXP, [c7])
+        g.add_operator(bmg.OperatorType.EXP, [c2])
+        g.add_operator(bmg.OperatorType.EXP, [c8])
         # test LOG
         # Log needs exactly one operand:
         with self.assertRaises(ValueError):


### PR DESCRIPTION
Summary:
When a negative real is passed as the operand to an EXP operator, BMG now treats the output as type probability. Otherwise, the output continues to be positive real.

I will add support for this to the beanstalk compiler in the next diff.

Reviewed By: wtaha

Differential Revision: D24282382

