### PR TITLE
Get logistic regression test case working with BMG inference

### DIFF
--- a/src/beanmachine/ppl/inference/bmg_inference.py
+++ b/src/beanmachine/ppl/inference/bmg_inference.py
@@ -27,3 +27,25 @@ class BMGInference:
         bmg = BMGraphBuilder()
         bmg.accumulate_graph(queries, observations)
         return bmg.infer(num_samples)
+
+    def to_dot(
+        self,
+        queries: List[RVIdentifier],
+        observations: Dict[RVIdentifier, Tensor],
+        after_transform: bool = True,
+        label_edges: bool = False,
+    ) -> str:
+        bmg = BMGraphBuilder()
+        bmg.accumulate_graph(queries, observations)
+        graph_types = False
+        inf_types = False
+        point_at_input = True
+        edge_requirements = False
+        return bmg.to_dot(
+            graph_types,
+            inf_types,
+            edge_requirements,
+            point_at_input,
+            after_transform,
+            label_edges,
+        )

--- a/src/beanmachine/ppl/utils/bm_graph_builder.py
+++ b/src/beanmachine/ppl/utils/bm_graph_builder.py
@@ -1439,6 +1439,7 @@ class BMGraphBuilder:
         edge_requirements: bool = False,
         point_at_input: bool = False,
         after_transform: bool = False,
+        label_edges: bool = True,
     ) -> str:
         """This dumps the entire accumulated graph state, including
         orphans, as a DOT graph description; nodes are enumerated in the order
@@ -1469,9 +1470,15 @@ class BMGraphBuilder:
             for (child, edge_name, req) in zip(
                 node.children, node.edges, node.requirements
             ):
-                edge_label = edge_name
-                if edge_requirements:
-                    edge_label += ":" + req.short_name
+                if label_edges:
+                    edge_label = edge_name
+                    if edge_requirements:
+                        edge_label += ":" + req.short_name
+                elif edge_requirements:
+                    edge_label = req.short_name
+                else:
+                    edge_label = ""
+
                 # Bayesian networks are typically drawn with the arrows
                 # in the direction of data flow, not in the direction
                 # of dependency.


### PR DESCRIPTION
Summary:
I've made my new JIT-based BMGInference engine work with my little Bayesian logistic regression test case:

* test now actually does inference. And gets a reasonable answer even with thin data.
* Inference engine can now dump the generated BMG graph as a DOT file.
* Added another option to DOT output to make it less verbose. Most of the time we don't need to know the labels on the edges; they are clear from context.

Reviewed By: wtaha

Differential Revision: D25411072

