### PR TITLE
Move RVIdentifier to a separate file

### DIFF
--- a/src/beanmachine/ppl/diagnostics/diagnostics.py
+++ b/src/beanmachine/ppl/diagnostics/diagnostics.py
@@ -9,7 +9,7 @@ import numpy as np
 import pandas as pd
 import plotly
 from beanmachine.ppl.inference.monte_carlo_samples import MonteCarloSamples
-from beanmachine.ppl.model.utils import RVIdentifier
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
 from plotly.subplots import make_subplots
 from torch import Tensor
 

--- a/src/beanmachine/ppl/experimental/abc/abc_smc_infer.py
+++ b/src/beanmachine/ppl/experimental/abc/abc_smc_infer.py
@@ -11,7 +11,8 @@ from beanmachine.ppl.inference.abstract_infer import VerboseLevel
 from beanmachine.ppl.inference.proposer.single_site_random_walk_proposer import (
     SingleSiteRandomWalkProposer,
 )
-from beanmachine.ppl.model.utils import LogLevel, RVIdentifier
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
+from beanmachine.ppl.model.utils import LogLevel
 from beanmachine.ppl.world import World
 from torch import Tensor
 from tqdm.auto import tqdm  # pyre-ignore

--- a/src/beanmachine/ppl/experimental/abc/adaptive_abc_smc_infer.py
+++ b/src/beanmachine/ppl/experimental/abc/adaptive_abc_smc_infer.py
@@ -13,7 +13,8 @@ from beanmachine.ppl.inference.proposer.single_site_random_walk_proposer import 
     SingleSiteRandomWalkProposer,
 )
 from beanmachine.ppl.inference.utils import safe_log_prob_sum
-from beanmachine.ppl.model.utils import LogLevel, RVIdentifier
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
+from beanmachine.ppl.model.utils import LogLevel
 from beanmachine.ppl.world import World
 from torch import Tensor
 from tqdm.auto import tqdm  # pyre-ignore

--- a/src/beanmachine/ppl/experimental/gp/kernels.py
+++ b/src/beanmachine/ppl/experimental/gp/kernels.py
@@ -2,7 +2,7 @@ import copy
 
 import gpytorch.kernels as kernels
 import torch
-from beanmachine.ppl.model.utils import RVIdentifier
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
 
 
 class KernelMixin(torch.nn.Module):

--- a/src/beanmachine/ppl/experimental/gp/likelihoods.py
+++ b/src/beanmachine/ppl/experimental/gp/likelihoods.py
@@ -4,7 +4,7 @@ import copy
 import beanmachine.ppl as bm
 import gpytorch.likelihoods as likelihoods
 import torch
-from beanmachine.ppl.model.utils import RVIdentifier
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
 
 
 class GpytorchMixin(torch.nn.Module):

