### PR TITLE
Fix for the small bug noticed in the previous diff

### DIFF
--- a/src/beanmachine/ppl/utils/single_assignment.py
+++ b/src/beanmachine/ppl/utils/single_assignment.py
@@ -799,7 +799,7 @@ class SingleAssignment:
         # TODO: We do not yet handle slices other than straightforward
         # indices; we should also handle the other kinds of slices.
         return PatternRule(
-            assign(value=subscript(slice=index(value=_not_identifier))),
+            assign(value=subscript(value=name(), slice=index(value=_not_identifier))),
             self._transform_with_name(
                 "a",
                 lambda source_term: source_term.value.slice.value,

--- a/src/beanmachine/ppl/utils/tests/single_assignment_test.py
+++ b/src/beanmachine/ppl/utils/tests/single_assignment_test.py
@@ -2662,19 +2662,13 @@ def f(x):
         self.check_rewrites(terms, self.s._handle_assign_subscript_slice_all())
         self.check_rewrites(terms)
 
-    def test_assign_subscript_slice_index_too_soon(self) -> None:
+    def test_assign_subscript_slice_index_2_not_too_soon(self) -> None:
         """Test rewrites like a,b = c[d.e] → x = d.e; a,b = c[x]."""
 
         terms = [
             """
 def f(x):
-    a,b = c.c[d.e]""",
-            """
-def f(x):
-    a1 = d.e
-    a, b = c.c[a1]""",
+    a, b = c.c[d.e]""",
         ]
 
         self.check_rewrites(terms, self.s._handle_assign_subscript_slice_index_2())
-        # self.check_rewrites(terms, self.s._handle_assign_subscript_slice_all())
-        # self.check_rewrites(terms)


### PR DESCRIPTION
Summary:
This diff tweaks one of the rules for rewriting subscripts so that it cannot be applied too early.

The test case introduced in the previous diff to illustrate the issue is also modified to now make it clear that the tweaked rewrite achieves the intended behavior.

Unnecessary commented out lines are also removed.

Differential Revision: D26412283

