### PR TITLE
Add test cases for previous diff, ensure functional returns tensor

### DIFF
--- a/src/beanmachine/ppl/inference/abstract_mh_infer.py
+++ b/src/beanmachine/ppl/inference/abstract_mh_infer.py
@@ -360,7 +360,13 @@ class AbstractMHInference(AbstractMCInference, metaclass=ABCMeta):
             for query in self.queries_:
                 # unsqueeze the sampled value tensor, which adds an extra dimension
                 # along which we'll be adding samples generated at each iteration
-                query_val = self.world_.call(query).unsqueeze(0).clone().detach()
+                raw_val = self.world_.call(query)
+                # TODO: Consider allowing values that can be converted to tensors.
+                if not isinstance(raw_val, Tensor):
+                    raise TypeError(
+                        "The value returned by a queried function must be a tensor."
+                    )
+                query_val = raw_val.unsqueeze(0).clone().detach()
                 if query not in queries_sample:
                     queries_sample[query] = query_val
                 else:

--- a/src/beanmachine/ppl/inference/tests/inference_error_reporting_test.py
+++ b/src/beanmachine/ppl/inference/tests/inference_error_reporting_test.py
@@ -10,6 +10,16 @@ def f():
     pass
 
 
+@bm.random_variable
+def g(n):
+    pass
+
+
+@bm.functional
+def h():
+    return 123  # BAD; needs to be a tensor
+
+
 class InferenceErrorReportingTest(unittest.TestCase):
     def test_inference_error_reporting(self):
         mh = bm.SingleSiteAncestralMetropolisHastings()
@@ -48,4 +58,37 @@ class InferenceErrorReportingTest(unittest.TestCase):
         self.assertEqual(
             str(ex.exception),
             "An observed value is required to be a tensor but is of type float.",
+        )
+
+        # You can't make inferences on rv-of-rv
+        with self.assertRaises(TypeError) as ex:
+            mh.infer([g(f())], {}, 10)
+        self.assertEqual(
+            str(ex.exception),
+            "The arguments to a query must not be random variables.",
+        )
+
+        # You can't make inferences on rv-of-rv
+        with self.assertRaises(TypeError) as ex:
+            mh.infer([f()], {g(f()): tensor(123)}, 10)
+        self.assertEqual(
+            str(ex.exception),
+            "The arguments to an observation must not be random variables.",
+        )
+
+        # SSAMH requires that observations must be of random variables, not
+        # functionals
+        with self.assertRaises(TypeError) as ex:
+            mh.infer([f()], {h(): tensor(123)}, 10)
+        self.assertEqual(
+            str(ex.exception),
+            "An observation must observe a random_variable, not a functional.",
+        )
+
+        # A functional is required to return a tensor.
+        with self.assertRaises(TypeError) as ex:
+            mh.infer([h()], {}, 10)
+        self.assertEqual(
+            str(ex.exception),
+            "The value returned by a queried function must be a tensor.",
         )


### PR DESCRIPTION
Summary: In this diff I add test cases for the previous diff, and make explicit an additional model requirement: anything queried must return a tensor. (We always had this requirement, but previously we crashed with an "int has no unsqueeze" exception rather than an informative exception that tells the user what they did wrong.)

Differential Revision: D26409053

