### PR TITLE
Insert TO_PROBABILITY nodes as required

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/clara_cgm_test.py
+++ b/src/beanmachine/ppl/compiler/tests/clara_cgm_test.py
@@ -165,10 +165,6 @@ def observation():
         # TODO: torch.logsumexp(torch.tensor([pos_sum, neg_sum]), dim=0)
         # TODO: in the compiler
 
-        # PROBLEM: Here we have the sum of two probabilities, so we cannot
-        # prove that the input to Bernoulli is probability. The best we can
-        # say is that it is a positive real because exp(anything) is a
-        # positive real.
         log_prob_item = (pos_sum.exp() + neg_sum.exp()).log()
         log_prob = log_prob + log_prob_item
     return Bernoulli(log_prob.exp())
@@ -191,10 +187,39 @@ class ClaraCGMTest(unittest.TestCase):
 
         num_samples = 1000
         inference = BMGInference()
-        # TODO: Right now this gives an error because (as noted above)
-        # we do not know that the sum of two reals is a probability.
-        # Until we've figured out how to fix that, note that this
-        # should produce an exception.
-        # TODO: Have this throw a better exception than ValueError.
-        with self.assertRaises(ValueError):
-            inference.infer(queries, observations, num_samples)
+        mcsamples = inference.infer(queries, observations, num_samples)
+        prevalence_samples = mcsamples[prevalence()]
+        observed = prevalence_samples.mean()
+        # TODO: What is going on here? Should be around 0.5.
+        expected = 0.02
+        self.assertAlmostEqual(first=observed, second=expected, delta=0.05)
+
+        sens_bob = mcsamples[sensitivity(bob)]
+        observed = sens_bob.mean()
+        expected = bob.sensitivity
+        self.assertAlmostEqual(first=observed, second=expected, delta=0.15)
+
+        sens_joe = mcsamples[sensitivity(joe)]
+        observed = sens_joe.mean()
+        expected = joe.sensitivity
+        self.assertAlmostEqual(first=observed, second=expected, delta=0.15)
+
+        sens_sue = mcsamples[sensitivity(sue)]
+        observed = sens_sue.mean()
+        expected = sue.sensitivity
+        self.assertAlmostEqual(first=observed, second=expected, delta=0.15)
+
+        spec_bob = mcsamples[specificity(bob)]
+        observed = spec_bob.mean()
+        expected = bob.specificity
+        self.assertAlmostEqual(first=observed, second=expected, delta=0.15)
+
+        spec_joe = mcsamples[specificity(joe)]
+        observed = spec_joe.mean()
+        expected = joe.specificity
+        self.assertAlmostEqual(first=observed, second=expected, delta=0.15)
+
+        spec_sue = mcsamples[specificity(sue)]
+        observed = spec_sue.mean()
+        expected = sue.specificity
+        self.assertAlmostEqual(first=observed, second=expected, delta=0.15)

--- a/src/beanmachine/ppl/compiler/tests/clara_test.py
+++ b/src/beanmachine/ppl/compiler/tests/clara_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-
+# Copyright (c) Facebook, Inc. and its affiliates.
 # Non-vectorized CLARA model with probabilities represented
 # as straight probabilities, not negative reals.
 
@@ -107,9 +107,6 @@ def observation():
         for ii in range(0, n_spec_buckets):  # ii pos int
             # Sum of reals
             spec = spec + L_K_spec[spec_idx, ii] * eta_spec(ii)
-        # PROBLEM: We know that phi(spec) is a probability, but
-        # we have no way of knowing that 0.48 * phi(spec) + 0.5 is
-        # a probability.
         prob_spec = 0.48 * phi(spec) + 0.5  # pos real, should be prob
 
         sens = sens_f_mean
@@ -131,17 +128,6 @@ def observation():
                 neg_sum = neg_sum * prob_spec  # pos real or real, should be prob
 
         idx = idx + n_labels[i]
-
-        # PROBLEM: Even if we know that pos_sum and neg_sum
-        # are probs, how do we know that the sum of them
-        # is a probability? What reason do we have to believe
-        # that this sum is between 0.0 and 1.0?
-
-        # (I know it is true and you know it is true -- it is
-        # true because they *started* as summing to 1.0 and
-        # we have only made them both *smaller* so their sum
-        # must be smaller than 1.0. But how does BMG know that?)
-
         prob_i = (pos_sum + neg_sum) ** n_repeats[i]
         prob = prob * prob_i
 
