### PR TITLE
Add backprop methods to Add, Multiply, StochasticOps and Normal Distribution

### DIFF
--- a/src/beanmachine/graph/distribution/distribution.h
+++ b/src/beanmachine/graph/distribution/distribution.h
@@ -54,17 +54,46 @@ class Distribution : public graph::Node {
     throw std::runtime_error(
         "gradient_log_prob_param has not been implemented for this distribution.");
   }
+  /*
+  In backward gradient propagation, increments the back_grad by the gradient of
+  the log prob of the distribution w.r.t. the sampled value.
+  :param value: value of the child Sample operator, a single draw from the
+  distribution
+  :param back_grad: back_grad1 of the child Sample operator, to be incremented
+  :param adjunct: a multiplier that represents the gradient of the target
+  function w.r.t the log prob of this distribution. It uses the default value
+  1.0 if the direct child is a StochasticOperator, but requires input if the
+  direct child is a mixture distribution.
+  */
   virtual void backward_value(
       const graph::NodeValue& /* value */,
       graph::DoubleVector& /* back_grad */,
       double /* adjunct */ = 1.0) const {}
-  virtual void backward_param(
-      const graph::NodeValue& /* value */,
-      double /* adjunct */ = 1.0) const {}
+  /*
+  Similar to backward_value, except that it is used when the child operator is
+  IId_Sample
+  */
   virtual void backward_value_iid(
       const graph::NodeValue& /* value */,
       graph::DoubleVector& /* back_grad */,
       double /* adjunct */ = 1.0) const {}
+  /*
+  In backward gradient propagation, increments the back_grad1 of each parent
+  node w.r.t. the log prob of the distribution, evaluated at the given value.
+  :param value: value of the child Sample operator, a single draw from the
+  distribution
+  :param adjunct: a multiplier that represents the gradient of the
+  target function w.r.t the log prob of this distribution. It uses the default
+  value 1.0 if the direct child is a StochasticOperator, but requires input if
+  the direct child is a mixture distribution.
+  */
+  virtual void backward_param(
+      const graph::NodeValue& /* value */,
+      double /* adjunct */ = 1.0) const {}
+  /*
+  Similar to backward_param, except that it is used when the child operator is
+  IId_Sample
+  */
   virtual void backward_param_iid(
       const graph::NodeValue& /* value */,
       double /* adjunct */ = 1.0) const {}

--- a/src/beanmachine/graph/distribution/normal.h
+++ b/src/beanmachine/graph/distribution/normal.h
@@ -21,6 +21,22 @@ class Normal : public Distribution {
       const graph::NodeValue& value,
       double& grad1,
       double& grad2) const override;
+
+  void backward_value(
+      const graph::NodeValue& value,
+      graph::DoubleVector& back_grad,
+      double adjunct = 1.0) const override;
+  void backward_param(const graph::NodeValue& value, double adjunct = 1.0)
+      const override;
+  void backward_value_iid(
+      const graph::NodeValue& value,
+      graph::DoubleVector& back_grad,
+      double adjunct = 1.0) const override;
+  void backward_param_iid(const graph::NodeValue& value, double adjunct = 1.0)
+      const override;
+
+  static void
+  _grad1_log_prob_value(double& grad1, double val, double m, double s_sq);
 };
 
 } // namespace distribution

