### PR TITLE
Stop generating decorators for lifted functions in JIT compiler workflow

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/comparison_rewriting_test.py
+++ b/src/beanmachine/ppl/compiler/tests/comparison_rewriting_test.py
@@ -49,11 +49,7 @@ class ComparisonRewritingTest(unittest.TestCase):
         observed = astor.to_source(bmgast)
         expected = """
 def y_helper(bmg):
-    from beanmachine.ppl.utils.memoize import memoize
-    from beanmachine.ppl.utils.probabilistic import probabilistic
 
-    @probabilistic(bmg)
-    @memoize
     def y():
         a1 = 0.0
         r4 = []

--- a/src/beanmachine/ppl/compiler/tests/jit_test.py
+++ b/src/beanmachine/ppl/compiler/tests/jit_test.py
@@ -180,8 +180,6 @@ class JITTest(unittest.TestCase):
         observed = astor.to_source(bmgast)
         expected = """
 def f_helper(bmg):
-    from beanmachine.ppl.utils.memoize import memoize
-    from beanmachine.ppl.utils.probabilistic import probabilistic
 
     def f(x):
         a2 = bmg.handle_dot_get(math, 'exp')
@@ -196,11 +194,7 @@ def f_helper(bmg):
         observed = astor.to_source(bmgast)
         expected = """
 def norm_helper(bmg):
-    from beanmachine.ppl.utils.memoize import memoize
-    from beanmachine.ppl.utils.probabilistic import probabilistic
 
-    @probabilistic(bmg)
-    @memoize
     def norm(n):
         global counter
         a1 = 1

--- a/src/beanmachine/ppl/utils/rules.py
+++ b/src/beanmachine/ppl/utils/rules.py
@@ -196,6 +196,12 @@ fail: Rule = PatternRule(failPattern, _identity, "fail")
 is_list: Rule = PatternRule(list, _identity, "is_list")
 
 
+def always_replace(value: Any, name: str = "always_replace") -> Rule:
+    """always_replace(value) produces a rule that replaces anything with
+    the given value. It always succeeds."""
+    return projection_rule(lambda x: value, name)
+
+
 def pattern_rules(
     pairs: List[Tuple[Pattern, Callable[[Any], Any]]], name: str = "pattern_rules"
 ) -> Rule:
@@ -1041,6 +1047,8 @@ class RuleDomain:
     def specific_child(
         self, child: str, rule: Rule, name: str = "specific_child"
     ) -> Rule:
+        """Apply a rule to a specific child.  If it succeeds, replace the child
+        with the new value; otherwise, fail. The child is required to exist."""
         return SpecificChild(child, rule, self.get_children, self.construct, name)
 
     # CONSIDER: Should we implement a class for bottom-up traversal, so that


### PR DESCRIPTION
Summary:
In the original lowering phase of the compiler we lowered an entire module at once, and then called the methods in the lowered module. We now use a "jit" technique where we lower one function body at a time.

The entire-module approach requires the lowered functions to be decorated with two decorators: a memoizer, and a probabilistic-control-flow decorator. But these functions will be subsumed by code in the graph builder itself eventually; we do not need or want to complicate things further by doing this work in decorators.

We have not yet implemented all the functionality in the original module lowering code to the jitted workflow, and we have plenty of tests which would break that depend on the old workflow still.  Therefore I want to optionally disable generation of decorators on lowered functions, depending on whether we are in the whole-module or per-function mode.

The functions of the memoization decorator are now entirely performed by the graph accumulator in the jit workflow, and those of the probabilistic decorator will be done in an upcoming diff; no tests of the jit workflow currently depend on the action of either decorator. We can therefore safely remove both of them in the jit workflow.

Reviewed By: wtaha

Differential Revision: D26516431

