### PR TITLE
Add error checking for functionals that do not return a graph node

### DIFF
--- a/src/beanmachine/ppl/compiler/bm_graph_builder.py
+++ b/src/beanmachine/ppl/compiler/bm_graph_builder.py
@@ -1479,6 +1479,10 @@ class BMGraphBuilder:
         key = MemoizationKey(rv.wrapper, rv.arguments)
         if key not in self.rv_map:
             value = self._function_to_bmg_function(rv.function)(*rv.arguments)
+            if isinstance(value, Tensor):
+                value = self.add_constant_tensor(value)
+            if not isinstance(value, BMGNode):
+                raise TypeError("A functional must return a tensor.")
             self.rv_map[key] = value
             return value
         return self.rv_map[key]

--- a/src/beanmachine/ppl/compiler/tests/bmg_bad_models_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_bad_models_test.py
@@ -22,6 +22,11 @@ def do_it():
     return norm(flip())
 
 
+@bm.functional
+def bad_functional():
+    return 123
+
+
 class BMGBadModelsTest(unittest.TestCase):
     def test_bmg_inference_error_reporting(self):
 
@@ -87,9 +92,18 @@ class BMGBadModelsTest(unittest.TestCase):
             "An observation must observe a random_variable, not a functional.",
         )
 
-        # TODO: Verify that a query that returns a non-node fails at runtime.
+        # A functional must always return a value that can be represented
+        # in the graph.
+        with self.assertRaises(TypeError) as ex:
+            BMGInference().infer([bad_functional()], {}, 10)
+        self.assertEqual(
+            str(ex.exception),
+            "A functional must return a tensor.",
+        )
+
         # TODO: Verify we handle correctly the case where a queried value is
         # a constant, because that is not directly supported by BMG but
         # it would be nice to have.
+
         # TODO: Verify that an RV that returns an unsupported distribution
         # is an error.


### PR DESCRIPTION
Summary:
We expect that a functional will always return a stochastic quantity which is already represented as a graph node. However, it is legal for a functional to return an ordinary tensor value. It is NOT legal for a functional to return a non-tensor value, even if we can represent it in the graph. (Such as an integer value.) Bean Machine rejects such functionals and so too should the compiler.

Note that we have not yet implemented or tested what happens when you do a query on a constant tensor; this is not supported directly by BMG because BMG requires that the object of a query be an operator, not a constant.  That will come in a later diff.

We also do not yet test what happens when a random_variable returns an unsupported distribution. That will come in a later diff as well.

Reviewed By: kshah1997

Differential Revision: D26431998

