### PR TITLE
Add comparison operators to graph builder

### DIFF
--- a/src/beanmachine/ppl/utils/bm_graph_builder.py
+++ b/src/beanmachine/ppl/utils/bm_graph_builder.py
@@ -76,12 +76,17 @@ from beanmachine.ppl.compiler.bmg_nodes import (
     DirichletNode,
     DistributionNode,
     DivisionNode,
+    EqualNode,
     ExpNode,
     FlatNode,
     GammaNode,
+    GreaterThanEqualNode,
+    GreaterThanNode,
     HalfCauchyNode,
     IfThenElseNode,
     IndexNode,
+    LessThanEqualNode,
+    LessThanNode,
     LogNode,
     MapNode,
     MatrixMultiplicationNode,
@@ -90,6 +95,7 @@ from beanmachine.ppl.compiler.bmg_nodes import (
     NegateNode,
     NegativeRealNode,
     NormalNode,
+    NotEqualNode,
     NotNode,
     Observation,
     OperatorNode,
@@ -648,6 +654,132 @@ class BMGraphBuilder:
 
     # TODO: This code is not very well organized; consider sorting it
     # into alpha order by operation.
+
+    @memoize
+    def add_greater_than(self, left: BMGNode, right: BMGNode) -> BMGNode:
+        if isinstance(left, ConstantNode):
+            if isinstance(right, ConstantNode):
+                return self.add_constant(left.value > right.value)
+
+        node = GreaterThanNode(left, right)
+        self.add_node(node)
+        return node
+
+    def handle_greater_than(self, input: Any, other: Any) -> Any:
+        if (not isinstance(input, BMGNode)) and (not isinstance(other, BMGNode)):
+            return input > other
+        if not isinstance(input, BMGNode):
+            input = self.add_constant(input)
+        if not isinstance(other, BMGNode):
+            other = self.add_constant(other)
+        if isinstance(input, ConstantNode) and isinstance(other, ConstantNode):
+            return input.value > other.value
+        return self.add_greater_than(input, other)
+
+    @memoize
+    def add_greater_than_equal(self, left: BMGNode, right: BMGNode) -> BMGNode:
+        if isinstance(left, ConstantNode):
+            if isinstance(right, ConstantNode):
+                return self.add_constant(left.value >= right.value)
+
+        node = GreaterThanEqualNode(left, right)
+        self.add_node(node)
+        return node
+
+    def handle_greater_than_equal(self, input: Any, other: Any) -> Any:
+        if (not isinstance(input, BMGNode)) and (not isinstance(other, BMGNode)):
+            return input >= other
+        if not isinstance(input, BMGNode):
+            input = self.add_constant(input)
+        if not isinstance(other, BMGNode):
+            other = self.add_constant(other)
+        if isinstance(input, ConstantNode) and isinstance(other, ConstantNode):
+            return input.value >= other.value
+        return self.add_greater_than_equal(input, other)
+
+    @memoize
+    def add_less_than(self, left: BMGNode, right: BMGNode) -> BMGNode:
+        if isinstance(left, ConstantNode):
+            if isinstance(right, ConstantNode):
+                return self.add_constant(left.value < right.value)
+
+        node = LessThanNode(left, right)
+        self.add_node(node)
+        return node
+
+    def handle_less_than(self, input: Any, other: Any) -> Any:
+        if (not isinstance(input, BMGNode)) and (not isinstance(other, BMGNode)):
+            return input < other
+        if not isinstance(input, BMGNode):
+            input = self.add_constant(input)
+        if not isinstance(other, BMGNode):
+            other = self.add_constant(other)
+        if isinstance(input, ConstantNode) and isinstance(other, ConstantNode):
+            return input.value < other.value
+        return self.add_less_than(input, other)
+
+    @memoize
+    def add_less_than_equal(self, left: BMGNode, right: BMGNode) -> BMGNode:
+        if isinstance(left, ConstantNode):
+            if isinstance(right, ConstantNode):
+                return self.add_constant(left.value <= right.value)
+
+        node = LessThanEqualNode(left, right)
+        self.add_node(node)
+        return node
+
+    def handle_less_than_equal(self, input: Any, other: Any) -> Any:
+        if (not isinstance(input, BMGNode)) and (not isinstance(other, BMGNode)):
+            return input <= other
+        if not isinstance(input, BMGNode):
+            input = self.add_constant(input)
+        if not isinstance(other, BMGNode):
+            other = self.add_constant(other)
+        if isinstance(input, ConstantNode) and isinstance(other, ConstantNode):
+            return input.value <= other.value
+        return self.add_less_than_equal(input, other)
+
+    @memoize
+    def add_equal(self, left: BMGNode, right: BMGNode) -> BMGNode:
+        if isinstance(left, ConstantNode):
+            if isinstance(right, ConstantNode):
+                return self.add_constant(left.value == right.value)
+
+        node = EqualNode(left, right)
+        self.add_node(node)
+        return node
+
+    def handle_equal(self, input: Any, other: Any) -> Any:
+        if (not isinstance(input, BMGNode)) and (not isinstance(other, BMGNode)):
+            return input == other
+        if not isinstance(input, BMGNode):
+            input = self.add_constant(input)
+        if not isinstance(other, BMGNode):
+            other = self.add_constant(other)
+        if isinstance(input, ConstantNode) and isinstance(other, ConstantNode):
+            return input.value == other.value
+        return self.add_equal(input, other)
+
+    @memoize
+    def add_not_equal(self, left: BMGNode, right: BMGNode) -> BMGNode:
+        if isinstance(left, ConstantNode):
+            if isinstance(right, ConstantNode):
+                return self.add_constant(left.value != right.value)
+
+        node = NotEqualNode(left, right)
+        self.add_node(node)
+        return node
+
+    def handle_not_equal(self, input: Any, other: Any) -> Any:
+        if (not isinstance(input, BMGNode)) and (not isinstance(other, BMGNode)):
+            return input != other
+        if not isinstance(input, BMGNode):
+            input = self.add_constant(input)
+        if not isinstance(other, BMGNode):
+            other = self.add_constant(other)
+        if isinstance(input, ConstantNode) and isinstance(other, ConstantNode):
+            return input.value != other.value
+        return self.add_not_equal(input, other)
 
     @memoize
     def add_addition(self, left: BMGNode, right: BMGNode) -> BMGNode:

--- a/src/beanmachine/ppl/utils/tests/bm_graph_builder_test.py
+++ b/src/beanmachine/ppl/utils/tests/bm_graph_builder_test.py
@@ -10,11 +10,17 @@ from beanmachine.ppl.compiler.bmg_nodes import (
     BernoulliNode,
     BooleanNode,
     DivisionNode,
+    EqualNode,
     ExpNode,
+    GreaterThanEqualNode,
+    GreaterThanNode,
+    LessThanEqualNode,
+    LessThanNode,
     LogNode,
     MatrixMultiplicationNode,
     MultiplicationNode,
     NegateNode,
+    NotEqualNode,
     NotNode,
     PowerNode,
     RealNode,
@@ -942,6 +948,116 @@ digraph "graph" {
         self.assertTrue(isinstance(bmg.handle_function(ta2, [s], {"mat2": gt1}), n))
         self.assertTrue(isinstance(bmg.handle_function(ta2, [gt1, s]), n))
         self.assertTrue(isinstance(bmg.handle_function(ta2, [gt1], {"mat2": s}), n))
+
+    def test_comparison(self) -> None:
+        """Test comparison"""
+        bmg = BMGraphBuilder()
+
+        t1 = tensor(1.0)
+        t2 = tensor(2.0)
+        f = tensor(False)
+        t = tensor(True)
+        g1 = bmg.add_real(1.0)
+        g2 = bmg.add_real(2.0)
+        s = bmg.add_sample(bmg.add_halfcauchy(bmg.add_real(0.5)))
+
+        self.assertEqual(bmg.handle_equal(t2, t1), f)
+        self.assertEqual(bmg.handle_equal(t1, t1), t)
+        self.assertEqual(bmg.handle_equal(t1, t2), f)
+        self.assertEqual(bmg.handle_equal(g2, t1), f)
+        self.assertEqual(bmg.handle_equal(g1, t1), t)
+        self.assertEqual(bmg.handle_equal(g1, t2), f)
+        self.assertEqual(bmg.handle_equal(t2, g1), f)
+        self.assertEqual(bmg.handle_equal(t1, g1), t)
+        self.assertEqual(bmg.handle_equal(t1, g2), f)
+        self.assertEqual(bmg.handle_equal(g2, g1), f)
+        self.assertEqual(bmg.handle_equal(g1, g1), t)
+        self.assertEqual(bmg.handle_equal(g1, g2), f)
+        self.assertTrue(isinstance(bmg.handle_equal(s, t1), EqualNode))
+        self.assertTrue(isinstance(bmg.handle_equal(t1, s), EqualNode))
+
+        self.assertEqual(bmg.handle_not_equal(t2, t1), t)
+        self.assertEqual(bmg.handle_not_equal(t1, t1), f)
+        self.assertEqual(bmg.handle_not_equal(t1, t2), t)
+        self.assertEqual(bmg.handle_not_equal(g2, t1), t)
+        self.assertEqual(bmg.handle_not_equal(g1, t1), f)
+        self.assertEqual(bmg.handle_not_equal(g1, t2), t)
+        self.assertEqual(bmg.handle_not_equal(t2, g1), t)
+        self.assertEqual(bmg.handle_not_equal(t1, g1), f)
+        self.assertEqual(bmg.handle_not_equal(t1, g2), t)
+        self.assertEqual(bmg.handle_not_equal(g2, g1), t)
+        self.assertEqual(bmg.handle_not_equal(g1, g1), f)
+        self.assertEqual(bmg.handle_not_equal(g1, g2), t)
+        self.assertTrue(isinstance(bmg.handle_not_equal(s, t1), NotEqualNode))
+        self.assertTrue(isinstance(bmg.handle_not_equal(t1, s), NotEqualNode))
+
+        self.assertEqual(bmg.handle_greater_than(t2, t1), t)
+        self.assertEqual(bmg.handle_greater_than(t1, t1), f)
+        self.assertEqual(bmg.handle_greater_than(t1, t2), f)
+        self.assertEqual(bmg.handle_greater_than(g2, t1), t)
+        self.assertEqual(bmg.handle_greater_than(g1, t1), f)
+        self.assertEqual(bmg.handle_greater_than(g1, t2), f)
+        self.assertEqual(bmg.handle_greater_than(t2, g1), t)
+        self.assertEqual(bmg.handle_greater_than(t1, g1), f)
+        self.assertEqual(bmg.handle_greater_than(t1, g2), f)
+        self.assertEqual(bmg.handle_greater_than(g2, g1), t)
+        self.assertEqual(bmg.handle_greater_than(g1, g1), f)
+        self.assertEqual(bmg.handle_greater_than(g1, g2), f)
+        self.assertTrue(isinstance(bmg.handle_greater_than(s, t1), GreaterThanNode))
+        self.assertTrue(isinstance(bmg.handle_greater_than(t1, s), GreaterThanNode))
+
+        self.assertEqual(bmg.handle_greater_than_equal(t2, t1), t)
+        self.assertEqual(bmg.handle_greater_than_equal(t1, t1), t)
+        self.assertEqual(bmg.handle_greater_than_equal(t1, t2), f)
+        self.assertEqual(bmg.handle_greater_than_equal(g2, t1), t)
+        self.assertEqual(bmg.handle_greater_than_equal(g1, t1), t)
+        self.assertEqual(bmg.handle_greater_than_equal(g1, t2), f)
+        self.assertEqual(bmg.handle_greater_than_equal(t2, g1), t)
+        self.assertEqual(bmg.handle_greater_than_equal(t1, g1), t)
+        self.assertEqual(bmg.handle_greater_than_equal(t1, g2), f)
+        self.assertEqual(bmg.handle_greater_than_equal(g2, g1), t)
+        self.assertEqual(bmg.handle_greater_than_equal(g1, g1), t)
+        self.assertEqual(bmg.handle_greater_than_equal(g1, g2), f)
+        self.assertTrue(
+            isinstance(bmg.handle_greater_than_equal(s, t1), GreaterThanEqualNode)
+        )
+        self.assertTrue(
+            isinstance(bmg.handle_greater_than_equal(t1, s), GreaterThanEqualNode)
+        )
+
+        self.assertEqual(bmg.handle_less_than(t2, t1), f)
+        self.assertEqual(bmg.handle_less_than(t1, t1), f)
+        self.assertEqual(bmg.handle_less_than(t1, t2), t)
+        self.assertEqual(bmg.handle_less_than(g2, t1), f)
+        self.assertEqual(bmg.handle_less_than(g1, t1), f)
+        self.assertEqual(bmg.handle_less_than(g1, t2), t)
+        self.assertEqual(bmg.handle_less_than(t2, g1), f)
+        self.assertEqual(bmg.handle_less_than(t1, g1), f)
+        self.assertEqual(bmg.handle_less_than(t1, g2), t)
+        self.assertEqual(bmg.handle_less_than(g2, g1), f)
+        self.assertEqual(bmg.handle_less_than(g1, g1), f)
+        self.assertEqual(bmg.handle_less_than(g1, g2), t)
+        self.assertTrue(isinstance(bmg.handle_less_than(s, t1), LessThanNode))
+        self.assertTrue(isinstance(bmg.handle_less_than(t1, s), LessThanNode))
+
+        self.assertEqual(bmg.handle_less_than_equal(t2, t1), f)
+        self.assertEqual(bmg.handle_less_than_equal(t1, t1), t)
+        self.assertEqual(bmg.handle_less_than_equal(t1, t2), t)
+        self.assertEqual(bmg.handle_less_than_equal(g2, t1), f)
+        self.assertEqual(bmg.handle_less_than_equal(g1, t1), t)
+        self.assertEqual(bmg.handle_less_than_equal(g1, t2), t)
+        self.assertEqual(bmg.handle_less_than_equal(t2, g1), f)
+        self.assertEqual(bmg.handle_less_than_equal(t1, g1), t)
+        self.assertEqual(bmg.handle_less_than_equal(t1, g2), t)
+        self.assertEqual(bmg.handle_less_than_equal(g2, g1), f)
+        self.assertEqual(bmg.handle_less_than_equal(g1, g1), t)
+        self.assertEqual(bmg.handle_less_than_equal(g1, g2), t)
+        self.assertTrue(
+            isinstance(bmg.handle_less_than_equal(s, t1), LessThanEqualNode)
+        )
+        self.assertTrue(
+            isinstance(bmg.handle_less_than_equal(t1, s), LessThanEqualNode)
+        )
 
     def test_negation(self) -> None:
         """Test negation"""


### PR DESCRIPTION
Summary:
We can now accumulate comparison operations into the graph builder; this will be necessary for error reporting, because we do not yet support comparison operators in BMG.

We do not yet transform model code containing comparison operators into calls to the graph builder methods; that will be in an upcoming diff.

Reviewed By: wtaha

Differential Revision: D24401918

