### PR TITLE
Add support for negative reals in BMG ADD operator

### DIFF
--- a/src/beanmachine/graph/operator/multiaryop.cpp
+++ b/src/beanmachine/graph/operator/multiaryop.cpp
@@ -10,8 +10,10 @@ Add::Add(const std::vector<graph::Node*>& in_nodes)
     : MultiaryOperator(graph::OperatorType::ADD, in_nodes) {
   graph::ValueType type0 = in_nodes[0]->value.type;
   if (type0 != graph::AtomicType::REAL and
-      type0 != graph::AtomicType::POS_REAL) {
-    throw std::invalid_argument("operator ADD requires real/pos_real parent");
+      type0 != graph::AtomicType::POS_REAL and
+      type0 != graph::AtomicType::NEG_REAL) {
+    throw std::invalid_argument(
+        "operator ADD requires a real, pos_real or neg_real parent");
   }
   value = graph::NodeValue(type0);
 }
@@ -20,7 +22,8 @@ void Add::eval(std::mt19937& /* gen */) {
   assert(in_nodes.size() > 1);
   const graph::NodeValue& parent0 = in_nodes[0]->value;
   if (parent0.type == graph::AtomicType::REAL or
-      parent0.type == graph::AtomicType::POS_REAL) {
+      parent0.type == graph::AtomicType::POS_REAL or
+      parent0.type == graph::AtomicType::NEG_REAL) {
     value._double = parent0._double;
 
     for (uint i = 1; i < in_nodes.size(); i++) {

--- a/src/beanmachine/graph/tests/operator_test.py
+++ b/src/beanmachine/graph/tests/operator_test.py
@@ -105,12 +105,20 @@ class TestOperators(unittest.TestCase):
         g.add_operator(bmg.OperatorType.MULTIPLY, [c4, c5])
         g.add_operator(bmg.OperatorType.MULTIPLY, [c3, c4, c5])
         # test ADD
+        # Add requires two or more operands
         with self.assertRaises(ValueError):
             g.add_operator(bmg.OperatorType.ADD, [])
         with self.assertRaises(ValueError):
             g.add_operator(bmg.OperatorType.ADD, [c1])
+        # All operands must be (1) the same type, and (2)
+        # real, neg real or pos real.
+        with self.assertRaises(ValueError):
+            g.add_operator(bmg.OperatorType.ADD, [c1, c8])
+        with self.assertRaises(ValueError):
+            g.add_operator(bmg.OperatorType.ADD, [c3, c3])
         g.add_operator(bmg.OperatorType.ADD, [c1, c2])
         g.add_operator(bmg.OperatorType.ADD, [c1, c2, c1])
+        g.add_operator(bmg.OperatorType.ADD, [c8, c8, c8])
         # test POW
         with self.assertRaises(ValueError):
             g.add_operator(bmg.OperatorType.POW, [])


### PR DESCRIPTION
Summary:
The n-ary ADD operator in BMG now supports negative reals. The rules are now:

* All operands must be of the same type
* That type can be negative real, positive real, or real
* The output type is the same as the input type

I will add support to the beanstalk compiler in the next diff.

Reviewed By: nimar

Differential Revision: D24285627

