### PR TITLE
Start implementing a stochastic tensor node

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/bmg_nodes_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_nodes_test.py
@@ -19,6 +19,7 @@ from beanmachine.ppl.compiler.bmg_nodes import (
     RealNode,
     SampleNode,
     StudentTNode,
+    TensorNode,
 )
 from beanmachine.ppl.compiler.bmg_types import (
     Boolean,
@@ -28,8 +29,10 @@ from beanmachine.ppl.compiler.bmg_types import (
     PositiveReal,
     Probability,
     Real,
+    Tensor as BMGTensor,
     Zero,
 )
+from torch import Size
 
 
 class BMGNodesTest(unittest.TestCase):
@@ -87,6 +90,10 @@ class BMGNodesTest(unittest.TestCase):
         self.assertEqual(norm.inf_type, Real)
         self.assertEqual(stut.inf_type, Real)
 
+        # Tensors
+        # TODO: See notes in TensorNode class for how we should improve this.
+        self.assertEqual(TensorNode([half, norm], Size([2])).inf_type, BMGTensor)
+
     def test_requirements(self) -> None:
         """test_requirements"""
 
@@ -120,8 +127,11 @@ class BMGNodesTest(unittest.TestCase):
 
         # Distributions
 
-        self.assertEqual(BernoulliNode(prob).requirements, [Probability])
-        self.assertEqual(BetaNode(pos, pos).requirements, [PositiveReal, PositiveReal])
+        bern = BernoulliNode(prob)
+        beta = BetaNode(pos, pos)
+
+        self.assertEqual(bern.requirements, [Probability])
+        self.assertEqual(beta.requirements, [PositiveReal, PositiveReal])
         self.assertEqual(BinomialNode(nat, prob).requirements, [Natural, Probability])
         self.assertEqual(GammaNode(pos, pos).requirements, [PositiveReal, PositiveReal])
         self.assertEqual(Chi2Node(pos).requirements, [PositiveReal])
@@ -130,6 +140,13 @@ class BMGNodesTest(unittest.TestCase):
         self.assertEqual(NormalNode(real, pos).requirements, [Real, PositiveReal])
         self.assertEqual(
             StudentTNode(pos, pos, pos).requirements, [PositiveReal, Real, PositiveReal]
+        )
+
+        # Tensors
+        # TODO: See notes in TensorNode class for how we should improve this.
+        self.assertEqual(
+            TensorNode([SampleNode(bern), SampleNode(beta)], Size([2])).requirements,
+            [Boolean, Probability],
         )
 
     def test_inputs_and_outputs(self) -> None:


### PR DESCRIPTION
Summary:
In order to make operators like logsumexp work, we'll need to first be able to represent a graph node which is logically a tensor whose elements are also graph nodes.  This diff is a first step in that direction.

Longer term we will need to add support for this sort of node in BMG itself; when we do that we will need to do work to make sure it complies with the type requirements of BMG.  But for now all we need to do is get the bare minimum necessary working for the CLARA model.  Thus, I've left the type analysis marked as TODO, along with a few other work items that are not necessary at this time.

This diff just creates the node class itself. In upcoming diffs we will:

* create the methods in the graph accumulator that add the node to the graph
* map the tensor() constructor to methods that create this node.
* build a node to represent LogSumExp operations
* create methods to add that node to the graph
* map the logsumexp() method
* test the whole thing end to end
* start working on related operators that operate on the values of a tensor

Reviewed By: wtaha

Differential Revision: D25895112

