### PR TITLE
Add improved error reporting for compiler crashes

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/bm_to_bmg_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bm_to_bmg_test.py
@@ -5,7 +5,6 @@ import unittest
 import astor
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
 from beanmachine.ppl.compiler.bm_to_bmg import (
-    _bm_function_to_bmg_ast,
     _bm_function_to_bmg_function,
     to_bmg,
     to_cpp,

--- a/src/beanmachine/ppl/compiler/tests/jit_test.py
+++ b/src/beanmachine/ppl/compiler/tests/jit_test.py
@@ -93,7 +93,7 @@ class JITTest(unittest.TestCase):
 
         self.assertTrue(norm.is_random_variable)
 
-        bmgast = _bm_function_to_bmg_ast(f, "f_helper")
+        bmgast, _ = _bm_function_to_bmg_ast(f, "f_helper")
         observed = astor.to_source(bmgast)
         expected = """
 def f_helper(bmg):
@@ -109,7 +109,7 @@ def f_helper(bmg):
     return f"""
         self.assertEqual(observed.strip(), expected.strip())
 
-        bmgast = _bm_function_to_bmg_ast(norm, "norm_helper")
+        bmgast, _ = _bm_function_to_bmg_ast(norm, "norm_helper")
         observed = astor.to_source(bmgast)
         expected = """
 def norm_helper(bmg):


### PR DESCRIPTION
Summary: I've added some improved error reporting for compiler crashes. This just re-uses an earlier helper class I created for this, but using it required some refactorings to internal methods so that all the information for the error report is available.

Reviewed By: kshah1997

Differential Revision: D26128879

