### PR TITLE
Update CircleCI config for pytorch 1.7.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,9 @@ commands:
           command: sudo pip install --progress-bar off numpy
       - run:
           name: "Install pytorch"
-          command: sudo pip install --progress-bar off torch==1.6.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
+          command: >
+            sudo pip install --progress-bar off torch==1.7.0+cpu
+            -f https://download.pytorch.org/whl/torch_stable.html
 
   dev_install:
     description: "Install beanmachine[dev] in editable mode via pip"


### PR DESCRIPTION
Summary:
Pytorch recently release their [v1.7.0](https://github.com/pytorch/pytorch/releases/tag/v1.7.0), which for some reason breaks our current CircleCI testing configs (even though we've fixed the version number of pytorch explicitly, we didn't fix it for gpytorch, which has also [updated recently](https://github.com/cornellius-gp/gpytorch/releases/tag/v1.3.0) and now requires pytorch 1.7).

This diff is an attempt to address the warnings and reduce the noise in our testing framework {emoji:1f604}

Differential Revision: D25280695

