### PR TITLE
Start building JIT compiler for Beanstalk

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/bm_to_bmg_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bm_to_bmg_test.py
@@ -2,7 +2,9 @@
 """Tests for bm_to_bmg.py"""
 import unittest
 
+import astor
 from beanmachine.ppl.compiler.bm_to_bmg import (
+    _bm_function_to_bmg_ast,
     to_bmg,
     to_cpp,
     to_dot,
@@ -2281,3 +2283,23 @@ def z():
 """
         with self.assertRaises(RecursionError):
             to_bmg(bad_model_2)
+
+    def test_function_transformation(self) -> None:
+        """Unit tests for _bm_function_to_bmg_ast from bm_to_bmg.py"""
+
+        def f(x):
+            return math.log(x)
+
+        self.maxDiff = None
+        observed = astor.to_source(_bm_function_to_bmg_ast(f))
+        expected = """
+def f_helper(bmg):
+
+    def f(x):
+        a2 = bmg.handle_dot_get(math, 'log')
+        r3 = [x]
+        r4 = {}
+        r1 = bmg.handle_function(a2, [*r3], r4)
+        return r1
+    return f"""
+        self.assertEqual(observed.strip(), expected.strip())


### PR DESCRIPTION
Summary:
As noted in the previous diff, I am prototyping up a "just in time" style compiler; here we have a helper method that I will need. This method takes a reference to a function, obtains its source code, transforms it into the lifted form, and then captures it inside an outer helper function which closes it over a graph builder.

In the next diff I will then compile this new method inside the module the original came from, and obtain a reference to the lifted function.

Reviewed By: wtaha

Differential Revision: D24904328

