### PR TITLE
Continue building parts for JIT compiler

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/bm_to_bmg_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bm_to_bmg_test.py
@@ -5,12 +5,14 @@ import unittest
 import astor
 from beanmachine.ppl.compiler.bm_to_bmg import (
     _bm_function_to_bmg_ast,
+    _bm_function_to_bmg_function,
     to_bmg,
     to_cpp,
     to_dot,
     to_python,
     to_python_raw,
 )
+from beanmachine.ppl.utils.bm_graph_builder import BMGraphBuilder
 from beanmachine.ppl.utils.memoize import RecursionError
 
 
@@ -2283,23 +2285,3 @@ def z():
 """
         with self.assertRaises(RecursionError):
             to_bmg(bad_model_2)
-
-    def test_function_transformation(self) -> None:
-        """Unit tests for _bm_function_to_bmg_ast from bm_to_bmg.py"""
-
-        def f(x):
-            return math.log(x)
-
-        self.maxDiff = None
-        observed = astor.to_source(_bm_function_to_bmg_ast(f))
-        expected = """
-def f_helper(bmg):
-
-    def f(x):
-        a2 = bmg.handle_dot_get(math, 'log')
-        r3 = [x]
-        r4 = {}
-        r1 = bmg.handle_function(a2, [*r3], r4)
-        return r1
-    return f"""
-        self.assertEqual(observed.strip(), expected.strip())

--- a/src/beanmachine/ppl/compiler/tests/jit_test.py
+++ b/src/beanmachine/ppl/compiler/tests/jit_test.py
@@ -1,0 +1,100 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+"""Tests for bm_to_bmg.py"""
+import math
+import unittest
+
+import astor
+import beanmachine.ppl as bm
+from beanmachine.ppl.compiler.bm_to_bmg import (
+    _bm_function_to_bmg_ast,
+    _bm_function_to_bmg_function,
+)
+from beanmachine.ppl.compiler.bmg_nodes import ExpNode
+from beanmachine.ppl.utils.bm_graph_builder import BMGraphBuilder
+from torch.distributions import Normal
+
+
+def f(x):
+    return math.exp(x)
+
+
+# TODO: support aliases on bm.random_variable
+
+
+@bm.random_variable
+def norm():
+    return Normal(0.0, 1.0)
+
+
+class JITTest(unittest.TestCase):
+    def test_function_transformation_1(self) -> None:
+        """Unit tests for JIT functions"""
+
+        self.maxDiff = None
+
+        # Verify code generation of lifted, nested form of
+        # functions f(x), norm(), above.
+
+        bmgast = _bm_function_to_bmg_ast(f, "f_helper")
+        observed = astor.to_source(bmgast)
+        expected = """
+def f_helper(bmg):
+    from beanmachine.ppl.utils.memoize import memoize
+    from beanmachine.ppl.utils.probabilistic import probabilistic
+
+    def f(x):
+        a2 = bmg.handle_dot_get(math, 'exp')
+        r3 = [x]
+        r4 = {}
+        r1 = bmg.handle_function(a2, [*r3], r4)
+        return r1
+    return f"""
+        self.assertEqual(observed.strip(), expected.strip())
+
+        bmgast = _bm_function_to_bmg_ast(norm, "norm_helper")
+        observed = astor.to_source(bmgast)
+        expected = """
+def norm_helper(bmg):
+    from beanmachine.ppl.utils.memoize import memoize
+    from beanmachine.ppl.utils.probabilistic import probabilistic
+
+    @probabilistic(bmg)
+    @memoize
+    def norm():
+        a4 = 0.0
+        a3 = [a4]
+        a7 = 1.0
+        a5 = [a7]
+        r2 = bmg.handle_addition(a3, a5)
+        r6 = {}
+        r1 = bmg.handle_function(Normal, [*r2], r6)
+        return bmg.handle_sample(r1)
+    return norm
+"""
+        self.assertEqual(observed.strip(), expected.strip())
+
+        # Now obtain both lifted functions; call both and verify
+        # that the graph builder accumulates the desired graph.
+
+        bmg = BMGraphBuilder()
+
+        lifted_f = _bm_function_to_bmg_function(f, bmg)
+        lifted_norm = _bm_function_to_bmg_function(norm, bmg)
+
+        result = lifted_f(lifted_norm())
+        self.assertTrue(isinstance(result, ExpNode))
+        dot = bmg.to_dot(point_at_input=True)
+        expected = """
+digraph "graph" {
+  N0[label=0.0];
+  N1[label=1.0];
+  N2[label=Normal];
+  N3[label=Sample];
+  N4[label=Exp];
+  N0 -> N2[label=mu];
+  N1 -> N2[label=sigma];
+  N2 -> N3[label=operand];
+  N3 -> N4[label=operand];
+}
+"""
+        self.assertEqual(dot.strip(), expected.strip())


### PR DESCRIPTION
Summary:
In the previous diff we showed that we could generate an AST for a lifted function that was closed over a graph builder.  In this diff we build on this work in a few ways:

* The function decorators put on random variable functions are now imported inside the scope of the helper function, thereby decreasing the amount of "pollution" of the outer namespace further.
* We now compile the generated source code and execute it. The global variable context for the execution is that of the *original* module, so if the lifted function makes use of a global, it should still work.
* I've moved the test cases to their own module.
* The test case is extended to show the code generation of both a normal function and a random variable
* The test case calls the functions and verifies that the supplied graph builder accumulates the graph.

The next steps will be to obtain the random variable id object returned during execution of a model, turn that into a lifted function and use it to accumulate the random variable into a graph builder.

Reviewed By: wtaha

Differential Revision: D24938503

