### PR TITLE
Introduce RVWrapper

### DIFF
--- a/src/beanmachine/ppl/inference/abstract_mh_infer.py
+++ b/src/beanmachine/ppl/inference/abstract_mh_infer.py
@@ -10,7 +10,7 @@ import torch.distributions as dist
 import torch.tensor as tensor
 from beanmachine.ppl.inference.abstract_infer import AbstractInference, VerboseLevel
 from beanmachine.ppl.inference.utils import Block, BlockType
-from beanmachine.ppl.model.utils import LogLevel, RVIdentifier, get_wrapper
+from beanmachine.ppl.model.utils import LogLevel, RVIdentifier
 from beanmachine.ppl.world.variable import TransformType
 from torch import Tensor
 from tqdm.auto import tqdm  # pyre-ignore
@@ -170,7 +170,7 @@ class AbstractMHInference(AbstractInference, metaclass=ABCMeta):
         """
         markov_blanket = set({block.first_node})
         markov_blanket_func = {}
-        markov_blanket_func[get_wrapper(block.first_node.function)] = [block.first_node]
+        markov_blanket_func[block.first_node.wrapper] = [block.first_node]
         pos_proposal_log_updates, neg_proposal_log_updates = tensor(0.0), tensor(0.0)
         children_log_updates, nodes_log_updates = tensor(0.0), tensor(0.0)
         # We will go through all family of random variable in the block. Note
@@ -241,9 +241,9 @@ class AbstractMHInference(AbstractInference, metaclass=ABCMeta):
                     # We create a dictionary from node family to the node itself
                     # as the match with block happens at the family level and
                     # this makes the lookup much faster.
-                    if get_wrapper(new_node.function) not in markov_blanket_func:
-                        markov_blanket_func[get_wrapper(new_node.function)] = []
-                    markov_blanket_func[get_wrapper(new_node.function)].append(new_node)
+                    if new_node.wrapper not in markov_blanket_func:
+                        markov_blanket_func[new_node.wrapper] = []
+                    markov_blanket_func[new_node.wrapper].append(new_node)
                 markov_blanket |= new_nodes_to_be_added
 
         proposal_log_updates = pos_proposal_log_updates + neg_proposal_log_updates
@@ -284,7 +284,7 @@ class AbstractMHInference(AbstractInference, metaclass=ABCMeta):
             blocks.append(Block(first_node=node, type=BlockType.SINGLENODE, block=[]))
         for block in self.blocks_:
             first_node_str = block[0]
-            first_nodes = self.world_.get_all_nodes_from_func(first_node_str)
+            first_nodes = self.world_.get_all_nodes_from_wrapper(first_node_str)
             for node in first_nodes:
                 blocks.append(
                     Block(first_node=node, type=BlockType.SEQUENTIAL, block=block)

--- a/src/beanmachine/ppl/inference/tests/compositional_infer_test.py
+++ b/src/beanmachine/ppl/inference/tests/compositional_infer_test.py
@@ -19,8 +19,6 @@ from beanmachine.ppl.inference.proposer.single_site_uniform_proposer import (
     SingleSiteUniformProposer,
 )
 from beanmachine.ppl.inference.utils import Block, BlockType
-from beanmachine.ppl.model.statistical_model import sample
-from beanmachine.ppl.model.utils import get_wrapper
 from beanmachine.ppl.world.utils import BetaDimensionTransform
 from beanmachine.ppl.world.variable import TransformType, Variable
 from beanmachine.ppl.world.world import World
@@ -88,27 +86,27 @@ class CompositionalInferenceTest(unittest.TestCase):
             return dist.Categorical(self.alpha())
 
     class SampleTransformModel(object):
-        @sample
+        @bm.random_variable
         def realspace(self):
             return dist.Normal(tensor(0.0), tensor(1.0))
 
-        @sample
+        @bm.random_variable
         def halfspace(self):
             return dist.Gamma(tensor(2.0), tensor(2.0))
 
-        @sample
+        @bm.random_variable
         def simplex(self):
             return dist.Dirichlet(tensor([0.1, 0.9]))
 
-        @sample
+        @bm.random_variable
         def interval(self):
             return dist.Uniform(tensor(1.0), tensor(3.0))
 
-        @sample
+        @bm.random_variable
         def beta(self):
             return dist.Beta(tensor(1.0), tensor(1.0))
 
-        @sample
+        @bm.random_variable
         def discrete(self):
             return dist.Poisson(tensor(2.0))
 
@@ -269,7 +267,7 @@ class CompositionalInferenceTest(unittest.TestCase):
                 first_nodes.append(block.first_node)
                 self.assertEqual(
                     block.block,
-                    list(map(get_wrapper, [foo_0_key.function, bar_0_key.function])),
+                    [foo_0_key.wrapper, bar_0_key.wrapper],
                 )
             if block.type == BlockType.SINGLENODE:
                 self.assertEqual(block.block, [])
@@ -282,7 +280,7 @@ class CompositionalInferenceTest(unittest.TestCase):
             Block(
                 first_node=foo_0_key,
                 type=BlockType.SEQUENTIAL,
-                block=list(map(get_wrapper, [foo_0_key.function, bar_0_key.function])),
+                block=[foo_0_key.wrapper, bar_0_key.wrapper],
             )
         )
 

--- a/src/beanmachine/ppl/model/__init__.py
+++ b/src/beanmachine/ppl/model/__init__.py
@@ -1,4 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
+from beanmachine.ppl.model.rv_wrapper import RVWrapper
 from beanmachine.ppl.model.statistical_model import (
     StatisticalModel,
     functional,
@@ -6,16 +7,17 @@ from beanmachine.ppl.model.statistical_model import (
     random_variable,
     sample,
 )
-from beanmachine.ppl.model.utils import RVIdentifier, get_beanmachine_logger
+from beanmachine.ppl.model.utils import LogLevel, RVIdentifier, get_beanmachine_logger
 
 
 __all__ = [
-    "Mode",
     "RVIdentifier",
+    "RVWrapper",
     "StatisticalModel",
     "functional",
     "query",
     "random_variable",
     "sample",
     "get_beanmachine_logger",
+    "LogLevel",
 ]

--- a/src/beanmachine/ppl/model/rv_wrapper.py
+++ b/src/beanmachine/ppl/model/rv_wrapper.py
@@ -1,0 +1,93 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import dataclasses
+import inspect
+from functools import update_wrapper
+from typing import Callable
+
+import beanmachine.ppl.world
+from beanmachine.ppl.model.utils import RVIdentifier
+
+
+@dataclasses.dataclass(eq=True)
+class RVWrapper:
+    """
+    A class that wraps any function that's defined with @random_variable decorator, e.g.
+    ```
+    @random_variable
+    def foo(i):
+        return Normal(0, 1)
+
+    print(type(foo)) # <- should be `RVWrapper`
+
+    foo(1) # <- this will invoke `RVWrapper.__call__`
+    ```
+    """
+
+    function: Callable
+    is_random_variable: bool = True
+
+    def __post_init__(self):
+        """dataclasses.dataclass generates the __init__ for us and will run
+        __post_init__ every time after __init__ is called"""
+        # Copy metadata (docstring, etc.) from original function over to wrapper
+        update_wrapper(wrapper=self, wrapped=self.function)
+
+    def __get__(self, instance, owner=None):
+        """
+        In Python, calling `a.b` is basically equivalent to
+        ```
+        type(a).__dict__['b'].__get__(a, type(a))
+        ```
+
+        Additionally, class methods have type "function" at definition time; they only
+        become "method" when we try to access `some_instance.some_method`... where
+        `some_method.__get__` is invoked under the hood.
+
+        So, by defining `RVWrapper.__get__`, we are able to obtain a reference to the
+        instance object, e.g.
+        ```
+        class Foo:
+            @bm.random_variable
+            def bar(self):
+                ...
+
+        type(Foo.bar)  # <- should be RVWrapper (this is also a class attribute)
+        type(Foo.bar.function)  # <- should be "function" (i.e. not bound)
+        foo = Foo()
+        type(foo.bar)  # <- should be another RVWrapper. This'll be a copy of Foo.bar
+                       # with function replaced by a "method" (i.e. bound function)
+        type(foo.bar.function)  # <- should be "method"
+        type(foo.bar.function.__self__)  # <- should be foo
+        ```
+
+        Related reading:
+        https://docs.python.org/3/reference/datamodel.html#invoking-descriptors
+        """
+        # "function" becomes "method" (with reference to "self") when __get__ is called
+        # while trying to call __get__ on a "method" changes nothing
+        bound_method = self.function.__get__(instance, owner)
+        # dataclasses.replace return a new instance (without modifying the current one)
+        return dataclasses.replace(self, function=bound_method)
+
+    def __call__(self, *args):
+        """The main body of the decorator, which will invoked on regular function call"""
+        identifier = RVIdentifier(arguments=args, wrapper=self)
+        world = beanmachine.ppl.world.world_context.get()
+
+        if world:
+            if self.is_random_variable:
+                return world.update_graph(node=identifier)
+            else:
+                return world.update_functionals(node=identifier)
+        else:
+            return identifier
+
+    def __hash__(self):
+        return hash(self.function)
+
+    @property
+    def model(self):
+        """A quicker way to retrieve a reference to the instance object"""
+        if inspect.ismethod(self.function):
+            return self.function.__self__
+        return None

--- a/src/beanmachine/ppl/model/tests/rv_wrapper_test.py
+++ b/src/beanmachine/ppl/model/tests/rv_wrapper_test.py
@@ -1,0 +1,91 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import inspect
+import unittest
+
+import beanmachine.ppl as bm
+import torch
+import torch.distributions as dist
+from beanmachine.ppl.model.rv_wrapper import RVWrapper
+from beanmachine.ppl.model.utils import RVIdentifier
+from beanmachine.ppl.world import World
+
+
+# used in testing global random variable
+@bm.random_variable
+def foo():
+    return dist.Normal(torch.tensor(0.0), torch.tensor(1.0))
+
+
+class RVWrapperTest(unittest.TestCase):
+    class SampleModel:
+        @bm.random_variable
+        def foo(self):
+            return dist.Normal(torch.tensor(0.0), torch.tensor(1.0))
+
+        @bm.random_variable
+        def bar(self):
+            return dist.Normal(self.foo(), torch.tensor(1.0))
+
+        @bm.random_variable
+        def baz(self, i: int):
+            return dist.Normal(self.foo(), self.bar())
+
+        def demo(self):
+            pass
+
+    def test_rv_wrapper_type(self):
+        model = self.SampleModel()
+
+        self.assertIsInstance(model.foo, RVWrapper)
+        self.assertIsInstance(model.bar, RVWrapper)
+        self.assertIsInstance(foo, RVWrapper)
+        self.assertIsInstance(self.SampleModel.bar, RVWrapper)
+
+    def test_rv_wrapper_instance_binding(self):
+        m = self.SampleModel()
+
+        self.assertFalse(inspect.ismethod(foo.function))
+        self.assertFalse(inspect.ismethod(self.SampleModel.foo.function))
+        self.assertTrue(inspect.ismethod(m.foo.function))
+
+        # check if m.foo.function is correctly bound to model
+        self.assertIs(m.foo.function.__self__, m)
+        self.assertIs(m.foo.model, m)  # this is equivalent to the line above
+        # method.__func__ should refer to the underlying (unbound) function
+        self.assertIs(m.foo.function.__func__, self.SampleModel.foo.function)
+
+        # check if global random variable is indeed unbound
+        self.assertIsNone(foo.model)
+
+    def test_calling_rv_wrapper(self):
+        world = World()
+        model = self.SampleModel()
+
+        baz_key = model.baz(1)
+        self.assertIsInstance(baz_key, RVIdentifier)
+
+        self.assertIsInstance(baz_key.wrapper, RVWrapper)
+        self.assertEqual(baz_key.wrapper, model.baz)
+        # Notice that when we call __get__, a new instance of RVWrapper is created,
+        # which might be at a different address (so we should check for value
+        # equivalence rather than address equivalence), i.e.
+        self.assertIsNot(baz_key.wrapper, model.baz)
+        # in fact, even on regular Python function, binding the same function twice
+        # will create two methods object
+        self.assertIsNot(model.demo, model.demo)
+
+        # RVIdentifier should store a tuple of arguments (excluding 'self')
+        self.assertTupleEqual(baz_key.arguments, (1,))
+
+        with world:
+            # the following calls should be equivalent
+            value1 = model.baz(1)
+            value2 = baz_key.wrapper(*baz_key.arguments)
+        self.assertEqual(value1, value2)
+
+        # the same applies for global random variable
+        foo_key = foo()
+        with world:
+            value1 = foo()
+            value2 = foo_key.wrapper(*foo_key.arguments)
+        self.assertEqual(value1, value2)

--- a/src/beanmachine/ppl/model/tests/statistical_model_test.py
+++ b/src/beanmachine/ppl/model/tests/statistical_model_test.py
@@ -4,7 +4,7 @@ import unittest
 import beanmachine.ppl as bm
 import torch
 import torch.distributions as dist
-from beanmachine.ppl.model.statistical_model import RVIdentifier
+from beanmachine.ppl.model import RVIdentifier
 from beanmachine.ppl.world import World
 
 

--- a/src/beanmachine/ppl/model/utils.py
+++ b/src/beanmachine/ppl/model/utils.py
@@ -1,5 +1,4 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
-import inspect
 import logging
 from dataclasses import dataclass
 from enum import Enum
@@ -8,22 +7,27 @@ from typing import Any
 import torch
 
 
-def get_wrapper(f):
-    """
-    Gets wrapped function given a Python callable
-    """
-    if inspect.ismethod(f):
-        return getattr(f.__self__, f.__name__ + "_wrapper")
-    return f._wrapper
-
-
 @dataclass(eq=True, frozen=True)
 class RVIdentifier:
-    function: Any
+    """
+    Creates a key to uniquely identify the Random Variable.
+
+    :param wrapper: reference to the decorator class that wraps the function
+    :param arguments: function arguments
+    """
+
     arguments: Any
+    wrapper: Any
 
     def __str__(self):
         return str(self.function.__name__) + str(self.arguments)
+
+    @property
+    def function(self):
+        return self.wrapper.function
+
+    def run(self):
+        return self.function(*self.arguments)
 
 
 class LogLevel(Enum):

--- a/src/beanmachine/ppl/utils/memoize.py
+++ b/src/beanmachine/ppl/utils/memoize.py
@@ -1,19 +1,19 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
-import inspect
-from functools import wraps
-from typing import Any, Dict, List
+import dataclasses
+from functools import update_wrapper
+from typing import Any, Callable, Dict, List
 
-from beanmachine.ppl.model import StatisticalModel
+from beanmachine.ppl.model import RVIdentifier
 from torch import Tensor
 
 
-def _get_memoization_key(f, args):
+def _get_memoization_key(wrapper, args):
     # The problem is that tensors can only be compared for equality with
     # torch.equal(t1, t2), and tensors do not hash via value equality.
     # If we have an argument that is a tensor, we'll replace it with
     # the tensor as a string and hope for the best.
     new_args = tuple(str(a) if isinstance(a, Tensor) else a for a in args)
-    return StatisticalModel.get_func_key(f, new_args)
+    return RVIdentifier(arguments=new_args, wrapper=wrapper)
 
 
 class RecursionError(Exception):
@@ -24,30 +24,47 @@ def memoize(f):
     """
     Decorator to be used to memoize arbitrary functions.
     """
+    return MemoizeWrapper(function=f)
 
-    cache: Dict[Any, Any] = {}
+
+@dataclasses.dataclass(eq=True)
+class MemoizeWrapper:
+    """
+    The actual class that decorates the function to memoize
+    """
+
+    function: Callable
+    cache: Dict[Any, Any] = dataclasses.field(default_factory=dict)
     # TODO: Can we use a more efficient type than a list? We don't know
     # TODO: if the key is hashable.
-    in_flight: List[Any] = []
+    in_flight: List[Any] = dataclasses.field(default_factory=list)
 
-    @wraps(f)
-    def wrapper(*args):
-        key = _get_memoization_key(f, args)
-        if key not in cache:
-            if key in in_flight:
+    def __post_init__(self):
+        """dataclasses.dataclass generates the __init__ for us and will run
+        __post_init__ every time after __init__ is called"""
+        # update metadata on the wrapper object
+        update_wrapper(wrapper=self, wrapped=self.function)
+
+    def __get__(self, instance, owner=None):
+        """Bind a reference to the instance object to self.funtion. Please refer to
+        beanmachine.ppl.model.rv_wrapper for details about the usage of this function"""
+        bound_method = self.function.__get__(instance, owner)
+        return dataclasses.replace(self, function=bound_method)
+
+    def __call__(self, *args):
+        """Main body of the decorator."""
+        key = _get_memoization_key(self, args)
+        if key not in self.cache:
+            if key in self.in_flight:
                 # TODO: Better error
                 raise RecursionError()
-            in_flight.append(key)
+            self.in_flight.append(key)
             try:
-                result = f(*args)
-                cache[key] = result
+                result = self.function(*args)
+                self.cache[key] = result
             finally:
-                in_flight.pop()
-        return cache[key]
+                self.in_flight.pop()
+        return self.cache[key]
 
-    if inspect.ismethod(f):
-        meth_name = f.__name__ + "_wrapper"
-        setattr(f.__self__, meth_name, wrapper)
-    else:
-        f._wrapper = wrapper
-    return wrapper
+    def __hash__(self):
+        return hash(self.function)

--- a/src/beanmachine/ppl/world/__init__.py
+++ b/src/beanmachine/ppl/world/__init__.py
@@ -12,7 +12,7 @@ from beanmachine.ppl.world.variable import (
     TransformType,
     Variable,
 )
-from beanmachine.ppl.world.world import World
+from beanmachine.ppl.world.world import World, world_context
 from beanmachine.ppl.world.world_vars import WorldVars
 
 
@@ -20,6 +20,7 @@ __all__ = [
     "ProposalDistribution",
     "Variable",
     "World",
+    "world_context",
     "get_default_transforms",
     "is_discrete",
     "Diff",

--- a/src/beanmachine/ppl/world/tests/world_test.py
+++ b/src/beanmachine/ppl/world/tests/world_test.py
@@ -730,6 +730,9 @@ class WorldTest(unittest.TestCase):
         self.assertNotIn(model2.bar(), world1.diff_.vars())
         self.assertNotIn(model1.Y(), world1.diff_.vars())
 
+        world1.accept_diff()
+        self.assertTrue(world1.variables_.contains_wrapper(model1.C))
+
     def test_value_consistentcy_in_world(self):
         model = self.SampleModel()
 

--- a/src/beanmachine/ppl/world/world_vars.py
+++ b/src/beanmachine/ppl/world/world_vars.py
@@ -2,7 +2,7 @@
 from collections import defaultdict
 from typing import Dict, Optional
 
-from beanmachine.ppl.model.utils import RVIdentifier, get_wrapper
+from beanmachine.ppl.model.utils import RVIdentifier
 from beanmachine.ppl.world.variable import Variable
 from torch import Tensor, tensor
 
@@ -28,30 +28,27 @@ class WorldVars(object):
         in the WorldVars.
         """
         self.data_[node] = value
