### PR TITLE
Fix to MVN scale in NMC proposer

### DIFF
--- a/src/beanmachine/ppl/inference/proposer/tests/single_site_real_space_newtonian_monte_carlo_proposer_test.py
+++ b/src/beanmachine/ppl/inference/proposer/tests/single_site_real_space_newtonian_monte_carlo_proposer_test.py
@@ -91,12 +91,8 @@ class SingleSiteRealSpaceNewtonianMonteCarloProposerTest(unittest.TestCase):
         expected_scale_tril = torch.cholesky(
             tensor([[0.5000, 0.4000], [0.4000, 0.5000]])
         )
-        self.assertAlmostEqual(
-            abs((mean - expected_mean).sum().item()), 0.0, delta=0.01
-        )
-        self.assertAlmostEqual(
-            abs((scale_tril - expected_scale_tril).sum().item()), 0.0, delta=0.01
-        )
+        self.assertTrue(torch.isclose(mean, expected_mean).all())
+        self.assertTrue(torch.isclose(scale_tril, expected_scale_tril).all())
 
     def test_mean_scale_tril(self):
         model = self.SampleNormalModel()
@@ -131,10 +127,8 @@ class SingleSiteRealSpaceNewtonianMonteCarloProposerTest(unittest.TestCase):
 
         expected_mean = tensor([1.0, 1.0])
         expected_scale_tril = torch.cholesky(tensor([[1.0, 0.8], [0.8, 1]]))
-        self.assertAlmostEqual((mean - expected_mean).sum().item(), 0.0, delta=0.01)
-        self.assertAlmostEqual(
-            (scale_tril - expected_scale_tril).sum().item(), 0.0, delta=0.01
-        )
+        self.assertTrue(torch.isclose(mean, expected_mean).all())
+        self.assertTrue(torch.isclose(scale_tril, expected_scale_tril).all())
 
     def test_mean_scale_tril_for_iids(self):
         model = self.SampleNormalModel()
@@ -169,10 +163,8 @@ class SingleSiteRealSpaceNewtonianMonteCarloProposerTest(unittest.TestCase):
 
         expected_mean = tensor([1.0, 1.0, 1.0, 1.0])
         expected_scale_tril = torch.eye(4)
-        self.assertAlmostEqual((mean - expected_mean).sum().item(), 0.0, delta=0.01)
-        self.assertAlmostEqual(
-            (scale_tril - expected_scale_tril).sum().item(), 0.0, delta=0.01
-        )
+        self.assertTrue(torch.isclose(mean, expected_mean).all())
+        self.assertTrue(torch.isclose(scale_tril, expected_scale_tril).all())
 
     def test_multi_mean_scale_tril_computation_in_inference(self):
         model = self.SampleLogisticRegressionModel()

--- a/src/beanmachine/ppl/inference/tests/inference_integration_test_nightly.py
+++ b/src/beanmachine/ppl/inference/tests/inference_integration_test_nightly.py
@@ -1,0 +1,40 @@
+import unittest
+
+import beanmachine.ppl as bm
+import torch
+import torch.distributions as dist
+
+
+class IntegrationTest(unittest.TestCase):
+    class LogisticRegressionModel(object):
+        @bm.random_variable
+        def theta_0(self):
+            return dist.Normal(0.0, 1.0)
+
+        @bm.random_variable
+        def theta_1(self):
+            return dist.Normal(0.0, torch.ones(3))
+
+        @bm.random_variable
+        def y(self, X):
+            logits = (X * self.theta_1() + self.theta_0()).sum(-1)
+            return dist.Bernoulli(logits=logits)
+
+    def test_logistic_regression(self):
+        torch.manual_seed(1)
+        true_coefs = torch.tensor([1.0, 2.0, 3.0])
+        true_intercept = torch.tensor(1.0)
+        X = torch.randn(3000, 3)
+        Y = dist.Bernoulli(logits=(X * true_coefs + true_intercept).sum(-1)).sample()
+        model = self.LogisticRegressionModel()
+        nw = bm.SingleSiteNewtonianMonteCarlo()
+        samples_nw = nw.infer(
+            queries=[model.theta_1(), model.theta_0()],
+            observations={model.y(X): Y},
+            num_samples=1000,
+            num_chains=1,
+        )
+        coefs_mean = samples_nw[model.theta_1()].view(-1, 3).mean(0)
+        intercept_mean = samples_nw[model.theta_0()].view(-1).mean(0)
+        self.assertTrue(torch.isclose(coefs_mean, true_coefs, atol=0.15).all())
+        self.assertTrue(torch.isclose(intercept_mean, true_intercept, atol=0.15).all())

--- a/src/beanmachine/ppl/inference/tests/single_site_newtonian_monte_carlo_test.py
+++ b/src/beanmachine/ppl/inference/tests/single_site_newtonian_monte_carlo_test.py
@@ -28,25 +28,6 @@ class SingleSiteNewtonianMonteCarloTest(unittest.TestCase):
         def bar(self):
             return dist.Normal(self.foo(), torch.tensor(1.0))
 
-    class SampleLogisticRegressionModel(object):
-        @bm.random_variable
-        def theta_0(self):
-            return dist.Normal(tensor(0.0), tensor(1.0))
-
-        @bm.random_variable
-        def theta_1(self):
-            return dist.Normal(tensor(0.0), tensor(1.0))
-
-        @bm.random_variable
-        def x(self, i):
-            return dist.Normal(tensor(0.0), tensor(1.0))
-
-        @bm.random_variable
-        def y(self, i):
-            y = self.theta_1() * self.x(i) + self.theta_0()
-            probs = 1 / (1 + (y * -1).exp())
-            return dist.Bernoulli(probs)
-
     class SampleTransformModel(object):
         @sample
         def realspace(self):


### PR DESCRIPTION
Summary: As we discovered while discussing D25874172 (https://github.com/facebookincubator/beanmachine/commit/d83cea68149b3b2911a4fc18f909aeb05d73805b), the value passed to the multivariate normal's `scale_tril` parameter is not the correct Cholesky factor for the inverse of the Hessian. This replaces that with the correct factor that is obtained using the properties of a permutation matrix (derivation in comment).

Differential Revision: D26162424

