### PR TITLE
Fix some type annotation issues, add assertions

### DIFF
--- a/src/beanmachine/ppl/compiler/bm_graph_builder.py
+++ b/src/beanmachine/ppl/compiler/bm_graph_builder.py
@@ -1130,14 +1130,14 @@ class BMGraphBuilder:
         return self.add_log(input)
 
     @memoize
-    def add_tensor(self, size: torch.Size, *data: List[BMGNode]) -> TensorNode:
-        node = TensorNode(data, size)
+    def add_tensor(self, size: torch.Size, *data: BMGNode) -> TensorNode:
+        node = TensorNode(list(data), size)
         self.add_node(node)
         return node
 
     @memoize
-    def add_logsumexp(self, *inputs: List[BMGNode]) -> TensorNode:
-        node = LogSumExpNode(inputs)
+    def add_logsumexp(self, *inputs: BMGNode) -> TensorNode:
+        node = LogSumExpNode(list(inputs))
         self.add_node(node)
         return node
 
@@ -1288,6 +1288,7 @@ class BMGraphBuilder:
     def _handle_tensor_constructor(
         self, arguments: List[Any], kwargs: Dict[str, Any]
     ) -> Any:
+        assert isinstance(arguments, list)
         # TODO: Handle kwargs
         flattened_args = list(_flatten_all_lists(arguments))
         if not any(isinstance(arg, BMGNode) for arg in flattened_args):
@@ -1382,9 +1383,9 @@ class BMGraphBuilder:
         return self.rv_map[rv]
 
     @memoize
-    def add_map(self, *elements) -> MapNode:
+    def add_map(self, *elements: BMGNode) -> MapNode:
         # TODO: Verify that the list is well-formed.
-        node = MapNode(elements)
+        node = MapNode(list(elements))
         self.add_node(node)
         return node
 

--- a/src/beanmachine/ppl/compiler/bmg_nodes.py
+++ b/src/beanmachine/ppl/compiler/bmg_nodes.py
@@ -55,6 +55,7 @@ class InputList:
     inputs: List["BMGNode"]
 
     def __init__(self, node: "BMGNode", inputs: List["BMGNode"]) -> None:
+        assert isinstance(inputs, list)
         self.node = node
         self.inputs = inputs
         for i in inputs:
@@ -109,7 +110,7 @@ class BMGNode(ABC):
     # To avoid this confusion, in this class we will explicitly call out
     # that the edges represent inputs.
 
-    inputs: List["BMGNode"]
+    inputs: InputList
     outputs: ItemCounter
 
     # See comments in InputList above for invariants we maintain on these members.
@@ -120,6 +121,7 @@ class BMGNode(ABC):
     _edges: Optional[List[str]] = None
 
     def __init__(self, inputs: List["BMGNode"]):
+        assert isinstance(inputs, list)
         self.inputs = InputList(self, inputs)
         self.outputs = ItemCounter()
         # We cannot compute the inf type or graph type yet because
@@ -639,6 +641,7 @@ class TensorNode(BMGNode):
     _size: torch.Size
 
     def __init__(self, items: List[BMGNode], size: torch.Size):
+        assert isinstance(items, list)
         BMGNode.__init__(self, items)
         self._size = size
 
@@ -1673,6 +1676,7 @@ class OperatorNode(BMGNode, metaclass=ABCMeta):
     The inputs are the operands of each operator."""
 
     def __init__(self, inputs: List[BMGNode]):
+        assert isinstance(inputs, list)
         BMGNode.__init__(self, inputs)
 
 
@@ -1702,6 +1706,7 @@ class LogSumExpNode(OperatorNode):
     # TODO: Similarly we might want to support logsumexp on dimensions other than 1.
 
     def __init__(self, inputs: List[BMGNode]):
+        assert isinstance(inputs, list)
         OperatorNode.__init__(self, inputs)
 
     def _compute_edge_names(self) -> List[str]:


### PR DESCRIPTION
Summary:
There were some type annotation issues in a couple of the compiler files:

* A `*args` formal with a type annotation should have the element type of the list as its annotation; that is `BMGNode`, not `List[BMGNode]` if args are nodes. That is easy to fix, but this belies a more serious error.
* A `*args` formal is not of `List` type in the first place! It is iterable, but not necessarily a list. There were several places in the compiler where we assumed that a collection of args was a list, which is wrong.
* To fix the above issue I did two things. First, there are a few places where we need to use the `list()` constructor to ensure that a collection is a list. Second, I added assertions that back up the type annotations on several code paths where we got this wrong; this effectively regression-tests those bugs.
* Some time ago when I refactored the input list to be an `InputList` rather than a `List[BMGNode]` I forgot to update the type annotation. That's now fixed.
* Added a missing type annotation

Reviewed By: wtaha

Differential Revision: D26109100

