### PR TITLE
Refactor problem fixer into many smaller classes

### DIFF
--- a/src/beanmachine/ppl/compiler/fix_additions.py
+++ b/src/beanmachine/ppl/compiler/fix_additions.py
@@ -1,0 +1,48 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
+from beanmachine.ppl.compiler.bmg_nodes import AdditionNode, BMGNode, NegateNode
+from beanmachine.ppl.compiler.bmg_types import One
+
+
+class AdditionFixer:
+    """This class takes a Bean Machine Graph builder and attempts to
+    rewrite reachable additions of the form:
+
+    * add(1, negate(prob)) or add(negate(prob), 1) -> complement(prob)
+    * add(1, negate(bool)) or add(negate(bool), 1) -> complement(bool)"""
+
+    bmg: BMGraphBuilder
+
+    def __init__(self, bmg: BMGraphBuilder) -> None:
+        self.bmg = bmg
+
+    def _addition_to_complement(self, node: AdditionNode) -> BMGNode:
+        assert node.can_be_complement
+        # We have 1+(-x) or (-x)+1 where x is either P or B, and require
+        # a P or B. Complement(x) is of the same type as x if x is P or B.
+        if node.left.inf_type == One:
+            other = node.right
+        else:
+            assert node.right.inf_type == One
+            other = node.left
+        assert isinstance(other, NegateNode)
+        return self.bmg.add_complement(other.operand)
+
+    def additions_to_complements(self) -> None:
+        replacements = {}
+        nodes = self.bmg._traverse_from_roots()
+        for node in nodes:
+            for i in range(len(node.inputs)):
+                c = node.inputs[i]
+                if not isinstance(c, AdditionNode):
+                    continue
+                assert isinstance(c, AdditionNode)
+                if not c.can_be_complement:
+                    continue
+                if c in replacements:
+                    node.inputs[i] = replacements[c]
+                    continue
+                replacement = self._addition_to_complement(c)
+                node.inputs[i] = replacement
+                replacements[c] = replacement

--- a/src/beanmachine/ppl/compiler/fix_observations.py
+++ b/src/beanmachine/ppl/compiler/fix_observations.py
@@ -1,0 +1,47 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
+from beanmachine.ppl.compiler.bmg_types import (
+    Boolean,
+    Natural,
+    PositiveReal,
+    Probability,
+    Real,
+    supremum,
+    type_of_value,
+)
+from beanmachine.ppl.compiler.error_report import ErrorReport, ImpossibleObservation
+
+
+class ObservationsFixer:
+    """This class takes a Bean Machine Graph builder and attempts to
+    fix violations of BMG type system requirements in observation nodes.
+    It also finds observations that are impossible -- say, an observation
+    that a Boolean node is -3.14 -- and reports them as errors."""
+
+    errors: ErrorReport
+    bmg: BMGraphBuilder
+
+    def __init__(self, bmg: BMGraphBuilder) -> None:
+        self.errors = ErrorReport()
+        self.bmg = bmg
+
+    def fix_observations(self) -> None:
+        for o in self.bmg.all_observations():
+            v = o.value
+            inf = type_of_value(v)
+            gt = o.operand.graph_type
+            if supremum(inf, gt) != gt:
+                self.errors.add_error(ImpossibleObservation(o))
+            elif gt == Boolean:
+                o.value = bool(v)
+            elif gt == Natural:
+                o.value = int(v)
+            elif gt in {Probability, PositiveReal, Real}:
+                o.value = float(v)
+            else:
+                # TODO: How should we deal with observations of
+                # TODO: matrix-valued samples?
+                pass
+            # TODO: Handle the case where there are two inconsistent
+            # TODO: observations of the same sample

