### PR TITLE
Remove negative log from BMG

### DIFF
--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -293,8 +293,6 @@ enum class OperatorType {
   LOGSUMEXP,
   LOG,
   POW,
-  NEGATIVE_LOG,
-  // TODO: We can remove NEGATIVE_LOG once we have a NEG_REAL type implemented.
   LOG1MEXP,
 };
 

--- a/src/beanmachine/graph/operator/gradient.cpp
+++ b/src/beanmachine/graph/operator/gradient.cpp
@@ -121,19 +121,6 @@ void Logistic::compute_gradients() {
       f_grad * in_nodes[0]->grad2;
 }
 
-void NegativeLog::compute_gradients() {
-  assert(in_nodes.size() == 1);
-  // f(x) = -log(x)
-  // f'(x) = -1 / x
-  // f''(x) = 1 / (x^2) = f'(x) * f'(x)
-  double x = in_nodes[0]->value._double;
-  double f_grad = -1.0 / x;
-  double f_grad2 = f_grad * f_grad;
-  grad1 = f_grad * in_nodes[0]->grad1;
-  grad2 = f_grad2 * in_nodes[0]->grad1 * in_nodes[0]->grad1 +
-      f_grad * in_nodes[0]->grad2;
-}
-
 void Pow::compute_gradients() {
   assert(in_nodes.size() == 2);
   // We wish to compute the first and second derivatives of x ** y.

--- a/src/beanmachine/graph/operator/register.cpp
+++ b/src/beanmachine/graph/operator/register.cpp
@@ -78,9 +78,5 @@ bool Log1mExp::is_registered = OperatorFactory::register_op(
 bool Log::is_registered =
     OperatorFactory::register_op(graph::OperatorType::LOG, &(Log::new_op));
 
-bool NegativeLog::is_registered = OperatorFactory::register_op(
-    graph::OperatorType::NEGATIVE_LOG,
-    &(NegativeLog::new_op));
-
 } // namespace oper
 } // namespace beanmachine

--- a/src/beanmachine/graph/operator/tests/operator_test.cpp
+++ b/src/beanmachine/graph/operator/tests/operator_test.cpp
@@ -485,54 +485,6 @@ TEST(testoperator, log) {
   EXPECT_NEAR(grad2, -27.0904, 1e-3);
 }
 
-TEST(testoperator, negative_log) {
-  Graph g;
-  // negative tests: exactly one pos_real or probability should be the input
-  EXPECT_THROW(
-      g.add_operator(OperatorType::NEGATIVE_LOG, std::vector<uint>{}),
-      std::invalid_argument);
-  auto neg_real = g.add_constant(-1.5);
-  EXPECT_THROW(
-      g.add_operator(OperatorType::NEGATIVE_LOG, std::vector<uint>{neg_real}),
-      std::invalid_argument);
-  auto pos1 = g.add_constant_pos_real(1.0);
-  EXPECT_THROW(
-      g.add_operator(OperatorType::NEGATIVE_LOG, std::vector<uint>{pos1, pos1}),
-      std::invalid_argument);
-  // y ~ Normal(-log(x^2), 1)
-  // If we observe x = 0.5 then the mean should be -log(0.25) = 1.386.
-  auto prior = g.add_distribution(
-      DistributionType::FLAT, AtomicType::POS_REAL, std::vector<uint>{});
-  auto x = g.add_operator(OperatorType::SAMPLE, std::vector<uint>{prior});
-  auto x_sq = g.add_operator(OperatorType::MULTIPLY, std::vector<uint>{x, x});
-  auto log_x_sq =
-      g.add_operator(OperatorType::NEGATIVE_LOG, std::vector<uint>{x_sq});
-  auto likelihood = g.add_distribution(
-      DistributionType::NORMAL,
-      AtomicType::REAL,
-      std::vector<uint>{log_x_sq, pos1});
-  auto y = g.add_operator(OperatorType::SAMPLE, std::vector<uint>{likelihood});
-  g.query(y);
-  g.observe(x, 0.5);
-  const auto& means = g.infer_mean(10000, InferenceType::NMC);
-  EXPECT_NEAR(means[0], 1.386, 0.01);
-  g.observe(y, 0.0);
-  // check gradient:
-  // Verified in pytorch using the following code:
-  //
-  // x = tensor(0.5, requires_grad=True)
-  // fx = Normal(-(x * x).log(), tensor(1.0)).log_prob(tensor(0.0))
-  // f1x = grad(fx, x, create_graph=True)
-  // f2x = grad(f1x, x)
-  //
-  // f1x -> 5.5452 and f2x -> -27.0904
-  double grad1 = 0;
-  double grad2 = 0;
-  g.gradient_log_prob(x, grad1, grad2);
-  EXPECT_NEAR(grad1, 5.5452, 1e-3);
-  EXPECT_NEAR(grad2, -27.0904, 1e-3);
-}
-
 TEST(testoperator, pow) {
   Graph g;
   // There must be exactly two operands.

--- a/src/beanmachine/graph/operator/unaryop.cpp
+++ b/src/beanmachine/graph/operator/unaryop.cpp
@@ -267,35 +267,6 @@ void Log::eval(std::mt19937& /* gen */) {
   }
 }
 
