### PR TITLE
Remove unnecessary node-to-boolean feature from graph accumulator

### DIFF
--- a/src/beanmachine/ppl/compiler/bmg_nodes.py
+++ b/src/beanmachine/ppl/compiler/bmg_nodes.py
@@ -370,9 +370,6 @@ class BooleanNode(ConstantNode):
     def _value_to_python(self) -> str:
         return str(bool(self.value))
 
-    def __bool__(self) -> bool:
-        return self.value
-
 
 class NaturalNode(ConstantNode):
     """An integer constant restricted to non-negative values"""
@@ -563,9 +560,6 @@ class RealNode(ConstantNode):
     def _value_to_python(self) -> str:
         return str(float(self.value))
 
-    def __bool__(self) -> bool:
-        return bool(self.value)
-
 
 class TensorNode(ConstantNode):
     """A tensor constant"""
@@ -609,9 +603,6 @@ class TensorNode(ConstantNode):
     def _value_to_python(self) -> str:
         t = TensorNode._tensor_to_python(self.value)
         return f"tensor({t})"
-
-    def __bool__(self) -> bool:
-        return bool(self.value)
 
 
 # ####

--- a/src/beanmachine/ppl/compiler/tests/bm_graph_builder_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bm_graph_builder_test.py
@@ -226,20 +226,6 @@ Node 8 type 3 parents [ 6 7 ] children [ 9 ] positive real 1e-10
 Node 9 type 3 parents [ 8 ] children [ ] real 0"""
         self.assertEqual(tidy(observed), tidy(expected))
 
-    def test_graph_builder_3(self) -> None:
-        """Test 3"""
-        bmg = BMGraphBuilder()
-        self.assertTrue(bmg.add_real(1.0))
-        self.assertTrue(bmg.add_boolean(True))
-        self.assertTrue(bmg.add_tensor(tensor(True)))
-        self.assertTrue(bmg.add_tensor(tensor(1.0)))
-        self.assertTrue(bmg.add_tensor(tensor([1.0])))
-        self.assertFalse(bmg.add_real(0.0))
-        self.assertFalse(bmg.add_boolean(False))
-        self.assertFalse(bmg.add_tensor(tensor(False)))
-        self.assertFalse(bmg.add_tensor(tensor(0.0)))
-        self.assertFalse(bmg.add_tensor(tensor([0.0])))
-
     # The "add" methods do exactly that: add a node to the graph if it is not
     # already there.
     #


### PR DESCRIPTION
Summary:
When I was first designing the graph accumulator I thought it might sometimes be necessary to have a node which represented a constant have the same truth value as the constant; this was as part of an early experiment in stochastic control flows.

That went nowhere, but the code was still in the product. I've deleted it and the test case which verified it.

Reviewed By: feynmanliang, wtaha

Differential Revision: D25773689

