### PR TITLE
Fix bugs in phi detection

### DIFF
--- a/src/beanmachine/ppl/utils/bm_graph_builder.py
+++ b/src/beanmachine/ppl/utils/bm_graph_builder.py
@@ -226,6 +226,12 @@ def _is_functional_call(f) -> bool:
 def _is_phi(f: Any) -> bool:
     if not isinstance(f, Callable):
         return False
+    if not hasattr(f, "__name__"):
+        return False
+    if f.__name__ != "cdf":
+        return False
+    if not hasattr(f, "__self__"):
+        return False
     s = f.__self__
     if not isinstance(s, Normal):
         return False


### PR DESCRIPTION
Summary:
We need to be able to tell if the phi function is called with a graph node as its argument; for our purposes the phi function is any function of the form `Normal(0, 1).cdf`.

I wrote a little method to detect when this function is the one being called but I made two very silly mistakes. The first is: I check the function to see if it is a member of `Normal` by checking `__self__`, but not all function objects have a `__self__` attribute, so this can crash. The second is: I never checked the name of the function! All member functions of `Normal(0, 1)` were treated as phi. Whoops.

Reviewed By: wtaha

Differential Revision: D25279291

