### PR TITLE
Rework BMA test model for compiler to use public API

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/bm_to_bmg_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bm_to_bmg_test.py
@@ -1920,67 +1920,6 @@ digraph "graph" {
 """
 
 
-source18 = """
-import beanmachine.ppl as bm
-from torch.distributions import HalfCauchy, Normal, StudentT
-from torch import tensor
-
-@bm.random_variable
-def result():
-    return Normal(mean(), 1.0)
-
-@bm.functional
-def mean():
-  return true_value() + bias()
-
-@bm.random_variable
-def true_value():
-    return StudentT(3, 0, 10)
-
-@bm.random_variable
-def bias():
-    return Normal(0, sigma())
-
-@bm.random_variable
-def sigma():
-    return HalfCauchy(tensor(1.))
-"""
-
-expected_dot_18 = """
-digraph "graph" {
-  N00[label=3.0];
-  N01[label=0.0];
-  N02[label=10.0];
-  N03[label=StudentT];
-  N04[label=Sample];
-  N05[label=1.0];
-  N06[label=HalfCauchy];
-  N07[label=Sample];
-  N08[label=0];
-  N09[label=Normal];
-  N10[label=Sample];
-  N11[label="+"];
-  N12[label=1.0];
-  N13[label=Normal];
-  N14[label=Sample];
-  N00 -> N03[label=df];
-  N01 -> N03[label=loc];
-  N02 -> N03[label=scale];
-  N03 -> N04[label=operand];
-  N04 -> N11[label=left];
-  N05 -> N06[label=scale];
-  N06 -> N07[label=operand];
-  N07 -> N09[label=sigma];
-  N08 -> N09[label=mu];
-  N09 -> N10[label=operand];
-  N10 -> N11[label=right];
-  N11 -> N13[label=mu];
-  N12 -> N13[label=sigma];
-  N13 -> N14[label=operand];
-}
-"""
-
-
 # Test comparison operators; these are not supported
 # in BMG yet but we need to be able to detect use of
 # them and give an error, so we will verify that we
@@ -2211,16 +2150,12 @@ class CompilerTest(unittest.TestCase):
         observed = to_dot(source16)
         self.assertEqual(observed.strip(), expected_dot_16.strip())
 
-    def disabled_test_to_dot_17(self) -> None:
-        # TODO: Crashes the compiler; figure out why
-        self.maxDiff = None
-        observed = to_dot(source17)
-        self.assertEqual(observed.strip(), expected_dot_17.strip())
+    def test_dictionary_crash(self) -> None:
+        # TODO: This crashes the compiler; figure out why.
+        from beanmachine.ppl.compiler.internal_error import LiftedCompilationError
 
-    def test_to_dot_18(self) -> None:
-        self.maxDiff = None
-        observed = to_dot(source18, point_at_input=True)
-        self.assertEqual(observed.strip(), expected_dot_18.strip())
+        with self.assertRaises(LiftedCompilationError):
+            observed = to_dot("r3 = dict(**a4, **a6)")
 
     def disabled_test_to_cpp_1(self) -> None:
         """Tests for to_cpp from bm_to_bmg.py"""

--- a/src/beanmachine/ppl/compiler/tests/bma_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bma_test.py
@@ -1,19 +1,18 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
-"""End-to-end test of realistic coin flip model"""
+"""End-to-end compiler test for Bayesian Meta-Analysis model"""
+
 import sys
 import unittest
 
-from beanmachine.ppl.compiler.bm_to_bmg import infer
-
-
-source = """
 import beanmachine.ppl as bm
-import torch
+from beanmachine.ppl.inference.bmg_inference import BMGInference
 from torch import tensor
 from torch.distributions import HalfCauchy, Normal, StudentT
 
+
 class Group:
     level = 2
+
 
 class Team:
     group: Group
@@ -21,6 +20,7 @@ class Team:
 
     def __init__(self, group: Group):
         self.group = group
+
 
 class Experiment:
     result: float
@@ -32,6 +32,7 @@ class Experiment:
         self.result = result
         self.stddev = stddev
         self.team = team
+
 
 group1 = Group()
 group2 = Group()
@@ -63,17 +64,21 @@ experiments = [
     Experiment(10.74, 0.8, team4),
 ]
 
+
 @bm.random_variable
 def true_value():
     return StudentT(1.0)
+
 
 @bm.random_variable
 def bias_size(level):
     return HalfCauchy(1.0)
 
+
 @bm.random_variable
 def node_bias(node):
     return Normal(0, bias_size(node.level))
+
 
 @bm.random_variable
 def result(experiment):
@@ -85,40 +90,6 @@ def result(experiment):
     )
     return Normal(mean, experiment.stddev)
 
