### PR TITLE
Add a ToProbabilityNode to the graph builder

### DIFF
--- a/src/beanmachine/ppl/compiler/bmg_nodes.py
+++ b/src/beanmachine/ppl/compiler/bmg_nodes.py
@@ -2957,6 +2957,48 @@ class ToPositiveRealNode(UnaryOperatorNode):
         return True
 
 
+class ToProbabilityNode(UnaryOperatorNode):
+    operator_type = OperatorType.TO_PROBABILITY
+
+    def __init__(self, operand: BMGNode):
+        UnaryOperatorNode.__init__(self, operand)
+
+    @property
+    def graph_type(self) -> BMGLatticeType:
+        return Probability
+
+    @property
+    def inf_type(self) -> BMGLatticeType:
+        return Probability
+
+    @property
+    def requirements(self) -> List[Requirement]:
+        # TODO: A ToProbabilityNode's input must be real, positive real
+        # or probability, but we don't have a bound for that. However,
+        # we do not need one, since this node is only ever added when
+        # a requirement violation exists in the graph! We will only
+        # add this node when it is legal to do so; it does not matter
+        # what requirement we give here.
+        return [upper_bound(Real)]
+
+    @property
+    def label(self) -> str:
+        return "ToProb"
+
+    @property
+    def size(self) -> torch.Size:
+        return torch.Size([])
+
+    def __str__(self) -> str:
+        return "ToProb(" + str(self.operand) + ")"
+
+    def support(self) -> Iterator[Any]:
+        return self.operand.support()
+
+    def _supported_in_bmg(self) -> bool:
+        return True
+
+
 # ####
 # #### Marker nodes
 # ####

--- a/src/beanmachine/ppl/compiler/tests/unary_nodes_test.py
+++ b/src/beanmachine/ppl/compiler/tests/unary_nodes_test.py
@@ -19,6 +19,7 @@ from beanmachine.ppl.compiler.bmg_nodes import (
     RealNode,
     SampleNode,
     ToPositiveRealNode,
+    ToProbabilityNode,
     ToRealNode,
 )
 from beanmachine.ppl.compiler.bmg_types import (
@@ -117,6 +118,12 @@ class UnaryNodesTest(unittest.TestCase):
         self.assertEqual(ToPositiveRealNode(beta).inf_type, PositiveReal)
         self.assertEqual(ToPositiveRealNode(bino).inf_type, PositiveReal)
         self.assertEqual(ToPositiveRealNode(half).inf_type, PositiveReal)
+
+        # To Probability
+        # Input must be real, positive real, or probability
+        self.assertEqual(ToProbabilityNode(norm).inf_type, Probability)
+        self.assertEqual(ToProbabilityNode(half).inf_type, Probability)
+        self.assertEqual(ToProbabilityNode(beta).inf_type, Probability)
 
     def test_requirements_unary(self) -> None:
         """test_requirements_unary"""


### PR DESCRIPTION
Summary:
The graph builder now has a class to represent the new TO_PROBABILITY operation in BMG.

This diff just adds the class; we will construct it and use it in later diffs.

Reviewed By: wtaha

Differential Revision: D25571104

