### PR TITLE
Add special extra fixer to transform some observations into factors

### DIFF
--- a/src/beanmachine/ppl/compiler/bm_graph_builder.py
+++ b/src/beanmachine/ppl/compiler/bm_graph_builder.py
@@ -337,6 +337,11 @@ class BMGraphBuilder:
 
     query_rv_map: Dict[Query, RVIdentifier]
 
+    # This allows us to turn on a special problem-fixing pass to help
+    # work around problems under investigation.
+
+    _fix_observe_true: bool = False
+
     def __init__(self) -> None:
         self.rv_map = {}
         self.lifted_map = {}
@@ -1846,7 +1851,7 @@ g = graph.Graph()
     def _fix_problems(self) -> None:
         from beanmachine.ppl.compiler.fix_problems import fix_problems
 
-        fix_problems(self).raise_errors()
+        fix_problems(self, self._fix_observe_true).raise_errors()
 
     def infer(
         self,

--- a/src/beanmachine/ppl/compiler/fix_observe_true.py
+++ b/src/beanmachine/ppl/compiler/fix_observe_true.py
@@ -1,0 +1,74 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
+from beanmachine.ppl.compiler.bmg_nodes import (
+    BernoulliNode,
+    BMGNode,
+    ExpNode,
+    Observation,
+    SampleNode,
+    ToPositiveRealNode,
+    ToProbabilityNode,
+    ToRealNode,
+    UnaryOperatorNode,
+)
+from beanmachine.ppl.compiler.bmg_types import Boolean
+
+
+def _is_conversion(n: BMGNode) -> bool:
+    return (
+        isinstance(n, ToPositiveRealNode)
+        or isinstance(n, ToProbabilityNode)
+        or isinstance(n, ToRealNode)
+    )
+
+
+def _skip_conversions(n: BMGNode) -> BMGNode:
+    while _is_conversion(n):
+        assert isinstance(n, UnaryOperatorNode)
+        n = n.operand
+    return n
+
+
+class ObserveTrueFixer:
+    # A common technique in model design is to boost the probability density
+    # score of a particular quantity by converting it to a probability
+    # and then observing that a coin flip of that probability comes up heads.
+    # This should be logically equivalent to boosting by adding an EXP_PRODUCT
+    # factor, but when we run models like that through BMG inference, we're
+    # getting different results than when we add a factor.
+    #
+    # To work around the problem while we diagnose it we can use this fixer.
+    # It looks for graphs of the form:
+    #
+    #      SOMETHING --> EXP --> TO_PROB --> BERNOULLI --> SAMPLE --> OBSERVE TRUE
+    #
+    # and converts them to
+    #
+    #      SOMETHING --> EXP --> TO_PROB --> BERNOULLI --> SAMPLE
+    #        \
+    #         --> EXP_PRODUCT
+
+    bmg: BMGraphBuilder
+
+    def __init__(self, bmg: BMGraphBuilder) -> None:
+        self.bmg = bmg
+
+    def _fix_observation(self, o: Observation) -> None:
+        if o.graph_type != Boolean or not o.value:
+            return
+        sample = o.operand
+        if not isinstance(sample, SampleNode):
+            return
+        bern = sample.operand
+        if not isinstance(bern, BernoulliNode):
+            return
+        exp = _skip_conversions(bern.probability)
+        if not isinstance(exp, ExpNode):
+            return
+        self.bmg.add_exp_product(exp.operand)
+        self.bmg.remove_leaf(o)
+
+    def fix_observe_true(self) -> None:
+        for o in self.bmg.all_observations():
+            self._fix_observation(o)

--- a/src/beanmachine/ppl/compiler/tests/fix_observe_true_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_observe_true_test.py
@@ -1,0 +1,218 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import unittest
+
+import beanmachine.ppl as bm
+from beanmachine.ppl.inference import BMGInference
+from torch import tensor
+from torch.distributions import Bernoulli, Beta
+
+
+# This is a very simplified version of a CLARA model; this is the sort of model
+# that we want to apply our workaround of removing observations on.
+
+
+@bm.random_variable
+def sensitivity(labeler):
+    return Beta(1, 1)
+
+
+@bm.random_variable
+def specificity(labeler):
+    return Beta(2, 2)
+
+
+@bm.random_variable
+def prevalence():
+    return Beta(0.5, 0.5)
+
+
+@bm.random_variable
+def observation():
+    bob = 0
+    sue = 1
+    pos_sum = prevalence().log() + sensitivity(bob).log() + sensitivity(sue).log()
+    neg_sum = (
+        (1 - prevalence()).log()
+        + (1 - specificity(bob)).log()
+        + (1 - specificity(sue)).log()
+    )
+    log_prob = (pos_sum.exp() + neg_sum.exp()).log()
+    return Bernoulli(log_prob.exp())
+
+
+class FixObserveTrueTest(unittest.TestCase):
+    def test_fix_observe_true(self) -> None:
+        self.maxDiff = None
+        observations = {observation(): tensor(1.0)}
+        queries = []
+
+        bmg = BMGInference()
+        observed = bmg.to_dot(queries, observations)
+
+        # Here's the model as it would be handed off to BMG normally.
+
+        expected = """
+digraph "graph" {
+  N00[label=0.5];
+  N01[label=Beta];
+  N02[label=Sample];
+  N03[label=1.0];
+  N04[label=Beta];
+  N05[label=Sample];
+  N06[label=Sample];
+  N07[label=2.0];
+  N08[label=Beta];
+  N09[label=Sample];
+  N10[label=Sample];
+  N11[label=Log];
+  N12[label=Log];
+  N13[label="+"];
+  N14[label=Log];
+  N15[label="+"];
+  N16[label=Exp];
+  N17[label=ToPosReal];
+  N18[label=complement];
+  N19[label=Log];
+  N20[label=complement];
+  N21[label=Log];
+  N22[label="+"];
+  N23[label=complement];
+  N24[label=Log];
+  N25[label="+"];
+  N26[label=Exp];
+  N27[label=ToPosReal];
+  N28[label="+"];
+  N29[label=Log];
+  N30[label=Exp];
+  N31[label=ToProb];
+  N32[label=Bernoulli];
+  N33[label=Sample];
+  N34[label="Observation True"];
+  N00 -> N01;
+  N00 -> N01;
+  N01 -> N02;
+  N02 -> N11;
+  N02 -> N18;
+  N03 -> N04;
+  N03 -> N04;
+  N04 -> N05;
+  N04 -> N06;
+  N05 -> N12;
+  N06 -> N14;
+  N07 -> N08;
+  N07 -> N08;
+  N08 -> N09;
+  N08 -> N10;
+  N09 -> N20;
+  N10 -> N23;
+  N11 -> N13;
+  N12 -> N13;
+  N13 -> N15;
+  N14 -> N15;
+  N15 -> N16;
+  N16 -> N17;
+  N17 -> N28;
+  N18 -> N19;
+  N19 -> N22;
+  N20 -> N21;
+  N21 -> N22;
+  N22 -> N25;
+  N23 -> N24;
+  N24 -> N25;
+  N25 -> N26;
+  N26 -> N27;
+  N27 -> N28;
+  N28 -> N29;
+  N29 -> N30;
+  N30 -> N31;
+  N31 -> N32;
+  N32 -> N33;
+  N33 -> N34;
+}
+"""
+        self.assertEqual(observed.strip(), expected.strip())
+
+        # Now let's force an additional rewriting pass:
+        bmg = BMGInference()
+        bmg._fix_observe_true = True
+        observed = bmg.to_dot(queries, observations)
+        expected = """
+digraph "graph" {
+  N00[label=0.5];
+  N01[label=Beta];
+  N02[label=Sample];
+  N03[label=1.0];
+  N04[label=Beta];
+  N05[label=Sample];
+  N06[label=Sample];
+  N07[label=2.0];
+  N08[label=Beta];
+  N09[label=Sample];
+  N10[label=Sample];
+  N11[label=Log];
+  N12[label=Log];
+  N13[label="+"];
+  N14[label=Log];
+  N15[label="+"];
+  N16[label=Exp];
+  N17[label=ToPosReal];
+  N18[label=complement];
+  N19[label=Log];
+  N20[label=complement];
+  N21[label=Log];
+  N22[label="+"];
+  N23[label=complement];
+  N24[label=Log];
+  N25[label="+"];
+  N26[label=Exp];
+  N27[label=ToPosReal];
+  N28[label="+"];
+  N29[label=Log];
+  N30[label=Exp];
+  N31[label=ToProb];
+  N32[label=Bernoulli];
+  N33[label=Sample];
+  N34[label=ExpProduct];
+  N00 -> N01;
+  N00 -> N01;
+  N01 -> N02;
+  N02 -> N11;
+  N02 -> N18;
+  N03 -> N04;
+  N03 -> N04;
+  N04 -> N05;
+  N04 -> N06;
+  N05 -> N12;
+  N06 -> N14;
+  N07 -> N08;
+  N07 -> N08;
+  N08 -> N09;
+  N08 -> N10;
+  N09 -> N20;
+  N10 -> N23;
+  N11 -> N13;
+  N12 -> N13;
+  N13 -> N15;
+  N14 -> N15;
+  N15 -> N16;
+  N16 -> N17;
+  N17 -> N28;
+  N18 -> N19;
+  N19 -> N22;
+  N20 -> N21;
+  N21 -> N22;
+  N22 -> N25;
+  N23 -> N24;
+  N24 -> N25;
+  N25 -> N26;
+  N26 -> N27;
+  N27 -> N28;
+  N28 -> N29;
+  N29 -> N30;
+  N29 -> N34;
+  N30 -> N31;
+  N31 -> N32;
+  N32 -> N33;
+}
+"""
+        self.assertEqual(observed.strip(), expected.strip())

--- a/src/beanmachine/ppl/inference/bmg_inference.py
+++ b/src/beanmachine/ppl/inference/bmg_inference.py
@@ -13,6 +13,9 @@ from torch import Tensor
 
 
 class BMGInference:
+
+    _fix_observe_true: bool = False
+
     def __init__(self):
         pass
 
@@ -21,6 +24,7 @@ class BMGInference:
     ) -> BMGraphBuilder:
         _verify_queries_and_observations(queries, observations, True)
         bmg = BMGraphBuilder()
+        bmg._fix_observe_true = self._fix_observe_true
         bmg.accumulate_graph(queries, observations)
         return bmg
 


### PR DESCRIPTION
Summary:
To work around a problem we are still diagnosing in BMG, I've implemented a special extra graph-fixing pass. This pass detects graphs that look like this: (image is a fragment of the graph produced in the new test case)

{F374999274}

and replaces the observation with a factor:

{F375000156}

Since this is not necessarily intended to be a permanent feature of our graph transformations, I've ensured that it is only activated by a hidden switch. As illustrated in the test case below, to turn it on you need to do:

        bmg = BMGInference()
        bmg._fix_observe_true = True

before doing inference or visualizing the graph.

The same private flag also exists on `BMGraphBuilder`, should you be testing directly against the graph accumulator.

Reviewed By: kshah1997

Differential Revision: D26500793

