### PR TITLE
Starting to implement SSA rewrites for subscripts

### DIFF
--- a/src/beanmachine/ppl/utils/single_assignment.py
+++ b/src/beanmachine/ppl/utils/single_assignment.py
@@ -776,7 +776,7 @@ class SingleAssignment:
             "handle_assign_subscript",
         )
 
-    def _handle_assign_subscript_slice(self) -> Rule:
+    def _handle_assign_subscript_slice_index(self) -> Rule:
         # This rule eliminates indexing expressions where the collection
         # indexed is an identifier but the index is not. We rewrite:
         #
@@ -803,7 +803,7 @@ class SingleAssignment:
                     ),
                 ),
             ),
-            "handle_assign_subscript_slice",
+            "handle_assign_subscript_slice_index",
         )
 
     def _handle_assign_binop_left(self) -> Rule:
@@ -1588,7 +1588,7 @@ class SingleAssignment:
             [
                 self._handle_assign_unaryop(),
                 self._handle_assign_subscript(),
-                self._handle_assign_subscript_slice(),
+                self._handle_assign_subscript_slice_index(),
                 self._handle_assign_binop_left(),
                 self._handle_assign_binop_right(),
                 self._handle_assign_attribute(),


### PR DESCRIPTION
Summary:
This diff is intended to start a stack of diffs to implement SSA rewrites for subscripts. This diff starts with the observation that we already treat one case of subscripts, namely, indexing. It appears that even for this case we may need an additional rule to enable the simplification itself.

Upcoming diffs will introduce a rewrite set for subscripts and test cases to help verify whether more rewrites are needed to handle this cases. Once that is out of the way, we will look at other cases of slicing.

Differential Revision: D26409994

