### PR TITLE
Add error checking for calls to rvs with named arguments

### DIFF
--- a/src/beanmachine/ppl/compiler/bm_graph_builder.py
+++ b/src/beanmachine/ppl/compiler/bm_graph_builder.py
@@ -1248,15 +1248,15 @@ class BMGraphBuilder:
         return (f, args, kwargs)
 
     def _handle_random_variable_call_checked(
-        self, function: Any, arguments: List[Any], kwargs: Dict[str, Any]
+        self, function: Any, arguments: List[Any]
     ) -> BMGNode:
         assert isinstance(arguments, list)
 
         # We have a call to a random variable function. There are two
         # cases. Either we have only ordinary values for arguments, or
         # we have one or more graph nodes.
-        if only_ordinary_arguments(arguments, kwargs):
-            rv = function(*arguments, **kwargs)
+        if only_ordinary_arguments(arguments, {}):
+            rv = function(*arguments)
             assert isinstance(rv, RVIdentifier)
             return self._rv_to_node(rv)
 
@@ -1273,8 +1273,11 @@ class BMGraphBuilder:
         self, function: Any, arguments: List[Any], kwargs: Dict[str, Any]
     ) -> BMGNode:
 
-        # TODO: Random variable calls do not support kwargs.
-        # TODO: Throw an exception if we have some?
+        if len(kwargs) != 0:
+            # TODO: Better error
+            raise ValueError(
+                "Random variable function calls must not have named arguments."
+            )
 
         # If we have one or more graph nodes as arguments to an RV function call
         # then we need to try every possible value for those arguments. We require
@@ -1297,7 +1300,7 @@ class BMGraphBuilder:
                     # TODO: Better exception
                     raise ValueError("Stochastic control flow is too complex.")
 
-        return self._handle_random_variable_call_checked(function, arguments, kwargs)
+        return self._handle_random_variable_call_checked(function, arguments)
 
     def _handle_functional_call(
         self, function: Any, arguments: List[Any], kwargs: Dict[str, Any]

--- a/src/beanmachine/ppl/compiler/tests/jit_test.py
+++ b/src/beanmachine/ppl/compiler/tests/jit_test.py
@@ -121,6 +121,12 @@ def bad_functional_2():
     )
 
 
+@bm.functional
+def bad_functional_3():
+    # Calling rv functions with named arguments is not allowed.
+    return flips(n=1)
+
+
 class JITTest(unittest.TestCase):
     def test_function_transformation_1(self) -> None:
         """Unit tests for JIT functions"""
@@ -408,3 +414,19 @@ digraph "graph" {
         with self.assertRaises(ValueError) as ex:
             bmg.accumulate_graph(queries, observations)
         self.assertEqual(str(ex.exception), "Stochastic control flow is too complex.")
+
+    def test_bad_control_flow_3(self) -> None:
+        """Unit tests for JIT functions"""
+
+        self.maxDiff = None
+
+        bmg = BMGraphBuilder()
+        queries = [bad_functional_3()]
+        observations = {}
+        # TODO: Better exception class
+        with self.assertRaises(ValueError) as ex:
+            bmg.accumulate_graph(queries, observations)
+        self.assertEqual(
+            str(ex.exception),
+            "Random variable function calls must not have named arguments.",
+        )


### PR DESCRIPTION
Summary: It's not legal to call a random variable function with a named argument. We now detect that situation when accumulating graph nodes; if we are processing a call to an rv function we throw an exception if there are any named arguments.  This then saves on having to do any further analysis of the named args.

Reviewed By: wtaha

Differential Revision: D26238824

