### PR TITLE
Add error checking for calls to functionals with named arguments

### DIFF
--- a/src/beanmachine/ppl/compiler/bm_graph_builder.py
+++ b/src/beanmachine/ppl/compiler/bm_graph_builder.py
@@ -1306,13 +1306,14 @@ class BMGraphBuilder:
         self, function: Any, arguments: List[Any], kwargs: Dict[str, Any]
     ) -> BMGNode:
 
+        if len(kwargs) != 0:
+            # TODO: Better error
+            raise ValueError("Functional calls must not have named arguments.")
+
         # TODO: What happens if we have a @functional that does not return
         # TODO: a graph node? A functional that returns a constant is
         # TODO: weird, but it should be legal.  Figure out what the
         # TODO: right thing to do is for this scenario.
-
-        # TODO: Functional calls do not support kwargs.
-        # TODO: Throw an exception if we have some?
 
         # We have a call to a functional function. There are two
         # cases. Either we have only ordinary values for arguments, or
@@ -1338,7 +1339,7 @@ class BMGraphBuilder:
         # We lose nothing by doing this and we gain memoization that allows
         # us to skip doing the call if we have done it before. That's a win.
 
-        rv = function(*arguments, **kwargs)
+        rv = function(*arguments)
         assert isinstance(rv, RVIdentifier)
         return self._rv_to_node(rv)
 

--- a/src/beanmachine/ppl/compiler/tests/jit_test.py
+++ b/src/beanmachine/ppl/compiler/tests/jit_test.py
@@ -127,6 +127,12 @@ def bad_functional_3():
     return flips(n=1)
 
 
+@bm.functional
+def bad_functional_4():
+    # Calling functionals with named arguments is not allowed.
+    return exp_coin_2(c=1)
+
+
 class JITTest(unittest.TestCase):
     def test_function_transformation_1(self) -> None:
         """Unit tests for JIT functions"""
@@ -429,4 +435,20 @@ digraph "graph" {
         self.assertEqual(
             str(ex.exception),
             "Random variable function calls must not have named arguments.",
+        )
+
+    def test_bad_control_flow_4(self) -> None:
+        """Unit tests for JIT functions"""
+
+        self.maxDiff = None
+
+        bmg = BMGraphBuilder()
+        queries = [bad_functional_4()]
+        observations = {}
+        # TODO: Better exception class
+        with self.assertRaises(ValueError) as ex:
+            bmg.accumulate_graph(queries, observations)
+        self.assertEqual(
+            str(ex.exception),
+            "Functional calls must not have named arguments.",
         )


### PR DESCRIPTION
Summary: Calls to `bm.functional` functions must not have named arguments. The graph accumulator now detects this situation and raises an exception.

Reviewed By: wtaha

Differential Revision: D26239348

