### PR TITLE
Add support for expm1 operator to BM->BMG compiler

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/bmg_arithmetic_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_arithmetic_test.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# BM -> BMG compiler arithmetic tests
+
+import unittest
+
+import beanmachine.ppl as bm
+import torch
+from beanmachine.ppl.inference.bmg_inference import BMGInference
+from torch.distributions import Beta, HalfCauchy, Normal
+
+
+@bm.random_variable
+def beta():
+    return Beta(2.0, 2.0)
+
+
+@bm.random_variable
+def norm():
+    return Normal(0.0, 1.0)
+
+
+@bm.random_variable
+def hc():
+    return HalfCauchy(1.0)
+
+
+@bm.functional
+def expm1_prob():
+    return beta().expm1()
+
+
+@bm.functional
+def expm1_real():
+    return torch.expm1(norm())
+
+
+@bm.functional
+def expm1_negreal():
+    return torch.Tensor.expm1(-hc())
+
+
+class BMGArithmeticTest(unittest.TestCase):
+    def test_bmg_arithmetic_expm1(self) -> None:
+        self.maxDiff = None
+
+        observed = BMGInference().to_dot([expm1_prob()], {})
+        expected = """
+digraph "graph" {
+  N0[label=2.0];
+  N1[label=Beta];
+  N2[label=Sample];
+  N3[label=ToPosReal];
+  N4[label=ExpM1];
+  N5[label=Query];
+  N0 -> N1;
+  N0 -> N1;
+  N1 -> N2;
+  N2 -> N3;
+  N3 -> N4;
+  N4 -> N5;
+}"""
+        self.assertEqual(observed.strip(), expected.strip())
+
+        observed = BMGInference().to_dot([expm1_real()], {})
+        expected = """
+digraph "graph" {
+  N0[label=0.0];
+  N1[label=1.0];
+  N2[label=Normal];
+  N3[label=Sample];
+  N4[label=ExpM1];
+  N5[label=Query];
+  N0 -> N2;
+  N1 -> N2;
+  N2 -> N3;
+  N3 -> N4;
+  N4 -> N5;
+}"""
+        self.assertEqual(observed.strip(), expected.strip())
+
+        observed = BMGInference().to_dot([expm1_negreal()], {})
+        expected = """
+digraph "graph" {
+  N0[label=1.0];
+  N1[label=HalfCauchy];
+  N2[label=Sample];
+  N3[label="-"];
+  N4[label=ExpM1];
+  N5[label=Query];
+  N0 -> N1;
+  N1 -> N2;
+  N2 -> N3;
+  N3 -> N4;
+  N4 -> N5;
+}"""
+        self.assertEqual(observed.strip(), expected.strip())

--- a/src/beanmachine/ppl/compiler/tests/unary_nodes_test.py
+++ b/src/beanmachine/ppl/compiler/tests/unary_nodes_test.py
@@ -7,6 +7,7 @@ from beanmachine.ppl.compiler.bmg_nodes import (
     BetaNode,
     BinomialNode,
     ComplementNode,
+    ExpM1Node,
     ExpNode,
     HalfCauchyNode,
     LogNode,
@@ -93,6 +94,20 @@ class UnaryNodesTest(unittest.TestCase):
         self.assertEqual(ExpNode(norm).inf_type, PositiveReal)
         self.assertEqual(ExpNode(neg).inf_type, Probability)
 
+        # ExpM1
+        # expm1 Boolean -> PositiveReal
+        # expm1 Probability -> PositiveReal
+        # expm1 Natural -> PositiveReal
+        # expm1 PositiveReal -> PositiveReal
+        # expm1 Real -> Real
+        # expm1 NegativeReal -> NegativeReal
+        self.assertEqual(ExpM1Node(bern).inf_type, PositiveReal)
+        self.assertEqual(ExpM1Node(beta).inf_type, PositiveReal)
+        self.assertEqual(ExpM1Node(bino).inf_type, PositiveReal)
+        self.assertEqual(ExpM1Node(half).inf_type, PositiveReal)
+        self.assertEqual(ExpM1Node(norm).inf_type, Real)
+        self.assertEqual(ExpM1Node(neg).inf_type, NegativeReal)
+
         # Log of prob is negative real, otherwise real.
         self.assertEqual(LogNode(bern).inf_type, NegativeReal)
         self.assertEqual(LogNode(beta).inf_type, NegativeReal)
@@ -167,6 +182,15 @@ class UnaryNodesTest(unittest.TestCase):
         self.assertEqual(ExpNode(half).requirements, [PositiveReal])
         self.assertEqual(ExpNode(norm).requirements, [Real])
         self.assertEqual(ExpNode(neg).requirements, [NegativeReal])
+
+        # ExpM1 requires that its operand be negative real, positive real or real.
+
+        self.assertEqual(ExpM1Node(bern).requirements, [PositiveReal])
+        self.assertEqual(ExpM1Node(beta).requirements, [PositiveReal])
+        self.assertEqual(ExpM1Node(bino).requirements, [PositiveReal])
+        self.assertEqual(ExpM1Node(half).requirements, [PositiveReal])
+        self.assertEqual(ExpM1Node(norm).requirements, [Real])
+        self.assertEqual(ExpM1Node(neg).requirements, [NegativeReal])
 
         # Log requires that its operand be probability or positive real.
         self.assertEqual(LogNode(bern).requirements, [Probability])


### PR DESCRIPTION
Summary:
(Normally I split adding a new operator up into multiple diffs but we've been down this road so many times now that I feel OK about doing it all at once, even though that makes a rather large diff.)

In this diff I add support to the Beanstalk compiler for the `expm1()` operator, which has the semantics of `exp(x) - 1`.

We support this operator directly in BMG, and so it is straightforward to turn applications of this function in a model into the BMG node.

Note that we do not detect instances of, say `rv().exp() - 1.0` and turn them into `expm1` nodes. We could do so by adding appropriate code to `fix_problems.py`. If `rv()` is of type negative real or positive real, it might be worthwhile to do so because we can get a more precise type analysis in these cases.

Reviewed By: wtaha

Differential Revision: D26187219

