### PR TITLE
Fix flagging of random variable and functional functions

### DIFF
--- a/src/beanmachine/ppl/compiler/bm_graph_builder.py
+++ b/src/beanmachine/ppl/compiler/bm_graph_builder.py
@@ -239,11 +239,11 @@ def only_ordinary_arguments(args, kwargs) -> bool:
 
 
 def _is_random_variable_call(f) -> bool:
-    return hasattr(f, "is_random_variable")
+    return hasattr(f, "is_random_variable") and f.is_random_variable
 
 
 def _is_functional_call(f) -> bool:
-    return hasattr(f, "is_functional")
+    return hasattr(f, "is_functional") and f.is_functional
 
 
 def _is_phi(f: Any, arguments: List[Any], kwargs: Dict[str, Any]) -> bool:

--- a/src/beanmachine/ppl/model/statistical_model.py
+++ b/src/beanmachine/ppl/model/statistical_model.py
@@ -74,6 +74,7 @@ class StatisticalModel(object):
             setattr(f.__self__, meth_name, wrapper)
         else:
             f._wrapper = wrapper
+        wrapper.is_functional = False
         wrapper.is_random_variable = True
         return wrapper
 
@@ -107,6 +108,7 @@ class StatisticalModel(object):
         else:
             f._wrapper = wrapper
         wrapper.is_functional = True
+        wrapper.is_random_variable = False
         return wrapper
 
 


### PR DESCRIPTION
Summary: I was setting a flag on `random_variable` and `functional` functions to tell them apart, and then making the dumb assumption that the existence of the flag and its value were the same.  I've fixed that.  This will come in handy in my next diff.

Reviewed By: wtaha

Differential Revision: D26386920