-        if hasattr(node, "function"):
-            self.var_funcs_[get_wrapper(node.function)].add(node)
+        self.var_funcs_[node.wrapper].add(node)
 
-    def contains_node_by_func(self, node_func: str) -> bool:
+    def contains_wrapper(self, func_wrapper) -> bool:
         """
         Returns whether the WorlVars contains the node with function node_func.
 
-        :params node_func: the node_func of the node to looked up in the
-        worldvars.
-        :returns: whether a node with node_func exists in WorldVars.
+        :params func_wrapper: the wrapper of the node to looked up in the
+        WorldVars.
+        :returns: whether a node with func_wrapper exists in WorldVars.
         """
-        if node_func in self.var_funcs_:
-            return True
-        return False
+        return func_wrapper in self.var_funcs_
 
-    def get_nodes_by_func(self, node_func: str):
+    def get_nodes_by_wrapper(self, func_wrapper):
         """
-        Get the nodes in WorldVars with the given node_func.
+        Get the nodes in WorldVars with the given func_wrapper.
 
-        :params node_func: the node_func to be looked up in WorldVars.
+        :params func_wrapper: the wrapper to be looked up in WorldVars.
         :returns: the variable of the node in WorldVars and None if the node
         does not exist.
         """
-        return self.var_funcs_[node_func]
+        return self.var_funcs_[func_wrapper]
 
     def get_node(self, node: RVIdentifier) -> Optional[Variable]:
         """
@@ -61,9 +58,7 @@ class WorldVars(object):
         :returns: the variable of the node in WorldVars and None if the node
         does not exist.
         """
