### PR TITLE
Improve verification of RVIDs in query and observations during inference

### DIFF
--- a/src/beanmachine/ppl/inference/bmg_inference.py
+++ b/src/beanmachine/ppl/inference/bmg_inference.py
@@ -22,7 +22,7 @@ class BMGInference:
         observations: Dict[RVIdentifier, Tensor],
         num_samples: int,
     ) -> MonteCarloSamples:
-        _verify_queries_and_observations(queries, observations)
+        _verify_queries_and_observations(queries, observations, True)
         # TODO: Add num_chains
         # TODO: Add verbose level
         # TODO: Add logging

--- a/src/beanmachine/ppl/inference/rejection_sampling_infer.py
+++ b/src/beanmachine/ppl/inference/rejection_sampling_infer.py
@@ -22,6 +22,8 @@ class RejectionSampling(AbstractMCInference, metaclass=ABCMeta):
     algorithms will inherit from this class, and override the single_inference_step method
     """
 
+    _observations_must_be_rv = False
+
     def __init__(self, max_attempts_per_sample=1e4, tolerance=0.0):
         super().__init__()
         self.num_accepted_samples = 0

--- a/src/beanmachine/ppl/inference/tests/single_site_ancestral_mh_test.py
+++ b/src/beanmachine/ppl/inference/tests/single_site_ancestral_mh_test.py
@@ -50,7 +50,7 @@ class SingleSiteAncestralMetropolisHastingsTest(unittest.TestCase):
         mh = bm.SingleSiteAncestralMetropolisHastings()
 
         queries = [model.mu()]
-        observations = {model.K(): torch.tensor(2.0)}
+        observations = {}
 
         torch.manual_seed(42)
         samples = mh.infer(queries, observations, num_samples=5, num_chains=1)

--- a/src/beanmachine/ppl/model/rv_identifier.py
+++ b/src/beanmachine/ppl/model/rv_identifier.py
@@ -14,3 +14,15 @@ class RVIdentifier:
     @property
     def function(self):
         return self.wrapper.__wrapped__
+
+    @property
+    def is_functional(self):
+        w = self.wrapper
+        assert hasattr(w, "is_functional")
+        return w.is_functional
+
+    @property
+    def is_random_variable(self):
+        w = self.wrapper
+        assert hasattr(w, "is_random_variable")
+        return w.is_random_variable


### PR DESCRIPTION
Summary:
This diff improves upon the API boundary error checking for queries and observations passed to inference:

* Some inference algorithms support observing a `functional`; some only support observing a `random_variable`.  I've set the default to the latter; to disable this error check, add `_observations_must_be_rv = False` to the inference class declaration
* `RVID` objects can now self-describe whether they are a `random_variable` or `functional`.
* RV-of-RV is not supported in Bean Machine, so we detect this scenario and raise an exception. That is, you must not do this:

    random_variable
    def norm(n):
      return Normal(0, 1)
    random_variable
    def flip():
       return Bernoulli(0.5)
    ...
    mh.infer([norm(flip())] ...)

because that makes an RV whose argument is another RV. The correct way to do this is to make a `functional` that returns `norm(flip())` and then query the functional.

* To silence flake8 "function too complex" warnings I've broken up query and observation checking into their own functions

Reviewed By: horizon-blue

Differential Revision: D26389684

