### PR TITLE
Fix rewrite of while loops

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/jit_test.py
+++ b/src/beanmachine/ppl/compiler/tests/jit_test.py
@@ -79,6 +79,9 @@ def exp_coin_3():
 @bm.random_variable
 def coin_with_class():
     C()
+    f = True
+    while f:
+        f = not f
     return Beta(2.0, 2.0)
 
 
@@ -311,8 +314,11 @@ digraph "graph" {
     def test_function_transformation_6(self) -> None:
         """Unit tests for JIT functions"""
 
-        # This test regresses an issue where we had a crash when an RV contained
-        # a class constructor.
+        # This test regresses some crashing bugs. The compiler crashed if an
+        # RV function contained:
+        #
+        # * a class constructor
+        # * a while loop
 
         self.maxDiff = None
 


### PR DESCRIPTION
Summary:
The single assignment phase of the compiler seeks to reduce the model to a version of Python that has the same semantics but fewer features used than regular python. There were several (known!) bugs in the rewriter that eliminates all but the simplest form of `while` loops. Our goal state is that the only possible `while` loop in the rewritten form is a `while True:` with no `else` clause.  (Recall that Python has an `else` clause on `while` which has the semantics of "run the body of the `else` if and only if the loop was exited by a break".)

In the most general case we rewrite

    while c:
      body
    else:
      alternative

to

    while True:
      w1 = c
      if w1:
        body
      else
        break
    if not w1:
      alternative

Note that the alternative only runs if `body` contains a `break`.

We have rewrite rules for three situations:

* while True with an else clause -- rare but legal!
* while not_true with an else clause
* while not_true with no else clause

We then get to the goal state which is "while True with no else clause".

Reviewed By: wtaha

Differential Revision: D26131121

