### PR TITLE
Remove negative log node from compiler

### DIFF
--- a/src/beanmachine/ppl/compiler/bmg_nodes.py
+++ b/src/beanmachine/ppl/compiler/bmg_nodes.py
@@ -2461,60 +2461,6 @@ class LogNode(UnaryOperatorNode):
         return True
 
 
-class NegativeLogNode(UnaryOperatorNode):
-    """BMG supports a node with the semantics of -log(x), so that we can
-    take advantage in the type system that -log(P) for probability P is
-    known to be a positive real."""
-
-    operator_type = OperatorType.NEGATIVE_LOG
-
-    def __init__(self, operand: BMGNode):
-        UnaryOperatorNode.__init__(self, operand)
-
-    # The typing rules are:
-    # * if input is P, output is R+
-    # * if input is R+, output is R
-    # Nothing else is legal
-
-    @property
-    def inf_type(self) -> BMGLatticeType:
-        if supremum(self.operand.inf_type, Probability) == Probability:
-            return PositiveReal
-        return Real
-
-    @property
-    def graph_type(self) -> BMGLatticeType:
-        t = self.operand.graph_type
-        if t == Probability:
-            return PositiveReal
-        if t == PositiveReal:
-            return Real
-        return Malformed
-
-    @property
-    def requirements(self) -> List[Requirement]:
-        if supremum(self.operand.inf_type, Probability) == Probability:
-            return [Probability]
-        return [PositiveReal]
-
-    @property
-    def label(self) -> str:
-        return "NegLog"
-
-    @property
-    def size(self) -> torch.Size:
-        return self.operand.size
-
-    def __str__(self) -> str:
-        return "NegLog(" + str(self.operand) + ")"
-
-    def support(self) -> Iterator[Any]:
-        return SetOfTensors(-(torch.log(o)) for o in self.operand.support())
-
-    def _supported_in_bmg(self) -> bool:
-        return True
-
-
 # BMG supports three different kinds of negation:
 
 # * The "complement" node with a Boolean operand has the semantics

--- a/src/beanmachine/ppl/compiler/tests/unary_nodes_test.py
+++ b/src/beanmachine/ppl/compiler/tests/unary_nodes_test.py
@@ -12,7 +12,6 @@ from beanmachine.ppl.compiler.bmg_nodes import (
     LogNode,
     NaturalNode,
     NegateNode,
-    NegativeLogNode,
     NormalNode,
     PhiNode,
     PositiveRealNode,
@@ -99,13 +98,6 @@ class UnaryNodesTest(unittest.TestCase):
         self.assertEqual(LogNode(bino).inf_type, Real)
         self.assertEqual(LogNode(half).inf_type, Real)
 
-        # Negative Log of probability or smaller is Positive Real;
-        # otherwise Real.
-        self.assertEqual(NegativeLogNode(bern).inf_type, PositiveReal)
-        self.assertEqual(NegativeLogNode(beta).inf_type, PositiveReal)
-        self.assertEqual(NegativeLogNode(bino).inf_type, Real)
-        self.assertEqual(NegativeLogNode(half).inf_type, Real)
-
         # Phi of anything is Probability
         self.assertEqual(PhiNode(bern).inf_type, Probability)
         self.assertEqual(PhiNode(beta).inf_type, Probability)
@@ -174,12 +166,6 @@ class UnaryNodesTest(unittest.TestCase):
         self.assertEqual(LogNode(beta).requirements, [Probability])
         self.assertEqual(LogNode(bino).requirements, [PositiveReal])
         self.assertEqual(LogNode(half).requirements, [PositiveReal])
-
-        # Negative Log requires that its operand be positive real or probability.
-        self.assertEqual(NegativeLogNode(bern).requirements, [Probability])
-        self.assertEqual(NegativeLogNode(beta).requirements, [Probability])
-        self.assertEqual(NegativeLogNode(bino).requirements, [PositiveReal])
-        self.assertEqual(NegativeLogNode(half).requirements, [PositiveReal])
 
         # Phi requires that its operand be real.
         self.assertEqual(PhiNode(bern).requirements, [Real])

--- a/src/beanmachine/ppl/utils/bm_graph_builder.py
+++ b/src/beanmachine/ppl/utils/bm_graph_builder.py
@@ -88,7 +88,6 @@ from beanmachine.ppl.compiler.bmg_nodes import (
     MultiplicationNode,
     NaturalNode,
     NegateNode,
-    NegativeLogNode,
     NegativeRealNode,
     NormalNode,
     NotNode,
@@ -917,16 +916,6 @@ class BMGraphBuilder:
         if isinstance(operand, ConstantNode):
             return self.add_constant(math.log(operand.value))
         node = LogNode(operand)
-        self.add_node(node)
-        return node
-
-    @memoize
-    def add_negative_log(self, operand: BMGNode) -> BMGNode:
-        if isinstance(operand, TensorNode):
-            return self.add_constant(-(torch.log(operand.value)))
-        if isinstance(operand, ConstantNode):
-            return self.add_constant(-(math.log(operand.value)))
-        node = NegativeLogNode(operand)
         self.add_node(node)
         return node
 


### PR DESCRIPTION
Summary: Since we now have negative real support in the BMG type system, we no longer need the negative log node. I'm removing it from the compiler in this diff, and from BMG proper in the next.

Reviewed By: wtaha

Differential Revision: D24340695

