### PR TITLE
Move cycle detection to its own test, make end-to-end

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/cycle_detector_test.py
+++ b/src/beanmachine/ppl/compiler/tests/cycle_detector_test.py
@@ -1,0 +1,53 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import unittest
+
+import beanmachine.ppl as bm
+from beanmachine.ppl.inference.bmg_inference import BMGInference
+from beanmachine.ppl.utils.memoize import RecursionError
+from torch.distributions import Bernoulli
+
+
+# The dependency graph here is x -> y -> z -> x
+
+
+@bm.random_variable
+def bad_cycle_1_x():
+    return Bernoulli(bad_cycle_1_y())
+
+
+@bm.random_variable
+def bad_cycle_1_y():
+    return Bernoulli(bad_cycle_1_z())
+
+
+@bm.random_variable
+def bad_cycle_1_z():
+    return Bernoulli(bad_cycle_1_x())
+
+
+# The dependency graph here is z -> x(2) -> y(0) -> x(1) -> y(0)
+
+
+@bm.random_variable
+def bad_cycle_2_x(n):
+    return Bernoulli(bad_cycle_2_y(0))
+
+
+@bm.random_variable
+def bad_cycle_2_y(n):
+    return Bernoulli(bad_cycle_2_x(n + 1))
+
+
+@bm.random_variable
+def bad_cycle_2_z():
+    return Bernoulli(bad_cycle_2_x(2))
+
+
+class CycleDetectorTest(unittest.TestCase):
+    def test_bad_cyclic_model_1(self) -> None:
+        with self.assertRaises(RecursionError):
+            BMGInference().infer([bad_cycle_1_x()], {}, 1)
+
+    def test_bad_cyclic_model_2(self) -> None:
+        with self.assertRaises(RecursionError):
+            BMGInference().infer([bad_cycle_2_z()], {}, 1)


### PR DESCRIPTION
Summary: We detect in the compiler when a model contains a cycle and therefore cannot be rendered as a DAG; I've moved the tests for that into their own unit test module. Moreover, they now are "end to end style", operating on actual objects declared in the test rather than on a string containing the source code.

Reviewed By: feynmanliang

Differential Revision: D25786562

