### PR TITLE
Start implementing logsumexp operator

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/bmg_nodes_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_nodes_test.py
@@ -11,6 +11,7 @@ from beanmachine.ppl.compiler.bmg_nodes import (
     FlatNode,
     GammaNode,
     HalfCauchyNode,
+    LogSumExpNode,
     NaturalNode,
     NegativeRealNode,
     NormalNode,
@@ -94,6 +95,9 @@ class BMGNodesTest(unittest.TestCase):
         # TODO: See notes in TensorNode class for how we should improve this.
         self.assertEqual(TensorNode([half, norm], Size([2])).inf_type, BMGTensor)
 
+        # LogSumExp is always real.
+        self.assertEqual(LogSumExpNode([half, norm]).inf_type, Real)
+
     def test_requirements(self) -> None:
         """test_requirements"""
 
@@ -147,6 +151,17 @@ class BMGNodesTest(unittest.TestCase):
         self.assertEqual(
             TensorNode([SampleNode(bern), SampleNode(beta)], Size([2])).requirements,
             [Boolean, Probability],
+        )
+
+        # LogSumExp requires the dimension be natural and the values be
+        # real, positive real, or negative real.
+
+        self.assertEqual(LogSumExpNode([real, pos]).requirements, [Real, Real])
+        self.assertEqual(
+            LogSumExpNode([pos, nat]).requirements, [PositiveReal, PositiveReal]
+        )
+        self.assertEqual(
+            LogSumExpNode([neg, neg]).requirements, [NegativeReal, NegativeReal]
         )
 
     def test_inputs_and_outputs(self) -> None:


### PR DESCRIPTION
Summary:
I've started implementing the logsumexp operator.

The problem we're going to have with this operator is that in the original python model, the typical usage will be something like:

    y = tensor([norm(1), norm(2), ... ]).logsumexp(dim=1)

That is, we have an explicit tensor constructed from samples and we wish to efficiently and accurately compute the logsumexp.  But in BMG we do not have a "tensor made up of samples" node; we just have a logsumexp node whose inputs are the samples.

We will therefore need to *accumulate* the graph in the first form but *output* it in the second form. We therefore have a somewhat multi-purpose `LogSumExpNode` implementation here; the expectation is that we will construct it in the "stochastic tensor as argument" form and then transform it to eliminate the unsupported tensor node from the BMG graph.

That will all come in upcoming diffs.  For now I'm just creating the node and computing the type requirements of each input.  The type requirements are based on the final form, not on the original form.

Reviewed By: wtaha

Differential Revision: D26007732