--- a/src/beanmachine/ppl/experimental/inference_compilation/ic_infer.py
+++ b/src/beanmachine/ppl/experimental/inference_compilation/ic_infer.py
@@ -19,7 +19,7 @@ from ...inference.proposer.abstract_single_site_single_step_proposer import (
 from ...inference.proposer.single_site_ancestral_proposer import (
     SingleSiteAncestralProposer,
 )
-from ...model.utils import RVIdentifier
+from ...model.rv_identifier import RVIdentifier
 from ...world import ProposalDistribution, Variable, World
 from . import utils
 

--- a/src/beanmachine/ppl/experimental/neutra/iafflow.py
+++ b/src/beanmachine/ppl/experimental/neutra/iafflow.py
@@ -27,7 +27,7 @@ from typing import List, Tuple
 import torch
 import torch.nn as nn
 from beanmachine.ppl.experimental.neutra.iaflayer import InverseAutoregressiveLayer
-from beanmachine.ppl.model.utils import RVIdentifier
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
 from beanmachine.ppl.world import World
 from torch import Tensor
 

--- a/src/beanmachine/ppl/experimental/neutra/iafmcmc_infer.py
+++ b/src/beanmachine/ppl/experimental/neutra/iafmcmc_infer.py
@@ -2,7 +2,7 @@ from typing import List, Optional
 
 from beanmachine.ppl.experimental.neutra.iafmcmc_proposer import IAFMCMCProposer
 from beanmachine.ppl.inference.abstract_mh_infer import AbstractMHInference
-from beanmachine.ppl.model.utils import RVIdentifier
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
 from beanmachine.ppl.world.world import TransformType
 
 

--- a/src/beanmachine/ppl/experimental/neutra/iafmcmc_proposer.py
+++ b/src/beanmachine/ppl/experimental/neutra/iafmcmc_proposer.py
@@ -27,7 +27,7 @@ from beanmachine.ppl.experimental.neutra.train import IAFMap
 from beanmachine.ppl.inference.proposer.abstract_single_site_proposer import (
     AbstractSingleSiteProposer,
 )
-from beanmachine.ppl.model.utils import RVIdentifier
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
 from beanmachine.ppl.world import World
 from torch import Tensor, tensor
 

--- a/src/beanmachine/ppl/experimental/neutra/tests/iafmcmc_jacobian_test.py
+++ b/src/beanmachine/ppl/experimental/neutra/tests/iafmcmc_jacobian_test.py
@@ -8,7 +8,7 @@ import torch.distributions as dist
 from beanmachine.ppl.experimental.neutra.iafmcmc_proposer import IAFMCMCProposer
 from beanmachine.ppl.experimental.neutra.maskedautoencoder import MaskedAutoencoder
 from beanmachine.ppl.inference.abstract_mh_infer import AbstractMHInference
-from beanmachine.ppl.model.utils import RVIdentifier
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
 from beanmachine.ppl.world import Variable, World
 from beanmachine.ppl.world.world import TransformType
 from torch import nn, tensor as tensor

--- a/src/beanmachine/ppl/experimental/neutra/train.py
+++ b/src/beanmachine/ppl/experimental/neutra/train.py
@@ -26,7 +26,7 @@ import torch
 import torch.distributions as dist
 import torch.nn as nn
 from beanmachine.ppl.experimental.neutra.iafflow import InverseAutoregressiveFlow
-from beanmachine.ppl.model.utils import RVIdentifier
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
 from beanmachine.ppl.world import World
 
 

--- a/src/beanmachine/ppl/experimental/tests/gp/kernel_test.py
+++ b/src/beanmachine/ppl/experimental/tests/gp/kernel_test.py
@@ -6,7 +6,7 @@ import gpytorch
 import gpytorch.distributions as dist
 import torch
 from beanmachine.ppl.experimental.gp import kernels
-from beanmachine.ppl.model.utils import RVIdentifier
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
 
 
 class KernelTests(unittest.TestCase):

--- a/src/beanmachine/ppl/experimental/tests/gp/likelihood_test.py
+++ b/src/beanmachine/ppl/experimental/tests/gp/likelihood_test.py
@@ -5,7 +5,7 @@ import beanmachine.ppl as bm
 import gpytorch
 import torch
 from beanmachine.ppl.experimental.gp import likelihoods
-from beanmachine.ppl.model.utils import RVIdentifier
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
 
 
 class LikelihoodTest(unittest.TestCase):

--- a/src/beanmachine/ppl/inference/abstract_infer.py
+++ b/src/beanmachine/ppl/inference/abstract_infer.py
@@ -10,7 +10,8 @@ import torch.multiprocessing as mp
 from torch import Tensor
 from torch.multiprocessing import Queue
 
-from ..model.utils import LogLevel, RVIdentifier
+from ..model.rv_identifier import RVIdentifier
+from ..model.utils import LogLevel
 from ..world import World
 from .monte_carlo_samples import MonteCarloSamples
 

--- a/src/beanmachine/ppl/inference/abstract_mh_infer.py
+++ b/src/beanmachine/ppl/inference/abstract_mh_infer.py
@@ -10,7 +10,8 @@ import torch.distributions as dist
 import torch.tensor as tensor
 from beanmachine.ppl.inference.abstract_infer import AbstractInference, VerboseLevel
 from beanmachine.ppl.inference.utils import Block, BlockType
-from beanmachine.ppl.model.utils import LogLevel, RVIdentifier, get_wrapper
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
+from beanmachine.ppl.model.utils import LogLevel, get_wrapper
 from beanmachine.ppl.world.variable import TransformType
 from torch import Tensor
 from tqdm.auto import tqdm  # pyre-ignore

--- a/src/beanmachine/ppl/inference/compositional_infer.py
+++ b/src/beanmachine/ppl/inference/compositional_infer.py
@@ -13,7 +13,8 @@ from beanmachine.ppl.inference.proposer.single_site_newtonian_monte_carlo_propos
 from beanmachine.ppl.inference.proposer.single_site_uniform_proposer import (
     SingleSiteUniformProposer,
 )
-from beanmachine.ppl.model.utils import RVIdentifier, get_wrapper
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
+from beanmachine.ppl.model.utils import get_wrapper
 
 
 class CompositionalInference(AbstractMHInference):

--- a/src/beanmachine/ppl/inference/monte_carlo_samples.py
+++ b/src/beanmachine/ppl/inference/monte_carlo_samples.py
@@ -4,7 +4,7 @@ import copy
 from typing import Dict, List, Union
 
 from beanmachine.ppl.inference.monte_carlo_samples_data import MonteCarloSamplesData
-from beanmachine.ppl.model.utils import RVIdentifier
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
 from torch import Tensor
 
 

--- a/src/beanmachine/ppl/inference/monte_carlo_samples_data.py
+++ b/src/beanmachine/ppl/inference/monte_carlo_samples_data.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from typing import Dict, List, Union
 
 import torch
-from beanmachine.ppl.model.utils import RVIdentifier
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
 from torch import Tensor
 
 

--- a/src/beanmachine/ppl/inference/predictive.py
+++ b/src/beanmachine/ppl/inference/predictive.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Optional
 
 import torch
 from beanmachine.ppl.inference.monte_carlo_samples import MonteCarloSamples
-from beanmachine.ppl.model.utils import RVIdentifier
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
 from torch.distributions import Categorical
 
 from .single_site_ancestral_mh import SingleSiteAncestralMetropolisHastings

--- a/src/beanmachine/ppl/inference/proposer/abstract_single_site_proposer.py
+++ b/src/beanmachine/ppl/inference/proposer/abstract_single_site_proposer.py
@@ -2,7 +2,7 @@
 from abc import ABCMeta, abstractmethod
 from typing import Dict, List, Optional, Tuple
 
-from beanmachine.ppl.model.utils import RVIdentifier
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
 from beanmachine.ppl.world.world import TransformType, World
 from torch import Tensor
 

--- a/src/beanmachine/ppl/inference/proposer/abstract_single_site_single_step_proposer.py
+++ b/src/beanmachine/ppl/inference/proposer/abstract_single_site_single_step_proposer.py
@@ -7,7 +7,8 @@ from beanmachine.ppl.inference.proposer.abstract_single_site_proposer import (
     AbstractSingleSiteProposer,
 )
 from beanmachine.ppl.inference.utils import safe_log_prob_sum
-from beanmachine.ppl.model.utils import LogLevel, RVIdentifier
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
+from beanmachine.ppl.model.utils import LogLevel
 from beanmachine.ppl.world import ProposalDistribution, Variable, World
 from torch import Tensor
 

--- a/src/beanmachine/ppl/inference/proposer/single_site_ancestral_proposer.py
+++ b/src/beanmachine/ppl/inference/proposer/single_site_ancestral_proposer.py
@@ -4,7 +4,7 @@ from typing import Dict, Tuple
 from beanmachine.ppl.inference.proposer.abstract_single_site_single_step_proposer import (
     AbstractSingleSiteSingleStepProposer,
 )
-from beanmachine.ppl.model.utils import RVIdentifier
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
 from beanmachine.ppl.world import ProposalDistribution, Variable, World
 
 

--- a/src/beanmachine/ppl/inference/proposer/single_site_half_space_newtonian_monte_carlo_proposer.py
+++ b/src/beanmachine/ppl/inference/proposer/single_site_half_space_newtonian_monte_carlo_proposer.py
@@ -12,7 +12,7 @@ from beanmachine.ppl.inference.proposer.newtonian_monte_carlo_utils import (
 from beanmachine.ppl.inference.proposer.single_site_ancestral_proposer import (
     SingleSiteAncestralProposer,
 )
-from beanmachine.ppl.model.utils import RVIdentifier
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
 from beanmachine.ppl.utils import tensorops  # pyre-ignore
 from beanmachine.ppl.world import ProposalDistribution, Variable, World
 from torch import Tensor

--- a/src/beanmachine/ppl/inference/proposer/single_site_hamiltonian_monte_carlo_proposer.py
+++ b/src/beanmachine/ppl/inference/proposer/single_site_hamiltonian_monte_carlo_proposer.py
@@ -10,7 +10,7 @@ from beanmachine.ppl.inference.proposer.newtonian_monte_carlo_utils import (
 from beanmachine.ppl.inference.proposer.single_site_ancestral_proposer import (
     SingleSiteAncestralProposer,
 )
-from beanmachine.ppl.model.utils import RVIdentifier
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
 from beanmachine.ppl.world import Variable, World
 from beanmachine.ppl.world.variable import TransformType
 from torch import Tensor, tensor

--- a/src/beanmachine/ppl/inference/proposer/single_site_newtonian_monte_carlo_proposer.py
+++ b/src/beanmachine/ppl/inference/proposer/single_site_newtonian_monte_carlo_proposer.py
@@ -15,7 +15,7 @@ from beanmachine.ppl.inference.proposer.single_site_real_space_newtonian_monte_c
 from beanmachine.ppl.inference.proposer.single_site_simplex_newtonian_monte_carlo_proposer import (
     SingleSiteSimplexNewtonianMonteCarloProposer,
 )
-from beanmachine.ppl.model.utils import RVIdentifier
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
 from beanmachine.ppl.world import ProposalDistribution, Variable, World
 from beanmachine.ppl.world.variable import TransformType
 from torch import Tensor

--- a/src/beanmachine/ppl/inference/proposer/single_site_no_u_turn_sampler_proposer.py
+++ b/src/beanmachine/ppl/inference/proposer/single_site_no_u_turn_sampler_proposer.py
@@ -9,7 +9,7 @@ from beanmachine.ppl.inference.proposer.newtonian_monte_carlo_utils import (
 from beanmachine.ppl.inference.proposer.single_site_ancestral_proposer import (
     SingleSiteAncestralProposer,
 )
-from beanmachine.ppl.model.utils import RVIdentifier
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
 from beanmachine.ppl.world import Variable, World
 from torch import Tensor, tensor
 

--- a/src/beanmachine/ppl/inference/proposer/single_site_random_walk_proposer.py
+++ b/src/beanmachine/ppl/inference/proposer/single_site_random_walk_proposer.py
@@ -6,7 +6,7 @@ import torch.distributions as dist
 from beanmachine.ppl.inference.proposer.single_site_ancestral_proposer import (
     SingleSiteAncestralProposer,
 )
-from beanmachine.ppl.model.utils import RVIdentifier
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
 from beanmachine.ppl.world import ProposalDistribution, Variable, World
 from beanmachine.ppl.world.variable import TransformType
 from torch import Tensor, tensor

--- a/src/beanmachine/ppl/inference/proposer/single_site_real_space_newtonian_monte_carlo_proposer.py
+++ b/src/beanmachine/ppl/inference/proposer/single_site_real_space_newtonian_monte_carlo_proposer.py
@@ -15,7 +15,7 @@ from beanmachine.ppl.inference.proposer.normal_eig import NormalEig
 from beanmachine.ppl.inference.proposer.single_site_ancestral_proposer import (
     SingleSiteAncestralProposer,
 )
-from beanmachine.ppl.model.utils import RVIdentifier
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
 from beanmachine.ppl.utils import tensorops  # pyre-ignore
 from beanmachine.ppl.world import ProposalDistribution, Variable, World
 from torch import Tensor, tensor

--- a/src/beanmachine/ppl/inference/proposer/single_site_simplex_newtonian_monte_carlo_proposer.py
+++ b/src/beanmachine/ppl/inference/proposer/single_site_simplex_newtonian_monte_carlo_proposer.py
@@ -12,7 +12,7 @@ from beanmachine.ppl.inference.proposer.newtonian_monte_carlo_utils import (
 from beanmachine.ppl.inference.proposer.single_site_ancestral_proposer import (
     SingleSiteAncestralProposer,
 )
-from beanmachine.ppl.model.utils import RVIdentifier
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
 from beanmachine.ppl.utils import tensorops  # pyre-ignore
 from beanmachine.ppl.world import ProposalDistribution, Variable, World
 from torch import Tensor

--- a/src/beanmachine/ppl/inference/proposer/single_site_uniform_proposer.py
+++ b/src/beanmachine/ppl/inference/proposer/single_site_uniform_proposer.py
@@ -6,7 +6,7 @@ import torch.distributions as dist
 from beanmachine.ppl.inference.proposer.single_site_ancestral_proposer import (
     SingleSiteAncestralProposer,
 )
-from beanmachine.ppl.model.utils import RVIdentifier
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
 from beanmachine.ppl.world import ProposalDistribution, Variable, World
 
 

--- a/src/beanmachine/ppl/inference/proposer/tests/abstract_single_site_single_step_proposer_test.py
+++ b/src/beanmachine/ppl/inference/proposer/tests/abstract_single_site_single_step_proposer_test.py
@@ -13,7 +13,7 @@ from beanmachine.ppl.inference.proposer.abstract_single_site_single_step_propose
 from beanmachine.ppl.inference.proposer.single_site_half_space_newtonian_monte_carlo_proposer import (
     SingleSiteHalfSpaceNewtonianMonteCarloProposer,
 )
-from beanmachine.ppl.model.utils import RVIdentifier
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
 from beanmachine.ppl.world import ProposalDistribution, Variable, World
 from beanmachine.ppl.world.world import TransformType
 

--- a/src/beanmachine/ppl/inference/rejection_sampling_infer.py
+++ b/src/beanmachine/ppl/inference/rejection_sampling_infer.py
@@ -6,7 +6,8 @@ from typing import Dict
 
 import torch
 from beanmachine.ppl.inference.abstract_infer import AbstractInference, VerboseLevel
-from beanmachine.ppl.model.utils import LogLevel, RVIdentifier
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
+from beanmachine.ppl.model.utils import LogLevel
 from beanmachine.ppl.world import World
 from torch import Tensor
 from tqdm.auto import tqdm  # pyre-ignore

--- a/src/beanmachine/ppl/inference/single_site_ancestral_mh.py
+++ b/src/beanmachine/ppl/inference/single_site_ancestral_mh.py
@@ -3,7 +3,7 @@ from beanmachine.ppl.inference.abstract_mh_infer import AbstractMHInference
 from beanmachine.ppl.inference.proposer.single_site_ancestral_proposer import (
     SingleSiteAncestralProposer,
 )
-from beanmachine.ppl.model.utils import RVIdentifier
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
 
 
 class SingleSiteAncestralMetropolisHastings(AbstractMHInference):

--- a/src/beanmachine/ppl/inference/single_site_hamiltonian_monte_carlo.py
+++ b/src/beanmachine/ppl/inference/single_site_hamiltonian_monte_carlo.py
@@ -5,7 +5,7 @@ from beanmachine.ppl.inference.abstract_mh_infer import AbstractMHInference
 from beanmachine.ppl.inference.proposer.single_site_hamiltonian_monte_carlo_proposer import (
     SingleSiteHamiltonianMonteCarloProposer,
 )
-from beanmachine.ppl.model.utils import RVIdentifier
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
 from beanmachine.ppl.world.world import TransformType
 
 

--- a/src/beanmachine/ppl/inference/single_site_newtonian_monte_carlo.py
+++ b/src/beanmachine/ppl/inference/single_site_newtonian_monte_carlo.py
@@ -5,7 +5,7 @@ from beanmachine.ppl.inference.abstract_mh_infer import AbstractMHInference
 from beanmachine.ppl.inference.proposer.single_site_newtonian_monte_carlo_proposer import (
     SingleSiteNewtonianMonteCarloProposer,
 )
-from beanmachine.ppl.model.utils import RVIdentifier
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
 from beanmachine.ppl.world.world import TransformType
 
 

--- a/src/beanmachine/ppl/inference/single_site_no_u_turn_sampler.py
+++ b/src/beanmachine/ppl/inference/single_site_no_u_turn_sampler.py
@@ -2,7 +2,7 @@
 from typing import List, Optional
 
 from beanmachine.ppl.inference.abstract_mh_infer import AbstractMHInference
-from beanmachine.ppl.model.utils import RVIdentifier
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
 from beanmachine.ppl.world.world import TransformType
 
 from .proposer.single_site_no_u_turn_sampler_proposer import (

--- a/src/beanmachine/ppl/inference/single_site_random_walk.py
+++ b/src/beanmachine/ppl/inference/single_site_random_walk.py
@@ -5,7 +5,7 @@ from beanmachine.ppl.inference.abstract_mh_infer import AbstractMHInference
 from beanmachine.ppl.inference.proposer.single_site_random_walk_proposer import (
     SingleSiteRandomWalkProposer,
 )
-from beanmachine.ppl.model.utils import RVIdentifier
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
 from beanmachine.ppl.world.world import TransformType
 
 

--- a/src/beanmachine/ppl/inference/single_site_uniform_mh.py
+++ b/src/beanmachine/ppl/inference/single_site_uniform_mh.py
@@ -5,7 +5,7 @@ from beanmachine.ppl.inference.abstract_mh_infer import AbstractMHInference
 from beanmachine.ppl.inference.proposer.single_site_uniform_proposer import (
     SingleSiteUniformProposer,
 )
-from beanmachine.ppl.model.utils import RVIdentifier
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
 from beanmachine.ppl.world.world import TransformType
 
 

--- a/src/beanmachine/ppl/inference/tests/compositional_infer_test.py
+++ b/src/beanmachine/ppl/inference/tests/compositional_infer_test.py
@@ -19,7 +19,6 @@ from beanmachine.ppl.inference.proposer.single_site_uniform_proposer import (
     SingleSiteUniformProposer,
 )
 from beanmachine.ppl.inference.utils import Block, BlockType
-from beanmachine.ppl.model.statistical_model import sample
 from beanmachine.ppl.model.utils import get_wrapper
 from beanmachine.ppl.world.utils import BetaDimensionTransform
 from beanmachine.ppl.world.variable import TransformType, Variable
@@ -88,27 +87,27 @@ class CompositionalInferenceTest(unittest.TestCase):
             return dist.Categorical(self.alpha())
 
     class SampleTransformModel(object):
-        @sample
+        @bm.random_variable
         def realspace(self):
             return dist.Normal(tensor(0.0), tensor(1.0))
 
-        @sample
+        @bm.random_variable
         def halfspace(self):
             return dist.Gamma(tensor(2.0), tensor(2.0))
 
-        @sample
+        @bm.random_variable
         def simplex(self):
             return dist.Dirichlet(tensor([0.1, 0.9]))
 
-        @sample
+        @bm.random_variable
         def interval(self):
             return dist.Uniform(tensor(1.0), tensor(3.0))
 
-        @sample
+        @bm.random_variable
         def beta(self):
             return dist.Beta(tensor(1.0), tensor(1.0))
 
-        @sample
+        @bm.random_variable
         def discrete(self):
             return dist.Poisson(tensor(2.0))
 

--- a/src/beanmachine/ppl/inference/utils.py
+++ b/src/beanmachine/ppl/inference/utils.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import List
 
-from beanmachine.ppl.model.utils import RVIdentifier
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
 from torch import Tensor, tensor
 
 

--- a/src/beanmachine/ppl/model/__init__.py
+++ b/src/beanmachine/ppl/model/__init__.py
@@ -1,4 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
 from beanmachine.ppl.model.statistical_model import (
     StatisticalModel,
     functional,
@@ -6,7 +7,7 @@ from beanmachine.ppl.model.statistical_model import (
     random_variable,
     sample,
 )
-from beanmachine.ppl.model.utils import RVIdentifier, get_beanmachine_logger
+from beanmachine.ppl.model.utils import get_beanmachine_logger
 
 
 __all__ = [

--- a/src/beanmachine/ppl/model/rv_identifier.py
+++ b/src/beanmachine/ppl/model/rv_identifier.py
@@ -1,0 +1,12 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+from dataclasses import dataclass
+from typing import Callable, Tuple
+
+
+@dataclass(eq=True, frozen=True)
+class RVIdentifier:
+    function: Callable
+    arguments: Tuple
+
+    def __str__(self):
+        return str(self.function.__name__) + str(self.arguments)

--- a/src/beanmachine/ppl/model/statistical_model.py
+++ b/src/beanmachine/ppl/model/statistical_model.py
@@ -3,7 +3,7 @@ import inspect
 import warnings
 from functools import wraps
 
-from beanmachine.ppl.model.utils import RVIdentifier
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
 from beanmachine.ppl.world.world import world_context
 
 

--- a/src/beanmachine/ppl/model/utils.py
+++ b/src/beanmachine/ppl/model/utils.py
@@ -1,9 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import inspect
 import logging
-from dataclasses import dataclass
 from enum import Enum
-from typing import Any
 
 import torch
 
@@ -15,15 +13,6 @@ def get_wrapper(f):
     if inspect.ismethod(f):
         return getattr(f.__self__, f.__name__ + "_wrapper")
     return f._wrapper
-
-
-@dataclass(eq=True, frozen=True)
-class RVIdentifier:
-    function: Any
-    arguments: Any
-
-    def __str__(self):
-        return str(self.function.__name__) + str(self.arguments)
 
 
 class LogLevel(Enum):

--- a/src/beanmachine/ppl/testlib/abstract_conjugate.py
+++ b/src/beanmachine/ppl/testlib/abstract_conjugate.py
@@ -12,7 +12,7 @@ from beanmachine.ppl.examples.conjugate_models.gamma_gamma import GammaGammaMode
 from beanmachine.ppl.examples.conjugate_models.gamma_normal import GammaNormalModel
 from beanmachine.ppl.examples.conjugate_models.normal_normal import NormalNormalModel
 from beanmachine.ppl.inference.abstract_infer import AbstractInference
-from beanmachine.ppl.model.utils import RVIdentifier
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
 from torch import Tensor
 
 
@@ -182,7 +182,7 @@ class AbstractConjugateTests(metaclass=ABCMeta):
         expected_mean, expected_std, queries, observations = moments
 
         if random_seed is not None:
-            torch.manual_seed(random_seed)
+            torch.manual_seed(123)
 
         predictions = mh.infer(
             queries,

--- a/src/beanmachine/ppl/world/diff.py
+++ b/src/beanmachine/ppl/world/diff.py
@@ -2,7 +2,7 @@
 from collections import defaultdict
 from typing import Dict, Optional
 
-from beanmachine.ppl.model.utils import RVIdentifier
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
 from beanmachine.ppl.world.variable import Variable
 from torch import Tensor, tensor
 

--- a/src/beanmachine/ppl/world/diff_stack.py
+++ b/src/beanmachine/ppl/world/diff_stack.py
@@ -2,7 +2,7 @@
 from collections import defaultdict
 from typing import List, Optional
 
-from beanmachine.ppl.model.utils import RVIdentifier
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
 from beanmachine.ppl.world.diff import Diff
 from beanmachine.ppl.world.variable import Variable
 from beanmachine.ppl.world.world_vars import WorldVars

--- a/src/beanmachine/ppl/world/tests/world_test.py
+++ b/src/beanmachine/ppl/world/tests/world_test.py
@@ -5,7 +5,7 @@ import unittest
 import beanmachine.ppl as bm
 import torch.distributions as dist
 import torch.tensor as tensor
-from beanmachine.ppl.model.utils import RVIdentifier
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
 from beanmachine.ppl.world import Variable, World
 
 

--- a/src/beanmachine/ppl/world/variable.py
+++ b/src/beanmachine/ppl/world/variable.py
@@ -7,7 +7,7 @@ import torch
 import torch.distributions as dist
 import torch.tensor as tensor
 from beanmachine.ppl.inference.utils import safe_log_prob_sum
-from beanmachine.ppl.model.utils import RVIdentifier
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
 from beanmachine.ppl.world.utils import (
     BetaDimensionTransform,
     get_default_transforms,

--- a/src/beanmachine/ppl/world/world.py
+++ b/src/beanmachine/ppl/world/world.py
@@ -4,7 +4,8 @@ import copy
 from collections import defaultdict
 from typing import Dict, List, Optional, Set, Tuple
 
-from beanmachine.ppl.model.utils import RVIdentifier, get_wrapper
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
+from beanmachine.ppl.model.utils import get_wrapper
 from beanmachine.ppl.utils.dotbuilder import print_graph
 from beanmachine.ppl.world.diff import Diff
 from beanmachine.ppl.world.diff_stack import DiffStack

--- a/src/beanmachine/ppl/world/world_vars.py
+++ b/src/beanmachine/ppl/world/world_vars.py
@@ -2,7 +2,8 @@
 from collections import defaultdict
 from typing import Dict, Optional
 
-from beanmachine.ppl.model.utils import RVIdentifier, get_wrapper
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
+from beanmachine.ppl.model.utils import get_wrapper
 from beanmachine.ppl.world.variable import Variable
 from torch import Tensor, tensor
 


### PR DESCRIPTION
Summary:
Move `RVIdentifier` from `beanmachine.ppl.model.utils` to `beanmachine.ppl.model.rv_identifier` and redirect the imports, mostly because `RVIdentifier` is an important class and it deserves its own place.

This diff was splitted from D25421261 to make the review process easier.

Differential Revision: D25416254

