### PR TITLE
Fix to failing nightly test - T83082230

### DIFF
--- a/src/beanmachine/ppl/inference/tests/single_site_random_walk_adaptive_conjugate_test_nightly.py
+++ b/src/beanmachine/ppl/inference/tests/single_site_random_walk_adaptive_conjugate_test_nightly.py
@@ -29,7 +29,7 @@ class SingleSiteAdaptiveRandomWalkConjugateTest(
     def test_gamma_normal_conjugate_run(self):
         self.mh = bm.SingleSiteRandomWalk(step_size=5.0)
         self.gamma_normal_conjugate_run(
-            self.mh, num_samples=5000, num_adaptive_samples=5000
+            self.mh, num_samples=6000, num_adaptive_samples=5000
         )
 
     def test_normal_normal_conjugate_run(self):


### PR DESCRIPTION
Summary: This diff fixes a failing nightly test. Basically, an  incidental change to testing code appears to have caused the random sample used in the test to change. The failing test was a result of a standard deviation being somewhat lower than the alpha confidence interval for this value. Such failures can easily occur as low-probability events when a sample changes. A small increase in the number of samples was made, and the test passed when this was done. Increasing the sample size is generally a safe way to respond to this kind of failing test, as it is unlikely to mask a serious underlying problem.

Reviewed By: yucenli, horizon-blue

Differential Revision: D25958740

