### PR TITLE
Suppress vmap warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,3 +2,16 @@
 # PEP 518: The minimum build requirement used in setup.py (before install depndencies)
 requires = ["setuptools", "wheel", "pybind11>=2.6.0"]
 build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+addopts = "-ra --import-mode=importlib --ignore-glob=tutorials/*.py"
+filterwarnings = [
+    # By default, all warnings are treated as errors
+    "error",
+    # patsy is a statsmodels dependency which currently triggers a DeprecationWarning
+    "default::DeprecationWarning:patsy.constraint",
+    # pytorch warns about vmap usage since it's experimental
+    "ignore:torch.vmap is an experimental prototype.*:UserWarning",
+    # pandas sometimes complains about binary compatibility with numpy
+    "default:numpy.ufunc size changed, may indicate binary incompatibility.*:RuntimeWarning"
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,18 +62,3 @@ ignore =
 max-complexity = 12
 exclude =
   build, dist, tutorials, website
-
-[tool:pytest]
-# any ignore= commands can be added here if needed
-addopts =
-  -ra
-  "--import-mode=importlib"
-  "--ignore-glob=tutorials/*.py"
-filterwarnings =
-    error
-    # patsy is a statsmodels dependency which currently triggers a DeprecationWarning
-    default::DeprecationWarning:patsy.constraint
-    # pytorch warns about vmap usage since it's experimental
-    default::UserWarning:torch
-    # pandas sometimes complains about binary compatibility with numpy
-    default:numpy.ufunc size changed, may indicate binary incompatibility.*:RuntimeWarning


### PR DESCRIPTION
Summary:
By default, all of the warnings in our codebase are raised as errors in our current pytest setting. However, this also include the `UserWarning` that we get by using the experimental vmap API. I addressed the error in D26091743 (https://github.com/facebookincubator/beanmachine/commit/fd3c09ac843503e1500a75ca9979ffbb1c0e0956) and at that time the workflow is passing, but for some reason my setting in `setup.cfg` was ignored and the `UserWarning` once again became an error [since 3 days ago](https://app.circleci.com/insights/github/facebookincubator/beanmachine/workflows/lint_and_test/overview?reporting-window=last-90-days)

According to [pytest's official doc](https://docs.pytest.org/en/stable/customize.html#setup-cfg), using setup.cfg is discouraged as it "might cause hard to track down problems." So I'm also moving pytest related settings to `pyproject.toml`

Differential Revision: D26180143

