### PR TITLE
Graph builder can now add factor nodes

### DIFF
--- a/src/beanmachine/ppl/compiler/bm_graph_builder.py
+++ b/src/beanmachine/ppl/compiler/bm_graph_builder.py
@@ -78,6 +78,8 @@ from beanmachine.ppl.compiler.bmg_nodes import (
     EqualNode,
     ExpM1Node,
     ExpNode,
+    ExpProductFactorNode,
+    FactorNode,
     FlatNode,
     GammaNode,
     GreaterThanEqualNode,
@@ -1614,6 +1616,12 @@ class BMGraphBuilder:
         self.add_node(node)
         return node
 
+    @memoize
+    def add_exp_product(self, *inputs: BMGNode) -> TensorNode:
+        node = ExpProductFactorNode(list(inputs))
+        self.add_node(node)
+        return node
+
     # ####
     # #### Output
     # ####
@@ -1735,8 +1743,8 @@ g = graph.Graph()
     def _traverse_from_roots(self) -> List[BMGNode]:
         """This returns a list of the reachable graph nodes
         in topologically sorted order. The ordering invariants are
-        (1) all sample, observation and query nodes are enumerated
-        in the order they were added, and
+        (1) all sample, observation, query and factor nodes are
+        enumerated in the order they were added, and
         (2) all inputs are enumerated before their outputs, and
         (3) inputs to the "left" are enumerated before those to
         the "right"."""
@@ -1749,12 +1757,13 @@ g = graph.Graph()
         # pass here as a sanity check.
 
         # TODO: Do we require sample nodes to be roots? Could we
-        # get by with just observations and queries?
+        # get by with just observations, queries and factors?
         def is_root(n: BMGNode) -> bool:
             return (
                 isinstance(n, SampleNode)
                 or isinstance(n, Observation)
                 or isinstance(n, Query)
+                or isinstance(n, FactorNode)
             )
 
         def key(n: BMGNode) -> int:

--- a/src/beanmachine/ppl/compiler/tests/bmg_factor_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_factor_test.py
@@ -1,0 +1,103 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import unittest
+
+from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
+
+
+def tidy(s: str) -> str:
+    return "\n".join(c.strip() for c in s.strip().split("\n")).strip()
+
+
+class BMGFactorTest(unittest.TestCase):
+    def test_bmg_factor(self) -> None:
+
+        bmg = BMGraphBuilder()
+        pos1 = bmg.add_pos_real(2.0)
+        real1 = bmg.add_real(3.0)
+        prob1 = bmg.add_probability(0.4)
+        dist1 = bmg.add_normal(real1, pos1)
+        x = bmg.add_sample(dist1)
+        x_sq = bmg.add_multiplication(x, x)
+        bmg.add_exp_product(x, prob1, x_sq)
+        bmg.add_observation(x, 7.0)
+        observed = bmg.to_dot(point_at_input=True, label_edges=False)
+        expected = """
+digraph "graph" {
+  N0[label=2.0];
+  N1[label=3.0];
+  N2[label=0.4];
+  N3[label=Normal];
+  N4[label=Sample];
+  N5[label="*"];
+  N6[label=ExpProduct];
+  N7[label="Observation 7.0"];
+  N0 -> N3;
+  N1 -> N3;
+  N2 -> N6;
+  N3 -> N4;
+  N4 -> N5;
+  N4 -> N5;
+  N4 -> N6;
+  N4 -> N7;
+  N5 -> N6;
+}
+"""
+        self.maxDiff = None
+        self.assertEqual(observed.strip(), expected.strip())
+
+        g = bmg.to_bmg()
+        observed = g.to_string()
+        expected = """
+Node 0 type 1 parents [ ] children [ 2 ] real 3
+Node 1 type 1 parents [ ] children [ 2 ] positive real 2
+Node 2 type 2 parents [ 0 1 ] children [ 3 ] unknown
+Node 3 type 3 parents [ 2 ] children [ 5 5 6 ] real 7
+Node 4 type 1 parents [ ] children [ 6 ] probability 0.4
+Node 5 type 3 parents [ 3 3 ] children [ 6 ] real 0
+Node 6 type 4 parents [ 3 4 5 ] children [ ] unknown
+"""
+        self.assertEqual(tidy(observed), tidy(expected))
+
+        observed = bmg.to_python()
+
+        expected = """
+from beanmachine import graph
+from torch import tensor
+g = graph.Graph()
+n0 = g.add_constant(3.0)
+n1 = g.add_constant_pos_real(2.0)
+n2 = g.add_distribution(
+  graph.DistributionType.NORMAL,
+  graph.AtomicType.REAL,
+  [n0, n1])
+n3 = g.add_operator(graph.OperatorType.SAMPLE, [n2])
+n4 = g.add_constant_probability(0.4)
+n5 = g.add_operator(graph.OperatorType.MULTIPLY, [n3, n3])
+n6 = g.add_factor(
+  graph.FactorType.EXP_PRODUCT,
+  [n3, n4, n5])
+g.observe(n3, 7.0)
+"""
+        self.assertEqual(observed.strip(), expected.strip())
+
+        observed = bmg.to_cpp()
+
+        expected = """
+graph::Graph g;
+uint n0 = g.add_constant(3.0);
+uint n1 = g.add_constant_pos_real(2.0);
+uint n2 = g.add_distribution(
+  graph::DistributionType::NORMAL,
+  graph::AtomicType::REAL,
+  std::vector<uint>({n0, n1}));
+uint n3 = g.add_operator(
+  graph::OperatorType::SAMPLE, std::vector<uint>({n2}));
+uint n4 = g.add_constant_probability(0.4);
+uint n5 = g.add_operator(
+  graph::OperatorType::MULTIPLY, std::vector<uint>({n3, n3}));
+n6 = g.add_factor(
+  graph::FactorType::EXP_PRODUCT,
+  std::vector<uint>({n3, n4, n5}));
+g.observe([n3], 7.0);
+"""
+        self.assertEqual(observed.strip(), expected.strip())


### PR DESCRIPTION
Summary:
The graph builder can now add exp_product factor nodes to the accumulated graph and render those nodes as a BMG graph, as a Python or C++ program fragment that builds a graph, or as DOT for visualization:

{F373943804}

I have not yet added the feature where we analyze a graph looking for

{F373944305}

to rewrite it into

{F373944336}

That will come in a later diff.

Reviewed By: kshah1997

Differential Revision: D26473082

