### PR TITLE
Add debugging helpers for JIT compiler

### DIFF
--- a/src/beanmachine/ppl/compiler/bm_to_bmg.py
+++ b/src/beanmachine/ppl/compiler/bm_to_bmg.py
@@ -506,7 +506,14 @@ def _bm_function_to_bmg_function(f: Callable, bmg: BMGraphBuilder) -> Callable:
 
     g = sys.modules[f.__module__].__dict__
     exec(c, g)  # noqa
-    return g[helper_name](bmg)
+    # For debugging purposes we'll stick some helpful information into
+    # the function object.
+    transformed = g[helper_name](bmg)
+    transformed.graph_builder = bmg
+    transformed.original = f
+    transformed.transformed_ast = a
+    transformed.transformed_source = astor.to_source(a)
+    return transformed
 
 
 def _bm_module_to_bmg_ast(source: str) -> ast.AST:


### PR DESCRIPTION
Summary: When we JIT compile a function, I now stash the original function, the graph builder that asked for the JIT compilation, the AST of the transformed function, and the source code of the transformed function into the transformed function. There is no user-facing feature that requires any of this; it is solely as an aid so that I can easily inspect the operation of the jitter while debugging it.

Reviewed By: wtaha

Differential Revision: D25447511