--- a/src/beanmachine/ppl/compiler/fix_tensor_ops.py
+++ b/src/beanmachine/ppl/compiler/fix_tensor_ops.py
@@ -1,0 +1,84 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
+from beanmachine.ppl.compiler.bmg_nodes import BMGNode, LogSumExpNode, TensorNode
+
+
+def _is_fixable_logsumexp(n: BMGNode) -> bool:
+    return (
+        isinstance(n, LogSumExpNode)
+        and len(n.inputs) == 1
+        and isinstance(n.inputs[0], TensorNode)
+    )
+
+
+class TensorOpsFixer:
+    """This class looks for reachable nodes in a graph which cannot be transformed
+    to BMG because they contain tensor operations which have no representation. We
+    rewrite those operations in a semantically equivalent form which can be
+    represented."""
+
+    # TODO: So far all we fix here is that a logsumexp node whose input is a
+    # tensor becomes a logsumexp node whose inputs are the elements of the tensor.
+    # We can do a lot better than that. For example, suppose we have:
+    #
+    # x = tensor([norm(1), norm(2)]) * 2.0
+    # y = x.logsumexp(dim=0)
+    #
+    # Right now we cannot fix that because the input to logsumexp is not a tensor
+    # node; it's a multiplication node. But we could first transform the graph to:
+    #
+    # x = tensor([norm(1) * 2.0, norm(2) * 2.0])
+    # y = x.logsumexp(dim=0)
+    #
+    # and now it is in a form that we can fix further.
+    #
+    # Making this sort of change will require us to iterate on these changes until
+    # we reach a fixpoint.
+
+    bmg: BMGraphBuilder
+
+    def __init__(self, bmg: BMGraphBuilder) -> None:
+        self.bmg = bmg
+
+    def _fix_logsumexp(self, n: LogSumExpNode) -> BMGNode:
+        assert len(n.inputs) == 1
+        t = n.inputs[0]
+        assert isinstance(t, TensorNode)
+        # If the tensor is a singleton then logsumexp is
+        # an identity.
+        assert len(t.inputs) >= 1
+        if len(t.inputs) == 1:
+            return t.inputs[0]
+        # Otherwise, we just make a LogSumExp whose inputs are the
+        # tensor node elements.
+        elements = t.inputs.inputs
+        assert isinstance(elements, list)
+        return self.bmg.add_logsumexp(*elements)
+
+    def fix_tensor_ops(self) -> None:
+        # Suppose we have a model with a query on some samples:
+        #
+        # @function def f():
+        #   return tensor([norm(), beta(), ... ]).logsumexp(dim=0)
+        #
+        # The graph accumulator will create a TensorNode containing the
+        # SampleNodes, and the LogSumExpNode's input will be the tensor.
+        # But we do not have a tensor-built-from-parts node in BMG.
+        #
+        # What we need to do is construct a new LogSumExpNode whose
+        # inputs are the samples; the TensorNode will become orphaned.
+        #
+        replacements = {}
+        nodes = self.bmg._traverse_from_roots()
+        for node in nodes:
+            for i in range(len(node.inputs)):
+                c = node.inputs[i]
+                if c in replacements:
+                    node.inputs[i] = replacements[c]
+                    continue
+                if _is_fixable_logsumexp(c):
+                    assert isinstance(c, LogSumExpNode)
+                    replacement = self._fix_logsumexp(c)
+                    node.inputs[i] = replacement
+                    replacements[c] = replacement

