### PR TITLE
Fix test error in world and statistical_model

### DIFF
--- a/src/beanmachine/ppl/model/tests/statistical_model_test.py
+++ b/src/beanmachine/ppl/model/tests/statistical_model_test.py
@@ -20,7 +20,7 @@ class StatisticalModelTest(unittest.TestCase):
 
         @bm.random_variable
         def baz(self):
-            return dist.Normal(self.foo(), self.bar())
+            return dist.Normal(self.foo(), self.bar().abs())
 
     class SampleLargeModel(object):
         @bm.random_variable
@@ -33,19 +33,19 @@ class StatisticalModelTest(unittest.TestCase):
 
         @bm.random_variable
         def baz(self):
-            return dist.Normal(self.foo(), self.bar())
+            return dist.Normal(self.foo(), self.bar().abs())
 
         @bm.random_variable
         def foobar(self):
-            return dist.Normal(self.baz(), self.bar())
+            return dist.Normal(self.baz(), self.bar().abs())
 
         @bm.random_variable
         def bazbar(self, i):
-            return dist.Normal(self.baz(), self.foo())
+            return dist.Normal(self.baz(), self.foo().abs())
 
         @bm.random_variable
         def foobaz(self):
-            return dist.Normal(self.bazbar(1), self.foo())
+            return dist.Normal(self.bazbar(1), self.foo().abs())
 
         @bm.functional
         def avg(self):
@@ -54,6 +54,7 @@ class StatisticalModelTest(unittest.TestCase):
     def test_rv_sample_assignment(self):
         model = self.SampleModel()
         world = World()
+        world.set_initialize_from_prior(True)
         foo_key = model.foo()
         bar_key = model.bar()
         baz_key = model.baz()
@@ -81,7 +82,7 @@ class StatisticalModelTest(unittest.TestCase):
         foo_expected_dist = dist.Normal(torch.tensor(0.0), torch.tensor(1.0))
         bar_expected_dist = dist.Normal(diff_vars[foo_key].value, torch.tensor(1.0))
         baz_expected_dist = dist.Normal(
-            diff_vars[foo_key].value, diff_vars[bar_key].value
+            diff_vars[foo_key].value, diff_vars[bar_key].value.abs()
         )
 
         self.assertEqual(foo_expected_dist.mean, diff_vars[foo_key].distribution.mean)
@@ -100,6 +101,7 @@ class StatisticalModelTest(unittest.TestCase):
     def test_rv_sample_assignment_with_large_model_with_index(self):
         model = self.SampleLargeModel()
         world = World()
+        world.set_initialize_from_prior(True)
         foo_key = model.foo()
         bar_key = model.bar()
         baz_key = model.baz()
@@ -147,16 +149,16 @@ class StatisticalModelTest(unittest.TestCase):
         foo_expected_dist = dist.Normal(torch.tensor(0.0), torch.tensor(1.0))
         bar_expected_dist = dist.Normal(diff_vars[foo_key].value, torch.tensor(1.0))
         baz_expected_dist = dist.Normal(
-            diff_vars[foo_key].value, diff_vars[bar_key].value
+            diff_vars[foo_key].value, diff_vars[bar_key].value.abs()
         )
         foobar_expected_dist = dist.Normal(
-            diff_vars[baz_key].value, diff_vars[bar_key].value
+            diff_vars[baz_key].value, diff_vars[bar_key].value.abs()
         )
         bazbar_expected_dist = dist.Normal(
-            diff_vars[baz_key].value, diff_vars[foo_key].value
+            diff_vars[baz_key].value, diff_vars[foo_key].value.abs()
         )
         foobaz_expected_dist = dist.Normal(
-            diff_vars[bazbar_key].value, diff_vars[foo_key].value
+            diff_vars[bazbar_key].value, diff_vars[foo_key].value.abs()
         )
 
         self.assertEqual(foo_expected_dist.mean, diff_vars[foo_key].distribution.mean)

--- a/src/beanmachine/ppl/world/tests/world_test.py
+++ b/src/beanmachine/ppl/world/tests/world_test.py
@@ -254,8 +254,8 @@ class WorldTest(unittest.TestCase):
 
         expected_node_update = (
             dist.Normal(tensor(0.0), tensor(1.0))
-            .log_prob(0.35)
-            .sub(dist.Normal(tensor(0.0), tensor(1.0)).log_prob(0.2))
+            .log_prob(tensor(0.35))
+            .sub(dist.Normal(tensor(0.0), tensor(1.0)).log_prob(tensor(0.2)))
         )
 
         children_log_update, world_log_update, _, score = world.propose_change(
@@ -298,8 +298,8 @@ class WorldTest(unittest.TestCase):
 
         expected_node_update = (
             dist.Normal(tensor(0.0), tensor(1.0))
-            .log_prob(0.55)
-            .sub(dist.Normal(tensor(0.0), tensor(1.0)).log_prob(0.35))
+            .log_prob(tensor(0.55))
+            .sub(dist.Normal(tensor(0.0), tensor(1.0)).log_prob(tensor(0.35)))
         )
 
         expected_children_log_update = (
@@ -698,9 +698,9 @@ class WorldTest(unittest.TestCase):
         )
 
         score = world.propose_change(foo_key, tensor(0.25))[3]
-        expected_score = dist.Normal(0, 1).log_prob(0.25) + dist.Normal(
+        expected_score = dist.Normal(0, 1).log_prob(tensor(0.25)) + dist.Normal(
             0.25, 1.0
-        ).log_prob(0.1)
+        ).log_prob(tensor(0.1))
         self.assertAlmostEqual(score, expected_score)
 
     def test_update_graph_in_nested_world(self):


### PR DESCRIPTION
Summary:
Background: T81756389

This diff address the validation error raised by `torch.Distribution` in beanmachine unittests. In particular, errors from the following two modules are fixed:

- `beanmachine.ppl.model.tests.statistical_model_tests`
- `beanmachine.ppl.world.tests.world_test`

Differential Revision: D25651066

