### PR TITLE
Handle jit compilation of "functionals" with ordinary arguments

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/jit_test.py
+++ b/src/beanmachine/ppl/compiler/tests/jit_test.py
@@ -41,6 +41,11 @@ def flip():
     return Bernoulli(coin())
 
 
+@bm.functional
+def exp_coin():
+    return coin().exp()
+
+
 class JITTest(unittest.TestCase):
     def test_function_transformation_1(self) -> None:
         """Unit tests for JIT functions"""
@@ -177,7 +182,7 @@ digraph "graph" {
         self.maxDiff = None
 
         bmg = BMGraphBuilder()
-        queries = [coin()]
+        queries = [coin(), exp_coin()]
         observations = {flip(): tensor(1.0)}
         bmg.accumulate_graph(queries, observations)
         dot = bmg.to_dot(point_at_input=True)
@@ -190,13 +195,17 @@ digraph "graph" {
   N4[label=Sample];
   N5[label="Observation tensor(1.)"];
   N6[label=Query];
+  N7[label=Exp];
+  N8[label=Query];
   N0 -> N1[label=alpha];
   N0 -> N1[label=beta];
   N1 -> N2[label=operand];
   N2 -> N3[label=probability];
   N2 -> N6[label=operator];
+  N2 -> N7[label=operand];
   N3 -> N4[label=operand];
   N4 -> N5[label=operand];
+  N7 -> N8[label=operator];
 }
 """
         self.assertEqual(dot.strip(), expected.strip())

--- a/src/beanmachine/ppl/utils/bm_graph_builder.py
+++ b/src/beanmachine/ppl/utils/bm_graph_builder.py
@@ -219,6 +219,10 @@ def _is_random_variable_call(f) -> bool:
     return hasattr(f, "is_random_variable")
 
 
+def _is_functional_call(f) -> bool:
+    return hasattr(f, "is_functional")
+
+
 def _is_phi(f: Any) -> bool:
     if not isinstance(f, Callable):
         return False
@@ -291,7 +295,7 @@ class BMGraphBuilder:
     # refer to a function that we need to transform into the "lifted" form. This
     # map tracks those so that we do not repeat work.
 
-    rv_map: Dict[RVIdentifier, Callable]
+    rv_map: Dict[RVIdentifier, BMGNode]
     lifted_map: Dict[Callable, Callable]
 
     def __init__(self) -> None:
@@ -1126,7 +1130,7 @@ class BMGraphBuilder:
         f, args, kwargs = self._canonicalize_function(function, arguments, kwargs)
 
         if is_ordinary_call(f, args, kwargs):
-            if _is_random_variable_call(f):
+            if _is_random_variable_call(f) or _is_functional_call(f):
                 return self._handle_ordinary_random_variable_call(f, args, kwargs)
             return f(*args, **kwargs)
 
@@ -1146,7 +1150,7 @@ class BMGraphBuilder:
 
         raise ValueError(f"Function {f} is not supported by Bean Machine Graph.")
 
-    def _rv_to_node(self, rv: RVIdentifier) -> SampleNode:
+    def _rv_to_node(self, rv: RVIdentifier) -> BMGNode:
         from beanmachine.ppl.compiler.bm_to_bmg import _bm_function_to_bmg_function
 
         if rv not in self.rv_map:


### PR DESCRIPTION
Summary:
I'm continuing down the list of scenarios listed in my previous diff for jit-compiled function calls.

In this diff, an easy one. A call to a "functional" function with normal arguments (that is, not themselves graph nodes) is handled exactly like a "random variable" call with normal arguments.  In both cases the function will return an RVIdentifier that captures both the function and the arguments; we can use our existing mechanism for compiling, executing and caching the resulting graph node.

Note that we do not yet handle the case where a "functional" returns a non-graph node. We'll deal with that in a later diff.

Reviewed By: wtaha

Differential Revision: D25077894