--- a/src/beanmachine/ppl/compiler/fix_unsupported.py
+++ b/src/beanmachine/ppl/compiler/fix_unsupported.py
@@ -1,0 +1,111 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+from typing import Optional
+
+from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
+from beanmachine.ppl.compiler.bmg_nodes import (
+    BMGNode,
+    Chi2Node,
+    ConstantNode,
+    DivisionNode,
+    UniformNode,
+)
+from beanmachine.ppl.compiler.bmg_types import PositiveReal
+from beanmachine.ppl.compiler.error_report import ErrorReport, UnsupportedNode
+
+
+class UnsupportedNodeFixer:
+    """This class takes a Bean Machine Graph builder and attempts to
+    fix all uses of unsupported operators by replacing them with semantically
+    equivalent nodes that are supported by BMG."""
+
+    errors: ErrorReport
+    bmg: BMGraphBuilder
+
+    def __init__(self, bmg: BMGraphBuilder) -> None:
+        self.errors = ErrorReport()
+        self.bmg = bmg
+
+    def _replace_division(self, node: DivisionNode) -> Optional[BMGNode]:
+        # BMG has no division node. We replace division by a constant with
+        # a multiplication:
+        #
+        # x / const --> x * (1 / const)
+        #
+        # And we replace division by a non-constant with a power:
+        #
+        # x / y --> x * (y ** (-1))
+        #
+        r = node.right
+        if isinstance(r, ConstantNode):
+            return self.bmg.add_multiplication(
+                node.left, self.bmg.add_constant(1.0 / r.value)
+            )
+        neg1 = self.bmg.add_constant(-1.0)
+        powr = self.bmg.add_power(r, neg1)
+        return self.bmg.add_multiplication(node.left, powr)
+
+    def _replace_uniform(self, node: UniformNode) -> Optional[BMGNode]:
+        # TODO: Suppose we have something like Uniform(1.0, 2.0).  Can we replace that
+        # with (Flat() + 1.0) ? The problem is that if there is an observation on
+        # a sample of the original uniform, we need to modify the observation to
+        # point to the sample, not the addition, and then we need to modify the value
+        # of the observation. But this is doable. Revisit this question later.
+        # For now, we can simply say that a uniform distribution over 0.0 to 1.0 can
+        # be replaced with a flat.
+        low = node.low
+        high = node.high
+        if (
+            isinstance(low, ConstantNode)
+            and float(low.value) == 0.0
+            and isinstance(high, ConstantNode)
+            and float(high.value) == 1.0
+        ):
+            return self.bmg.add_flat()
+        return None
+
+    def _replace_chi2(self, node: Chi2Node) -> BMGNode:
+        # Chi2(x), which BMG does not support, is exactly equivalent
+        # to Gamma(x * 0.5, 0.5), which BMG does support.
+        half = self.bmg.add_constant_of_type(0.5, PositiveReal)
+        mult = self.bmg.add_multiplication(node.df, half)
+        return self.bmg.add_gamma(mult, half)
+
+    def _replace_unsupported_node(self, node: BMGNode) -> Optional[BMGNode]:
+        # TODO:
+        # Not -> Complement
+        # Index/Map -> IfThenElse
+        if isinstance(node, Chi2Node):
+            return self._replace_chi2(node)
+        if isinstance(node, DivisionNode):
+            return self._replace_division(node)
+        if isinstance(node, UniformNode):
+            return self._replace_uniform(node)
+        return None
+
+    def fix_unsupported_nodes(self) -> None:
+        replacements = {}
+        reported = set()
+        nodes = self.bmg._traverse_from_roots()
+        for node in nodes:
+            for i in range(len(node.inputs)):
+                c = node.inputs[i]
+                if c._supported_in_bmg():
+                    continue
+                # We have an unsupported node. Have we already worked out its
+                # replacement node?
+                if c in replacements:
+                    node.inputs[i] = replacements[c]
+                    continue
+                # We have an unsupported node; have we already reported it as
+                # having no replacement?
+                if c in reported:
+                    continue
+                # We have an unsupported node and we don't know what to do.
+                replacement = self._replace_unsupported_node(c)
+                if replacement is None:
+                    self.errors.add_error(UnsupportedNode(c, node, node.edges[i]))
+                    reported.add(c)
+                else:
+                    replacements[c] = replacement
+                    node.inputs[i] = replacement


### PR DESCRIPTION
Summary:
The code which looks at an accumulated graph and either transforms it into a form that is compatible with the BMG type system, or gives an error if it is not, was getting too complicated for my liking.

I've split it up into five classes, each of which does one thing, and then we just activate each of the five in order.

We might in the future need to have more complex workflows here, where some passes need to be run more than once, or where we need to track whether progress has been made.  It will be easier to do that sort of work if the fixers are already broken up into smaller pieces like this.

Reviewed By: wtaha

Differential Revision: D26208322

