### PR TITLE
Add TO_PROBABILITY operator to BMG

### DIFF
--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -295,6 +295,7 @@ enum class OperatorType {
   POW,
   LOG1MEXP,
   MATRIX_MULTIPLY,
+  TO_PROBABILITY,
 };
 
 enum class DistributionType {

--- a/src/beanmachine/graph/operator/gradient.cpp
+++ b/src/beanmachine/graph/operator/gradient.cpp
@@ -31,6 +31,12 @@ void ToPosReal::compute_gradients() {
   grad2 = in_nodes[0]->grad2;
 }
 
+void ToProbability::compute_gradients() {
+  assert(in_nodes.size() == 1);
+  grad1 = in_nodes[0]->grad1;
+  grad2 = in_nodes[0]->grad2;
+}
+
 void Negate::compute_gradients() {
   assert(in_nodes.size() == 1);
   grad1 = -1 * in_nodes[0]->grad1;

--- a/src/beanmachine/graph/operator/register.cpp
+++ b/src/beanmachine/graph/operator/register.cpp
@@ -51,6 +51,10 @@ bool ToPosReal::is_registered = OperatorFactory::register_op(
     graph::OperatorType::TO_POS_REAL,
     &(ToPosReal::new_op));
 
+bool ToProbability::is_registered = OperatorFactory::register_op(
+    graph::OperatorType::TO_PROBABILITY,
+    &(ToProbability::new_op));
+
 bool Negate::is_registered = OperatorFactory::register_op(
     graph::OperatorType::NEGATE,
     &(Negate::new_op));

--- a/src/beanmachine/graph/operator/unaryop.cpp
+++ b/src/beanmachine/graph/operator/unaryop.cpp
@@ -89,6 +89,36 @@ void ToPosReal::eval(std::mt19937& /* gen */) {
   }
 }
 
+ToProbability::ToProbability(const std::vector<graph::Node*>& in_nodes)
+    : UnaryOperator(graph::OperatorType::TO_PROBABILITY, in_nodes) {
+  graph::ValueType type0 = in_nodes[0]->value.type;
+  if (type0 != graph::AtomicType::PROBABILITY and
+      type0 != graph::AtomicType::POS_REAL and
+      type0 != graph::AtomicType::REAL) {
+    throw std::invalid_argument(
+        "operator TO_PROBABILITY requires a "
+        "real, pos_real, or probability parent");
+  }
+  value = graph::NodeValue(graph::AtomicType::PROBABILITY);
+}
+
+void ToProbability::eval(std::mt19937& /* gen */) {
+  assert(in_nodes.size() == 1);
+  const graph::NodeValue& parent = in_nodes[0]->value;
+  if (parent.type == graph::AtomicType::PROBABILITY or
+      parent.type == graph::AtomicType::POS_REAL or
+      parent.type == graph::AtomicType::REAL) {
+    // note: we have to cast it to an NodeValue object rather than directly
+    // assigning to ensure that the usual boundary checks for probabilities
+    // are made
+    value = graph::NodeValue(graph::AtomicType::PROBABILITY, parent._double);
+  } else {
+    throw std::runtime_error(
+        "invalid parent type " + parent.type.to_string() +
+        " for TO_PROBABILITY operator at node_id " + std::to_string(index));
+  }
+}
+
 Negate::Negate(const std::vector<graph::Node*>& in_nodes)
     : UnaryOperator(graph::OperatorType::NEGATE, in_nodes) {
   graph::ValueType type0 = in_nodes[0]->value.type;

--- a/src/beanmachine/graph/operator/unaryop.h
+++ b/src/beanmachine/graph/operator/unaryop.h
@@ -83,6 +83,23 @@ class ToPosReal : public UnaryOperator {
   static bool is_registered;
 };
 
+class ToProbability : public UnaryOperator {
+ public:
+  explicit ToProbability(const std::vector<graph::Node*>& in_nodes);
+  ~ToProbability() override {}
+
+  void eval(std::mt19937& gen) override;
+  void compute_gradients() override;
+
+  static std::unique_ptr<Operator> new_op(
+      const std::vector<graph::Node*>& in_nodes) {
+    return std::make_unique<ToProbability>(in_nodes);
+  }
+
+ private:
+  static bool is_registered;
+};
+
 class Negate : public UnaryOperator {
  public:
   explicit Negate(const std::vector<graph::Node*>& in_nodes);

--- a/src/beanmachine/graph/pybindings.cpp
+++ b/src/beanmachine/graph/pybindings.cpp
@@ -56,7 +56,8 @@ PYBIND11_MODULE(graph, module) {
       .value("IF_THEN_ELSE", OperatorType::IF_THEN_ELSE)
       .value("LOG", OperatorType::LOG)
       .value("POW", OperatorType::POW)
-      .value("MATRIX_MULTIPLY", OperatorType::MATRIX_MULTIPLY);
+      .value("MATRIX_MULTIPLY", OperatorType::MATRIX_MULTIPLY)
+      .value("TO_PROBABILITY", OperatorType::TO_PROBABILITY);
 
   py::enum_<DistributionType>(module, "DistributionType")
       .value("TABULAR", DistributionType::TABULAR)


### PR DESCRIPTION
Summary:
BMG already has a TO_POSITIVE_REAL and TO_REAL nodes, but they both require that their operand already be known to fit into their type; that is, TO_POSITIVE_REAL turns a probability into a positive real, and TO_REAL turns a probability or positive real into a real.

We need a TO_PROBABILITY node that goes the other way: it turns a positive real or real into a probability.  We have need of this because it is common in a model to make an expression which you know and I know must be between 0.0 and 1.0, and needs to be used as a probability, but which the BMG type system will classify as a real or positive real.

Here are some examples; suppose PR is a positive real quantity, P is a probability:

* `0.4 * P + 0.5` -- we know this must fit into a probability, but BMG treats a sum of probabilities as a positive real.
* `1.0 - (0.4 * P + 0.5)` -- again we know that this must fit into a probability, but the parenthesized expression is a positive real according to BMG, and now we have the difference of positive real 1.0 and a positive real, which is a real according to BMG.
* `PR / (1 + PR)`  the quotient of two positive reals is a positive real according to BMG, but we know that this is between 0.0 and 1.0.

We could add operators for every special case we come up with, but that would be a lot of operators and we would undoubtedly miss some. Instead we can simply add a TO_PROBABILITY operator that takes a real or positive real and constrains it to the range of a probability for either (1) cases where we know that we will get a probability, or (2) cases where we don't get a probability but we wish to clamp a real quantity to that range.

Any thoughts and critiques would be very welcome.

Reviewed By: wtaha

Differential Revision: D25547971

