### PR TITLE
Start removing negative log feature

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/end_to_end_test.py
+++ b/src/beanmachine/ppl/compiler/tests/end_to_end_test.py
@@ -667,12 +667,13 @@ n1 = g.add_distribution(
   graph.AtomicType.PROBABILITY,
   [n0, n0])
 n2 = g.add_operator(graph.OperatorType.SAMPLE, [n1])
-n3 = g.add_operator(graph.OperatorType.NEGATIVE_LOG, [n2])
-n4 = g.add_distribution(
+n3 = g.add_operator(graph.OperatorType.LOG, [n2])
+n4 = g.add_operator(graph.OperatorType.NEGATE, [n3])
+n5 = g.add_distribution(
   graph.DistributionType.BETA,
   graph.AtomicType.PROBABILITY,
-  [n3, n0])
-n5 = g.add_operator(graph.OperatorType.SAMPLE, [n4])
+  [n4, n0])
+n6 = g.add_operator(graph.OperatorType.SAMPLE, [n5])
 """
 
 expected_cpp_6 = """
@@ -685,22 +686,25 @@ uint n1 = g.add_distribution(
 uint n2 = g.add_operator(
   graph::OperatorType::SAMPLE, std::vector<uint>({n1}));
 uint n3 = g.add_operator(
-  graph::OperatorType::NEGATIVE_LOG, std::vector<uint>({n2}));
-uint n4 = g.add_distribution(
+  graph::OperatorType::LOG, std::vector<uint>({n2}));
+uint n4 = g.add_operator(
+  graph::OperatorType::NEGATE, std::vector<uint>({n3}));
+uint n5 = g.add_distribution(
   graph::DistributionType::BETA,
   graph::AtomicType::PROBABILITY,
-  std::vector<uint>({n3, n0}));
-uint n5 = g.add_operator(
-  graph::OperatorType::SAMPLE, std::vector<uint>({n4}));
+  std::vector<uint>({n4, n0}));
+uint n6 = g.add_operator(
+  graph::OperatorType::SAMPLE, std::vector<uint>({n5}));
 """
 
 expected_bmg_6 = """
-Node 0 type 1 parents [ ] children [ 1 1 4 ] positive real 2
+Node 0 type 1 parents [ ] children [ 1 1 5 ] positive real 2
 Node 1 type 2 parents [ 0 0 ] children [ 2 ] unknown
 Node 2 type 3 parents [ 1 ] children [ 3 ] probability 1e-10
-Node 3 type 3 parents [ 2 ] children [ 4 ] positive real 1e-10
-Node 4 type 2 parents [ 3 0 ] children [ 5 ] unknown
-Node 5 type 3 parents [ 4 ] children [ ] probability 1e-10
+Node 3 type 3 parents [ 2 ] children [ 4 ] negative real -1e-10
+Node 4 type 3 parents [ 3 ] children [ 5 ] positive real 1e-10
+Node 5 type 2 parents [ 4 0 ] children [ 6 ] unknown
+Node 6 type 3 parents [ 5 ] children [ ] probability 1e-10
 """
 
 # Demonstrate that identity additions and multiplications

--- a/src/beanmachine/ppl/compiler/tests/fix_problems_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_problems_test.py
@@ -804,19 +804,13 @@ digraph "graph" {
 
         self.assertEqual(observed.strip(), expected.strip())
 
-    def disabled_test_fix_problems_11(self) -> None:
+    def test_fix_problems_11(self) -> None:
         """test_fix_problems_11"""
 
-        # TODO: We are adding support for negative reals as a type in the
-        # TODO: BMG type system, which means that we will be able to
-        # TODO: remove the NEG_LOG operator from BMG.  When we do,
-        # TODO: this test will be rewritten to show that we correctly
-        # TODO: allow -log(probability) to be used in contexts where
-        # TODO: a positive real is expected. Until then I will disable
-        # TODO: this test.
-
-        # Here we demonstrate that we can generate a node to treat
-        # the negative log of a probability as a positive real.
+        # Here we demonstrate that we treat the negative log of a
+        # probability as a positive real.  (In a previous iteration
+        # we generated a special negative log node, but now we can
+        # do it directly without fixing up the graph.)
 
         # @rv def beta1():
         #   return Beta(2.0, 2.0)
@@ -846,16 +840,16 @@ digraph "graph" {
   N0[label="2.0:R>=N"];
   N1[label="Beta:P>=P"];
   N2[label="Sample:P>=P"];
-  N3[label="Log:R>=R"];
-  N4[label="-:R>=R+"];
+  N3[label="Log:R->=R-"];
+  N4[label="-:R+>=R+"];
   N5[label="Beta:P>=P"];
   N6[label="Sample:P>=P"];
   N0 -> N1[label="alpha:R+"];
   N0 -> N1[label="beta:R+"];
   N0 -> N5[label="beta:R+"];
   N1 -> N2[label="operand:P"];
-  N2 -> N3[label="operand:R+"];
-  N3 -> N4[label="operand:R"];
+  N2 -> N3[label="operand:P"];
+  N3 -> N4[label="operand:R-"];
   N4 -> N5[label="alpha:R+"];
   N5 -> N6[label="operand:P"];
 }
@@ -877,21 +871,19 @@ digraph "graph" {
   N0[label="2.0:R>=N"];
   N1[label="Beta:P>=P"];
   N2[label="Sample:P>=P"];
-  N3[label="Log:R>=R"];
-  N4[label="-:R>=R+"];
+  N3[label="Log:R->=R-"];
+  N4[label="-:R+>=R+"];
   N5[label="Beta:P>=P"];
   N6[label="Sample:P>=P"];
-  N7[label="NegLog:R+>=R+"];
-  N8[label="2.0:R+>=N"];
+  N7[label="2.0:R+>=N"];
   N1 -> N2[label="operand:P"];
-  N2 -> N3[label="operand:R+"];
-  N2 -> N7[label="operand:P"];
-  N3 -> N4[label="operand:R"];
+  N2 -> N3[label="operand:P"];
+  N3 -> N4[label="operand:R-"];
+  N4 -> N5[label="alpha:R+"];
   N5 -> N6[label="operand:P"];
-  N7 -> N5[label="alpha:R+"];
-  N8 -> N1[label="alpha:R+"];
-  N8 -> N1[label="beta:R+"];
-  N8 -> N5[label="beta:R+"];
+  N7 -> N1[label="alpha:R+"];
+  N7 -> N1[label="beta:R+"];
+  N7 -> N5[label="beta:R+"];
 }
 """
         self.assertEqual(observed.strip(), expected.strip())


### PR DESCRIPTION
Summary:
Now that we have a type analysis that shows that log of a probability is a negative real, we can remove the "negative log" node. It's purpose was only to allow us to represent log probabilities as positive reals.

I've started by re-enabling the test that showed how neg(log(p)) was transformed into neglog(p), and updating it to show that we do a correct type analysis.

I will remove the rest of the code for this from Beanstalk and BMG in the next few diffs.

Reviewed By: wtaha

Differential Revision: D24338918