--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -334,7 +334,7 @@ enum class AggregationType { UNKNOWN = 0, NONE = 1, MEAN };
 
 struct DoubleVector {
   double _double;
-  Eigen::VectorXd _vector;
+  Eigen::Matrix<double, 1, Eigen::Dynamic> _vector;
 };
 
 class Node {
@@ -359,6 +359,9 @@ class Node {
   // only valid for stochastic nodes
   virtual double log_prob() const {
     return 0;
+  }
+  virtual bool needs_gradient() const {
+    return true;
   }
   // gradient_log_prob is also only valid for stochastic nodes
   // this function adds the gradients to the passed in gradients
@@ -421,6 +424,9 @@ class ConstNode : public Node {
   explicit ConstNode(NodeValue value) : Node(NodeType::CONSTANT, value) {}
   void eval(std::mt19937& /* unused */) override {}
   ~ConstNode() override {}
+  bool needs_gradient() const override {
+    return false;
+  }
 };
 
 // NOTE: the second kind of node -- Distribution is defined in distribution.h

--- a/src/beanmachine/graph/operator/backward.cpp
+++ b/src/beanmachine/graph/operator/backward.cpp
@@ -1,0 +1,58 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+#include <cmath>
+
+#include "beanmachine/graph/operator/controlop.h"
+#include "beanmachine/graph/operator/multiaryop.h"
+#include "beanmachine/graph/operator/unaryop.h"
+
+namespace beanmachine {
+namespace oper {
+
+bool approx_zero(double val) {
+  return std::abs(val) < graph::PRECISION;
+}
+
+// Note: that we use the following chain rule for the gradients of f(g(x))
+// first: f'(g(x)) g'(x), assuming f'(g(x)) is given by back_grad1.
+
+// dg(x1,...xn)/dxi = 1
+void Add::backward() {
+  for (const auto node : in_nodes) {
+    if (node->needs_gradient()) {
+      node->back_grad1._double += back_grad1._double;
+    }
+  }
+}
+
+// dg(x1,...xn)/dxi = g(x1, ..., xn) / xi
+void Multiply::backward() {
+  // if at least one parent value is likely zero.
+  if (approx_zero(value._double)) {
+    std::vector<graph::Node*> zeros;
+    double non_zero_prod = 1.0;
+    for (const auto node : in_nodes) {
+      if (approx_zero(node->value._double)) {
+        zeros.push_back(node);
+      } else {
+        non_zero_prod *= node->value._double;
+      }
+    }
+    if (zeros.size() == 1) {
+      // if there is only one zero, only its backgrad needs update
+      zeros.front()->back_grad1._double += back_grad1._double * non_zero_prod;
+      return;
+    } else if (zeros.size() > 1) {
+      // if multiple zeros, all grad increments are zero, no need to update
+      return;
+    } // otherwise, do the usual update
+  }
+  double shared_numerator = back_grad1._double * value._double;
+  for (const auto node : in_nodes) {
+    if (node->needs_gradient()) {
+      node->back_grad1._double += shared_numerator / node->value._double;
+    }
+  }
+}
+
+} // namespace oper
+} // namespace beanmachine

--- a/src/beanmachine/graph/operator/multiaryop.h
+++ b/src/beanmachine/graph/operator/multiaryop.h
@@ -31,6 +31,7 @@ class MultiaryOperator : public Operator {
   ~MultiaryOperator() override {}
   void eval(std::mt19937& /* gen */) override {}
   void compute_gradients() override {}
+  void backward() override {}
 };
 
 class Add : public MultiaryOperator {
@@ -40,6 +41,7 @@ class Add : public MultiaryOperator {
 
   void eval(std::mt19937& gen) override;
   void compute_gradients() override;
+  void backward() override;
 
   static std::unique_ptr<Operator> new_op(
       const std::vector<graph::Node*>& in_nodes) {
@@ -57,6 +59,7 @@ class Multiply : public MultiaryOperator {
 
   void eval(std::mt19937& gen) override;
   void compute_gradients() override;
+  void backward() override;
 
   static std::unique_ptr<Operator> new_op(
       const std::vector<graph::Node*>& in_nodes) {

--- a/src/beanmachine/graph/operator/stochasticop.cpp
+++ b/src/beanmachine/graph/operator/stochasticop.cpp
@@ -5,6 +5,22 @@
 namespace beanmachine {
 namespace oper {
 
+void Sample::_backward(bool skip_observed) {
+  const auto dist = static_cast<distribution::Distribution*>(in_nodes[0]);
+  dist->backward_param(value);
+  if (!(is_observed and skip_observed)) {
+    dist->backward_value(value, back_grad1);
+  }
+}
+
+void IIdSample::_backward(bool skip_observed) {
+  const auto dist = static_cast<distribution::Distribution*>(in_nodes[0]);
+  dist->backward_param_iid(value);
+  if (!(is_observed and skip_observed)) {
+    dist->backward_value_iid(value, back_grad1);
+  }
+}
+
 Sample::Sample(const std::vector<graph::Node*>& in_nodes)
     : StochasticOperator(graph::OperatorType::SAMPLE) {
   if (in_nodes.size() != 1 or

--- a/src/beanmachine/graph/operator/stochasticop.h
+++ b/src/beanmachine/graph/operator/stochasticop.h
@@ -43,6 +43,7 @@ class Sample : public oper::StochasticOperator {
  public:
   explicit Sample(const std::vector<graph::Node*>& in_nodes);
   ~Sample() override {}
+  void _backward(bool skip_observed) override;
 
   static std::unique_ptr<Operator> new_op(
       const std::vector<graph::Node*>& in_nodes) {
@@ -56,6 +57,7 @@ class IIdSample : public oper::StochasticOperator {
  public:
   explicit IIdSample(const std::vector<graph::Node*>& in_nodes);
   ~IIdSample() override {}
+  void _backward(bool skip_observed) override;
 
   static std::unique_ptr<Operator> new_op(
       const std::vector<graph::Node*>& in_nodes) {


### PR DESCRIPTION
Summary:
- add backward() to Add, Multiply, and StochasticOperator
- add _backward() to Sample and IId_Sample
- add backward_param(), backward_value, etc. to Normal
- update log_prob() in Normal

Differential Revision: D24583437