-        if node in self.data_:
-            return self.data_[node]
-        return None
+        return self.data_.get(node)
 
     def get_node_raise_error(self, node: RVIdentifier) -> Variable:
         """
@@ -96,7 +91,7 @@ class WorldVars(object):
         :param node: the node to delete
         """
         del self.data_[node]
-        self.var_funcs_[get_wrapper(node.function)].remove(node)
+        self.var_funcs_[node.wrapper].remove(node)
 
     def len(self) -> int:
         """


### PR DESCRIPTION
Summary:
TL;DR: This diff introduce the `RVWrapper` *class*, which replaces [our current wrapper *function*](https://fburl.com/diffusion/19jdj3gi). It allows us to

- check the object that the random variable function belongs to (with `RVWrapper.model`)
- makes it easier for us to distinguish a decorated function from a regular Python function (with `isinstance(foo, RVWrapper)`

The former is especially important for serialization (WIP), because we want to avoid name collision in different models.

(Feel free to suggest another name for the wrapper class. I'm calling it `RVWrapper` just because we already use the term `wrapper` in a few places to denote the thing that decorate the  original function)

(Note on compositional inference: it seems like we were using the unbounded function to denote random variables that should be put into the same block (i.e., if `m = SomeModel()` and a user says `m.foo` should be a block, then this applies to all instances of `SomeModel`). I'm not quite sure whether this is intentional or not... I made some changes so that whatever user provides only applies to the specific instance, but it's very easy to go back if that's what we actually want.

-----

As for why this is needed to obtain a reference to the object:

Currently, we define `random_variable` decorator roughly as follows:
```
def random_variable(f):
    wraps(f)
    def wrapper(*args):
        # updating graph, etc.
    return wrapper
```
When using it inside of a class, the decorator is called at declaration time. e.g., in the following case
```
class SomeModel:
    random_variable
    def foo(self, x):
        return Normal(0, 1)
```
The function `wrapper` effectively replace `foo` as an attribute of class `SomeModel`. In fact, if we weren't [using `wraps(f)` to update the metadata](https://docs.python.org/3/library/functools.html), `SomeModel.foo.__name__` would be `"wrapper"` instead of `"foo"`.

Because all of these happen at declaration time, `SomeModel.foo` is not bound to any instance and it has type `"function"`. Then,

```
model = SomeModel()
model.foo  # <- here
```
On the line denoted as "here", the `__get__` method of our `wrapper` function is invoked, which *creates a new `"method"` that's bound to `model`* (i.e. the first argument that we usually called `self` is now a reference to `model`). Notice that this is does not modify `wrapper` itself but wraps around it ([see this doc for a better explanation](https://docs.python.org/3/howto/descriptor.html#functions-and-methods)). On the wrapper's perspective, it's still a regular `"function"`, it just that the first argument happens to be a reference to model.

Before the change, when we call `model.foo(5)`, `RVIdentifier` will store something like the follows:
- function: a reference of `SomeModel.foo`  (not bound to any instance
- arguments: a tuple `(model, 5)`

In general, we can't really distinguish whether the first arguments comes from a function binding or whether it's an explicit argument, this is why wrapper function doesn't work if we want to get a reference of the object.

After the change, `RVIdentifier` will store something like this
- function: a reference of the actual `model.foo` (already bound by `RVWrapper.__get__`
- arguments:  a tuple `(5,)`

and we could easily obtain a reference to `model` using the `__self__` attribute of the method.

Differential Revision: D25153759

