### PR TITLE
dirichlet

### DIFF
--- a/src/beanmachine/graph/distribution/dirichlet.cpp
+++ b/src/beanmachine/graph/distribution/dirichlet.cpp
@@ -1,0 +1,101 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+#include <cmath>
+
+#include "beanmachine/graph/distribution/dirichlet.h"
+#include "beanmachine/graph/util.h"
+
+namespace beanmachine {
+namespace distribution {
+
+Dirichlet::Dirichlet(
+    graph::ValueType sample_type,
+    const std::vector<graph::Node*>& in_nodes)
+    : Distribution(graph::DistributionType::DIRICHLET, sample_type) {
+  // a Dirichlet has one parent which is a positive real matrix
+  // and outputs a col simplex matrix
+  if (sample_type.atomic_type != graph::AtomicType::PROBABILITY) {
+    throw std::invalid_argument("Dirichlet produces probability samples");
+  }
+  if (sample_type.variable_type != graph::VariableType::COL_SIMPLEX_MATRIX) {
+    throw std::invalid_argument(
+        "Dirichlet produces COL_SIMPLEX_MATRIX samples");
+  }
+  if (in_nodes.size() != 1) {
+    throw std::invalid_argument(
+        "Dirichlet distribution must have exactly one parent");
+  }
+  if (in_nodes[0]->value.type.variable_type !=
+          graph::VariableType::BROADCAST_MATRIX or
+      in_nodes[0]->value.type.atomic_type != graph::AtomicType::POS_REAL or
+      in_nodes[0]->value.type.cols != 1) {
+    throw std::invalid_argument(
+        "Dirichlet parent must be a positive real-valued matrix with one column.");
+  }
+}
+
+Eigen::MatrixXd Dirichlet::_matrix_sampler(std::mt19937& gen) const {
+  int n_rows = in_nodes[0]->value._matrix.rows();
+  Eigen::MatrixXd sample(n_rows, 1);
+
+  Eigen::MatrixXd param = in_nodes[0]->value._matrix;
+  for (int i = 0; i < n_rows; i++) {
+    std::gamma_distribution<double> gamma_dist(param(i), 1);
+    sample(i) = gamma_dist(gen);
+  }
+  return sample / sample.sum();
+}
+
+double Dirichlet::log_prob(const graph::NodeValue& value) const {
+  assert(value.type.variable_type == graph::VariableType::COL_SIMPLEX_MATRIX);
+  assert(value.type.column == 1);
+  Eigen::MatrixXd param = in_nodes[0]->value._matrix;
+
+  double log_prob = 0.0;
+  for (int i = 0; i < param.size(); i++) {
+    double alpha = param(i);
+    log_prob -= lgamma(alpha);
+    log_prob += std::log(value._matrix(i)) * (alpha - 1);
+  }
+  log_prob += lgamma(param.sum());
+
+  return log_prob;
+}
+
+void Dirichlet::log_prob_iid(
+    const graph::NodeValue& /* value */,
+    Eigen::MatrixXd& /* log_probs */) const {}
+
+// log_prob(x | a) =
+// log G(\sum(a_i)) - \sum(log G(a_i)) + \sum(log(x_i) * (a_i - 1))
+// grad1 w.r.t. x_i = (a_i - 1) / x_i
+// grad1 w.r.t. a_i = digamma(\sum(a_i)) - digamma(a_i) + log(x_i)
+// First order chain rule: f(g(x))' = f'(g(x)) g'(x)
+void Dirichlet::backward_value(
+    const graph::NodeValue& value,
+    graph::DoubleMatrix& back_grad,
+    double adjunct) const {
+  assert(value.type.variable_type == graph::VariableType::COL_SIMPLEX_MATRIX);
+  Eigen::MatrixXd x = value._matrix;
+  Eigen::MatrixXd param = in_nodes[0]->value._matrix;
+  for (int i = 0; i < param.size(); i++) {
+    back_grad._matrix(i) += adjunct * (param(i) - 1) / x(i);
+  }
+}
+
+void Dirichlet::backward_param(const graph::NodeValue& value, double adjunct)
+    const {
+  assert(value.type.variable_type == graph::VariableType::COL_SIMPLEX_MATRIX);
+  Eigen::MatrixXd x = value._matrix;
+  Eigen::MatrixXd param = in_nodes[0]->value._matrix;
+  double digamma_sum = util::polygamma(0, param.sum());
+  if (in_nodes[0]->needs_gradient()) {
+    for (int i = 0; i < param.size(); i++) {
+      double jacob =
+          std::log(x(i)) + digamma_sum - util::polygamma(0, param(i));
+      in_nodes[0]->back_grad1._matrix(i) += adjunct * jacob;
+    }
+  }
+}
+
+} // namespace distribution
+} // namespace beanmachine

