### PR TITLE
Add NEG_REAL support to LOGSUMEXP

### DIFF
--- a/src/beanmachine/graph/operator/multiaryop.cpp
+++ b/src/beanmachine/graph/operator/multiaryop.cpp
@@ -72,9 +72,10 @@ LogSumExp::LogSumExp(const std::vector<graph::Node*>& in_nodes)
     : MultiaryOperator(graph::OperatorType::LOGSUMEXP, in_nodes) {
   graph::ValueType type0 = in_nodes[0]->value.type;
   if (type0 != graph::AtomicType::REAL and
+      type0 != graph::AtomicType::NEG_REAL and
       type0 != graph::AtomicType::POS_REAL) {
     throw std::invalid_argument(
-        "operator LOGSUMEXP requires a real or pos_real parent");
+        "operator LOGSUMEXP requires a real or pos/neg_real parent");
   }
   value = graph::NodeValue(graph::AtomicType::REAL);
 }
@@ -83,6 +84,7 @@ void LogSumExp::eval(std::mt19937& /* gen */) {
   assert(in_nodes.size() > 1);
   const graph::NodeValue& parent0 = in_nodes[0]->value;
   if (parent0.type == graph::AtomicType::REAL or
+      parent0.type == graph::AtomicType::NEG_REAL or
       parent0.type == graph::AtomicType::POS_REAL) {
     double max_val = parent0._double;
     for (uint i = 1; i < in_nodes.size(); i++) {

--- a/src/beanmachine/graph/operator/tests/operator_test.cpp
+++ b/src/beanmachine/graph/operator/tests/operator_test.cpp
@@ -375,7 +375,7 @@ TEST(testoperator, log1mexp) {
 
 TEST(testoperator, logsumexp) {
   Graph g;
-  // negative tests: two or more real/pos should be the input
+  // negative tests: two or more real/pos/neg should be the input
   EXPECT_THROW(
       g.add_operator(OperatorType::LOGSUMEXP, std::vector<uint>{}),
       std::invalid_argument);
@@ -386,6 +386,12 @@ TEST(testoperator, logsumexp) {
   auto prob1 = g.add_constant_probability(0.5);
   EXPECT_THROW(
       g.add_operator(OperatorType::LOGSUMEXP, std::vector<uint>{prob1, prob1}),
+      std::invalid_argument);
+  auto neg1 = g.add_constant_neg_real(-1.0);
+  g.add_operator(OperatorType::LOGSUMEXP, std::vector<uint>{pos1, pos1});
+  g.add_operator(OperatorType::LOGSUMEXP, std::vector<uint>{neg1, neg1});
+  EXPECT_THROW(
+      g.add_operator(OperatorType::LOGSUMEXP, std::vector<uint>{pos1, neg1}),
       std::invalid_argument);
   // y ~ Normal(logsumexp(x^2, z^3), 1) and x = 0.5, z = -0.5
   // note: ln[exp(0.25) + exp(-0.125)] = 0.773


### PR DESCRIPTION
Summary: make LOGSUMEXP support all NEG_REAL parents

Reviewed By: nimar

Differential Revision: D24693382

