### PR TITLE
Add method to graph builder for creating tensor nodes.

### DIFF
--- a/src/beanmachine/ppl/compiler/bm_graph_builder.py
+++ b/src/beanmachine/ppl/compiler/bm_graph_builder.py
@@ -109,6 +109,7 @@ from beanmachine.ppl.compiler.bmg_nodes import (
     RealNode,
     SampleNode,
     StudentTNode,
+    TensorNode,
     ToPositiveRealNode,
     ToProbabilityNode,
     ToRealNode,
@@ -1110,6 +1111,12 @@ class BMGraphBuilder:
         if isinstance(input, ConstantNode):
             return math.log(input.value)
         return self.add_log(input)
+
+    @memoize
+    def add_tensor(self, size: torch.Size, *data: List[BMGNode]) -> TensorNode:
+        node = TensorNode(data, size)
+        self.add_node(node)
+        return node
 
     def _canonicalize_function(
         self, function: Any, arguments: List[Any], kwargs: Dict[str, Any]

--- a/src/beanmachine/ppl/compiler/bmg_nodes.py
+++ b/src/beanmachine/ppl/compiler/bmg_nodes.py
@@ -686,7 +686,7 @@ class TensorNode(BMGNode):
     def label(self) -> str:
         # TODO: Better string representation; maybe something like
         # _tensor_to_label above.
-        return "tensor"
+        return "Tensor"
 
     def support(self) -> Iterator[Any]:
         s = self.size


### PR DESCRIPTION
Summary:
We are going to need to represent tensors that contain graph nodes while accumulating the graph. This is the next step in that change; we are simply adding a method to the graph builder that creates a graph node.

Note that as with all graph accumulation operations, adding an existing node simply re-uses that node. The graph is automatically deduplicated.

{F360122181}

Reviewed By: wtaha

Differential Revision: D25930049

