### PR TITLE
Allow negative reals in EXP_PRODUCT factor

### DIFF
--- a/src/beanmachine/graph/factor/exp_product.cpp
+++ b/src/beanmachine/graph/factor/exp_product.cpp
@@ -11,15 +11,18 @@ ExpProduct::ExpProduct(const std::vector<graph::Node*>& in_nodes)
     : Factor(graph::FactorType::EXP_PRODUCT) {
   // an ExpProduct factor must have at least one parent
   if (in_nodes.size() < 1) {
-    throw std::invalid_argument("ExpProduct factor needs at least one parent");
+    throw std::invalid_argument(
+        "factor EXP_PRODUCT requires one or more parents");
   }
-  // the parent should be real, positive, or probability
+
+  // the parent should be real, positive, negative, or probability
   for (const graph::Node* parent : in_nodes) {
     if (parent->value.type != graph::AtomicType::REAL and
         parent->value.type != graph::AtomicType::POS_REAL and
+        parent->value.type != graph::AtomicType::NEG_REAL and
         parent->value.type != graph::AtomicType::PROBABILITY) {
       throw std::invalid_argument(
-          "ExpProduct parents must be real, positive, or a probability");
+          "factor EXP_PRODUCT requires real, pos_real, neg_real or probability parents");
     }
   }
 }

--- a/src/beanmachine/graph/factor/tests/exp_product_test.cpp
+++ b/src/beanmachine/graph/factor/tests/exp_product_test.cpp
@@ -20,7 +20,10 @@ TEST(testfactor, exp_product) {
   uint pos1 = g.add_constant_pos_real(2.0);
   uint real1 = g.add_constant(3.0);
   uint prob1 = g.add_constant_probability(0.4);
-  g.add_factor(FactorType::EXP_PRODUCT, std::vector<uint>{pos1, real1, prob1});
+  uint neg1 = g.add_constant_neg_real(-1.0);
+  g.add_factor(
+      FactorType::EXP_PRODUCT,
+      std::vector<uint>{pos1, real1, prob1, neg1, neg1});
   uint dist1 = g.add_distribution(
       DistributionType::NORMAL,
       AtomicType::REAL,


### PR DESCRIPTION
Summary:
We should allow negative real inputs to EXP_PRODUCT. I forgot to add this when I implemented negative reals.

I've also updated the error messages to have the same format as the other operators.

Reviewed By: kshah1997

Differential Revision: D26472543

