### PR TITLE
Assignment LHS is unnamed list list

### DIFF
--- a/src/beanmachine/ppl/utils/ast_patterns.py
+++ b/src/beanmachine/ppl/utils/ast_patterns.py
@@ -303,6 +303,13 @@ def ast_list(elts: Pattern = _any, ctx: Pattern = _any, ast_op=ast.List) -> Patt
     return type_and_attributes(ast_op, {"elts": elts, "ctx": ctx})
 
 
+def ast_luple(elts: Pattern = _any, ctx: Pattern = _any) -> Pattern:
+    return match_any(
+        type_and_attributes(ast.List, {"elts": elts, "ctx": ctx}),
+        type_and_attributes(ast.Tuple, {"elts": elts, "ctx": ctx}),
+    )
+
+
 def ast_dict(keys: Pattern = _any, values: Pattern = _any) -> Pattern:
     return type_and_attributes(ast.Dict, {"keys": keys, "values": values})
 

--- a/src/beanmachine/ppl/utils/tests/single_assignment_test.py
+++ b/src/beanmachine/ppl/utils/tests/single_assignment_test.py
@@ -2439,3 +2439,62 @@ def f(x):
         self.check_rewrites(terms, self.s._handle_left_value_list_star())
         self.check_rewrites(terms, self.s._handle_left_value_all())
         self.check_rewrites(terms)
+
+    def test_left_value_list_list_star(self) -> None:
+        """Test rewrites like [*a.b] = z → [*y] = z; a.b = y."""
+
+        terms = [
+            """
+def f(x):
+    [*a.b] = z
+    [*a[b]] = z
+    (*a.b,) = z
+    (*a[b],) = z""",
+            """
+def f(x):
+    [*x1] = z
+    a.b = x1
+    [*x2] = z
+    a[b] = x2
+    [*x3] = z
+    a.b = x3
+    [*x4] = z
+    a[b] = x4""",
+        ]
+
+        self.check_rewrites(terms, self.s._handle_left_value_list_star())
+        self.check_rewrites(terms, self.s._handle_left_value_all())
+        self.check_rewrites(terms)
+
+    def test_left_value_list_list_star(self) -> None:
+        """Test rewrites like [[a.b]] = z → [y] = z; [a.b] = y.
+        Note that this should also work for things where a.b is simply c.
+        It also pattern matches both tuples and lists as if they are the same."""
+
+        terms = [
+            """
+def f(x):
+    [[a.b]] = z
+    [[a[b]]] = z
+    ([a.b],) = z
+    ([a[b]],) = z
+    [[a]] = z
+    [[a],b] = z""",
+            """
+def f(x):
+    [x1] = z
+    [a.b] = x1
+    [x2] = z
+    [a[b]] = x2
+    [x3] = z
+    [a.b] = x3
+    [x4] = z
+    [a[b]] = x4
+    [x5] = z
+    [a] = x5
+    [[a], b] = z""",
+        ]
+
+        self.check_rewrites(terms, self.s._handle_left_value_list_list_star())
+        self.check_rewrites(terms, self.s._handle_left_value_all())
+        self.check_rewrites(terms)


### PR DESCRIPTION
Summary:
Rewrites like [[e]] = z → [y] = z; [e] = y.

Note: This type of rewrite should not be "generalized" to have anything come after [e] because that would change order of evaluation within the pattern.

Also, in this diff we introduce the abstraction of "luple", which is used to pattern match against either a list or a tuple (hence the name).

Differential Revision: D26261016

