### PR TITLE
Add helper entrypoints to BMGInference

### DIFF
--- a/src/beanmachine/ppl/inference/__init__.py
+++ b/src/beanmachine/ppl/inference/__init__.py
@@ -1,4 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
+from beanmachine.ppl.inference.bmg_inference import BMGInference
 from beanmachine.ppl.inference.compositional_infer import CompositionalInference
 from beanmachine.ppl.inference.predictive import Predictive, empirical, simulate
 from beanmachine.ppl.inference.rejection_sampling_infer import RejectionSampling
@@ -20,6 +21,7 @@ from .single_site_no_u_turn_sampler import SingleSiteNoUTurnSampler
 
 
 __all__ = [
+    "BMGInference",
     "CompositionalInference",
     "RejectionSampling",
     "SingleSiteAncestralMetropolisHastings",

--- a/src/beanmachine/ppl/inference/bmg_inference.py
+++ b/src/beanmachine/ppl/inference/bmg_inference.py
@@ -37,6 +37,8 @@ class BMGInference:
         after_transform: bool = True,
         label_edges: bool = False,
     ) -> str:
+        """Produce a string containing a program in the GraphViz DOT language
+        representing the graph deduced from the model."""
         bmg = BMGraphBuilder()
         bmg.accumulate_graph(queries, observations)
         graph_types = False
@@ -51,3 +53,25 @@ class BMGInference:
             after_transform,
             label_edges,
         )
+
+    def to_cpp(
+        self,
+        queries: List[RVIdentifier],
+        observations: Dict[RVIdentifier, Tensor],
+    ) -> str:
+        """Produce a string containing a C++ program fragment which
+        produces the graph deduced from the model."""
+        bmg = BMGraphBuilder()
+        bmg.accumulate_graph(queries, observations)
+        return bmg.to_cpp()
+
+    def to_python(
+        self,
+        queries: List[RVIdentifier],
+        observations: Dict[RVIdentifier, Tensor],
+    ) -> str:
+        """Produce a string containing a Python program fragment which
+        produces the graph deduced from the model."""
+        bmg = BMGraphBuilder()
+        bmg.accumulate_graph(queries, observations)
+        return bmg.to_python()


### PR DESCRIPTION
Summary: I've added two additional entrypoints to BMGInference that produce a CPP and a Python program fragment which when executed produce the desired graph.

Reviewed By: kshah1997

Differential Revision: D26466165

