### PR TITLE
Avoids divid-by-zero in NUTS

### DIFF
--- a/src/beanmachine/ppl/inference/proposer/single_site_no_u_turn_sampler_proposer.py
+++ b/src/beanmachine/ppl/inference/proposer/single_site_no_u_turn_sampler_proposer.py
@@ -123,7 +123,10 @@ class SingleSiteNoUTurnSamplerProposer(SingleSiteAncestralProposer):
             acceptance_prob = self._compute_new_step_acceptance_probability(
                 node, node_var, world, theta, r, step_size
             )
-            if torch.pow(acceptance_prob, a) < threshold:
+            if (
+                torch.is_nonzero(acceptance_prob)
+                and torch.pow(acceptance_prob, a) < threshold
+            ):
                 # stop if the acceptance probability crosses the threshold
                 break
         self.step_size = step_size.detach()


### PR DESCRIPTION
Summary:
In current implementation of NUTS proposer, it's possible to raise zero to a negative power when  `acceptance_prob == 0.0` and  `a == -1`.

This undefine behavior would usually be evaluated to NaN when running in Buck's opt mode (or in regular conda/pip). However, in dev mode, Buck's `UndefinedBehaviorSanitizer` is going to complain about this usage and terminates any program that uses the proposer.

Differential Revision: D24495518

