### PR TITLE
Start adding gradient backward methods to BMGraph

### DIFF
--- a/src/beanmachine/graph/distribution/distribution.h
+++ b/src/beanmachine/graph/distribution/distribution.h
@@ -54,6 +54,20 @@ class Distribution : public graph::Node {
     throw std::runtime_error(
         "gradient_log_prob_param has not been implemented for this distribution.");
   }
+  virtual void backward_value(
+      const graph::NodeValue& /* value */,
+      graph::DoubleVector& /* back_grad */,
+      double /* adjunct */ = 1.0) const {}
+  virtual void backward_param(
+      const graph::NodeValue& /* value */,
+      double /* adjunct */ = 1.0) const {}
+  virtual void backward_value_iid(
+      const graph::NodeValue& /* value */,
+      graph::DoubleVector& /* back_grad */,
+      double /* adjunct */ = 1.0) const {}
+  virtual void backward_param_iid(
+      const graph::NodeValue& /* value */,
+      double /* adjunct */ = 1.0) const {}
   graph::DistributionType dist_type;
   graph::ValueType sample_type;
 

--- a/src/beanmachine/graph/operator/operator.h
+++ b/src/beanmachine/graph/operator/operator.h
@@ -22,6 +22,7 @@ class Operator : public graph::Node {
       const override;
   void eval(std::mt19937& gen) override;
   void compute_gradients() override;
+  void backward() override {}
   graph::OperatorType op_type;
 };
 

--- a/src/beanmachine/graph/operator/stochasticop.h
+++ b/src/beanmachine/graph/operator/stochasticop.h
@@ -33,6 +33,10 @@ class StochasticOperator : public Operator {
     return true;
   }
   void compute_gradients() override {}
+  void backward() override {
+    _backward(true);
+  }
+  virtual void _backward(bool /* skip_observed */) {}
 };
 
 class Sample : public oper::StochasticOperator {


### PR DESCRIPTION
Summary:
- added backward() to Add, Multiply and StochasticOperator
- added backward_param(), backward_value() to Normal distribution
- added eval_and_grad() to Graph for testing backward gradient propagation

Differential Revision: D24481928

