### PR TITLE
Start removing compiler inference hack

### DIFF
--- a/src/beanmachine/ppl/compiler/bm_to_bmg.py
+++ b/src/beanmachine/ppl/compiler/bm_to_bmg.py
@@ -585,8 +585,9 @@ def to_bmg(source: str):
 
 
 def infer(source: str, num_samples: int = 1000) -> List[Any]:
+    # TODO: Remove this API
     mod_globals = _execute(source)
     bmg = mod_globals["bmg"]
     observations = mod_globals["observations"] if "observations" in mod_globals else {}
     queries = mod_globals["queries"] if "queries" in mod_globals else []
-    return bmg.infer(queries, observations, num_samples)
+    return bmg.infer_deprecated(queries, observations, num_samples)

--- a/src/beanmachine/ppl/utils/bm_graph_builder.py
+++ b/src/beanmachine/ppl/utils/bm_graph_builder.py
@@ -1582,12 +1582,13 @@ g = graph.Graph()
             node = self._rv_to_node(q)
             self.add_query(node)
 
-    def infer(
+    def infer_deprecated(
         self,
         queries: List[OperatorNode],
         observations: Dict[SampleNode, Any],
         num_samples: int,
-    ) -> Dict[Any, List[Any]]:
+    ) -> List[Any]:
+        # TODO: Remove this method
 
         from beanmachine.ppl.compiler.fix_problems import fix_problems
 


### PR DESCRIPTION
Summary: As an initial step along the way to getting inference going in the compiler, I added an "infer" method to the graph builder. I want to redesign that API; step one is renaming the old API so as to not conflict with the new one which will also be named "infer".

Reviewed By: wtaha

Differential Revision: D25288486

