### PR TITLE
Continue adding TO_PROBABILITY support to graph builder

### DIFF
--- a/src/beanmachine/ppl/utils/bm_graph_builder.py
+++ b/src/beanmachine/ppl/utils/bm_graph_builder.py
@@ -110,6 +110,7 @@ from beanmachine.ppl.compiler.bmg_nodes import (
     StudentTNode,
     TensorNode,
     ToPositiveRealNode,
+    ToProbabilityNode,
     ToRealNode,
     UniformNode,
 )
@@ -1040,6 +1041,16 @@ class BMGraphBuilder:
         if isinstance(operand, ConstantNode):
             return self.add_positive_real(float(operand.value))
         node = ToPositiveRealNode(operand)
+        self.add_node(node)
+        return node
+
+    @memoize
+    def add_to_probability(self, operand: BMGNode) -> BMGNode:
+        if isinstance(operand, ProbabilityNode):
+            return operand
+        if isinstance(operand, ConstantNode):
+            return self.add_probability(float(operand.value))
+        node = ToProbabilityNode(operand)
         self.add_node(node)
         return node
 

--- a/src/beanmachine/ppl/utils/tests/bm_graph_builder_test.py
+++ b/src/beanmachine/ppl/utils/tests/bm_graph_builder_test.py
@@ -1413,6 +1413,22 @@ digraph "graph" {
         # to_positive_real nodes are deduplicated
         self.assertEqual(bmg.add_to_positive_real(beta22), to_pr)
 
+    def test_to_probability(self) -> None:
+        """Test to_probability"""
+        bmg = BMGraphBuilder()
+        h = bmg.add_probability(0.5)
+        # to_probability on a prob constant is an identity
+        self.assertEqual(bmg.add_to_probability(h), h)
+        # We have (hc / (0.5 + hc)) which is always between
+        # 0 and 1, but the quotient of two positive reals
+        # is a positive real. Force it to be a probability.
+        hc = bmg.add_halfcauchy(h)
+        s = bmg.add_addition(hc, h)
+        q = bmg.add_division(hc, s)
+        to_p = bmg.add_to_probability(q)
+        # to_probability nodes are deduplicated
+        self.assertEqual(bmg.add_to_probability(q), to_p)
+
     def test_sizes(self) -> None:
         bmg = BMGraphBuilder()
         t = bmg.add_tensor(tensor([1.0, 2.0]))


### PR DESCRIPTION
Summary: I'm just adding the ability to add to_prob nodes to the graph builder in this diff; in subsequent diffs we will detect situations where we need to force a real to a probability and insert the node.

Reviewed By: wtaha

Differential Revision: D25595389

