### PR TITLE
Enable simple stochastic control flows in jitted compiler workflow

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/clara_categorical_test.py
+++ b/src/beanmachine/ppl/compiler/tests/clara_categorical_test.py
@@ -92,20 +92,142 @@ class ClaraCategoricalTest(unittest.TestCase):
             category_of_item(bar_jpg),
         ]
 
-        with self.assertRaises(ValueError) as ex:
-            # TODO: Implement jitted stochastic control flows.
-            # TODO: We should be able to accumulate the graph even if we cannot
-            # make it work in BMG.
-            BMGInference().to_dot(queries, observations, after_transform=False)
-
-        observed = str(ex.exception)
-
-        expected = "Jitted stochastic control flows are not yet implemented"
+        observed = BMGInference().to_dot(queries, observations, after_transform=False)
+        expected = """
+digraph "graph" {
+  N00[label="[1.0,1.0,1.0]"];
+  N01[label=Dirichlet];
+  N02[label=Sample];
+  N03[label=Categorical];
+  N04[label=Sample];
+  N05[label=0];
+  N06[label="[10.0,5.0,1.0]"];
+  N07[label=Dirichlet];
+  N08[label=Sample];
+  N09[label=1];
+  N10[label="[5.0,10.0,1.0]"];
+  N11[label=Dirichlet];
+  N12[label=Sample];
+  N13[label=2];
+  N14[label="[1.0,1.0,10.0]"];
+  N15[label=Dirichlet];
+  N16[label=Sample];
+  N17[label=map];
+  N18[label=index];
+  N19[label=Categorical];
+  N20[label=Sample];
+  N21[label="Observation tensor(0)"];
+  N22[label=Sample];
+  N23[label=Sample];
+  N24[label=Sample];
+  N25[label=map];
+  N26[label=index];
+  N27[label=Categorical];
+  N28[label=Sample];
+  N29[label="Observation tensor(1)"];
+  N30[label=Sample];
+  N31[label=index];
+  N32[label=Categorical];
+  N33[label=Sample];
+  N34[label="Observation tensor(2)"];
+  N35[label=index];
+  N36[label=Categorical];
+  N37[label=Sample];
+  N38[label="Observation tensor(2)"];
+  N39[label=Query];
+  N40[label=Query];
+  N00 -> N01;
+  N01 -> N02;
+  N02 -> N03;
+  N03 -> N04;
+  N03 -> N30;
+  N04 -> N18;
+  N04 -> N26;
+  N04 -> N39;
+  N05 -> N17;
+  N05 -> N25;
+  N06 -> N07;
+  N07 -> N08;
+  N07 -> N22;
+  N08 -> N17;
+  N09 -> N17;
+  N09 -> N25;
+  N10 -> N11;
+  N11 -> N12;
+  N11 -> N23;
+  N12 -> N17;
+  N13 -> N17;
+  N13 -> N25;
+  N14 -> N15;
+  N15 -> N16;
+  N15 -> N24;
+  N16 -> N17;
+  N17 -> N18;
+  N17 -> N31;
+  N18 -> N19;
+  N19 -> N20;
+  N20 -> N21;
+  N22 -> N25;
+  N23 -> N25;
+  N24 -> N25;
+  N25 -> N26;
+  N25 -> N35;
+  N26 -> N27;
+  N27 -> N28;
+  N28 -> N29;
+  N30 -> N31;
+  N30 -> N35;
+  N30 -> N40;
+  N31 -> N32;
+  N32 -> N33;
+  N33 -> N34;
+  N35 -> N36;
+  N36 -> N37;
+  N37 -> N38;
+}
+"""
         self.assertEqual(expected.strip(), observed.strip())
 
+        # TODO: We do not yet support Dirichlet, Categorical
+        # or map/index nodes in BMG.  Revisit this test when we do.
         # TODO: Raise a better error than a generic ValueError
+        # TODO: These error messages are needlessly repetitive.
+        # Deduplicate them.
+        # TODO: These error messages are phrased in terms of the
+        # graph operations, not the source code.
         with self.assertRaises(ValueError) as ex:
             BMGInference().infer(queries, observations, 10)
         observed = str(ex.exception)
