### PR TITLE
Add type checking on inference APIs

### DIFF
--- a/src/beanmachine/ppl/inference/bmg_inference.py
+++ b/src/beanmachine/ppl/inference/bmg_inference.py
@@ -6,6 +6,7 @@ inferences on Bean Machine models."""
 from typing import Dict, List
 
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
+from beanmachine.ppl.inference.abstract_infer import _verify_queries_and_observations
 from beanmachine.ppl.inference.monte_carlo_samples import MonteCarloSamples
 from beanmachine.ppl.model.rv_identifier import RVIdentifier
 from torch import Tensor
@@ -21,6 +22,7 @@ class BMGInference:
         observations: Dict[RVIdentifier, Tensor],
         num_samples: int,
     ) -> MonteCarloSamples:
+        _verify_queries_and_observations(queries, observations)
         # TODO: Add num_chains
         # TODO: Add verbose level
         # TODO: Add logging

--- a/src/beanmachine/ppl/inference/tests/inference_error_reporting_test.py
+++ b/src/beanmachine/ppl/inference/tests/inference_error_reporting_test.py
@@ -1,0 +1,51 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import unittest
+
+import beanmachine.ppl as bm
+from torch import tensor
+
+
+@bm.random_variable
+def f():
+    pass
+
+
+class InferenceErrorReportingTest(unittest.TestCase):
+    def test_inference_error_reporting(self):
+        mh = bm.SingleSiteAncestralMetropolisHastings()
+        with self.assertRaises(TypeError) as ex:
+            mh.infer(None, {}, 10)
+        self.assertEqual(
+            str(ex.exception),
+            "Parameter 'queries' is required to be a list but is of type NoneType.",
+        )
+        with self.assertRaises(TypeError) as ex:
+            mh.infer([], 123, 10)
+        self.assertEqual(
+            str(ex.exception),
+            "Parameter 'observations' is required to be a dictionary but is of type int.",
+        )
+
+        # Should be f():
+        with self.assertRaises(TypeError) as ex:
+            mh.infer([f], {}, 10)
+        self.assertEqual(
+            str(ex.exception),
+            "A query is required to be a random variable but is of type function.",
+        )
+
+        # Should be f():
+        with self.assertRaises(TypeError) as ex:
+            mh.infer([f()], {f: tensor(True)}, 10)
+        self.assertEqual(
+            str(ex.exception),
+            "An observation is required to be a random variable but is of type function.",
+        )
+
+        # Should be a tensor
+        with self.assertRaises(TypeError) as ex:
+            mh.infer([f()], {f(): 123.0}, 10)
+        self.assertEqual(
+            str(ex.exception),
+            "An observed value is required to be a tensor but is of type float.",
+        )

--- a/src/beanmachine/ppl/tests/smoke_test.py
+++ b/src/beanmachine/ppl/tests/smoke_test.py
@@ -29,7 +29,9 @@ class ToplevelSmokeTest(unittest.TestCase):
         bm.Diagnostics(samples)
 
         # Rejection Sampling
-        samples = bm.RejectionSampling().infer([foo_sum(2)], {foo(0): False}, 1000, 1)
+        samples = bm.RejectionSampling().infer(
+            [foo_sum(2)], {foo(0): tensor(0.0)}, 1000, 1
+        )
         bm.Diagnostics(samples)
 
         # NUTS


### PR DESCRIPTION
Summary:
If you pass in something other than a random variable as a query, or something other than a tensor as an observation, inference eventually crashes with an obscure and unhelpful error message.

Our primary API should be more user-friendly and let the novice know they've done something wrong.

I personally am prone to writing `[flip]` instead of `[flip()]` which gives the unhelpful error that `function` does not have an attribute `function`.

We now interrogate the queries and observations to ensure they are properly typed and give a helpful error if they are not.

Reviewed By: feynmanliang

Differential Revision: D25790657

