### PR TITLE
Rewrite world as a context

### DIFF
--- a/src/beanmachine/ppl/experimental/inference_compilation/ic_infer.py
+++ b/src/beanmachine/ppl/experimental/inference_compilation/ic_infer.py
@@ -19,7 +19,7 @@ from ...inference.proposer.abstract_single_site_single_step_proposer import (
 from ...inference.proposer.single_site_ancestral_proposer import (
     SingleSiteAncestralProposer,
 )
-from ...model.utils import RVIdentifier, get_wrapper
+from ...model.utils import RVIdentifier
 from ...world import ProposalDistribution, Variable, World
 from . import utils
 
@@ -336,7 +336,7 @@ class ICInference(AbstractMHInference):
         obs_vec = torch.stack(
             list(
                 map(
-                    lambda node: get_wrapper(node.function)(*node.arguments),
+                    lambda node: self.world_.call(node),
                     sorted(observation_keys, key=str),
                 )
             ),

--- a/src/beanmachine/ppl/experimental/neutra/tests/iafmcmc_do_adaptation_test.py
+++ b/src/beanmachine/ppl/experimental/neutra/tests/iafmcmc_do_adaptation_test.py
@@ -6,16 +6,11 @@ import torch.distributions as dist
 from beanmachine.ppl.distribution.flat import Flat
 from beanmachine.ppl.experimental.neutra.iafmcmc_proposer import IAFMCMCProposer
 from beanmachine.ppl.experimental.neutra.maskedautoencoder import MaskedAutoencoder
-from beanmachine.ppl.model.statistical_model import StatisticalModel
-from beanmachine.ppl.model.utils import Mode
-from beanmachine.ppl.world import Variable
+from beanmachine.ppl.world import Variable, World
 from torch import nn, tensor as tensor
 
 
 class IAFMCMCProposerDoAdaptationTest(unittest.TestCase):
-    def tearDown(self):
-        StatisticalModel.reset()
-
     class Target(dist.Distribution):
         has_enumerate_support = False
         support = dist.constraints.real
@@ -59,10 +54,9 @@ class IAFMCMCProposerDoAdaptationTest(unittest.TestCase):
     def test_neal_funnel(self):
         # set up the world in Bean machine
         model = self.NealFunnel()
-        world = StatisticalModel.reset()
+        world = World()
         foo_key = model.foo()
         bar_key = model.bar()
-        StatisticalModel.set_mode(Mode.INFERENCE)
 
         world.set_observations({bar_key: tensor([0.1, 0.1])})
         # set up the node_var in Bean machine

--- a/src/beanmachine/ppl/experimental/neutra/tests/iafmcmc_jacobian_test.py
+++ b/src/beanmachine/ppl/experimental/neutra/tests/iafmcmc_jacobian_test.py
@@ -8,17 +8,13 @@ import torch.distributions as dist
 from beanmachine.ppl.experimental.neutra.iafmcmc_proposer import IAFMCMCProposer
 from beanmachine.ppl.experimental.neutra.maskedautoencoder import MaskedAutoencoder
 from beanmachine.ppl.inference.abstract_mh_infer import AbstractMHInference
-from beanmachine.ppl.model.statistical_model import StatisticalModel
-from beanmachine.ppl.model.utils import Mode, RVIdentifier
-from beanmachine.ppl.world import Variable
+from beanmachine.ppl.model.utils import RVIdentifier
+from beanmachine.ppl.world import Variable, World
 from beanmachine.ppl.world.world import TransformType
 from torch import nn, tensor as tensor
 
 
 class IAFJacobainTest(unittest.TestCase):
-    def tearDown(self):
-        StatisticalModel.reset()
-
     class SampleModel(object):
         @bm.random_variable
         def foo(self):
@@ -52,12 +48,11 @@ class IAFJacobainTest(unittest.TestCase):
         )
 
     def test_jacobain_for_iaf_proposer(self):
-        world = StatisticalModel.reset()
+        world = World()
         model = self.SampleModel()
         foo_key = model.foo()
         bar_key = model.bar()
 
-        StatisticalModel.set_mode(Mode.INFERENCE)
         world.set_observations({bar_key: tensor([0.1, 0.1])})
         world_vars = world.variables_.vars()
 

--- a/src/beanmachine/ppl/experimental/neutra/tests/train_test.py
+++ b/src/beanmachine/ppl/experimental/neutra/tests/train_test.py
@@ -7,16 +7,11 @@ import torch.tensor as tensor
 from beanmachine.ppl.distribution.flat import Flat
 from beanmachine.ppl.experimental.neutra.maskedautoencoder import MaskedAutoencoder
 from beanmachine.ppl.experimental.neutra.train import IAFMap
-from beanmachine.ppl.model.statistical_model import StatisticalModel
-from beanmachine.ppl.model.utils import Mode
-from beanmachine.ppl.world import Variable
+from beanmachine.ppl.world import Variable, World
 from torch import nn
 
 
 class TraininfTest(unittest.TestCase):
-    def tearDown(self):
-        StatisticalModel.reset()
-
     class SampleModel(object):
         @bm.random_variable
         def foo(self):
@@ -61,12 +56,11 @@ class TraininfTest(unittest.TestCase):
 
     def test_normal_normal(self):
         # set up the world in Bean machine
-        world = StatisticalModel.reset()
+        world = World()
         model = self.SampleModel()
         foo_key = model.foo()
         bar_key = model.bar()
 
-        StatisticalModel.set_mode(Mode.INFERENCE)
         world.set_observations({bar_key: tensor([0.1, 0.1])})
         # set up the node_var in Bean machine
         world_vars = world.variables_.vars()
@@ -138,10 +132,9 @@ class TraininfTest(unittest.TestCase):
     def test_neal_funnel(self):
         # set up the world in Bean machine
         model = self.NealFunnel()
-        world = StatisticalModel.reset()
+        world = World()
         foo_key = model.foo()
         bar_key = model.bar()
-        StatisticalModel.set_mode(Mode.INFERENCE)
 
         world.set_observations({bar_key: tensor([0.1, 0.1])})
         # set up the node_var in Bean machine

--- a/src/beanmachine/ppl/experimental/tests/inference_compilation_test.py
+++ b/src/beanmachine/ppl/experimental/tests/inference_compilation_test.py
@@ -7,15 +7,10 @@ import torch.distributions as dist
 from beanmachine.ppl.distribution import Flat
 from beanmachine.ppl.examples.conjugate_models import NormalNormalModel
 from beanmachine.ppl.experimental.inference_compilation.ic_infer import ICInference
-from beanmachine.ppl.model.statistical_model import StatisticalModel
 from torch import tensor
 
 
 class InferenceCompilationTest(unittest.TestCase):
-    def tearDown(self) -> None:
-        # reset the StatisticalModel to prevent subsequent tests from failing
-        StatisticalModel.reset()
-
     class RandomGaussianSum:
         @bm.random_variable
         def N(self):

--- a/src/beanmachine/ppl/inference/abstract_infer.py
+++ b/src/beanmachine/ppl/inference/abstract_infer.py
@@ -10,7 +10,6 @@ import torch.multiprocessing as mp
 from torch import Tensor
 from torch.multiprocessing import Queue
 
-from ..model.statistical_model import StatisticalModel
 from ..model.utils import LogLevel, RVIdentifier
 from ..world import World
 from .monte_carlo_samples import MonteCarloSamples
@@ -38,9 +37,8 @@ class AbstractInference(object, metaclass=ABCMeta):
     _rand_int_max: ClassVar[int] = 2 ** 62
 
     def __init__(self):
-        self.world_ = World()
-        self.initial_world_ = self.world_
-        StatisticalModel.reset()
+        self.initial_world_ = World()
+        self.world_ = self.initial_world_
         self.queries_ = []
         self.observations_ = {}
 
@@ -148,18 +146,10 @@ class AbstractInference(object, metaclass=ABCMeta):
             self.reset()
         return monte_carlo_samples
 
-    def initialize_infer(self):
-        """
-        Initialize inference
-        """
-        self.initial_world_ = self.world_.copy()
-        StatisticalModel.set_world(self.world_)
-
     def reset(self):
         """
         Resets world, mode and observation
         """
-        self.world_ = self.initial_world_
-        StatisticalModel.reset()
+        self.world_ = self.initial_world_.copy()
         self.queries_ = []
         self.observations_ = {}

--- a/src/beanmachine/ppl/inference/proposer/tests/abstract_single_site_single_step_proposer_test.py
+++ b/src/beanmachine/ppl/inference/proposer/tests/abstract_single_site_single_step_proposer_test.py
@@ -13,17 +13,12 @@ from beanmachine.ppl.inference.proposer.abstract_single_site_single_step_propose
 from beanmachine.ppl.inference.proposer.single_site_half_space_newtonian_monte_carlo_proposer import (
     SingleSiteHalfSpaceNewtonianMonteCarloProposer,
 )
-from beanmachine.ppl.model.statistical_model import StatisticalModel
 from beanmachine.ppl.model.utils import RVIdentifier
 from beanmachine.ppl.world import ProposalDistribution, Variable, World
 from beanmachine.ppl.world.world import TransformType
 
 
 class SingleSiteCustomProposerTest(unittest.TestCase):
-    def tearDown(self) -> None:
-        # reset the StatisticalModel to prevent subsequent tests from failing
-        StatisticalModel.reset()
-
     class CustomProposer(AbstractSingleSiteSingleStepProposer):
         def get_proposal_distribution(
             self,

--- a/src/beanmachine/ppl/inference/proposer/tests/single_site_no_u_turn_sampler_proposer_test.py
+++ b/src/beanmachine/ppl/inference/proposer/tests/single_site_no_u_turn_sampler_proposer_test.py
@@ -8,8 +8,7 @@ import torch.tensor as tensor
 from beanmachine.ppl.inference.proposer.single_site_no_u_turn_sampler_proposer import (
     SingleSiteNoUTurnSamplerProposer,
 )
-from beanmachine.ppl.model.statistical_model import StatisticalModel
-from beanmachine.ppl.world import Variable
+from beanmachine.ppl.world import Variable, World
 from torch.autograd import grad
 
 
@@ -21,7 +20,7 @@ class SingleSiteNoUTurnSamplerProposerTest(unittest.TestCase):
         self.assertAlmostEqual(k.item(), 1.775)
 
     def test_nuts_leapfrog_step(self):
-        world = StatisticalModel.reset()
+        world = World()
         proposer = SingleSiteNoUTurnSamplerProposer()
         distribution = dist.Normal(0, 1)
         val = tensor(1.0)
@@ -65,7 +64,7 @@ class SingleSiteNoUTurnSamplerProposerTest(unittest.TestCase):
         self.assertAlmostEqual(proposer_r, handwritten_r)
 
     def test_nuts_build_tree_base_case_invalid(self):
-        world = StatisticalModel.reset()
+        world = World()
         proposer = SingleSiteNoUTurnSamplerProposer()
         distribution = dist.Normal(0, 1)
         val = tensor(1.0)
@@ -114,7 +113,7 @@ class SingleSiteNoUTurnSamplerProposerTest(unittest.TestCase):
         self.assertAlmostEqual(output[8], tensor(1.0))
 
     def test_nuts_build_tree_base_case_valid(self):
-        world = StatisticalModel.reset()
+        world = World()
         proposer = SingleSiteNoUTurnSamplerProposer()
         distribution = dist.Normal(0, 1)
         val = tensor(1.0)
@@ -180,7 +179,7 @@ class SingleSiteNoUTurnSamplerProposerTest(unittest.TestCase):
         self.assertAlmostEqual(output[8], tensor(1.0))
 
     def test_nuts_build_tree(self):
-        world = StatisticalModel.reset()
+        world = World()
         proposer = SingleSiteNoUTurnSamplerProposer()
         distribution = dist.Normal(0, 1)
         val = tensor(1.0)
@@ -260,7 +259,7 @@ class SingleSiteNoUTurnSamplerProposerTest(unittest.TestCase):
         self.assertAlmostEqual(output[8], tensor(2.0))
 
     def test_nuts_compute_hamiltonian(self):
-        world = StatisticalModel.reset()
+        world = World()
         proposer = SingleSiteNoUTurnSamplerProposer()
         distribution = dist.Normal(0, 1)
         val = tensor(1.0)

--- a/src/beanmachine/ppl/inference/tests/compositional_infer_test.py
+++ b/src/beanmachine/ppl/inference/tests/compositional_infer_test.py
@@ -19,7 +19,7 @@ from beanmachine.ppl.inference.proposer.single_site_uniform_proposer import (
     SingleSiteUniformProposer,
 )
 from beanmachine.ppl.inference.utils import Block, BlockType
-from beanmachine.ppl.model.statistical_model import StatisticalModel, sample
+from beanmachine.ppl.model.statistical_model import sample
 from beanmachine.ppl.model.utils import get_wrapper
 from beanmachine.ppl.world.utils import BetaDimensionTransform
 from beanmachine.ppl.world.variable import TransformType, Variable
@@ -27,10 +27,6 @@ from beanmachine.ppl.world.world import World
 
 
 class CompositionalInferenceTest(unittest.TestCase):
-    def tearDown(self) -> None:
-        # reset the StatisticalModel to prevent subsequent tests from failing
-        StatisticalModel.reset()
-
     class SampleModel(object):
         @bm.random_variable
         def foo(self):

--- a/src/beanmachine/ppl/model/__init__.py
+++ b/src/beanmachine/ppl/model/__init__.py
@@ -6,7 +6,7 @@ from beanmachine.ppl.model.statistical_model import (
     random_variable,
     sample,
 )
-from beanmachine.ppl.model.utils import Mode, RVIdentifier, get_beanmachine_logger
+from beanmachine.ppl.model.utils import RVIdentifier, get_beanmachine_logger
 
 
 __all__ = [

--- a/src/beanmachine/ppl/model/tests/statistical_model_test.py
+++ b/src/beanmachine/ppl/model/tests/statistical_model_test.py
@@ -4,15 +4,11 @@ import unittest
 import beanmachine.ppl as bm
 import torch
 import torch.distributions as dist
-from beanmachine.ppl.model.statistical_model import RVIdentifier, StatisticalModel
-from beanmachine.ppl.model.utils import Mode
+from beanmachine.ppl.model.statistical_model import RVIdentifier
+from beanmachine.ppl.world import World
 
 
 class StatisticalModelTest(unittest.TestCase):
-    def tearDown(self) -> None:
-        # reset the StatisticalModel to prevent subsequent tests from failing
-        StatisticalModel.reset()
-
     class SampleModel(object):
         @bm.random_variable
         def foo(self):
@@ -57,15 +53,15 @@ class StatisticalModelTest(unittest.TestCase):
 
     def test_rv_sample_assignment(self):
         model = self.SampleModel()
-        world = StatisticalModel.reset()
+        world = World()
         foo_key = model.foo()
         bar_key = model.bar()
         baz_key = model.baz()
 
-        StatisticalModel.set_mode(Mode.INFERENCE)
-        model.foo()
-        model.bar()
-        model.baz()
+        with world:
+            model.foo()
+            model.bar()
+            model.baz()
 
         foo_expected_parent = set()
         foo_expected_children = set({bar_key, baz_key})
@@ -103,7 +99,7 @@ class StatisticalModelTest(unittest.TestCase):
 
     def test_rv_sample_assignment_with_large_model_with_index(self):
         model = self.SampleLargeModel()
-        world = StatisticalModel.reset()
+        world = World()
         foo_key = model.foo()
         bar_key = model.bar()
         baz_key = model.baz()
@@ -112,13 +108,13 @@ class StatisticalModelTest(unittest.TestCase):
         foobaz_key = model.foobaz()
         query_key = model.avg()
 
-        StatisticalModel.set_mode(Mode.INFERENCE)
-        model.foo()
-        model.bar()
-        model.baz()
-        model.foobar()
-        model.bazbar(1)
-        model.foobaz()
+        with world:
+            model.foo()
+            model.bar()
+            model.baz()
+            model.foobar()
+            model.bazbar(1)
+            model.foobaz()
 
         foo_expected_parent = set()
         foo_expected_children = set({bar_key, baz_key, bazbar_key, foobaz_key})

--- a/src/beanmachine/ppl/model/utils.py
+++ b/src/beanmachine/ppl/model/utils.py
@@ -26,15 +26,6 @@ class RVIdentifier:
         return str(self.function.__name__) + str(self.arguments)
 
 
-class Mode(Enum):
-    """
-    Stages/modes that a model will go through
-    """
-
-    INITIALIZE = 1
-    INFERENCE = 2
-
-
 class LogLevel(Enum):
     """
     Enum class mapping the logging levels to numeric values.

--- a/src/beanmachine/ppl/world/tests/diff_stack_test.py
+++ b/src/beanmachine/ppl/world/tests/diff_stack_test.py
@@ -4,9 +4,7 @@ import unittest
 import beanmachine.ppl as bm
 import torch.distributions as dist
 import torch.tensor as tensor
-from beanmachine.ppl.model.statistical_model import StatisticalModel
-from beanmachine.ppl.model.utils import Mode
-from beanmachine.ppl.world import Diff, Variable
+from beanmachine.ppl.world import Diff, Variable, World
 
 
 class DiffStackTest(unittest.TestCase):
@@ -21,10 +19,9 @@ class DiffStackTest(unittest.TestCase):
 
     def test_diffstack_change(self):
         model = self.SampleModel()
-        world = StatisticalModel.reset()
+        world = World()
         foo_key = model.foo()
         bar_key = model.bar()
-        StatisticalModel.set_mode(Mode.INFERENCE)
         world.set_observations({bar_key: tensor(0.1)})
         diff_vars = world.diff_stack_
         foo_var = Variable(


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookincubator/beanmachine/pull/463

This diff is an attempt to see if we can move away from a global "world" and use context to limit its scope.

Usage:
```
w = World()
with w:
    # calls to random variables or the wrapper functions
    # are going to be associated with `w`
    foo()
```

Additionally, when a world is activated, the outer context is kept and will be restored when we leave the context, which enable us to do something like
```
with World() as w1:
    # do something to update w1

    with World() as w2:
       # do something else to update w2

    # w1 context is restored, we can continue updating it if needed
```

The context is only necessary for function that invokes the `@random_variable` or `@functional` decorator. To simplify the process, I also added a method `World.get()` that activate the context and invoke the random variable.

So instead of
```
StatisticalModel.set_world(world)
StatisticalModel.set_mode(Mode.INFERENCE)
value = get_wrapper(node.function)(*node.arguments)
```
we could simply do
```
value = world.get(node)
```

Differential Revision: D24916384