### PR TITLE
Mark random variable functions

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/jit_test.py
+++ b/src/beanmachine/ppl/compiler/tests/jit_test.py
@@ -39,6 +39,8 @@ class JITTest(unittest.TestCase):
         # Verify code generation of lifted, nested form of
         # functions f(x), norm(), above.
 
+        self.assertTrue(norm.is_random_variable)
+
         bmgast = _bm_function_to_bmg_ast(f, "f_helper")
         observed = astor.to_source(bmgast)
         expected = """

--- a/src/beanmachine/ppl/model/statistical_model.py
+++ b/src/beanmachine/ppl/model/statistical_model.py
@@ -74,6 +74,7 @@ class StatisticalModel(object):
             setattr(f.__self__, meth_name, wrapper)
         else:
             f._wrapper = wrapper
+        wrapper.is_random_variable = True
         return wrapper
 
     @staticmethod
@@ -105,6 +106,7 @@ class StatisticalModel(object):
             setattr(f.__self__, meth_name, wrapper)
         else:
             f._wrapper = wrapper
+        wrapper.is_functional = True
         return wrapper
 
 


### PR DESCRIPTION
Summary:
For my JIT compiler I'm going to need to know when a function object is a random variable / functional, *before* I execute it. The easiest way to do that is to simply have the wrapper function generated by the decorator mark itself as being a random variable / functional; that way I can just check whether there is such an attribute.

I'll be making use of this in upcoming diffs.

Reviewed By: wtaha

Differential Revision: D25034512

