### PR TITLE
Fix shape error with singleton dims

### DIFF
--- a/src/beanmachine/ppl/diagnostics/diagnostics.py
+++ b/src/beanmachine/ppl/diagnostics/diagnostics.py
@@ -49,6 +49,9 @@ class BaseDiagnostics:
         self, query: RVIdentifier, chain: Optional[int] = None
     ):
         query_samples = self.samples[query]
+        if query_samples.shape[0] != 1:
+            # squeeze out non-chain singleton dims
+            query_samples = query_samples.squeeze()
         if chain is not None:
             query_samples = query_samples[chain].unsqueeze(0)
         return query_samples


### PR DESCRIPTION
Summary: Previously monte carlo samples with singleton dims (samples.shape == (4,2,1)) would cause a shape error. This squeezes out the dims during diagnostic computation.

Differential Revision: D25482062

