### PR TITLE
Fixing PyStan issue, ast.Module and ast.arguments in platform009

### DIFF
--- a/src/beanmachine/ppl/compiler/bm_to_bmg.py
+++ b/src/beanmachine/ppl/compiler/bm_to_bmg.py
@@ -347,11 +347,11 @@ from beanmachine.ppl.utils.probabilistic import probabilistic"""
 
 
 def _prepend_statements(module: ast.Module, statements: List[ast.stmt]) -> ast.Module:
-    return ast.Module(body=statements + module.body)
+    return ast.Module(body=statements + module.body, type_ignores=[])
 
 
 def _append_statements(module: ast.Module, statements: List[ast.stmt]) -> ast.Module:
-    return ast.Module(body=module.body + statements)
+    return ast.Module(body=module.body + statements, type_ignores=[])
 
 
 _samples_to_calls = AllListMembers(
@@ -449,6 +449,7 @@ def _bm_function_to_bmg_ast(f: Callable, helper_name: str) -> ast.AST:
     name = bmg_f.name
     helper_arg = ast.arg(arg="bmg", annotation=None)
     helper_args = ast.arguments(
+        posonlyargs=[],
         args=[helper_arg],
         vararg=None,
         kwonlyargs=[],
@@ -472,7 +473,7 @@ def _bm_function_to_bmg_ast(f: Callable, helper_name: str) -> ast.AST:
         returns=None,
     )
 
-    helper = ast.Module(body=[helper_func])
+    helper = ast.Module(body=[helper_func], type_ignores=[])
     ast.fix_missing_locations(helper)
 
     return helper

--- a/src/beanmachine/ppl/utils/single_assignment.py
+++ b/src/beanmachine/ppl/utils/single_assignment.py
@@ -1336,7 +1336,13 @@ class SingleAssignment:
         #    return r
         # y=p()
         _empty_ast_arguments = ast.arguments(
-            args=[], vararg=None, kwonlyargs=[], kw_defaults=[], kwarg=None, defaults=[]
+            posonlyargs=[],
+            args=[],
+            vararg=None,
+            kwonlyargs=[],
+            kw_defaults=[],
+            kwarg=None,
+            defaults=[],
         )
         return PatternRule(
             assign(value=ast_listComp()),
@@ -1394,7 +1400,13 @@ class SingleAssignment:
         #    return r
         # y=p()
         _empty_ast_arguments = ast.arguments(
-            args=[], vararg=None, kwonlyargs=[], kw_defaults=[], kwarg=None, defaults=[]
+            posonlyargs=[],
+            args=[],
+            vararg=None,
+            kwonlyargs=[],
+            kw_defaults=[],
+            kwarg=None,
+            defaults=[],
         )
         return PatternRule(
             assign(value=ast_setComp()),
@@ -1456,7 +1468,13 @@ class SingleAssignment:
         #    return r
         # y=p()
         _empty_ast_arguments = ast.arguments(
-            args=[], vararg=None, kwonlyargs=[], kw_defaults=[], kwarg=None, defaults=[]
+            posonlyargs=[],
+            args=[],
+            vararg=None,
+            kwonlyargs=[],
+            kw_defaults=[],
+            kwarg=None,
+            defaults=[],
         )
         return PatternRule(
             assign(value=ast_dictComp()),


### PR DESCRIPTION
Summary:
Breaking changes in platform009 (Python 3.8)
- `ast.Module` requires an additional `type_ignores` argument
- `ast.arguments` requires an additional `posonlyargs` argument
- For pystan macro: Use LLVM OpenMP instead of gcc OpenMP

Differential Revision: D26130050

