### PR TITLE
Skip GP inference test due to timeout

### DIFF
--- a/src/beanmachine/ppl/experimental/tests/gp/inference_test.py
+++ b/src/beanmachine/ppl/experimental/tests/gp/inference_test.py
@@ -52,6 +52,7 @@ class InferenceTests(unittest.TestCase):
         self.lengthscale_prior = lengthscale_prior
         self.period_length_prior = period_length_prior
 
+    @unittest.skip("Flaky timeout.")
     def test_simple_regression(self):
         torch.manual_seed(1)
         n_samples = 100


### PR DESCRIPTION
Summary: This test is causing timeouts sporadically, so I am skipping it for now. It an experimental module test so it isn't testing anything code to the library.

Differential Revision: D25950913

