### PR TITLE
Create API for BMG inference from BM models

### DIFF
--- a/src/beanmachine/ppl/compiler/bmg_nodes.py
+++ b/src/beanmachine/ppl/compiler/bmg_nodes.py
@@ -3109,8 +3109,7 @@ class Query(BMGNode):
         return True
 
     def _add_to_graph(self, g: Graph, d: Dict[BMGNode, int]) -> int:
-        g.query(d[self.operator])
-        return -1
+        return g.query(d[self.operator])
 
     def _to_python(self, d: Dict["BMGNode", int]) -> str:
         return f"g.query(n{d[self.operator]})"

--- a/src/beanmachine/ppl/inference/bmg_inference.py
+++ b/src/beanmachine/ppl/inference/bmg_inference.py
@@ -1,0 +1,29 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+"""An inference engine which uses Bean Machine Graph to make
+inferences on Bean Machine models."""
+
+from typing import Dict, List
+
+from beanmachine.ppl.inference.monte_carlo_samples import MonteCarloSamples
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
+from beanmachine.ppl.utils.bm_graph_builder import BMGraphBuilder
+from torch import Tensor
+
+
+class BMGInference:
+    def __init__(self):
+        pass
+
+    def infer(
+        self,
+        queries: List[RVIdentifier],
+        observations: Dict[RVIdentifier, Tensor],
+        num_samples: int,
+    ) -> MonteCarloSamples:
+        # TODO: Add num_chains
+        # TODO: Add verbose level
+        # TODO: Add logging
+        bmg = BMGraphBuilder()
+        bmg.accumulate_graph(queries, observations)
+        return bmg.infer(num_samples)


### PR DESCRIPTION
Summary:
We have now realized Michael's original dream of making Bean Machine Graph "just another inference engine" for a subset of Bean Machine models.   It's a little rough around the edges still, but we actually have an end-to-end solution for the first time with this diff.

To match the pattern established by other inference engines, I've created an object to represent the inference engine; it is a thin wrapper around a BMGraphBuilder which does the actual work:

* jit-compile the functions underlying each query and observation into a lifted form
* execute the lifted form, which populates the graph builder as it runs
* type check the resulting graph for compatibility with BMG
* generate a BMG graph object and run inference on it
* format the resulting sample array into a dictionary of tensors

Still to come:

* Much more testing
* Better error reporting
* Tweaks to BMG and the compiler to support CLARA model
* Improvements to the API such as support for logging, multiple chains, and so on.

Reviewed By: wtaha

Differential Revision: D25291072

