### PR TITLE
Minor change to requirements analysis

### DIFF
--- a/src/beanmachine/ppl/compiler/bmg_nodes.py
+++ b/src/beanmachine/ppl/compiler/bmg_nodes.py
@@ -3524,9 +3524,7 @@ class Query(BMGNode):
 
     @property
     def requirements(self) -> List[Requirement]:
-        # TODO: Rather than passing along the inf type as the
-        # requirement, consider simply creating an "any" requirement object.
-        return [self.inf_type]
+        return [self.graph_type]
 
     @property
     def size(self) -> torch.Size:

--- a/src/beanmachine/ppl/compiler/tests/bmg_query_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_query_test.py
@@ -32,27 +32,42 @@ def c():
 
 
 class BMGQueryTest(unittest.TestCase):
-    def disabled_test_constant_functional(self) -> None:
-
-        # TODO: This test is disabled because there is a bug
-        # in the type checker which crashes when it tries
-        # to verify the type of a queried one-hot tensor.
-        # Fix that bug and then re-enable this test
-
+    def test_constant_functional(self) -> None:
         self.maxDiff = None
 
         observed = BMGInference().to_dot([c()], {})
-        expected = """ """
+        expected = """
+digraph "graph" {
+  N0[label=1.0];
+  N1[label=Query];
+  N0 -> N1;
+}"""
         self.assertEqual(expected.strip(), observed.strip())
 
+        # TODO: This is wrong; we need to ensure that we do NOT
+        # TODO: emit the g.query(n0) when the node is a constant.
         observed = BMGInference().to_cpp([c()], {})
-        expected = """ """
+        expected = """
+graph::Graph g;
+uint n0 = g.add_constant(torch::from_blob((float[]){1.0}, {}));
+g.query(n0);
+         """
         self.assertEqual(expected.strip(), observed.strip())
 
+        # TODO: This is wrong; we need to ensure that we do NOT
+        # TODO: emit the g.query(n0) when the node is a constant.
         observed = BMGInference().to_python([c()], {})
-        expected = """ """
+        expected = """
+from beanmachine import graph
+from torch import tensor
+g = graph.Graph()
+n0 = g.add_constant(tensor(1.0))
+g.query(n0)
+        """
         self.assertEqual(expected.strip(), observed.strip())
 
-        observed = BMGInference().infer([c()], {}, 1)[c()]
-        expected = """ """
-        self.assertEqual(str(expected).strip(), observed.strip())
+        # TODO: This part of the test is disabled because it raises
+        # an exception when we add a query on a constant.
+        # observed = BMGInference().infer([c()], {}, 1)[c()]
+        # expected = """ """
+        # self.assertEqual(str(expected).strip(), observed.strip())

--- a/src/beanmachine/ppl/compiler/tests/bmg_types_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_types_test.py
@@ -152,7 +152,12 @@ class BMGTypesTest(unittest.TestCase):
         bmg.add_sample(bern)
         bmg.add_query(mult)
 
-        observed = bmg.to_dot(True, True, True, True)
+        observed = bmg.to_dot(
+            graph_types=True,
+            inf_types=True,
+            edge_requirements=True,
+            point_at_input=True,
+        )
         expected = """
 digraph "graph" {
   N00[label="1.0:T>=OH"];
@@ -174,7 +179,7 @@ digraph "graph" {
   N04 -> N05[label="right:P"];
   N05 -> N06[label="mu:R"];
   N05 -> N07[label="probability:P"];
-  N05 -> N10[label="operator:P"];
+  N05 -> N10[label="operator:M"];
   N06 -> N08[label="operand:R"];
   N07 -> N09[label="operand:B"];
 }"""

--- a/src/beanmachine/ppl/compiler/tests/fix_problems_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_problems_test.py
@@ -37,7 +37,12 @@ class FixProblemsTest(unittest.TestCase):
         bmg.add_sample(bern)
         bmg.add_query(mult)
 
-        observed = bmg.to_dot(True, False, True, True)
+        observed = bmg.to_dot(
+            graph_types=True,
+            inf_types=False,
+            edge_requirements=True,
+            point_at_input=True,
+        )
         expected = """
 digraph "graph" {
   N00[label="1.0:T"];
@@ -59,14 +64,19 @@ digraph "graph" {
   N04 -> N05[label="right:P"];
   N05 -> N06[label="mu:R"];
   N05 -> N07[label="probability:P"];
-  N05 -> N10[label="operator:P"];
+  N05 -> N10[label="operator:M"];
   N06 -> N08[label="operand:R"];
   N07 -> N09[label="operand:B"];
 }"""
         self.assertEqual(observed.strip(), expected.strip())
 
         fix_problems(bmg)
-        observed = bmg.to_dot(True, False, True, True)
+        observed = bmg.to_dot(
+            graph_types=True,
+            inf_types=False,
+            edge_requirements=True,
+            point_at_input=True,
+        )
         expected = """
 digraph "graph" {
   N00[label="1.0:T"];


### PR DESCRIPTION
Summary:
We had a crash when querying a constant node containing the value 1.0.  The reason why is interesting, and indicates that I should do a pass over the requirements analysis to see if this mistake occurs anywhere else.

Every node has two types: it's "inf type", which is "what is the smallest type in the type lattice I could convert this value into?", and its "graph" type, which is "what BMG type am I in the actual final BMG graph?"

These can be different because we have some "fake" types that we use during analysis. For instance, if we have a node containing the constant zero then that could be converted into a bool or a negative real, but there is  no type in the BMG type system that is "more specific than both bool or negative real". But at the same time, a bool may not be converted to a negative real, and a negative real may not be converted to a bool.  I therefore have a "fake" zero type just for this situation, so that the type analyzer can easily express that constant zero is convertable to both these "real" types.

Similarly we have a fake "one" type which is convertible to both bool and simplex, for the same reason.

Each *edge* in the graph has a *requirement*. For example, the edge in the graph which is the input to a bernoulli has the "probability" requirement.  If the graph type of the input cannot be forced to "probability" then the model has no representation in BMG.

The question at hand is: what is the requirement on the edge that flows from a queried node into a query?

I wanted to represent the notion of "there is no requirement". A query does not force a node to have a particular type.  So I just said that the requirement is that the queried node be its inf type.

That's wrong though.  Suppose the query is querying the constant node 1.0.  Its inf type is "one", but there is no node that has *graph type* "one" because that's not a real type in the BMG graph type system.  I did not correctly handle this case, and we crashed on it.

What is the correct thing to do? Well probably the most correct thing would be to actually create a "this edge imposes no requirement" concept in the type checker, and I likely will do that in an upcoming diff.

But for now, what I'll do is impose the requirement on a query node that the input node be its own graph type, because *that* requirement really is *always* met. The requirement that your graph type be your graph type is plainly a tautology.

This caused two tests which verify requirements on edges to change.

The test which led to this discovery in the first place now runs farther without crashing but then exposes several other bugs in the code generation and inference steps which are documented in the comments to the test case.

This mistake of putting a requirement on an input equal to its inf type when what I really mean is "I don't care" is probably replicated throughout the requirements analysis code. I'll do a pass over it later and see if I can find more bugs like this.

Reviewed By: wtaha

Differential Revision: D26653948

