### PR TITLE
Implement not-equals operator on bools in compiler

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/boolean_comparisons_test.py
+++ b/src/beanmachine/ppl/compiler/tests/boolean_comparisons_test.py
@@ -50,8 +50,33 @@ def eq_x_y():
 
 
 @bm.functional
-def ne_x_1():
+def neq_x_0():
+    # flip(0)
+    return flip(0) != 0.0
+
+
+@bm.functional
+def neq_x_1():
+    # not flip(0)
     return flip(0) != 1.0
+
+
+@bm.functional
+def neq_0_y():
+    # flip(1)
+    return 0 != flip(1)
+
+
+@bm.functional
+def neq_1_y():
+    # not flip(1)
+    return 1 != flip(0)
+
+
+@bm.functional
+def neq_x_y():
+    # if flip(0) then flip(1) else not flip(1)
+    return flip(0) != flip(1)
 
 
 class BooleanComparisonsTest(unittest.TestCase):
@@ -115,19 +140,62 @@ digraph "graph" {
         observed = BMGInference().to_dot([eq_1_y()], {})
         self.assertEqual(expected.strip(), observed.strip())
 
-    def test_boolean_comparison_errors_ne(self) -> None:
+    def test_boolean_comparison_errors_neq(self) -> None:
 
         self.maxDiff = None
-        bmg = BMGInference()
 
-        # TODO: Raise a better error than a generic ValueError
-        # TODO: This error is poorly phrased. "The operator of a query"?
-        # TODO: Surely that should be "operand".
-        with self.assertRaises(ValueError) as ex:
-            bmg.infer([ne_x_1()], {}, 10)
+        observed = BMGInference().to_dot([neq_x_y()], {})
         expected = """
-The model uses a != operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
+digraph "graph" {
+  N0[label=0.5];
+  N1[label=Bernoulli];
+  N2[label=Sample];
+  N3[label=Sample];
+  N4[label=complement];
+  N5[label=if];
+  N6[label=Query];
+  N0 -> N1;
+  N1 -> N2;
+  N1 -> N3;
+  N2 -> N5;
+  N3 -> N4;
+  N3 -> N5;
+  N4 -> N5;
+  N5 -> N6;
+}
+        """
+        self.assertEqual(expected.strip(), observed.strip())
+
+        observed = BMGInference().to_dot([neq_x_0()], {})
+        expected = """
+digraph "graph" {
+  N0[label=0.5];
+  N1[label=Bernoulli];
+  N2[label=Sample];
+  N3[label=Query];
+  N0 -> N1;
+  N1 -> N2;
+  N2 -> N3;
+}
 """
-        observed = str(ex.exception)
+        self.assertEqual(expected.strip(), observed.strip())
+        observed = BMGInference().to_dot([neq_0_y()], {})
+        self.assertEqual(expected.strip(), observed.strip())
+
+        observed = BMGInference().to_dot([neq_x_1()], {})
+        expected = """
+digraph "graph" {
+  N0[label=0.5];
+  N1[label=Bernoulli];
+  N2[label=Sample];
+  N3[label=complement];
+  N4[label=Query];
+  N0 -> N1;
+  N1 -> N2;
+  N2 -> N3;
+  N3 -> N4;
+}
+"""
+        self.assertEqual(expected.strip(), observed.strip())
+        observed = BMGInference().to_dot([neq_1_y()], {})
         self.assertEqual(expected.strip(), observed.strip())


### PR DESCRIPTION
Summary: The compiler now correctly translates not-equals operations where both operands are bools into BMG IF nodes.

Reviewed By: wtaha

Differential Revision: D26654143

