### PR TITLE
Give compiler errors for stochastic comparisons

### DIFF
--- a/src/beanmachine/ppl/compiler/bm_to_bmg.py
+++ b/src/beanmachine/ppl/compiler/bm_to_bmg.py
@@ -18,10 +18,16 @@ from beanmachine.ppl.utils.ast_patterns import (
     binop,
     call,
     constant_numeric,
+    equal,
     function_def,
+    greater_than,
+    greater_than_equal,
     index,
+    less_than,
+    less_than_equal,
     load,
     name,
+    not_equal,
     subscript,
     unaryop,
 )
@@ -188,6 +194,59 @@ _handle_power = PatternRule(
     ),
 )
 
+_handle_equal = PatternRule(
+    assign(value=equal()),
+    lambda a: ast.Assign(
+        a.targets,
+        _make_bmg_call("handle_equal", [a.value.left, a.value.comparators[0]]),
+    ),
+)
+
+_handle_not_equal = PatternRule(
+    assign(value=not_equal()),
+    lambda a: ast.Assign(
+        a.targets,
+        _make_bmg_call("handle_not_equal", [a.value.left, a.value.comparators[0]]),
+    ),
+)
+
+
+_handle_greater_than = PatternRule(
+    assign(value=greater_than()),
+    lambda a: ast.Assign(
+        a.targets,
+        _make_bmg_call("handle_greater_than", [a.value.left, a.value.comparators[0]]),
+    ),
+)
+
+_handle_greater_than_equal = PatternRule(
+    assign(value=greater_than_equal()),
+    lambda a: ast.Assign(
+        a.targets,
+        _make_bmg_call(
+            "handle_greater_than_equal", [a.value.left, a.value.comparators[0]]
+        ),
+    ),
+)
+
+_handle_less_than = PatternRule(
+    assign(value=less_than()),
+    lambda a: ast.Assign(
+        a.targets,
+        _make_bmg_call("handle_less_than", [a.value.left, a.value.comparators[0]]),
+    ),
+)
+
+_handle_less_than_equal = PatternRule(
+    assign(value=less_than_equal()),
+    lambda a: ast.Assign(
+        a.targets,
+        _make_bmg_call(
+            "handle_less_than_equal", [a.value.left, a.value.comparators[0]]
+        ),
+    ),
+)
+
 
 _handle_index = PatternRule(
     assign(value=subscript(slice=index())),
@@ -220,6 +279,12 @@ _math_to_bmg: Rule = _top_down(
                 _handle_division,
                 _handle_power,
                 _handle_index,
+                _handle_equal,
+                _handle_not_equal,
+                _handle_greater_than,
+                _handle_greater_than_equal,
+                _handle_less_than,
+                _handle_less_than_equal,
             ]
         )
     )

--- a/src/beanmachine/ppl/compiler/tests/fix_problems_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_problems_test.py
@@ -1039,3 +1039,38 @@ digraph "graph" {
 }
 """
         self.assertEqual(observed.strip(), expected.strip())
+
+    def test_fix_problems_15(self) -> None:
+        """test_fix_problems_15"""
+
+        # Comparisons involving a graph node have no representation in
+        # BMG and should produce an error.
+
+        # TODO: An equality comparison involving two Booleans could be
+        # TODO: turned into an if-then-else.  That is, for Booleans x, y:
+        # TODO: x == y  -->  if x then y else not y
+        # TODO: x != y  -->  if x then not y else y
+
+        self.maxDiff = None
+        bmg = BMGraphBuilder()
+
+        # @rv def normal():
+        #   return Normal(0, 1)
+        # @rv def t():
+        #   return StudentT(1, normal() > 1, 1)
+
+        zero = bmg.add_constant(0.0)
+        one = bmg.add_constant(1.0)
+        norm = bmg.add_normal(zero, one)
+        norms = bmg.add_sample(norm)
+        gt = bmg.add_greater_than(norms, one)
+        t = bmg.add_studentt(one, gt, one)
+        bmg.add_sample(t)
+
+        error_report = fix_problems(bmg)
+        observed = str(error_report)
+        expected = """
+The model uses a > operation unsupported by Bean Machine Graph.
+The unsupported node is the loc of a StudentT.
+"""
+        self.assertEqual(observed.strip(), expected.strip())

--- a/src/beanmachine/ppl/utils/ast_patterns.py
+++ b/src/beanmachine/ppl/utils/ast_patterns.py
@@ -163,6 +163,42 @@ def compare(left: Pattern = _any, ops: Pattern = _any, comparators: Pattern = _a
     )
 
 
+def equal(left: Pattern = _any, right: Pattern = _any):
+    return type_and_attributes(
+        ast.Compare, {"left": left, "ops": [ast.Eq], "comparators": [right]}
+    )
+
+
+def not_equal(left: Pattern = _any, right: Pattern = _any):
+    return type_and_attributes(
+        ast.Compare, {"left": left, "ops": [ast.NotEq], "comparators": [right]}
+    )
+
+
+def greater_than(left: Pattern = _any, right: Pattern = _any):
+    return type_and_attributes(
+        ast.Compare, {"left": left, "ops": [ast.Gt], "comparators": [right]}
+    )
+
+
+def greater_than_equal(left: Pattern = _any, right: Pattern = _any):
+    return type_and_attributes(
+        ast.Compare, {"left": left, "ops": [ast.GtE], "comparators": [right]}
+    )
+
+
+def less_than(left: Pattern = _any, right: Pattern = _any):
+    return type_and_attributes(
+        ast.Compare, {"left": left, "ops": [ast.Lt], "comparators": [right]}
+    )
+
+
+def less_than_equal(left: Pattern = _any, right: Pattern = _any):
+    return type_and_attributes(
+        ast.Compare, {"left": left, "ops": [ast.LtE], "comparators": [right]}
+    )
+
+
 def expr(value: Pattern = _any) -> Pattern:
     return type_and_attributes(ast.Expr, {"value": value})
 


### PR DESCRIPTION
Summary: We need to give an error when an attempt is made to compare anything with a stochastic node, because we have no ability at this time to compile it into a BMG graph. Here we turn statements of the form  `x = y op z` for op being any of `< > <= >= == !=` into graph nodes in the graph accumulator, and then detect in the problem fixer whether any such nodes remain and give an appropriate error.

Reviewed By: wtaha

Differential Revision: D24461905

