### PR TITLE
Better exception when a random variable fails to return a distribution

### DIFF
--- a/src/beanmachine/ppl/inference/tests/inference_error_reporting_test.py
+++ b/src/beanmachine/ppl/inference/tests/inference_error_reporting_test.py
@@ -7,7 +7,7 @@ from torch import tensor
 
 @bm.random_variable
 def f():
-    pass
+    return 123  # BAD, needs to be a distribution
 
 
 @bm.random_variable
@@ -91,4 +91,12 @@ class InferenceErrorReportingTest(unittest.TestCase):
         self.assertEqual(
             str(ex.exception),
             "The value returned by a queried function must be a tensor.",
+        )
+
+        # A random_variable is required to return a distribution
+        with self.assertRaises(TypeError) as ex:
+            mh.infer([f()], {}, 10)
+        self.assertEqual(
+            str(ex.exception),
+            "A random_variable is required to return a distribution.",
         )

--- a/src/beanmachine/ppl/world/world.py
+++ b/src/beanmachine/ppl/world/world.py
@@ -13,6 +13,7 @@ from beanmachine.ppl.world.diff_stack import DiffStack
 from beanmachine.ppl.world.variable import TransformData, TransformType, Variable
 from beanmachine.ppl.world.world_vars import WorldVars
 from torch import Tensor
+from torch.distributions import Distribution
 
 
 world_context = contextvars.ContextVar("beanmachine.ppl.world", default=None)
@@ -729,7 +730,12 @@ class World(object):
         self.add_node_to_world(node, node_var)
         self.stack_.append(node)
         with self:
-            node_var.distribution = node.function(*node.arguments)
+            d = node.function(*node.arguments)
+            if not isinstance(d, Distribution):
+                raise TypeError(
+                    "A random_variable is required to return a distribution."
+                )
+            node_var.distribution = d
         self.stack_.pop()
 
         obs_value = self.observations_[node] if node in self.observations_ else None


### PR DESCRIPTION
Summary: Bean Machine requires that a random variable returns a distribution; if the model author fails to do so, we were crashing with an attribute error when we attempted to fetch the support of the distribution. We now crash earlier and with a clear error message identifying the problem.

Reviewed By: jpchen

Differential Revision: D26435031