--- a/src/beanmachine/graph/distribution/dirichlet.h
+++ b/src/beanmachine/graph/distribution/dirichlet.h
@@ -1,0 +1,36 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+#pragma once
+#include "beanmachine/graph/distribution/distribution.h"
+
+namespace beanmachine {
+namespace distribution {
+
+class Dirichlet : public Distribution {
+ public:
+  Dirichlet(
+      graph::ValueType sample_type,
+      const std::vector<graph::Node*>& in_nodes);
+  ~Dirichlet() override {}
+  Eigen::MatrixXd _matrix_sampler(std::mt19937& gen) const override;
+  double log_prob(const graph::NodeValue& value) const override;
+  void log_prob_iid(
+      const graph::NodeValue& /* value */,
+      Eigen::MatrixXd& /* log_probs */) const override;
+  void gradient_log_prob_value(
+      const graph::NodeValue& /*value*/,
+      double& /*grad1*/,
+      double& /*grad2*/) const override {}
+  void gradient_log_prob_param(
+      const graph::NodeValue& /*value*/,
+      double& /*grad1*/,
+      double& /*grad2*/) const override {}
+  void backward_value(
+      const graph::NodeValue& value,
+      graph::DoubleMatrix& back_grad,
+      double adjunct = 1.0) const override;
+  void backward_param(const graph::NodeValue& value, double adjunct = 1.0)
+      const override;
+};
+
+} // namespace distribution
+} // namespace beanmachine

--- a/src/beanmachine/graph/distribution/distribution.h
+++ b/src/beanmachine/graph/distribution/distribution.h
@@ -106,6 +106,10 @@ class Distribution : public graph::Node {
     throw std::runtime_error(
         "_natural_sampler has not been implemented for this distribution.");
   }
+  virtual Eigen::MatrixXd _matrix_sampler(std::mt19937& /* gen */) const {
+    throw std::runtime_error(
+        "_matrix_sampler has not been implemented for this distribution.");
+  }
 };
 
 } // namespace distribution

--- a/src/beanmachine/graph/distribution/flat.h
+++ b/src/beanmachine/graph/distribution/flat.h
@@ -10,10 +10,12 @@ class Flat : public Distribution {
   Flat(
       graph::AtomicType sample_type,
       const std::vector<graph::Node*>& in_nodes);
+  Flat(graph::ValueType sample_type, const std::vector<graph::Node*>& in_nodes);
   ~Flat() override {}
   bool _bool_sampler(std::mt19937& gen) const override;
   double _double_sampler(std::mt19937& gen) const override;
   graph::natural_t _natural_sampler(std::mt19937& gen) const override;
+  Eigen::MatrixXd _matrix_sampler(std::mt19937& gen) const override;
   double log_prob(const graph::NodeValue& value) const override;
   void gradient_log_prob_value(
       const graph::NodeValue& value,
@@ -23,6 +25,7 @@ class Flat : public Distribution {
       const graph::NodeValue& value,
       double& grad1,
       double& grad2) const override;
+  std::uniform_real_distribution<double> _get_uniform_real_distribution() const;
 };
 
 } // namespace distribution