@@ -162,10 +148,5 @@ class ClaraTest(unittest.TestCase):
         observations = {observation(): tensor(1.0)}
         num_samples = 1000
         inference = BMGInference()
-        # TODO: Right now this gives an error because (as noted above)
-        # we do not know that the sum of two reals is a probability.
-        # Until we've figured out how to fix that, note that this
-        # should produce an exception.
-        # TODO: Have this throw a better exception than ValueError.
-        with self.assertRaises(ValueError):
-            inference.infer(queries, observations, num_samples)
+        # TODO: Check that the inference results are sensible.
+        inference.infer(queries, observations, num_samples)

--- a/src/beanmachine/ppl/compiler/tests/fix_problems_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_problems_test.py
@@ -1074,3 +1074,81 @@ The model uses a > operation unsupported by Bean Machine Graph.
 The unsupported node is the loc of a StudentT.
 """
         self.assertEqual(observed.strip(), expected.strip())
+
+    def test_fix_problems_16(self) -> None:
+
+        # If we use a positive real valued *operator* in a context where
+        # a probability is required, we allow it. But we don't allow constants.
+        #
+        # For example, if we have a probability divided by two, that's still a
+        # probability. But adding it to another probability results in a positive
+        # real even though we know it is still between 0.0 and 1.0.
+
+        self.maxDiff = None
+        bmg = BMGraphBuilder()
+
+        # @rv def beta():
+        #   return Beta(2, 2)
+        # @rv def flip():
+        #   return Bernoulli(beta() * 0.5 + 0.5)
+
+        two = bmg.add_constant(2.0)
+        half = bmg.add_constant(0.5)
+        beta = bmg.add_beta(two, two)
+        betas = bmg.add_sample(beta)
+        division = bmg.add_multiplication(betas, half)
+        addition = bmg.add_addition(division, half)
+        bern = bmg.add_bernoulli(addition)
+        bmg.add_sample(bern)
+
+        error_report = fix_problems(bmg)
+        self.assertEqual(str(error_report), "")
+        observed = bmg.to_dot(
+            graph_types=True,
+            inf_types=False,
+            edge_requirements=False,
+            point_at_input=True,
+            after_transform=True,
+        )
+
+        expected = """
+digraph "graph" {
+  N00[label="2.0:R+"];
+  N01[label="Beta:P"];
+  N02[label="Sample:P"];
+  N03[label="0.5:P"];
+  N04[label="*:P"];
+  N05[label="ToPosReal:R+"];
+  N06[label="0.5:R+"];
+  N07[label="+:R+"];
+  N08[label="ToProb:P"];
+  N09[label="Bernoulli:B"];
+  N10[label="Sample:B"];
+  N00 -> N01[label=alpha];
+  N00 -> N01[label=beta];
+  N01 -> N02[label=operand];
+  N02 -> N04[label=left];
+  N03 -> N04[label=right];
+  N04 -> N05[label=operand];
+  N05 -> N07[label=left];
+  N06 -> N07[label=right];
+  N07 -> N08[label=operand];
+  N08 -> N09[label=probability];
+  N09 -> N10[label=operand];
+}
+"""
+        self.assertEqual(observed.strip(), expected.strip())
+
+        # However attempting to do the same with a constant should fail.
+
+        bmg = BMGraphBuilder()
+
+        two = bmg.add_constant(2.5)
+        bern = bmg.add_bernoulli(two)
+        bmg.add_sample(bern)
+
+        error_report = fix_problems(bmg)
+        expected = """
+The probability of a Bernoulli is required to be a probability but is a positive real.
+"""
+        self.assertEqual(str(error_report).strip(), expected.strip())


### PR DESCRIPTION
Summary:
As noted in previous diffs in this stack, we occasionally have situations where BMG would analyze an expression as a positive real or real, when we know that it is a probability.  I've added code to the problem fixer which detects this situation and inserts a TO_PROBABILITY node.

This gets both CLARA model test cases working, though (1) inference results are not yet tested in the "complicated" case, and (2) inference results are not as expected in the "simplified" case -- the prevalence estimate seems way off.  I'd expect it to be around 50%, not 2%.  We will investigate why that is in the new year.

I've added a unit test for the problem fixer as well.

Reviewed By: wtaha

Differential Revision: D25687148

