### PR TITLE
Remove automatic addition of query nodes to functionals in compiler

### DIFF
--- a/src/beanmachine/ppl/compiler/bm_to_bmg.py
+++ b/src/beanmachine/ppl/compiler/bm_to_bmg.py
@@ -261,12 +261,6 @@ _handle_sample = PatternRule(
     ast_return(), lambda r: ast.Return(value=_make_bmg_call("handle_sample", [r.value]))
 )
 
-_handle_query = PatternRule(
-    ast_return(), lambda r: ast.Return(value=_make_bmg_call("handle_query", [r.value]))
-)
-
-# TODO: add_observation
-
 _math_to_bmg: Rule = _top_down(
     once(
         first(
@@ -311,8 +305,6 @@ _is_query: PatternRule = PatternRule(
 _no_params: PatternRule = PatternRule(function_def(args=arguments(args=[])))
 
 _sample_returns: Rule = _descend_until(_is_sample, _top_down(once(_handle_sample)))
-
-_query_returns: Rule = _descend_until(_is_query, _top_down(once(_handle_query)))
 
 _remove_query_decorator: Rule = _descend_until(
     _is_query,
@@ -391,7 +383,6 @@ _to_bmg = all_of(
         _math_to_bmg,
         _sample_returns,
         _sample_to_memoize,
-        _query_returns,
         _remove_query_decorator,
     ]
 )

--- a/src/beanmachine/ppl/compiler/bmg_nodes.py
+++ b/src/beanmachine/ppl/compiler/bmg_nodes.py
@@ -3061,11 +3061,7 @@ class Query(BMGNode):
     """A query is a marker on a node in the graph that indicates
     to the inference engine that the user is interested in
     getting a distribution of values of that node. It always
-    points to an operator node.
-
-    We represent queries in models with the @bm.functional annotation;
-    the compiler causes the returned nodes of such models
-    to have a query node accumulated into the graph builder."""
+    points to an operator node."""
 
     # TODO: As with observations, properly speaking there is no
     # need to represent a query as a *node*, and BMG does not

--- a/src/beanmachine/ppl/compiler/tests/bm_to_bmg_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bm_to_bmg_test.py
@@ -1961,25 +1961,23 @@ digraph "graph" {
   N09[label=Normal];
   N10[label=Sample];
   N11[label="+"];
-  N12[label=Query];
-  N13[label=1.0];
-  N14[label=Normal];
-  N15[label=Sample];
-  N03 -> N00[label=df];
-  N03 -> N01[label=loc];
-  N03 -> N02[label=scale];
-  N04 -> N03[label=operand];
-  N06 -> N05[label=scale];
-  N07 -> N06[label=operand];
-  N09 -> N07[label=sigma];
-  N09 -> N08[label=mu];
-  N10 -> N09[label=operand];
-  N11 -> N04[label=left];
-  N11 -> N10[label=right];
-  N12 -> N11[label=operator];
-  N14 -> N11[label=mu];
-  N14 -> N13[label=sigma];
-  N15 -> N14[label=operand];
+  N12[label=1.0];
+  N13[label=Normal];
+  N14[label=Sample];
+  N00 -> N03[label=df];
+  N01 -> N03[label=loc];
+  N02 -> N03[label=scale];
+  N03 -> N04[label=operand];
+  N04 -> N11[label=left];
+  N05 -> N06[label=scale];
+  N06 -> N07[label=operand];
+  N07 -> N09[label=sigma];
+  N08 -> N09[label=mu];
+  N09 -> N10[label=operand];
+  N10 -> N11[label=right];
+  N11 -> N13[label=mu];
+  N12 -> N13[label=sigma];
+  N13 -> N14[label=operand];
 }
 """
 
@@ -2222,7 +2220,7 @@ class CompilerTest(unittest.TestCase):
 
     def test_to_dot_18(self) -> None:
         self.maxDiff = None
-        observed = to_dot(source18)
+        observed = to_dot(source18, point_at_input=True)
         self.assertEqual(observed.strip(), expected_dot_18.strip())
 
     def disabled_test_to_cpp_1(self) -> None:

--- a/src/beanmachine/ppl/utils/bm_graph_builder.py
+++ b/src/beanmachine/ppl/utils/bm_graph_builder.py
@@ -1270,32 +1270,12 @@ class BMGraphBuilder:
             )
         setattr(operand, name, value)
 
+    # TODO: Should this be idempotent?
+    # TODO: Should it be an error to add two unequal observations to one node?
     def add_observation(self, observed: SampleNode, value: Any) -> Observation:
         node = Observation(observed, value)
         self.add_node(node)
         return node
-
-    def handle_query(self, value: Any) -> Any:
-        # When we have an @bm.functional function, we need to put a node
-        # in the graph indicating that the value returned is of
-        # interest to the user, and the inference engine should
-        # accumulate information about it.  Under what circumstances
-        # might that be useful? If the query function returns an
-        # ordinary value, there is nothing we can infer from it.
-        # But if it returns an operation in a probabilistic workflow,
-        # that node in the graph should be marked as being of interest.
-        #
-        # Adding a query to a node is idempotent; querying twice is the
-        # same as querying once, so the add_query method is memoized.
-        #
-        # Note that this function does not return the added query node.
-        # The query node is just a marker, not a value; we just keep
-        # using the value as it was before. We insert a node into the
-        # graph if necessary and then hand back the argument.
-
-        if isinstance(value, OperatorNode):
-            self.add_query(value)
-        return value
 
     @memoize
     def add_query(self, operator: OperatorNode) -> Query:
@@ -1490,9 +1470,6 @@ g = graph.Graph()
 
         # TODO: Error checking; verify that all observations are samples
         # TODO: and all queries are operators.
-
-        # TODO: Do not automatically insert query nodes based on
-        # TODO: source code annotations.
 
         for node, val in observations.items():
             self.add_observation(node, val)


### PR DESCRIPTION
Summary:
When we translate a model from BeanMachine to BMGraph, we must insert a "sample" graph node onto every distinct call to a `random_variable` method.

When I was first implementing the compiler I did not understand how "query" nodes were properly to be inserted, and made the incorrect assumption that we must insert a query node on every distinct call to a `functional` method, similar to how we insert a sample on every `random_variable`.

This is incorrect. The `functional` annotation marks computations that *can* be queried, not computations that *are* queried. The only query nodes added to the graph builder ought to be those pointing to nodes that were actually queried during inference.

I have therefore removed the code that automatically inserts query nodes on every call to a `functional`.

In an upcoming diff we will show how the new JIT compilation mechanism inserts query nodes into the graph correctly.

Reviewed By: wtaha

Differential Revision: D25258391

