### PR TITLE
Move comparison transformation testing to own module

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/bm_to_bmg_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bm_to_bmg_test.py
@@ -1919,79 +1919,6 @@ digraph "graph" {
 """
 
 
-# Test comparison operators; these are not supported
-# in BMG yet but we need to be able to detect use of
-# them and give an error, so we will verify that we
-# can lower code containing them correctly.
-
-source19 = """
-import beanmachine.ppl as bm
-from torch.distributions import Normal, StudentT
-from torch import tensor
-
-@bm.random_variable
-def x():
-    return Normal(0.0, 1.0)
-
-@bm.random_variable
-def y():
-    z = 0.0 < x() < 2.0
-    return StudentT(3.0, z, 4.0)
-"""
-
-expected_raw_19 = """
-from beanmachine.ppl.utils.memoize import memoize
-from beanmachine.ppl.utils.probabilistic import probabilistic
-from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
-_lifted_to_bmg: bool = True
-bmg = BMGraphBuilder()
-import beanmachine.ppl as bm
-from torch.distributions import Normal, StudentT
-from torch import tensor
-
-
-@probabilistic(bmg)
-@memoize
-def x():
-    a11 = 0.0
-    a9 = [a11]
-    a15 = 1.0
-    a12 = [a15]
-    r7 = bmg.handle_addition(a9, a12)
-    r13 = {}
-    r1 = bmg.handle_function(Normal, r7, r13)
-    return bmg.handle_sample(r1)
-
-
-@probabilistic(bmg)
-@memoize
-def y():
-    a2 = 0.0
-    r5 = []
-    r10 = {}
-    a4 = bmg.handle_function(x, r5, r10)
-    a6 = bmg.handle_less_than(a2, a4)
-    if a6:
-        a8 = 2.0
-        z = bmg.handle_less_than(a4, a8)
-    else:
-        z = a6
-    a20 = 3.0
-    a17 = [a20]
-    a21 = [z]
-    a16 = bmg.handle_addition(a17, a21)
-    a22 = 4.0
-    a18 = [a22]
-    r14 = bmg.handle_addition(a16, a18)
-    r19 = {}
-    r3 = bmg.handle_function(StudentT, r14, r19)
-    return bmg.handle_sample(r3)
-
-
-roots = [x(), y()]
-"""
-
-
 class CompilerTest(unittest.TestCase):
     def disabled_test_to_python_raw_1(self) -> None:
         # TODO: Something is wrong with the lowering of the named
@@ -2055,11 +1982,6 @@ class CompilerTest(unittest.TestCase):
         self.maxDiff = None
         observed = to_python_raw(source11)
         self.assertEqual(observed.strip(), expected_raw_11.strip())
-
-    def test_to_python_raw_19(self) -> None:
-        self.maxDiff = None
-        observed = to_python_raw(source19)
-        self.assertEqual(observed.strip(), expected_raw_19.strip())
 
     def disabled_test_to_python_1(self) -> None:
         self.maxDiff = None

--- a/src/beanmachine/ppl/compiler/tests/comparison_errors_test.py
+++ b/src/beanmachine/ppl/compiler/tests/comparison_errors_test.py
@@ -8,18 +8,9 @@ from torch.distributions import Bernoulli, Normal, StudentT
 
 # Comparisons involving a graph node have no representation in
 # BMG and should produce an error.
-
-
-# TODO: Add a test case for multiple comparison operations such as
-# r = x < y < z.  We lower these to a simpler form:
-# t1 = x < y
-# if t1:
-#   r = y < z
-# else:
-#   r = t1
-# which means that we need to not only handle a potentially stochastic
-# comparison operator, but also a potentially stochastic "if".
-# We do not handle that yet, but when we do come back and add a test here.
+#
+# Tests which show how the comparison operators are lowered into
+# a more fundamental form are in comparison_rewriting_test.py.
 
 
 @bm.random_variable

--- a/src/beanmachine/ppl/compiler/tests/comparison_rewriting_test.py
+++ b/src/beanmachine/ppl/compiler/tests/comparison_rewriting_test.py
@@ -1,0 +1,80 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+"""Comparison operators are not supported in BMG yet but we need to be able to detect
+use of them and give an error. Here we verify that we can rewrite code containing
+them correctly."""
+
+import unittest
+
+import astor
+import beanmachine.ppl as bm
+from beanmachine.ppl.compiler.bm_to_bmg import _bm_function_to_bmg_ast
+from torch.distributions import Normal, StudentT
+
+
+@bm.random_variable
+def x():
+    return Normal(0.0, 1.0)
+
+
+@bm.random_variable
+def y():
+    z = 0.0 < x() < 2.0
+    return StudentT(3.0, z, 4.0)
+
+
+class ComparisonRewritingTest(unittest.TestCase):
+    def test_comparison_rewriting_1(self) -> None:
+        self.maxDiff = None
+
+        # The key thing to note here is that we eliminate Python's weird
+        # comparison logic entirely; we reduce
+        #
+        # z = 0.0 < x() < 2.0
+        #
+        # to the equivalent of:
+        #
+        # tx = x()
+        # comp = 0.0 < tx
+        # if comp:
+        #   z = tx < 2.0
+        # else:
+        #   z = comp
+        #
+        # which has the same semantics but has only simple comparisons and
+        # simple control flows.
+
+        self.assertTrue(y.is_random_variable)
+
+        bmgast, _ = _bm_function_to_bmg_ast(y, "y_helper")
+        observed = astor.to_source(bmgast)
+        expected = """
+def y_helper(bmg):
+    from beanmachine.ppl.utils.memoize import memoize
+    from beanmachine.ppl.utils.probabilistic import probabilistic
+
+    @probabilistic(bmg)
+    @memoize
+    def y():
+        a1 = 0.0
+        r4 = []
+        r7 = {}
+        a3 = bmg.handle_function(x, r4, r7)
+        a5 = bmg.handle_less_than(a1, a3)
+        if a5:
+            a6 = 2.0
+            z = bmg.handle_less_than(a3, a6)
+        else:
+            z = a5
+        a13 = 3.0
+        a10 = [a13]
+        a14 = [z]
+        a9 = bmg.handle_addition(a10, a14)
+        a15 = 4.0
+        a11 = [a15]
+        r8 = bmg.handle_addition(a9, a11)
+        r12 = {}
+        r2 = bmg.handle_function(StudentT, r8, r12)
+        return bmg.handle_sample(r2)
+    return y
+"""
+        self.assertEqual(observed.strip(), expected.strip())


### PR DESCRIPTION
Summary: I'm continuing with my review of all our of compiler tests; in this diff I simply move one of the comparison tests to its own module, and make it use the JIT API rather than the original "transform this whole module" API.

Reviewed By: wtaha

Differential Revision: D26205243