--- a/src/beanmachine/graph/distribution/tests/dirichlet_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/dirichlet_test.cpp
@@ -1,0 +1,174 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+#include <gtest/gtest.h>
+#include <stdexcept>
+
+#include "beanmachine/graph/distribution/dirichlet.h"
+#include "beanmachine/graph/graph.h"
+
+using namespace beanmachine::graph;
+
+TEST(testdistrib, dirichlet_negative) {
+  Graph g;
+
+  Eigen::MatrixXd m1(3, 1);
+  m1 << 1.5, 1.0, 2.0;
+  uint cm1 = g.add_constant_pos_matrix(m1);
+  uint two = g.add_constant((natural_t)2);
+
+  // negative initialization tests
+  EXPECT_THROW(
+      g.add_distribution(
+          DistributionType::DIRICHLET,
+          ValueType(
+              VariableType::COL_SIMPLEX_MATRIX, AtomicType::PROBABILITY, 3, 1),
+          std::vector<uint>{two}),
+      std::invalid_argument);
+  EXPECT_THROW(
+      g.add_distribution(
+          DistributionType::DIRICHLET,
+          ValueType(
+              VariableType::COL_SIMPLEX_MATRIX, AtomicType::PROBABILITY, 3, 1),
+          std::vector<uint>{cm1, two}),
+      std::invalid_argument);
+  EXPECT_THROW(
+      g.add_distribution(
+          DistributionType::DIRICHLET,
+          ValueType(VariableType::BROADCAST_MATRIX, AtomicType::REAL, 3, 1),
+          std::vector<uint>{cm1}),
+      std::invalid_argument);
+
+  Eigen::MatrixXd m2(2, 2);
+  m2 << 1.5, 1.0, 2.0, 1.5;
+  uint cm2 = g.add_constant_pos_matrix(m2);
+  EXPECT_THROW(
+      g.add_distribution(
+          DistributionType::DIRICHLET,
+          ValueType(
+              VariableType::COL_SIMPLEX_MATRIX, AtomicType::PROBABILITY, 3, 1),
+          std::vector<uint>{cm2}),
+      std::invalid_argument);
+}
+
+TEST(testdistrib, dirichlet) {
+  Graph g;
+
+  Eigen::MatrixXd m1(3, 1);
+  m1 << 1.5, 1.0, 2.0;
+
+  uint flat_dist = g.add_distribution(
+      DistributionType::FLAT,
+      ValueType(VariableType::BROADCAST_MATRIX, AtomicType::POS_REAL, 3, 1),
+      std::vector<uint>{});
+  uint flat_sample = g.add_operator(OperatorType::SAMPLE, {flat_dist});
+  g.observe(flat_sample, m1);
+
+  uint diri_dist = g.add_distribution(
+      DistributionType::DIRICHLET,
+      ValueType(
+          VariableType::COL_SIMPLEX_MATRIX, AtomicType::PROBABILITY, 3, 1),
+      std::vector<uint>{flat_sample});
+
+  // test log prob
+  uint diri_sample = g.add_operator(OperatorType::SAMPLE, {diri_dist});
+  Eigen::MatrixXd obs(3, 1);
+  obs << 0.6, 0.06, 0.34;
+  g.observe(diri_sample, obs);
+  EXPECT_NEAR(g.full_log_prob(), 1.2403, 0.01);
+
+  // test backward_param() and backward_value()
+  // verify with PyTorch
+  // param = tensor([1.5, 1., 2.], requires_grad=True)
+  // diri = dist.Dirichlet(param)
+  // value = tensor([0.6, 0.06, 0.34], requires_grad=True)
+  // log_prob = diri.log_prob(value)
+  // grad(log_prob, param, retain_graph=True)
+  // grad(log_prob, value)
+  std::vector<DoubleMatrix*> grad1;
+  g.eval_and_grad(grad1);
+  EXPECT_EQ(grad1.size(), 2);
+  EXPECT_NEAR(grad1[0]->_matrix(0), 0.8416, 1e-3);
+  EXPECT_NEAR(grad1[0]->_matrix(1), -0.8473, 1e-3);
+  EXPECT_NEAR(grad1[0]->_matrix(2), -0.1127, 1e-3);
+  EXPECT_NEAR(grad1[1]->_matrix(0), 0.8333, 1e-3);
+  EXPECT_NEAR(grad1[1]->_matrix(1), 0.0, 1e-3);
+  EXPECT_NEAR(grad1[1]->_matrix(2), 2.9412, 1e-3);
+
+  // different shape
+  Graph g2;
+  flat_dist = g2.add_distribution(
+      DistributionType::FLAT,
+      ValueType(VariableType::BROADCAST_MATRIX, AtomicType::POS_REAL, 4, 1),
+      std::vector<uint>{});
+  uint p1 = g2.add_operator(OperatorType::SAMPLE, {flat_dist});
+
+  uint d1 = g2.add_distribution(
+      DistributionType::DIRICHLET,
+      ValueType(
+          VariableType::COL_SIMPLEX_MATRIX, AtomicType::PROBABILITY, 4, 1),
+      std::vector<uint>{p1});
+  uint x = g2.add_operator(OperatorType::SAMPLE, std::vector<uint>{d1});
+
+  Eigen::MatrixXd p1_obs(4, 1);
+  p1_obs << 2., 1., 3., 2.;
+  g2.observe(p1, p1_obs);
+  Eigen::MatrixXd p2_obs(4, 1);
+  Eigen::MatrixXd x_obs(4, 1);
+  x_obs << 0.05, 0.05, 0.8, 0.12;
+  g2.observe(x, x_obs);
+
+  // PyTorch verification
+  // p1 = tensor([2.0, 1., 3., 2.0], requires_grad=True)
+  // x = tensor([0.05, 0.05, 0.8, 0.12], requires_grad=True)
+  // d1 = dist.Dirichlet(p1)
+  // log_p = d1.log_prob(x)
+  // grad(log_p, p1, retain_graph=True)
+  // grad(log_p, x)
+  EXPECT_NEAR(g2.full_log_prob(), 2.2697, 1e-3);
+  std::vector<DoubleMatrix*> back_grad;
+  g2.eval_and_grad(back_grad);
+  EXPECT_EQ(back_grad.size(), 2);
+  // p1
+  EXPECT_NEAR(back_grad[0]->_matrix(0), -1.4029, 1e-3);
+  EXPECT_NEAR(back_grad[0]->_matrix(1), -0.4029, 1e-3);
+  EXPECT_NEAR(back_grad[0]->_matrix(2), 0.8697, 1e-3);
+  EXPECT_NEAR(back_grad[0]->_matrix(3), -0.5274, 1e-3);
+  // x
+  EXPECT_NEAR(back_grad[1]->_matrix(0), 20, 1e-3);
+  EXPECT_NEAR(back_grad[1]->_matrix(1), 0, 1e-3);
+  EXPECT_NEAR(back_grad[1]->_matrix(2), 2.5, 1e-3);
+  EXPECT_NEAR(back_grad[1]->_matrix(3), 8.3333, 1e-3);
+}
+
+TEST(testdistrib, dirichlet_sample) {
+  Graph g;
+  Eigen::MatrixXd m1(3, 1);
+  m1 << 1.5, 1.0, 2.0;
+  uint cm1 = g.add_constant_pos_matrix(m1);
+  uint diri_dist = g.add_distribution(
+      DistributionType::DIRICHLET,
+      ValueType(
+          VariableType::COL_SIMPLEX_MATRIX, AtomicType::PROBABILITY, 3, 1),
+      std::vector<uint>{cm1});
+
+  // test distribution of mean and variance
+  auto x = g.add_operator(OperatorType::SAMPLE, std::vector<uint>{diri_dist});
+  g.query(x);
+  std::vector<std::vector<NodeValue>> samples =
+      g.infer(100000, InferenceType::REJECTION);
+  Eigen::MatrixXd mean(3, 1);
+  Eigen::ArrayXd std(3, 1);
+  for (int i = 0; i < samples.size(); i++) {
+    mean += samples[i][0]._matrix;
+  }
+  mean /= samples.size();
+  EXPECT_NEAR(mean(0), 0.33, 0.01);
+  EXPECT_NEAR(mean(1), 0.22, 0.01);
+  EXPECT_NEAR(mean(2), 0.44, 0.01);
+  for (int i = 0; i < samples.size(); i++) {
+    std += (samples[i][0]._matrix - mean).array().pow(2);
+  }
+  std = (std / (100000 - 1)).cwiseSqrt();
+  EXPECT_NEAR(std(0), 0.201, 0.01);
+  EXPECT_NEAR(std(1), 0.1773, 0.01);
+  EXPECT_NEAR(std(2), 0.2119, 0.01);
+}