-queries = [true_value(), bias_size(0), bias_size(1), bias_size(2)]
-observations = {}
-for x in experiments:
-    observations[result(x)] = tensor(x.result)
-"""
-
-# Eight experiments, four teams, two groups, is very little data to
-# make good inferences from, so we should expect that the inference
-# engine does not get particularly close.
-
-# The true value is 10.0, but the observations given best match
-# a true value of 8.15.
-
-expected_true_value = 8.15
-
-# True exp bias size was 2.10 but observations given best match
-# a exp bias size of 0.42
-
-expected_exp_bias = 0.42
-
-# True team bias size was 1.32 but observations given best match
-# a team bias of 1.03
-
-expected_team_bias = 1.03
-
-# True group bias size was 1.52 but observations given best match
-# a group bias of 2.17
-
-expected_group_bias = 2.17
-
-
-def average(items):
-    return sum(items) / len(items)
-
 
 class BMATest(unittest.TestCase):
     @unittest.skipIf(
@@ -126,26 +97,41 @@ class BMATest(unittest.TestCase):
         reason="Numerical behavior seems to be different on MacOS",
     )
     def test_bma_inference(self) -> None:
-        """test_bma_inference from bma_test.py"""
+        queries = [true_value(), bias_size(0), bias_size(1), bias_size(2)]
+        observations = {result(x): tensor(x.result) for x in experiments}
 
-        # We've got a prior on the coin of Beta(2,2), so it is most
-        # likely to be actually fair, but still with some probability
-        # of being unfair in either direction.
-        #
-        # We flip the coin four times and get heads 25% of the time,
-        # so this is some evidence that the true fairness of the coin is
-        # closer to 25% than 50%.
-        #
-        # We sample 1000 times from the posterior and take the average;
-        # it should come out that the true fairness is now most likely
-        # to be around 37%.
+        # Eight experiments, four teams, two groups, is very little data to
+        # make good inferences from, so we should expect that the inference
+        # engine does not get particularly close.
 
-        self.maxDiff = None
-        observed = infer(source)
-        observed_true_value = average([x[0] for x in observed])
-        observed_exp_bias = average([x[1] for x in observed])
-        observed_team_bias = average([x[2] for x in observed])
-        observed_group_bias = average([x[3] for x in observed])
+        # The true value is 10.0, but the observations given best match
+        # a true value of 8.15.
+
+        expected_true_value = 8.15
+
+        # True exp bias size was 2.10 but observations given best match
+        # a exp bias size of 0.70
+
+        expected_exp_bias = 0.70
+
+        # True team bias size was 1.32 but observations given best match
+        # a team bias of 1.26
+
+        expected_team_bias = 1.26
+
+        # True group bias size was 1.52 but observations given best match
+        # a group bias of 1.50
+
+        expected_group_bias = 1.50
+
+        mcsamples = BMGInference().infer(queries, observations, 1000)
+
+        queries = [true_value(), bias_size(0), bias_size(1), bias_size(2)]
+
+        observed_true_value = mcsamples[true_value()].mean()
+        observed_exp_bias = mcsamples[bias_size(0)].mean()
+        observed_team_bias = mcsamples[bias_size(1)].mean()
+        observed_group_bias = mcsamples[bias_size(2)].mean()
 
         self.assertAlmostEqual(observed_true_value, expected_true_value, delta=0.1)
         self.assertAlmostEqual(observed_exp_bias, expected_exp_bias, delta=0.1)


### PR DESCRIPTION
Summary:
I've changed the BMA model in the compiler test cases to use the public `BMGInference` API rather than passing the source code around as a string.

A nice side effect of this change is doing so apparently now picks a different random seed in the inference engine so we get slighly more accurate results out.

This test case now makes redundant two of the original compiler test cases, so I've removed them. One of those tests had already been disabled because it was crashing the compiler; I isolated the cause of the crash and rewrote the test to exercise just that line. I'll track down the cause of that crash next.

Reviewed By: wtaha

Differential Revision: D25794619

