### PR TITLE
Add support for sigmoid function to BM->BMG compiler

### DIFF
--- a/src/beanmachine/ppl/compiler/bmg_nodes.py
+++ b/src/beanmachine/ppl/compiler/bmg_nodes.py
@@ -2808,6 +2808,46 @@ class ExpM1Node(UnaryOperatorNode):
         return True
 
 
+class LogisticNode(UnaryOperatorNode):
+    """This represents the operation 1/(1+exp(x)); it is generated when
+    a model contains calls to Tensor.sigmoid."""
+
+    operator_type = OperatorType.LOGISTIC
+
+    def __init__(self, operand: BMGNode):
+        UnaryOperatorNode.__init__(self, operand)
+
+    @property
+    def label(self) -> str:
+        return "Logistic"
+
+    def _compute_inf_type(self) -> BMGLatticeType:
+        return Probability
+
+    def _compute_graph_type(self) -> BMGLatticeType:
+        ot = self.operand.graph_type
+        if ot == Real:
+            return Probability
+        return Malformed
+
+    @property
+    def requirements(self) -> List[Requirement]:
+        return [Real]
+
+    @property
+    def size(self) -> torch.Size:
+        return self.operand.size
+
+    def __str__(self) -> str:
+        return "Logistic(" + str(self.operand) + ")"
+
+    def support(self) -> Iterator[Any]:
+        return SetOfTensors(torch.sigmoid(o) for o in self.operand.support())
+
+    def _supported_in_bmg(self) -> bool:
+        return True
+
+
 class LogNode(UnaryOperatorNode):
     """This represents a log operation; it is generated when
     a model contains calls to Tensor.log or math.log."""

--- a/src/beanmachine/ppl/compiler/tests/bmg_arithmetic_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_arithmetic_test.py
@@ -40,6 +40,21 @@ def expm1_negreal():
     return torch.Tensor.expm1(-hc())
 
 
+@bm.functional
+def logistic_prob():
+    return beta().sigmoid()
+
+
+@bm.functional
+def logistic_real():
+    return torch.sigmoid(norm())
+
+
+@bm.functional
+def logistic_negreal():
+    return torch.Tensor.sigmoid(-hc())
+
+
 class BMGArithmeticTest(unittest.TestCase):
     def test_bmg_arithmetic_expm1(self) -> None:
         self.maxDiff = None
@@ -93,5 +108,62 @@ digraph "graph" {
   N2 -> N3;
   N3 -> N4;
   N4 -> N5;
+}"""
+        self.assertEqual(observed.strip(), expected.strip())
+
+    def test_bmg_arithmetic_logistic(self) -> None:
+        self.maxDiff = None
+
+        observed = BMGInference().to_dot([logistic_prob()], {})
+        expected = """
+digraph "graph" {
+  N0[label=2.0];
+  N1[label=Beta];
+  N2[label=Sample];
+  N3[label=ToReal];
+  N4[label=Logistic];
+  N5[label=Query];
+  N0 -> N1;
+  N0 -> N1;
+  N1 -> N2;
+  N2 -> N3;
+  N3 -> N4;
+  N4 -> N5;
+}"""
+        self.assertEqual(observed.strip(), expected.strip())
+
+        observed = BMGInference().to_dot([logistic_real()], {})
+        expected = """
+digraph "graph" {
+  N0[label=0.0];
+  N1[label=1.0];
+  N2[label=Normal];
+  N3[label=Sample];
+  N4[label=Logistic];
+  N5[label=Query];
+  N0 -> N2;
+  N1 -> N2;
+  N2 -> N3;
+  N3 -> N4;
+  N4 -> N5;
+}"""
+        self.assertEqual(observed.strip(), expected.strip())
+
+        observed = BMGInference().to_dot([logistic_negreal()], {})
+        expected = """
+digraph "graph" {
+  N0[label=1.0];
+  N1[label=HalfCauchy];
+  N2[label=Sample];
+  N3[label="-"];
+  N4[label=ToReal];
+  N5[label=Logistic];
+  N6[label=Query];
+  N0 -> N1;
+  N1 -> N2;
+  N2 -> N3;
+  N3 -> N4;
+  N4 -> N5;
+  N5 -> N6;
 }"""
         self.assertEqual(observed.strip(), expected.strip())

--- a/src/beanmachine/ppl/compiler/tests/unary_nodes_test.py
+++ b/src/beanmachine/ppl/compiler/tests/unary_nodes_test.py
@@ -10,6 +10,7 @@ from beanmachine.ppl.compiler.bmg_nodes import (
     ExpM1Node,
     ExpNode,
     HalfCauchyNode,
+    LogisticNode,
     LogNode,
     NaturalNode,
     NegateNode,
@@ -108,6 +109,14 @@ class UnaryNodesTest(unittest.TestCase):
         self.assertEqual(ExpM1Node(norm).inf_type, Real)
         self.assertEqual(ExpM1Node(neg).inf_type, NegativeReal)
 
+        # Logistic always produces a probability
+        self.assertEqual(LogisticNode(bern).inf_type, Probability)
+        self.assertEqual(LogisticNode(beta).inf_type, Probability)
+        self.assertEqual(LogisticNode(bino).inf_type, Probability)
+        self.assertEqual(LogisticNode(half).inf_type, Probability)
+        self.assertEqual(LogisticNode(norm).inf_type, Probability)
+        self.assertEqual(LogisticNode(neg).inf_type, Probability)
+
         # Log of prob is negative real, otherwise real.
         self.assertEqual(LogNode(bern).inf_type, NegativeReal)
         self.assertEqual(LogNode(beta).inf_type, NegativeReal)
@@ -191,6 +200,15 @@ class UnaryNodesTest(unittest.TestCase):
         self.assertEqual(ExpM1Node(half).requirements, [PositiveReal])
         self.assertEqual(ExpM1Node(norm).requirements, [Real])
         self.assertEqual(ExpM1Node(neg).requirements, [NegativeReal])
+
+        # Logistic requires that its operand be real.
+
+        self.assertEqual(LogisticNode(bern).requirements, [Real])
+        self.assertEqual(LogisticNode(beta).requirements, [Real])
+        self.assertEqual(LogisticNode(bino).requirements, [Real])
+        self.assertEqual(LogisticNode(half).requirements, [Real])
+        self.assertEqual(LogisticNode(norm).requirements, [Real])
+        self.assertEqual(LogisticNode(neg).requirements, [Real])
 
         # Log requires that its operand be probability or positive real.
         self.assertEqual(LogNode(bern).requirements, [Probability])


### PR DESCRIPTION
Summary: The beanstalk compiler now supports compiling models which contain the `sigmoid()` operator; we compile this to the BMG `LOGISTIC` operator.

Reviewed By: wtaha

Differential Revision: D26189942