--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -305,6 +305,7 @@ enum class DistributionType {
   BERNOULLI_NOISY_OR,
   BETA,
   BINOMIAL,
+  DIRICHLET,
   FLAT,
   NORMAL,
   HALF_CAUCHY,

--- a/src/beanmachine/graph/pybindings.cpp
+++ b/src/beanmachine/graph/pybindings.cpp
@@ -71,7 +71,8 @@ PYBIND11_MODULE(graph, module) {
       .value("STUDENT_T", DistributionType::STUDENT_T)
       .value("BERNOULLI_LOGIT", DistributionType::BERNOULLI_LOGIT)
       .value("GAMMA", DistributionType::GAMMA)
-      .value("BIMIXTURE", DistributionType::BIMIXTURE);
+      .value("BIMIXTURE", DistributionType::BIMIXTURE)
+      .value("DIRICHLET", DistributionType::DIRICHLET);
 
   py::enum_<FactorType>(module, "FactorType")
       .value("EXP_PRODUCT", FactorType::EXP_PRODUCT);


### PR DESCRIPTION
Summary:
add `_matrix_sampler` method `Distributions`

implement `Dirichlet` class with sampling, log_prob, and backwards methods

extended `Flat` distribution to support broadcast matrices

Reviewed By: ericlippert

Differential Revision: D26495458

