### PR TITLE
Starting left value rewrites

### DIFF
--- a/src/beanmachine/ppl/utils/single_assignment.py
+++ b/src/beanmachine/ppl/utils/single_assignment.py
@@ -1609,6 +1609,7 @@ class SingleAssignment:
                 self._handle_assign_unary_dict(),
                 self._handle_assign_binary_dict_left(),
                 self._handle_assign_binary_dict_right(),
+                self._handle_left_value_all(),
             ]
         )
 
@@ -1876,6 +1877,11 @@ class SingleAssignment:
                 self._handle_assign_compare_lefthandside(),
             ]
         )
+
+    def _handle_left_value_all(self) -> Rule:
+        """Put the left_value of an assignment in SSA form"""
+        # TODO: Add the various rewrite rules into the following list
+        return first([])
 
     def single_assignment(self, node: ast.AST) -> ast.AST:
         return self._rules(node).expect_success()

--- a/src/beanmachine/ppl/utils/tests/single_assignment_test.py
+++ b/src/beanmachine/ppl/utils/tests/single_assignment_test.py
@@ -2178,3 +2178,15 @@ x = dict(**c, **a1)
         self.check_rewrite(
             source, expected, _some_top_down(self.s._handle_assign_binary_dict_right())
         )
+
+    def test_left_value_all(self) -> None:
+        """General tests for the full set of assignment left value rules"""
+        # TODO: Add rest of set normal forms to this example
+        normal_forms = [
+            """
+def f(x):
+    x = y
+        """
+        ]
+
+        self.check_rewrites(normal_forms, self.s._handle_left_value_all())


### PR DESCRIPTION
Summary: This diff starts a stack of rewrites that will implement what is expected to be approximately 8 rewrite rules needed to put left value expressions in assignment statements into SSA form

Differential Revision: D26203978

