### PR TITLE
Rewrite for subscript slice lower

### DIFF
--- a/src/beanmachine/ppl/utils/single_assignment.py
+++ b/src/beanmachine/ppl/utils/single_assignment.py
@@ -755,6 +755,7 @@ class SingleAssignment:
             [
                 self._handle_assign_subscript_slice_index_1(),
                 self._handle_assign_subscript_slice_index_2(),
+                self._handle_assign_subscript_slice_lower(),
             ]
         )
 
@@ -813,6 +814,33 @@ class SingleAssignment:
                 ),
             ),
             "handle_assign_subscript_slice_index_2",
+        )
+
+    def _handle_assign_subscript_slice_lower(self) -> Rule:
+        """Rewrites like e = a[b.c:] → x = b.c; e = a[x:]."""
+        return PatternRule(
+            assign(
+                value=subscript(
+                    value=name(), slice=slice_pattern(lower=_neither_name_nor_none)
+                )
+            ),
+            self._transform_with_name(
+                "a",
+                lambda source_term: source_term.value.slice.lower,
+                lambda source_term, new_name: ast.Assign(
+                    targets=source_term.targets,
+                    value=ast.Subscript(
+                        value=source_term.value.value,
+                        slice=ast.Slice(
+                            lower=ast.Name(id=new_name, ctx=ast.Load()),
+                            upper=source_term.value.slice.upper,
+                            step=source_term.value.slice.step,
+                        ),
+                        ctx=ast.Store(),
+                    ),
+                ),
+            ),
+            "_handle_assign_subscript_slice_lower",
         )
 
     def _handle_assign_binop_left(self) -> Rule:

--- a/src/beanmachine/ppl/utils/tests/single_assignment_test.py
+++ b/src/beanmachine/ppl/utils/tests/single_assignment_test.py
@@ -2278,7 +2278,8 @@ def f(x):
 def f(x):
     a1 = 0
     [a] = z[a1]
-    [b, *[c], d, e.f[g:h[i]].j] = z[1:]
+    a2 = 1
+    [b, *[c], d, e.f[g:h[i]].j] = z[a2:]
         """,
         ]
 
@@ -2539,7 +2540,8 @@ def f(x):
     [a] = x5
     a6 = 0
     [a] = z[a6]
-    [b] = z[1:]"""
+    a7 = 1
+    [b] = z[a7:]""",
         ]
         self.check_rewrites(terms)
 
@@ -2566,7 +2568,8 @@ def f(x):
 def f(x):
     a1 = 0
     a.b.c = z[a1]
-    [d] = z[1:]"""
+    a2 = 1
+    [d] = z[a2:]""",
         ]
 
         self.check_rewrites(terms)
@@ -2672,3 +2675,23 @@ def f(x):
         ]
 
         self.check_rewrites(terms, self.s._handle_assign_subscript_slice_index_2())
+
+    def test_assign_subscript_slice_lower(self) -> None:
+        """Test rewrites like e = a[b.c:] → x = b.c; e = a[x:]."""
+
+        terms = [
+            """
+def f(x):
+    a,b = c[d.e:]
+    a = b[c.d:e:f]""",
+            """
+def f(x):
+    a1 = d.e
+    a, b = c[a1:]
+    a2 = c.d
+    a = b[a2:e:f]""",
+        ]
+
+        self.check_rewrites(terms, self.s._handle_assign_subscript_slice_lower())
+        self.check_rewrites(terms, self.s._handle_assign_subscript_slice_all())
+        self.check_rewrites(terms)


### PR DESCRIPTION
Summary:
This diff implements the rule to rewrite expressions like e = a[b.c:] → x = b.c; e = a[x:].

Some minor updates were also made to reflect impact of these new rule on the overall system behavior.

Differential Revision: D26414634

