### PR TITLE
Move illegal recursion detector out of general-purpose memoizer

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/cycle_detector_test.py
+++ b/src/beanmachine/ppl/compiler/tests/cycle_detector_test.py
@@ -3,7 +3,6 @@ import unittest
 
 import beanmachine.ppl as bm
 from beanmachine.ppl.inference.bmg_inference import BMGInference
-from beanmachine.ppl.utils.memoize import RecursionError
 from torch.distributions import Bernoulli
 
 


### PR DESCRIPTION
Summary:
We need to detect if a model has an unbounded recursion amongst its random variables. Previous to this diff, the mechanism for doing so was in the general-purpose memoizer, but I use that thing for, you know, general purposes. It should only be doing cycle detection specifically when we are evaluating the lifted form of an RV for the first time.  I've moved the code out of the general-purpose memoizer and into the RVID-->BMGNode memoizer.

Also, there already is a RecursionError class; we don't need to make a new one.

Reviewed By: wtaha

Differential Revision: D26503756

