### PR TITLE
Slight refactoring to streamline new test method

### DIFF
--- a/src/beanmachine/ppl/utils/single_assignment.py
+++ b/src/beanmachine/ppl/utils/single_assignment.py
@@ -137,26 +137,28 @@ _unops: Pattern = match_any(ast.USub, ast.UAdd, ast.Invert, ast.Not)
 
 class SingleAssignment:
     _count: int
+    # TODO: Better naming convention. In particular, _rules is the reflexive
+    # transitive congruent extension of _rule. It would be nice to find
+    # terminology or refactoring that would make this easy to express more
+    # clearly than "s" does, but while still being concise.
+    _rule: Rule
     _rules: Rule
 
     def __init__(self) -> None:
         self._count = 0
-        self._rules = many(
-            _some_top_down(
-                first(
-                    [
-                        self._handle_compare_all(),
-                        self._handle_boolop_all(),
-                        self._handle_while(),
-                        self._handle_if(),
-                        self._handle_unassigned(),
-                        self._handle_return(),
-                        self._handle_for(),
-                        self._handle_assign(),
-                    ]
-                )
-            )
+        self._rule = first(
+            [
+                self._handle_compare_all(),
+                self._handle_boolop_all(),
+                self._handle_while(),
+                self._handle_if(),
+                self._handle_unassigned(),
+                self._handle_return(),
+                self._handle_for(),
+                self._handle_assign(),
+            ]
         )
+        self._rules = many(_some_top_down(self._rule))
 
     def _unique_id(self, prefix: str) -> str:
         self._count = self._count + 1


### PR DESCRIPTION
Summary:
This diff is a small refactoring in single_assignment.py to further improve a recent refactoring in the corresponding _test.py file (D26192159). In particular, we lift out a part of _rules (which we call _rule) so that we can more uniformly reconstruct _rules in the test file when we need it (without adding additional special casing at the point of use).

We also extend the test cases to illustrate the new and streamlined use case.

Stating this property explicitly required changing the definition of the check_rewrites method slightly: In one case, "many" was replaced by "once. As a result, a property of the check_rewrites (the third one in test_check_rewrites) needed revision as well.

Differential Revision: D26203010

