### PR TITLE
Small improvement to item counter wrapper class

### DIFF
--- a/src/beanmachine/ppl/utils/item_counter.py
+++ b/src/beanmachine/ppl/utils/item_counter.py
@@ -17,3 +17,13 @@ class ItemCounter:
             self.items[item] = 1
         else:
             self.items[item] = self.items[item] + 1
+
+    def remove_item(self, item: Any) -> None:
+        if item not in self.items:
+            return
+        count = self.items[item] - 1
+        if count == 0:
+            del self.items[item]
+        else:
+            assert count > 0
+            self.items[item] = count

--- a/src/beanmachine/ppl/utils/tests/item_counter_test.py
+++ b/src/beanmachine/ppl/utils/tests/item_counter_test.py
@@ -1,0 +1,23 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+"""Tests for item_counter.py"""
+import unittest
+
+from beanmachine.ppl.utils.item_counter import ItemCounter
+
+
+class ItemCounterTest(unittest.TestCase):
+    def test_item_counter(self) -> None:
+        i = ItemCounter()
+        self.assertTrue("a" not in i.items)
+        self.assertTrue("b" not in i.items)
+        i.add_item("a")
+        i.add_item("a")
+        i.add_item("b")
+        i.add_item("b")
+        self.assertEqual(i.items["a"], 2)
+        self.assertEqual(i.items["b"], 2)
+        i.remove_item("b")
+        i.remove_item("a")
+        i.remove_item("a")
+        self.assertTrue("a" not in i.items)
+        self.assertEqual(i.items["b"], 1)


### PR DESCRIPTION
Summary:
I'm going to need to keep track of the output nodes for each node in the graph builder, not just the input nodes. But it is possible for one node to output to the same node *twice*; if we have 1 + 1, for instance, then the "1" node is an input of the "+" node twice.

The set of outputs will change as the graph is edited and we must maintain the invariant that the output counts are correct. To prepare for this situation I've added item removal from my little item counting wrapper class.

Reviewed By: wtaha

Differential Revision: D25673672

