### PR TITLE
Fix to failing nightly testing conjugate prior tests (T83719932)

### DIFF
--- a/src/beanmachine/ppl/experimental/neutra/tests/iaf_conjugate_test_nightly.py
+++ b/src/beanmachine/ppl/experimental/neutra/tests/iaf_conjugate_test_nightly.py
@@ -115,7 +115,7 @@ class SingleSiteIAFConjugateTest(unittest.TestCase, AbstractConjugateTests):
             [],
         )
         self.normal_normal_conjugate_run(
-            iaf, num_samples=1000, num_adaptive_samples=5000
+            iaf, num_samples=2000, num_adaptive_samples=5000
         )
 
     def test_distant_normal_normal_conjugate_run(self):


### PR DESCRIPTION
Summary:
This diff is a safe fix to a nightly test failure reported in T83719932. This type of failure is typically a result of another diff that changed the exact random sample used in one of the hypothesis-testing-based conjugate prior unit tests. The fix is safe in that it is achieved by merely increasing the sample size, which moves the point where we are making the observation to another point that can only be more likely to represent the steady state behavior of the inference algorithm.

Ideally, rather than being caught by nightly testing on the latest landed diff, this type of issue would be much better indicated by some tripwire mechanism that alerts any developer about to submit a diff that they need to run the nightly test on their dev machine before submitting. Having the nightly tests run only on landed diffs feels a bit too far out in the development cycle. Somewhat independently, we also need a mechanism that points to a particular diff as the likely source of the change that introduced the test failure.  See T83835761 for followup on this point.

Reviewed By: horizon-blue

Differential Revision: D26137129

