### PR TITLE
Fix PyTorch Nightly Version on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ commands:
       - run:
           name: "Install pytorch"
           command: >
-            pip install --progress-bar off --pre torch -f
+            pip install --progress-bar off --pre torch==1.8.0.dev20210205 -f
             https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
 
   dev_install_beanmachine:
@@ -156,7 +156,7 @@ commands:
           command: pip install pytest pytest-xdist
       - run:
           name: "Run nightly tests and report overall runtimes"
-          no_output_timeout: 30m
+          no_output_timeout: 1h
           command: |
             export PYTHONUNBUFFERED=1
             pytest -n auto -o python_files="*_nightly.py" --durations=0


### PR DESCRIPTION
Summary:
As titled. The PyTorch previewed version sometimes too ahead of time and can lead to incompatibility with our other dependencies. This diff fix the nightly torch to a version that's known to work.

(I'm also changing the `install_requires` in setup.py so that if users happens to have PyTorch 1.7 installed, they will get an error upon installing beanmachine).

Differential Revision: D26468443