-        expected = "Jitted stochastic control flows are not yet implemented"
+        expected = """
+The model uses a Categorical operation unsupported by Bean Machine Graph.
+The unsupported node is the operand of a Sample.
+The model uses a Categorical operation unsupported by Bean Machine Graph.
+The unsupported node is the operand of a Sample.
+The model uses a Categorical operation unsupported by Bean Machine Graph.
+The unsupported node is the operand of a Sample.
+The model uses a Categorical operation unsupported by Bean Machine Graph.
+The unsupported node is the operand of a Sample.
+The model uses a Categorical operation unsupported by Bean Machine Graph.
+The unsupported node is the operand of a Sample.
+The model uses a Dirichlet operation unsupported by Bean Machine Graph.
+The unsupported node is the operand of a Sample.
+The model uses a Dirichlet operation unsupported by Bean Machine Graph.
+The unsupported node is the operand of a Sample.
+The model uses a Dirichlet operation unsupported by Bean Machine Graph.
+The unsupported node is the operand of a Sample.
+The model uses a Dirichlet operation unsupported by Bean Machine Graph.
+The unsupported node is the operand of a Sample.
+The model uses a index operation unsupported by Bean Machine Graph.
+The unsupported node is the probability of a Categorical.
+The model uses a index operation unsupported by Bean Machine Graph.
+The unsupported node is the probability of a Categorical.
+The model uses a index operation unsupported by Bean Machine Graph.
+The unsupported node is the probability of a Categorical.
+The model uses a index operation unsupported by Bean Machine Graph.
+The unsupported node is the probability of a Categorical.
+The model uses a map operation unsupported by Bean Machine Graph.
+The unsupported node is the left of a index.
+The model uses a map operation unsupported by Bean Machine Graph.
+The unsupported node is the left of a index.
+        """
         self.assertEqual(expected.strip(), observed.strip())

--- a/src/beanmachine/ppl/compiler/tests/jit_test.py
+++ b/src/beanmachine/ppl/compiler/tests/jit_test.py
@@ -165,6 +165,28 @@ def assertions_are_removed():
     return Bernoulli(0.5)
 
 
+@bm.random_variable
+def assertions_are_removed():
+    assert cause_side_effect()
+    return Bernoulli(0.5)
+
+
+@bm.random_variable
+def spike_and_slab(n):
+    if n:
+        return Bernoulli(0.5)
+    else:
+        return Normal(0, 1)
+
+
+# Try out a stochastic control flow where we choose
+# a mean from one of two distributions depending on
+# a coin flip.
+@bm.random_variable
+def choose_your_mean():
+    return Normal(spike_and_slab(flip()), 1)
+
+
 class JITTest(unittest.TestCase):
     def test_function_transformation_1(self) -> None:
         """Unit tests for JIT functions"""
@@ -545,3 +567,62 @@ digraph "graph" {
 
         # The side effect is not caused.
         self.assertEqual(observable_side_effect, 0)
+
+    def test_stochastic_control_flow_1(self) -> None:
+        self.maxDiff = None
+
+        bmg = BMGraphBuilder()
+        queries = [choose_your_mean()]
+        observations = {}
+        bmg.accumulate_graph(queries, observations)
+        # TODO: We cannot turn this into a BMG graph yet because we
+        # do not support the map/index nodes. But we could turn this
+        # particular model into an IF-THEN-ELSE control flow, which
+        # we do support. Consider making that transformation when the
+        # graph is accumulated.
+        observed = bmg.to_dot(
+            point_at_input=True, after_transform=False, label_edges=False
+        )
+        expected = """
+digraph "graph" {
+  N00[label=2.0];
+  N01[label=Beta];
+  N02[label=Sample];
+  N03[label=Bernoulli];
+  N04[label=Sample];
+  N05[label=0.0];
+  N06[label=1.0];
+  N07[label=Normal];
+  N08[label=Sample];
+  N09[label=0.5];
+  N10[label=Bernoulli];
+  N11[label=Sample];
+  N12[label=map];
+  N13[label=index];
+  N14[label=1];
+  N15[label=Normal];
+  N16[label=Sample];
+  N17[label=Query];
+  N00 -> N01;
+  N00 -> N01;
+  N01 -> N02;
+  N02 -> N03;
+  N03 -> N04;
+  N04 -> N13;
+  N05 -> N07;
+  N05 -> N12;
+  N06 -> N07;
+  N06 -> N12;
+  N07 -> N08;
+  N08 -> N12;
+  N09 -> N10;
+  N10 -> N11;
+  N11 -> N12;
+  N12 -> N13;
+  N13 -> N15;
+  N14 -> N15;
+  N15 -> N16;
+  N16 -> N17;
+}
+"""
+        self.assertEqual(expected.strip(), observed.strip())


### PR DESCRIPTION
Summary:
We can now handle stochastic workflows of the form:

    some_rv(some_other_rv())

in the jitted compiler workflow, subject to the following restrictions:

* the argument need not be just a call to an RV; it can be any functional, any rv, or any computation that produces a graph node.
* however, the argument must have finite support, and if there are multiple such arguments, our estimate of the number of "cases" to consider must be less than 1000.
* right now we generate a map/index pair of nodes to represent this stochastic choice; we do not yet represent them in BMG so we cannot transform such models into BMG graphs yet.
* We *could* transform to BMG models where the stochastic choice was between 0 (or false) and 1 (or true) by detecting this case and reducing it to an if-then-else node, which we do support in BMG.  I will add that in an upcoming diff.

Once we know how we will represent stochastic choice amongst more than 0/1, we will ensure that we can compile such graphs to BMG.

Reviewed By: wtaha

Differential Revision: D26558155

