### PR TITLE
Fix jit compilation of class methods

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/jit_test.py
+++ b/src/beanmachine/ppl/compiler/tests/jit_test.py
@@ -20,7 +20,8 @@ def f(x):
 
 
 class C:
-    pass
+    def m(self):
+        pass
 
 
 # TODO: support aliases on bm.random_variable
@@ -78,7 +79,7 @@ def exp_coin_3():
 
 @bm.random_variable
 def coin_with_class():
-    C()
+    C().m()
     f = True
     while f:
         f = not f
@@ -318,6 +319,7 @@ digraph "graph" {
         # RV function contained:
         #
         # * a class constructor
+        # * a call to a class method
         # * a while loop
 
         self.maxDiff = None


### PR DESCRIPTION
Summary:
In Python a call to a class method has an interesting implementation:

    class C:
      def m(self, x):
        ...
    c = C()
    cm = c.m
    cm(1)

Every time you have `c.m` in a Python program, what happens is Python constructs a new object, here stored in variable `cm`.  When you call `cm(1)`, what it really does is calls:

    cm.__func__(cm.__self__, 1)

where `cm.__func__` is equal to `C.m`.

The JIT compiler was not handling this situation correctly; what we should do is when we encounter a call to `cm(1)` here, we should JIT-compile `C.m` and then call the jitted helper function as `helper(cm.__self__, 1)`.  We were omitting the `cm.__self__` and getting an error.

We now canonicalize calls on a method object to be calls on the original function object and add `cm.__self__` as the first argument.

Reviewed By: kshah1997

Differential Revision: D26154119

