### PR TITLE
Test case to demonstrate rewriting bug

### DIFF
--- a/src/beanmachine/ppl/utils/tests/single_assignment_test.py
+++ b/src/beanmachine/ppl/utils/tests/single_assignment_test.py
@@ -1733,3 +1733,34 @@ y = p1(*r5, **r9)
 """
 
         self.check_rewrite(source, expected)
+
+    def test_single_assignment_nested_call_named_arg(self) -> None:
+        self.maxDiff = None
+
+        # This test points out a bug in the rewriting logic.
+        # We should be pulling the invocation of c() out into
+        # it's own top-level function call.
+        #
+        # The code below should be rewritten as something like:
+        #
+        # t1 = []
+        # t2 = {}
+        # t3 = c(*t1, **t2)
+        # t4 = []
+        # t5 = {'n' : t3}
+        # t6 = b(*t4, **t5)
+        # return t6
+
+        source = """
+def f():
+    return b(n=c())
+"""
+        expected = """
+def f():
+    r2 = []
+    r3 = dict(n=c())
+    r1 = b(*r2, **r3)
+    return r1
+"""
+
+        self.check_rewrite(source, expected)


### PR DESCRIPTION
Summary:
I noticed a bug in the rewriting logic; for some reason, nested function calls used as named arguments inside a function call are not being rewritten correctly.

The test passes but it should not; once the bug is fixed, we can either delete the test or change it to pass.

Reviewed By: wtaha

Differential Revision: D25449184

