### PR TITLE
Sync internal flake8 config with external CI

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,68 @@
 [flake8]
-# E203: black and flake8 disagree on whitespace before ':'
-# W503: black and flake8 disagree on how to place operators
-ignore = E203, W503, E741
-# TODO: decrease the line length limit once fixed in the Python code
-max-line-length = 105
+select = B,C,E,F,P,W,B9
+max-line-length = 80
+# Main Explanation Docs: https://github.com/grantmcconnaughey/Flake8Rules
+ignore =
+  # Black conflicts and overlaps.
+  # Found in https://github.com/psf/black/issues/429
+  B950, # Line too long.
+  E111, # Indentation is not a multiple of four.
+  E115, # Expected an indented block (comment).
+  E117, # Over-indented.
+  E121, # Continuation line under-indented for hanging indent.
+  E122, # Continuation line missing indentation or outdented.
+  E123, # Closing bracket does not match indentation of opening bracket's line.
+  E124, # Closing bracket does not match visual indentation.
+  E125, # Continuation line with same indent as next logical line.
+  E126, # Continuation line over-indented for hanging indent.
+  E127, # Continuation line over-indented for visual indent.
+  E128, # Continuation line under-indented for visual indent.
+  E129, # Visually indented line with same indent as next logical line.
+  E201, # Whitespace after '('.
+  E202, # Whitespace before ')'.
+  E203, # Whitespace before ':'.
+  E221, # Multiple spaces before operator.
+  E222, # Multiple spaces after operator.
+  E225, # Missing whitespace around operator.
+  E226, # Missing whitespace around arithmetic operator.
+  E227, # Missing whitespace around bitwise or shift operator.
+  E231, # Missing whitespace after ',', ';', or ':'.
+  E241, # Multiple spaces after ','.
+  E251, # Unexpected spaces around keyword / parameter equals.
+  E261, # At least two spaces before inline comment.
+  E262, # Inline comment should start with '# '.
+  E265, # Block comment should start with '# '.
+  E271, # Multiple spaces after keyword.
+  E272, # Multiple spaces before keyword.
+  E301, # Expected 1 blank line, found 0.
+  E302, # Expected 2 blank lines, found 0.
+  E303, # Too many blank lines (3).
+  E305, # Expected 2 blank lines after end of function or class.
+  E306, # Expected 1 blank line before a nested definition.
+  E501, # Line too long (82 > 79 characters).
+  E502, # The backslash is redundant between brackets.
+  E701, # Multiple statements on one line (colon).
+  E702, # Multiple statements on one line (semicolon).
+  E703, # Statement ends with a semicolon.
+  E704, # Multiple statements on one line (def).
+  W291, # Trailing whitespace.
+  W292, # No newline at end of file.
+  W293, # Blank line contains whitespace.
+  W391, # Blank line at end of file.
+
+  # Too opinionated.
+  E265, # Block comment should start with '# '.
+  E266, # Too many leading '#' for block comment.
+  E402, # Module level import not at top of file.
+  E722, # Do not use bare except, specify exception instead. (Duplicate of B001)
+  F811, # Redefinition of unused name from line n.
+  P207, # (Duplicate of B003)
+  P208, # (Duplicate of C403)
+  W503  # Line break occurred before a binary operator.
+max-complexity = 12
 exclude =
   build, dist, tutorials, website
+
 [tool:pytest]
 # any ignore= commands can be added here if needed
 addopts =

--- a/src/beanmachine/ppl/experimental/inference_compilation/ic_infer.py
+++ b/src/beanmachine/ppl/experimental/inference_compilation/ic_infer.py
@@ -145,7 +145,7 @@ class ICInference(AbstractMHInference):
         LOGGER_IC.warn(f"No IC artifact found for {node}, using ancestral proposer.")
         return SingleSiteAncestralProposer()
 
-    def compile(
+    def compile(  # noqa: C901
         self,
         observation_keys: Sequence[RVIdentifier],
         num_worlds: int = 100,

--- a/src/beanmachine/ppl/experimental/neutra/maskedautoencoder.py
+++ b/src/beanmachine/ppl/experimental/neutra/maskedautoencoder.py
@@ -76,7 +76,7 @@ class MaskedAutoencoder(nn.Module):
         g1.manual_seed(seed_num)  # assign a seed to generator
         self.create_masks_(in_layer, out_layer, n_block, hidden_layer, g1)
 
-    def create_masks_(
+    def create_masks_(  # noqa: C901
         self, in_layer: int, out_layer: int, n_block: int, hidden_layer: int, g1: Any
     ) -> None:
         """

--- a/src/beanmachine/ppl/inference/predictive.py
+++ b/src/beanmachine/ppl/inference/predictive.py
@@ -26,8 +26,8 @@ class Predictive(object):
     Class for the posterior predictive distribution.
     """
 
-    @staticmethod
-    def simulate(
+    @staticmethod  # noqa: C901
+    def simulate(  # noqa: C901
         queries: List[RVIdentifier],
         posterior: Optional[MonteCarloSamples] = None,
         num_samples: Optional[int] = None,


### PR DESCRIPTION
Summary: As titled. The inconsistency between internal and external linter config have made it hard for internal developers to check the issue locally, as some of the lint error only shows up on CI when a diff gets exported. Notice that things like max line length are still being check by the black linter.

Differential Revision: D24853706

