### PR TITLE
Prevent compiler from crashing when given unsupported code container

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/jit_test.py
+++ b/src/beanmachine/ppl/compiler/tests/jit_test.py
@@ -308,13 +308,11 @@ digraph "graph" {
 """
         self.assertEqual(dot.strip(), expected.strip())
 
-    def disabled_test_function_transformation_6(self) -> None:
+    def test_function_transformation_6(self) -> None:
         """Unit tests for JIT functions"""
 
-        # TODO: This test fails because of a bug where we crash if
-        # an RV function contains a call to a class constructor.
-        # The test will be enabled to regress the bug when the
-        # bug is fixed.
+        # This test regresses an issue where we had a crash when an RV contained
+        # a class constructor.
 
         self.maxDiff = None
 
@@ -324,6 +322,16 @@ digraph "graph" {
         bmg.accumulate_graph(queries, observations)
         dot = bmg.to_dot(point_at_input=True)
         expected = """
+digraph "graph" {
+  N0[label=2.0];
+  N1[label=Beta];
+  N2[label=Sample];
+  N3[label=Query];
+  N0 -> N1[label=alpha];
+  N0 -> N1[label=beta];
+  N1 -> N2[label=operand];
+  N2 -> N3[label=operator];
+}
 """
         self.assertEqual(dot.strip(), expected.strip())
 


### PR DESCRIPTION
Summary: The compiler which produces the "lifted" form of a function was assuming that it would always be given a normal function or method, and was crashing when given a class constructor. This diff causes the compiler to skip code containers that it does not support; we will assume that those containers do not need to be compiled for now, and add support to them later.

Reviewed By: kshah1997

Differential Revision: D26118433

