### PR TITLE
Continue implementing JIT compiler for beanstalk

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/jit_test.py
+++ b/src/beanmachine/ppl/compiler/tests/jit_test.py
@@ -73,15 +73,18 @@ def norm_helper(bmg):
 """
         self.assertEqual(observed.strip(), expected.strip())
 
-        # Now obtain both lifted functions; call both and verify
-        # that the graph builder accumulates the desired graph.
+        # * Obtain the lifted version of f.
+        # * Ask the graph builder to transform the rv associated
+        #   with norm() to a sample node.
+        # * Invoke the lifted f and verify that we accumulate an
+        #   exp(sample(normal(0, 1))) node into the graph.
 
         bmg = BMGraphBuilder()
 
         lifted_f = _bm_function_to_bmg_function(f, bmg)
-        lifted_norm = _bm_function_to_bmg_function(norm, bmg)
+        norm_sample = bmg._rv_to_node(norm())
 
-        result = lifted_f(lifted_norm())
+        result = lifted_f(norm_sample)
         self.assertTrue(isinstance(result, ExpNode))
         dot = bmg.to_dot(point_at_input=True)
         expected = """

--- a/src/beanmachine/ppl/utils/bm_graph_builder.py
+++ b/src/beanmachine/ppl/utils/bm_graph_builder.py
@@ -123,6 +123,7 @@ from beanmachine.ppl.compiler.bmg_types import (
     Real,
     Zero,
 )
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
 from beanmachine.ppl.utils.beanstalk_common import allowed_functions
 from beanmachine.ppl.utils.dotbuilder import DotBuilder
 from beanmachine.ppl.utils.memoize import memoize
@@ -1115,6 +1116,12 @@ class BMGraphBuilder:
             return self.handle_phi(*args, **kwargs)
 
         raise ValueError(f"Function {f} is not supported by Bean Machine Graph.")
+
+    def _rv_to_node(self, rv: RVIdentifier) -> SampleNode:
+        from beanmachine.ppl.compiler.bm_to_bmg import _bm_function_to_bmg_function
+
+        lifted = _bm_function_to_bmg_function(rv.function, self)
+        return lifted(*rv.arguments)
 
     @memoize
     def add_map(self, *elements) -> MapNode:


### PR DESCRIPTION
Summary:
I am continuing my incremental progress towards a JIT compiler in Beanstalk. In this diff, I extend the work in the previous diff by making a helper method on a graph builder which can turn an RVID into a sample node. It does so by:

* obtaining the function reference
* recompiling its source code into a helper method closed over a graph builder
* closing it over *this* graph builder
* invoking the lifted, closed-over function with the arguments captured in the RVID.

For simple cases where the RV just returns a distribution, this now works.  More complex RVs that involve calls to other RVs does not yet work.

In upcoming diffs:

* We'll build a cache to map RVID -> sample node
* We'll build a cache to map unlifted function -> lifted helper function

That will ensure that we do not compile the same functions over and over again when we encounter them, decreasing the amount of work the runtime must do.

Once that's done:

* We'll fix up function call handling in lifted code so that it, in turn, detects when it is calling a function that needs to be lifted.
* We'll add an inference method that takes RVIDs for queries and observations, jit-compiles them, and runs inference

Reviewed By: wtaha

Differential Revision: D24961042

