### PR TITLE
Remove restriction on query nodes in graph builder

### DIFF
--- a/src/beanmachine/ppl/compiler/bm_graph_builder.py
+++ b/src/beanmachine/ppl/compiler/bm_graph_builder.py
@@ -1426,7 +1426,12 @@ class BMGraphBuilder:
         return node
 
     @memoize
-    def add_query(self, operator: OperatorNode) -> Query:
+    def add_query(self, operator: BMGNode) -> Query:
+        # TODO: BMG requires that the target of a query be classified
+        # as an operator and that queries be unique; that is, every node
+        # is queried *exactly* zero or one times. Rather than making
+        # those restrictions here, instead detect bad queries in the
+        # problem fixing phase and report accordingly.
         node = Query(operator)
         self.add_node(node)
         return node
@@ -1605,6 +1610,9 @@ g = graph.Graph()
         queries: List[RVIdentifier],
         observations: Dict[RVIdentifier, Any],
     ) -> None:
+        # TODO: Add error handling and tests for scenarios where
+        # an rv does not return a distribution or a functional does
+        # not return an operation.
         for rv, val in observations.items():
             node = self._rv_to_node(rv)
             self.add_observation(node, val)

--- a/src/beanmachine/ppl/compiler/bmg_nodes.py
+++ b/src/beanmachine/ppl/compiler/bmg_nodes.py
@@ -3208,8 +3208,13 @@ class Observation(BMGNode):
 class Query(BMGNode):
     """A query is a marker on a node in the graph that indicates
     to the inference engine that the user is interested in
-    getting a distribution of values of that node. It always
-    points to an operator node."""
+    getting a distribution of values of that node."""
+
+    # TODO: BMG requires that the target of a query be classified
+    # as an operator and that queries be unique; that is, every node
+    # is queried *exactly* zero or one times. Rather than making
+    # those restrictions here, instead detect bad queries in the
+    # problem fixing phase and report accordingly.
 
     # TODO: As with observations, properly speaking there is no
     # need to represent a query as a *node*, and BMG does not
@@ -3217,17 +3222,16 @@ class Query(BMGNode):
 
     _edges = ["operator"]
 
-    def __init__(self, operator: OperatorNode):
+    def __init__(self, operator: BMGNode):
         BMGNode.__init__(self, [operator])
 
     @property
-    def operator(self) -> OperatorNode:
+    def operator(self) -> BMGNode:
         c = self.inputs[0]
-        assert isinstance(c, OperatorNode)
         return c
 
     @operator.setter
-    def operator(self, p: OperatorNode) -> None:
+    def operator(self, p: BMGNode) -> None:
         self.inputs[0] = p
 
     def _compute_graph_type(self) -> BMGLatticeType:


### PR DESCRIPTION
Summary:
BMG requires that a query on a graph node be placed exclusively on operator nodes. (Note that sample is an operator.) When creating a type in the graph accumulator to represent queries I therefore added a Python type annotation requiring the operand of a query to be an operator.

However, it is possible for a queried random variable to be a constant or other non-operator value as the graph is accumulated. This should be an error, but it should be an error when the BMG graph is built, not when the graph is accumulated.

I have not yet added the tests or the error reporting for these scenarios; a necessary first step is removing the restriction that a query node only be added to refer to an operator node. This diff is that first step; the remaining steps will happen in upcoming diffs.

Reviewed By: wtaha

Differential Revision: D25982797