-// TODO: Once we have more complete implementation of the NEG_REAL type,
-// TODO: we can remove this operator entirely.
-NegativeLog::NegativeLog(const std::vector<graph::Node*>& in_nodes)
-    : UnaryOperator(graph::OperatorType::NEGATIVE_LOG, in_nodes) {
-  graph::ValueType type0 = in_nodes[0]->value.type;
-  if (type0 == graph::AtomicType::POS_REAL) {
-    value = graph::NodeValue(graph::AtomicType::REAL);
-  } else if (type0 == graph::AtomicType::PROBABILITY) {
-    value = graph::NodeValue(graph::AtomicType::POS_REAL);
-  } else {
-    throw std::invalid_argument(
-        "operator NEG_LOG requires a pos_real or probability parent");
-  }
-}
-
-void NegativeLog::eval(std::mt19937& /* gen */) {
-  assert(in_nodes.size() == 1);
-  const graph::NodeValue& parent = in_nodes[0]->value;
-  if (parent.type == graph::AtomicType::POS_REAL or
-      parent.type == graph::AtomicType::PROBABILITY) {
-    value._double = -std::log(parent._double);
-  } else {
-    throw std::runtime_error(
-        "invalid parent type " +
-        std::to_string(static_cast<int>(parent.type.atomic_type)) +
-        " for NEGATIVE_LOG operator at node_id " + std::to_string(index));
-  }
-}
-
 Log1mExp::Log1mExp(const std::vector<graph::Node*>& in_nodes)
     : UnaryOperator(graph::OperatorType::LOG1MEXP, in_nodes) {
   graph::ValueType type0 = in_nodes[0]->value.type;

--- a/src/beanmachine/graph/operator/unaryop.h
+++ b/src/beanmachine/graph/operator/unaryop.h
@@ -202,23 +202,6 @@ class Log : public UnaryOperator {
   static bool is_registered;
 };
 
-class NegativeLog : public UnaryOperator {
- public:
-  explicit NegativeLog(const std::vector<graph::Node*>& in_nodes);
-  ~NegativeLog() override {}
-
-  void eval(std::mt19937& gen) override;
-  void compute_gradients() override;
-
-  static std::unique_ptr<Operator> new_op(
-      const std::vector<graph::Node*>& in_nodes) {
-    return std::make_unique<NegativeLog>(in_nodes);
-  }
-
- private:
-  static bool is_registered;
-};
-
 class Log1mExp : public UnaryOperator {
  public:
   explicit Log1mExp(const std::vector<graph::Node*>& in_nodes);

--- a/src/beanmachine/graph/pybindings.cpp
+++ b/src/beanmachine/graph/pybindings.cpp
@@ -55,8 +55,7 @@ PYBIND11_MODULE(graph, module) {
       .value("LOGSUMEXP", OperatorType::LOGSUMEXP)
       .value("IF_THEN_ELSE", OperatorType::IF_THEN_ELSE)
       .value("LOG", OperatorType::LOG)
-      .value("POW", OperatorType::POW)
-      .value("NEGATIVE_LOG", OperatorType::NEGATIVE_LOG);
+      .value("POW", OperatorType::POW);
 
   py::enum_<DistributionType>(module, "DistributionType")
       .value("TABULAR", DistributionType::TABULAR)


### PR DESCRIPTION
Summary: Now that we have a negative real type in the type system we no longer need a negative log node in BMG. I've removed it.

Reviewed By: wtaha

Differential Revision: D24347095

