### PR TITLE
Add NEG_REAL to pybind NodeValue type caster

### DIFF
--- a/src/beanmachine/graph/pybindings.h
+++ b/src/beanmachine/graph/pybindings.h
@@ -36,6 +36,7 @@ struct type_caster<NodeValue> : public type_caster_base<NodeValue> {
         }
         case AtomicType::PROBABILITY:
         case AtomicType::REAL:
+        case AtomicType::NEG_REAL:
         case AtomicType::POS_REAL: {
           return type_caster<double>::cast(src._double, policy, parent);
         }
@@ -53,6 +54,7 @@ struct type_caster<NodeValue> : public type_caster_base<NodeValue> {
               src._bmatrix, policy, parent);
         case AtomicType::REAL:
         case AtomicType::POS_REAL:
+        case AtomicType::NEG_REAL:
         case AtomicType::PROBABILITY:
           return type_caster<Eigen::MatrixXd>::cast(
               src._matrix, policy, parent);

--- a/src/beanmachine/graph/tests/graph_test.py
+++ b/src/beanmachine/graph/tests/graph_test.py
@@ -316,8 +316,14 @@ class TestBayesNet(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             g.add_constant_neg_real(1.25)
         self.assertTrue("neg_real must be <=0" in str(cm.exception))
-        g.add_constant_neg_real(-1.25)
+        neg1 = g.add_constant_neg_real(-1.25)
         expected = """
-Node 0 type 1 parents [ ] children [ ] negative real -1.25
-"""
+        Node 0 type 1 parents [ ] children [ ] negative real -1.25
+        """
         self.assertEqual(g.to_string().strip(), expected.strip())
+        add_negs = g.add_operator(graph.OperatorType.ADD, [neg1, neg1])
+        g.query(add_negs)
+        means = g.infer_mean(10)
+        self.assertAlmostEqual(means[0], -2.5)
+        samples = g.infer(10)
+        self.assertAlmostEqual(samples[0][0], -2.5)


### PR DESCRIPTION
Summary: - Add NEG_REAL to pybind NodeValue type caster

Reviewed By: kshah1997

Differential Revision: D24685218

