### PR TITLE
Rename TensorNode to ConstantTensorNode

### DIFF
--- a/src/beanmachine/ppl/compiler/bm_graph_builder.py
+++ b/src/beanmachine/ppl/compiler/bm_graph_builder.py
@@ -74,6 +74,7 @@ from beanmachine.ppl.compiler.bmg_nodes import (
     Chi2Node,
     ComplementNode,
     ConstantNode,
+    ConstantTensorNode,
     DirichletNode,
     DistributionNode,
     DivisionNode,
@@ -108,7 +109,6 @@ from beanmachine.ppl.compiler.bmg_nodes import (
     RealNode,
     SampleNode,
     StudentTNode,
-    TensorNode,
     ToPositiveRealNode,
     ToProbabilityNode,
     ToRealNode,
@@ -489,8 +489,8 @@ class BMGraphBuilder:
         return node
 
     @memoize
-    def add_tensor(self, value: Tensor) -> TensorNode:
-        node = TensorNode(value)
+    def add_tensor(self, value: Tensor) -> ConstantTensorNode:
+        node = ConstantTensorNode(value)
         self.add_node(node)
         return node
 
@@ -1056,7 +1056,7 @@ class BMGraphBuilder:
 
     @memoize
     def add_exp(self, operand: BMGNode) -> BMGNode:
-        if isinstance(operand, TensorNode):
+        if isinstance(operand, ConstantTensorNode):
             return self.add_constant(torch.exp(operand.value))
         if isinstance(operand, ConstantNode):
             return self.add_constant(math.exp(operand.value))
@@ -1067,7 +1067,7 @@ class BMGraphBuilder:
     def handle_exp(self, input: Any) -> Any:
         if isinstance(input, Tensor):
             return torch.exp(input)
-        if isinstance(input, TensorNode):
+        if isinstance(input, ConstantTensorNode):
             return torch.exp(input.value)
         if not isinstance(input, BMGNode):
             return math.exp(input)
@@ -1092,7 +1092,7 @@ class BMGraphBuilder:
 
     @memoize
     def add_log(self, operand: BMGNode) -> BMGNode:
-        if isinstance(operand, TensorNode):
+        if isinstance(operand, ConstantTensorNode):
             return self.add_constant(torch.log(operand.value))
         if isinstance(operand, ConstantNode):
             return self.add_constant(math.log(operand.value))
@@ -1103,7 +1103,7 @@ class BMGraphBuilder:
     def handle_log(self, input: Any) -> Any:
         if isinstance(input, Tensor):
             return torch.log(input)
-        if isinstance(input, TensorNode):
+        if isinstance(input, ConstantTensorNode):
             return torch.log(input.value)
         if not isinstance(input, BMGNode):
             return math.log(input)

--- a/src/beanmachine/ppl/compiler/tests/bm_graph_builder_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bm_graph_builder_test.py
@@ -10,6 +10,7 @@ from beanmachine.ppl.compiler.bmg_nodes import (
     AdditionNode,
     BernoulliNode,
     BooleanNode,
+    ConstantTensorNode,
     DivisionNode,
     EqualNode,
     ExpNode,
@@ -27,7 +28,6 @@ from beanmachine.ppl.compiler.bmg_nodes import (
     RealNode,
     SampleNode,
     SetOfTensors,
-    TensorNode,
     ToRealNode,
 )
 from beanmachine.ppl.compiler.bmg_types import PositiveReal, Real
@@ -305,7 +305,7 @@ Node 9 type 3 parents [ 8 ] children [ ] real 0"""
         gr1 = bmg.add_real(1.0)
         self.assertTrue(isinstance(gr1, RealNode))
         gt1 = bmg.add_tensor(t1)
-        self.assertTrue(isinstance(gt1, TensorNode))
+        self.assertTrue(isinstance(gt1, ConstantTensorNode))
 
         # torch defines a "static" add method that takes two values.
         # Calling torch.add(x, y) should be logically the same as x + y
@@ -447,9 +447,9 @@ Node 9 type 3 parents [ 8 ] children [ ] real 0"""
         gr2 = bmg.add_real(2.0)
         self.assertTrue(isinstance(gr2, RealNode))
         gt1 = bmg.add_tensor(t1)
-        self.assertTrue(isinstance(gt1, TensorNode))
+        self.assertTrue(isinstance(gt1, ConstantTensorNode))
         gt2 = bmg.add_tensor(t2)
-        self.assertTrue(isinstance(gt2, TensorNode))
+        self.assertTrue(isinstance(gt2, ConstantTensorNode))
 
         # torch defines a "static" div method that takes two values.
         # Calling torch.div(x, y) should be logically the same as x + y
@@ -581,7 +581,7 @@ Node 9 type 3 parents [ 8 ] children [ ] real 0"""
         gr1 = bmg.add_real(1.0)
         self.assertTrue(isinstance(gr1, RealNode))
         gt1 = bmg.add_tensor(t1)
-        self.assertTrue(isinstance(gt1, TensorNode))
+        self.assertTrue(isinstance(gt1, ConstantTensorNode))
 
         # torch defines a "static" exp method that takes one value.
         # TODO: torch.exp(x) requires that x be a tensor, not a float. We do
@@ -650,7 +650,7 @@ Node 9 type 3 parents [ 8 ] children [ ] real 0"""
         gr1 = bmg.add_real(1.0)
         self.assertTrue(isinstance(gr1, RealNode))
         gt1 = bmg.add_tensor(t1)
-        self.assertTrue(isinstance(gt1, TensorNode))
+        self.assertTrue(isinstance(gt1, ConstantTensorNode))
 
         # torch defines a "static" log method that takes one value.
         ta = torch.log
@@ -712,7 +712,7 @@ Node 9 type 3 parents [ 8 ] children [ ] real 0"""
         self.assertTrue(isinstance(gr1, RealNode))
         gr2 = bmg.add_real(2.0)
         gt1 = bmg.add_tensor(t1)
-        self.assertTrue(isinstance(gt1, TensorNode))
+        self.assertTrue(isinstance(gt1, ConstantTensorNode))
         gt2 = bmg.add_tensor(t2)
 
         # torch defines a "static" mul method that takes two values.
@@ -842,9 +842,9 @@ Node 9 type 3 parents [ 8 ] children [ ] real 0"""
 
         # Graph nodes
         gt1 = bmg.add_tensor(t1)
-        self.assertTrue(isinstance(gt1, TensorNode))
+        self.assertTrue(isinstance(gt1, ConstantTensorNode))
         gt2 = bmg.add_tensor(t2)
-        self.assertTrue(isinstance(gt2, TensorNode))
+        self.assertTrue(isinstance(gt2, ConstantTensorNode))
 
         # torch defines a "static" mm method that takes two values.
 
@@ -1059,7 +1059,7 @@ Node 9 type 3 parents [ 8 ] children [ ] real 0"""
         gr1 = bmg.add_real(1.0)
         self.assertTrue(isinstance(gr1, RealNode))
         gt1 = bmg.add_tensor(t1)
-        self.assertTrue(isinstance(gt1, TensorNode))
+        self.assertTrue(isinstance(gt1, ConstantTensorNode))
 
         # torch defines a "static" neg method that takes one value.
         # Calling torch.neg(x) should be logically the same as -x
@@ -1124,7 +1124,7 @@ Node 9 type 3 parents [ 8 ] children [ ] real 0"""
         gbt = bmg.add_boolean(True)
         self.assertTrue(isinstance(gbt, BooleanNode))
         gtt = bmg.add_tensor(tt)
-        self.assertTrue(isinstance(gtt, TensorNode))
+        self.assertTrue(isinstance(gtt, ConstantTensorNode))
 
         # torch defines a "static" logical_not method that takes one value.
         # Calling torch.logical_not(x) should be logically the same as "not x"
@@ -1187,7 +1187,7 @@ Node 9 type 3 parents [ 8 ] children [ ] real 0"""
         gr1 = bmg.add_real(1.0)
         self.assertTrue(isinstance(gr1, RealNode))
         gt1 = bmg.add_tensor(t1)
-        self.assertTrue(isinstance(gt1, TensorNode))
+        self.assertTrue(isinstance(gt1, ConstantTensorNode))
 
         # torch defines a "static" pow method that takes two values.
         # Calling torch.pow(x, y) should be logically the same as x ** y
@@ -1320,7 +1320,7 @@ Node 9 type 3 parents [ 8 ] children [ ] real 0"""
         gr1 = bmg.add_real(1.0)
         self.assertTrue(isinstance(gr1, RealNode))
         gt1 = bmg.add_tensor(t1)
-        self.assertTrue(isinstance(gt1, TensorNode))
+        self.assertTrue(isinstance(gt1, ConstantTensorNode))
 
         # torch.float is not a function, unlike torch.log, torch.add and so on.
 


### PR DESCRIPTION
Summary:
In order to compile models containing certain multiary operators (such as `logsumexp`), we will need nodes in the graph accumulator which represent a tensor whose elements are other graph nodes.  For example, we might have Bean Machine model code like:

    a = normal(1)
    b = normal(2)
    c = normal(3)
    s = tensor([a, b, c]).logsumexp(dim=0)

where a, b, c are sample nodes in the graph. We do not currently support calling the `tensor()` constructor with graph nodes as arguments but we will need to in order to make this work.

I want the type in the node hierarchy to be named `TensorNode`, but we already use that to represent a *constant* tensor.  (Note: at present we do not actually generate constant BMG matrix node from constant tensors, but we will eventually need to support this scenario. We'll get that working later.)

Therefore in this diff I am just renaming `TensorNode` to `ConstantTensorNode`. In an upcoming diff I will add a new type `TensorNode` to represent a tensor with graph nodes for elements.

Reviewed By: wtaha

Differential Revision: D25842188

