### PR TITLE
Renaming rewrite rules and test case

### DIFF
--- a/src/beanmachine/ppl/utils/single_assignment.py
+++ b/src/beanmachine/ppl/utils/single_assignment.py
@@ -749,7 +749,7 @@ class SingleAssignment:
             "handle_assign_dict",
         )
 
-    def _handle_assign_subscript(self) -> Rule:
+    def _handle_assign_subscript_slice_index_1(self) -> Rule:
         # This rule eliminates indexing expressions where the collection
         # indexed is not an identifier. We rewrite:
         #
@@ -776,7 +776,7 @@ class SingleAssignment:
             "handle_assign_subscript",
         )
 
-    def _handle_assign_subscript_slice_index(self) -> Rule:
+    def _handle_assign_subscript_slice_index_2(self) -> Rule:
         # This rule eliminates indexing expressions where the collection
         # indexed is an identifier but the index is not. We rewrite:
         #
@@ -803,7 +803,7 @@ class SingleAssignment:
                     ),
                 ),
             ),
-            "handle_assign_subscript_slice_index",
+            "handle_assign_subscript_slice_index_2",
         )
 
     def _handle_assign_binop_left(self) -> Rule:
@@ -1587,8 +1587,8 @@ class SingleAssignment:
         return first(
             [
                 self._handle_assign_unaryop(),
-                self._handle_assign_subscript(),
-                self._handle_assign_subscript_slice_index(),
+                self._handle_assign_subscript_slice_index_1(),
+                self._handle_assign_subscript_slice_index_2(),
                 self._handle_assign_binop_left(),
                 self._handle_assign_binop_right(),
                 self._handle_assign_attribute(),

--- a/src/beanmachine/ppl/utils/tests/single_assignment_test.py
+++ b/src/beanmachine/ppl/utils/tests/single_assignment_test.py
@@ -2604,7 +2604,7 @@ def f(x):
 
         self.check_rewrites(terms)
 
-    def test_assign_subscript_index(self) -> None:
+    def test_assign_subscript_slice_index_1(self) -> None:
         """Test rewrites like a,b = c[d.e] → x = d.e; a,b = c[x]."""
 
         terms = [
@@ -2617,6 +2617,6 @@ def f(x):
     a, b = c[a1]""",
         ]
 
-        self.check_rewrites(terms, self.s._handle_assign_subscript_slice_index())
+        self.check_rewrites(terms, self.s._handle_assign_subscript_slice_index_2())
         # self.check_rewrites(terms, self.s._handle_left_value_all())
         self.check_rewrites(terms)


### PR DESCRIPTION
Summary: The rewrite rules for index subscripts to clarify their role and relation to each other. Also, the test or the second one is renamed to be consistent.

Differential Revision: D26410618

