### PR TITLE
Add ability to discard leaf nodes from graph builder

### DIFF
--- a/src/beanmachine/ppl/compiler/bm_graph_builder.py
+++ b/src/beanmachine/ppl/compiler/bm_graph_builder.py
@@ -426,6 +426,17 @@ class BMGraphBuilder:
                 self.add_node(i)
             self.nodes[node] = len(self.nodes)
 
+    def remove_leaf(self, node: BMGNode) -> None:
+        """This removes a leaf node from the builder, and ensures that the
+        output edges of all its input nodes are removed as well."""
+        if len(node.outputs.items) != 0:
+            raise ValueError("remove_leaf requires a leaf node")
+        if node not in self.nodes:
+            raise ValueError("remove_leaf called with node from wrong builder")
+        for i in node.inputs.inputs:
+            i.outputs.remove_item(node)
+        del self.nodes[node]
+
     # ####
     # #### Graph accumulation for constant values
     # ####

--- a/src/beanmachine/ppl/compiler/tests/bm_graph_builder_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bm_graph_builder_test.py
@@ -1657,3 +1657,53 @@ digraph "graph" {
 }
 """
         self.assertEqual(observed.strip(), expected.strip())
+
+    def test_remove_leaf_from_builder(self) -> None:
+        bmg = BMGraphBuilder()
+        p = bmg.add_constant(0.5)
+        b = bmg.add_bernoulli(p)
+        s = bmg.add_sample(b)
+        o = bmg.add_observation(s, True)
+
+        observed = bmg.to_dot(point_at_input=True)
+        expected = """
+digraph "graph" {
+  N0[label=0.5];
+  N1[label=Bernoulli];
+  N2[label=Sample];
+  N3[label="Observation True"];
+  N0 -> N1[label=probability];
+  N1 -> N2[label=operand];
+  N2 -> N3[label=operand];
+}
+"""
+        self.assertEqual(observed.strip(), expected.strip())
+
+        with self.assertRaises(ValueError):
+            # Not a leaf
+            bmg.remove_leaf(s)
+
+        bmg.remove_leaf(o)
+        observed = bmg.to_dot(point_at_input=True)
+        expected = """
+digraph "graph" {
+  N0[label=0.5];
+  N1[label=Bernoulli];
+  N2[label=Sample];
+  N0 -> N1[label=probability];
+  N1 -> N2[label=operand];
+}
+"""
+        self.assertEqual(observed.strip(), expected.strip())
+
+        # Is a leaf now.
+        bmg.remove_leaf(s)
+        observed = bmg.to_dot(point_at_input=True)
+        expected = """
+digraph "graph" {
+  N0[label=0.5];
+  N1[label=Bernoulli];
+  N0 -> N1[label=probability];
+}
+"""
+        self.assertEqual(observed.strip(), expected.strip())


### PR DESCRIPTION
Summary: In order to implement the graph transformation requested by Kinjal I will need to be able to remove an observation from a graph. This is a special case which is not easier than the more general problem of removing an arbitrary leaf from the graph, so I might as well implement that.  (This will then allow me to implement another feature I have been meaning to do for some time, which is to trim unreachable nodes from the graph after an optimization pass. That will come in a later diff.)

Reviewed By: kshah1997

Differential Revision: D26491768

