### PR TITLE
Rename "children" to "inputs"

### DIFF
--- a/src/beanmachine/ppl/compiler/bm_graph_builder.py
+++ b/src/beanmachine/ppl/compiler/bm_graph_builder.py
@@ -397,8 +397,8 @@ class BMGraphBuilder:
         """This adds a node we've recently created to the node set;
         it maintains the invariant that all the input nodes are also added."""
         if node not in self.nodes:
-            for child in node.children:
-                self.add_node(child)
+            for i in node.inputs:
+                self.add_node(i)
             self.nodes[node] = len(self.nodes)
 
     # ####
@@ -1478,9 +1478,7 @@ class BMGraphBuilder:
             if inf_types:
                 node_label += ">=" + node.inf_type.short_name
             db.with_node(n, node_label)
-            for (child, edge_name, req) in zip(
-                node.children, node.edges, node.requirements
-            ):
+            for (i, edge_name, req) in zip(node.inputs, node.edges, node.requirements):
                 if label_edges:
                     edge_label = edge_name
                     if edge_requirements:
@@ -1493,8 +1491,8 @@ class BMGraphBuilder:
                 # Bayesian networks are typically drawn with the arrows
                 # in the direction of data flow, not in the direction
                 # of dependency.
-                start_node = to_id(nodes[child]) if point_at_input else n
-                end_node = n if point_at_input else to_id(nodes[child])
+                start_node = to_id(nodes[i]) if point_at_input else n
+                end_node = n if point_at_input else to_id(nodes[i])
                 db.with_edge(start_node, end_node, edge_label)
         return str(db)
 
@@ -1579,8 +1577,8 @@ g = graph.Graph()
         def visit(n: BMGNode) -> None:
             if n in seen:
                 return
-            for c in n.children:
-                visit(c)
+            for i in n.inputs:
+                visit(i)
             seen.add(n)
             result.append(n)
 

--- a/src/beanmachine/ppl/compiler/fix_problems.py
+++ b/src/beanmachine/ppl/compiler/fix_problems.py
@@ -413,14 +413,14 @@ class Fixer:
         reported = set()
         nodes = self.bmg._traverse_from_roots()
         for node in nodes:
-            for i in range(len(node.children)):
-                c = node.children[i]
+            for i in range(len(node.inputs)):
+                c = node.inputs[i]
                 if c._supported_in_bmg():
                     continue
                 # We have an unsupported node. Have we already worked out its
                 # replacement node?
                 if c in replacements:
-                    node.children[i] = replacements[c]
+                    node.inputs[i] = replacements[c]
                     continue
                 # We have an unsupported node; have we already reported it as
                 # having no replacement?
@@ -433,15 +433,15 @@ class Fixer:
                     reported.add(c)
                 else:
                     replacements[c] = replacement
-                    node.children[i] = replacement
+                    node.inputs[i] = replacement
 
     def _fix_unmet_requirements(self) -> None:
         nodes = self.bmg._traverse_from_roots()
         for node in nodes:
             requirements = node.requirements
             for i in range(len(requirements)):
-                node.children[i] = self.meet_requirement(
-                    node.children[i], requirements[i], node, node.edges[i]
+                node.inputs[i] = self.meet_requirement(
+                    node.inputs[i], requirements[i], node, node.edges[i]
                 )
 
     def _addition_to_complement(self, node: AdditionNode) -> BMGNode:
@@ -467,18 +467,18 @@ class Fixer:
         replacements = {}
         nodes = self.bmg._traverse_from_roots()
         for node in nodes:
-            for i in range(len(node.children)):
-                c = node.children[i]
+            for i in range(len(node.inputs)):
+                c = node.inputs[i]
                 if not isinstance(c, AdditionNode):
                     continue
                 assert isinstance(c, AdditionNode)
                 if not c.can_be_complement:
                     continue
                 if c in replacements:
-                    node.children[i] = replacements[c]
+                    node.inputs[i] = replacements[c]
                     continue
                 replacement = self._addition_to_complement(c)
-                node.children[i] = replacement
+                node.inputs[i] = replacement
                 replacements[c] = replacement
 
     def _fix_observations(self) -> None:


### PR DESCRIPTION
Summary:
In abstract syntax trees we always describe the inputs to an operation as its "children", but in the exciting world of Bayesian networks we describe inputs as "parents". Unfortunately I learned that after I wrote the graph accumulator.

For performance reasons we are going to need to track both inputs and outputs of each graph node, so now is a good time to make the renaming refactoring that turns "children" into "inputs". I'll add outputs in a later diff.

Reviewed By: wtaha

Differential Revision: D25670130

