### PR TITLE
NUTS mass matrix

### DIFF
--- a/src/beanmachine/ppl/inference/proposer/tests/single_site_no_u_turn_sampler_proposer_test.py
+++ b/src/beanmachine/ppl/inference/proposer/tests/single_site_no_u_turn_sampler_proposer_test.py
@@ -180,7 +180,7 @@ class SingleSiteNoUTurnSamplerProposerTest(unittest.TestCase):
 
     def test_nuts_build_tree(self):
         world = World()
-        proposer = SingleSiteNoUTurnSamplerProposer()
+        proposer = SingleSiteNoUTurnSamplerProposer(use_dense_mass_matrix=False)
         distribution = dist.Normal(0, 1)
         val = tensor(1.0)
         val.requires_grad_(True)

--- a/src/beanmachine/ppl/inference/single_site_no_u_turn_sampler.py
+++ b/src/beanmachine/ppl/inference/single_site_no_u_turn_sampler.py
@@ -17,6 +17,7 @@ class SingleSiteNoUTurnSampler(AbstractMHInference):
 
     def __init__(
         self,
+        use_dense_mass_matrix: bool = True,
         transform_type: TransformType = TransformType.DEFAULT,
         transforms: Optional[List] = None,
     ):
@@ -26,6 +27,7 @@ class SingleSiteNoUTurnSampler(AbstractMHInference):
             transforms=transforms,
         )
         self.proposer_ = {}
+        self.use_dense_mass_matrix = use_dense_mass_matrix
 
     def find_best_single_site_proposer(self, node: RVIdentifier):
         """
@@ -36,5 +38,7 @@ class SingleSiteNoUTurnSampler(AbstractMHInference):
         :returns: a proposer for the node
         """
         if node not in self.proposer_:
-            self.proposer_[node] = SingleSiteNoUTurnSamplerProposer()
+            self.proposer_[node] = SingleSiteNoUTurnSamplerProposer(
+                self.use_dense_mass_matrix
+            )
         return self.proposer_[node]

--- a/src/beanmachine/ppl/inference/tests/single_site_no_u_turn_conjugate_test_nightly.py
+++ b/src/beanmachine/ppl/inference/tests/single_site_no_u_turn_conjugate_test_nightly.py
@@ -12,38 +12,62 @@ class SingleSiteNoUTurnConjugateTest(unittest.TestCase, AbstractConjugateTests):
     # see Adapative HMC Conjugate Tests for more details
 
     def test_beta_binomial_conjugate_run(self):
+        nuts = SingleSiteNoUTurnSampler(use_dense_mass_matrix=False)
+        self.beta_binomial_conjugate_run(
+            nuts, num_samples=100, delta=0.05, num_adaptive_samples=50
+        )
         nuts = SingleSiteNoUTurnSampler()
         self.beta_binomial_conjugate_run(
             nuts, num_samples=100, delta=0.05, num_adaptive_samples=50
         )
 
     def test_gamma_gamma_conjugate_run(self):
+        nuts = SingleSiteNoUTurnSampler(use_dense_mass_matrix=False)
+        self.gamma_gamma_conjugate_run(
+            nuts, num_samples=200, delta=0.07, num_adaptive_samples=100
+        )
         nuts = SingleSiteNoUTurnSampler()
         self.gamma_gamma_conjugate_run(
             nuts, num_samples=200, delta=0.07, num_adaptive_samples=100
         )
 
     def test_gamma_normal_conjugate_run(self):
-        nuts = SingleSiteNoUTurnSampler()
+        nuts = SingleSiteNoUTurnSampler(use_dense_mass_matrix=False)
         # TODO: The delta in the following needs to be reduced
+        self.gamma_normal_conjugate_run(
+            nuts, num_samples=150, delta=0.16, num_adaptive_samples=50
+        )
+        nuts = SingleSiteNoUTurnSampler()
         self.gamma_normal_conjugate_run(
             nuts, num_samples=150, delta=0.16, num_adaptive_samples=50
         )
 
     def test_normal_normal_conjugate_run(self):
-        nuts = SingleSiteNoUTurnSampler()
+        nuts = SingleSiteNoUTurnSampler(use_dense_mass_matrix=False)
         # TODO: The delta in the following needs to be reduced
+        self.normal_normal_conjugate_run(
+            nuts, num_samples=200, delta=0.08, num_adaptive_samples=100
+        )
+        nuts = SingleSiteNoUTurnSampler()
         self.normal_normal_conjugate_run(
             nuts, num_samples=200, delta=0.08, num_adaptive_samples=100
         )
 
     def test_distant_normal_normal_conjugate_run(self):
+        nuts = SingleSiteNoUTurnSampler(use_dense_mass_matrix=False)
+        self.distant_normal_normal_conjugate_run(
+            nuts, num_samples=200, delta=0.15, num_adaptive_samples=100
+        )
         nuts = SingleSiteNoUTurnSampler()
         self.distant_normal_normal_conjugate_run(
             nuts, num_samples=200, delta=0.15, num_adaptive_samples=100
         )
 
     def test_dirichlet_categorical_conjugate_run(self):
+        nuts = SingleSiteNoUTurnSampler(use_dense_mass_matrix=False)
+        self.dirichlet_categorical_conjugate_run(
+            nuts, num_samples=200, delta=0.05, num_adaptive_samples=100
+        )
         nuts = SingleSiteNoUTurnSampler()
         self.dirichlet_categorical_conjugate_run(
             nuts, num_samples=200, delta=0.05, num_adaptive_samples=100

--- a/src/beanmachine/ppl/tests/smoke_test.py
+++ b/src/beanmachine/ppl/tests/smoke_test.py
@@ -34,6 +34,6 @@ class ToplevelSmokeTest(unittest.TestCase):
 
         # NUTS
         samples = bm.SingleSiteNoUTurnSampler().infer(
-            [bar()], {foo(0): tensor(0.0)}, 500, 1, num_adaptive_samples=500
+            [bar()], {foo(0): tensor(0.0)}, 100, 1, num_adaptive_samples=200
         )
         bm.Diagnostics(samples)


### PR DESCRIPTION
Summary:
adding mass matrix as default option for NUTS

run by calling `SingleSiteNoUTurnSampler(use_dense_mass_matrix=True)`

Reviewed By: nazanint

Differential Revision: D24293072

