### PR TITLE
Fixing our nightly tets

### DIFF
--- a/src/beanmachine/ppl/experimental/neutra/tests/iaf_conjugate_test_nightly.py
+++ b/src/beanmachine/ppl/experimental/neutra/tests/iaf_conjugate_test_nightly.py
@@ -115,7 +115,7 @@ class SingleSiteIAFConjugateTest(unittest.TestCase, AbstractConjugateTests):
             [],
         )
         self.normal_normal_conjugate_run(
-            iaf, num_samples=2000, num_adaptive_samples=5000
+            iaf, num_samples=10000, num_adaptive_samples=5000
         )
 
     def test_distant_normal_normal_conjugate_run(self):

--- a/src/beanmachine/ppl/inference/tests/single_site_no_u_turn_conjugate_test_nightly.py
+++ b/src/beanmachine/ppl/inference/tests/single_site_no_u_turn_conjugate_test_nightly.py
@@ -59,9 +59,9 @@ class SingleSiteNoUTurnConjugateTest(unittest.TestCase, AbstractConjugateTests):
     def test_dirichlet_categorical_conjugate_run(self):
         nuts = SingleSiteNoUTurnSampler(use_dense_mass_matrix=False)
         self.dirichlet_categorical_conjugate_run(
-            nuts, num_samples=200, num_adaptive_samples=100
+            nuts, num_samples=800, num_adaptive_samples=100
         )
         nuts = SingleSiteNoUTurnSampler()
         self.dirichlet_categorical_conjugate_run(
-            nuts, num_samples=200, num_adaptive_samples=100
+            nuts, num_samples=800, num_adaptive_samples=100
         )

--- a/src/beanmachine/ppl/inference/tests/single_site_random_walk_adaptive_conjugate_test_nightly.py
+++ b/src/beanmachine/ppl/inference/tests/single_site_random_walk_adaptive_conjugate_test_nightly.py
@@ -46,5 +46,5 @@ class SingleSiteAdaptiveRandomWalkConjugateTest(
     # TODO: Expected n_eff levels should be documented in tests
     def test_dirichlet_categorical_conjugate_run(self):
         self.dirichlet_categorical_conjugate_run(
-            self.mh, num_samples=1000, num_adaptive_samples=500
+            self.mh, num_samples=1500, num_adaptive_samples=500
         )


### PR DESCRIPTION
Summary:
Our failed nightly tests were primarily due to a low effective sample sizes. An easy fix is to increase `n_iter` per test.

Related tasks: T84058641, T84058600, T84366158, T84370835, T84366133, T84293201, T84201672, T84125562, T84125477, T84125505

Differential Revision: D26297712

