### PR TITLE
Implement >= on bools in compiler

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/boolean_comparisons_test.py
+++ b/src/beanmachine/ppl/compiler/tests/boolean_comparisons_test.py
@@ -6,9 +6,7 @@ from beanmachine.ppl.inference.bmg_inference import BMGInference
 from torch.distributions import Bernoulli
 
 
-# TODO: x != y  -->  if x then not y else y
 # TODO: x > y   -->  if x then not y else false
-# TODO: x >= y  -->  if x then true else not y
 # TODO: x < y   -->  if x then false else y
 # TODO: x <= y  -->  if x then y else true
 # TODO: x is y  -->  same as ==
@@ -17,6 +15,11 @@ from torch.distributions import Bernoulli
 @bm.random_variable
 def flip(n):
     return Bernoulli(0.5)
+
+
+#
+# ==
+#
 
 
 @bm.functional
@@ -40,13 +43,18 @@ def eq_0_y():
 @bm.functional
 def eq_1_y():
     # flip(1)
-    return 1 == flip(0)
+    return 1 == flip(1)
 
 
 @bm.functional
 def eq_x_y():
     # if flip(0) then flip(1) else not flip(1)
     return flip(0) == flip(1)
+
+
+#
+# !=
+#
 
 
 @bm.functional
@@ -70,17 +78,52 @@ def neq_0_y():
 @bm.functional
 def neq_1_y():
     # not flip(1)
-    return 1 != flip(0)
+    return 1 != flip(1)
 
 
 @bm.functional
 def neq_x_y():
-    # if flip(0) then flip(1) else not flip(1)
+    # if flip(0) then not flip(1) else flip(1)
     return flip(0) != flip(1)
 
 
+#
+# >=
+#
+
+
+@bm.functional
+def gte_x_0():
+    # true
+    return flip(0) >= 0.0
+
+
+@bm.functional
+def gte_x_1():
+    # flip(0)
+    return flip(0) >= 1.0
+
+
+@bm.functional
+def gte_0_y():
+    # not flip(1)
+    return 0 >= flip(1)
+
+
+@bm.functional
+def gte_1_y():
+    # true
+    return 1 >= flip(1)
+
+
+@bm.functional
+def gte_x_y():
+    # if flip(0) then true else not flip(1)
+    return flip(0) >= flip(1)
+
+
 class BooleanComparisonsTest(unittest.TestCase):
-    def test_boolean_comparison_errors_eq(self) -> None:
+    def test_boolean_comparison_eq(self) -> None:
 
         self.maxDiff = None
 
@@ -140,7 +183,7 @@ digraph "graph" {
         observed = BMGInference().to_dot([eq_1_y()], {})
         self.assertEqual(expected.strip(), observed.strip())
 
-    def test_boolean_comparison_errors_neq(self) -> None:
+    def test_boolean_comparison_neq(self) -> None:
 
         self.maxDiff = None
 
@@ -198,4 +241,94 @@ digraph "graph" {
 """
         self.assertEqual(expected.strip(), observed.strip())
         observed = BMGInference().to_dot([neq_1_y()], {})
+        self.assertEqual(expected.strip(), observed.strip())
+
+    def test_boolean_comparison_gte(self) -> None:
+
+        self.maxDiff = None
+
+        observed = BMGInference().to_dot([gte_x_y()], {})
+        expected = """
+digraph "graph" {
+  N0[label=0.5];
+  N1[label=Bernoulli];
+  N2[label=Sample];
+  N3[label=Sample];
+  N4[label=True];
+  N5[label=complement];
+  N6[label=if];
+  N7[label=Query];
+  N0 -> N1;
+  N1 -> N2;
+  N1 -> N3;
+  N2 -> N6;
+  N3 -> N5;
+  N4 -> N6;
+  N5 -> N6;
+  N6 -> N7;
+}
+        """
+        self.assertEqual(expected.strip(), observed.strip())
+
+        # TODO: Note that here we keep the sample in the graph even though it is
+        # not queried or observed. We might consider removing it.
+        observed = BMGInference().to_dot([gte_x_0()], {})
+        expected = """
+digraph "graph" {
+  N0[label=0.5];
+  N1[label=Bernoulli];
+  N2[label=Sample];
+  N3[label=True];
+  N4[label=Query];
+  N0 -> N1;
+  N1 -> N2;
+  N3 -> N4;
+}
+"""
+        self.assertEqual(expected.strip(), observed.strip())
+
+        observed = BMGInference().to_dot([gte_0_y()], {})
+        expected = """
+digraph "graph" {
+  N0[label=0.5];
+  N1[label=Bernoulli];
+  N2[label=Sample];
+  N3[label=complement];
+  N4[label=Query];
+  N0 -> N1;
+  N1 -> N2;
+  N2 -> N3;
+  N3 -> N4;
+}
+"""
+
+        self.assertEqual(expected.strip(), observed.strip())
+
+        observed = BMGInference().to_dot([gte_x_1()], {})
+        expected = """
+digraph "graph" {
+  N0[label=0.5];
+  N1[label=Bernoulli];
+  N2[label=Sample];
+  N3[label=Query];
+  N0 -> N1;
+  N1 -> N2;
+  N2 -> N3;
+}
+"""
+        self.assertEqual(expected.strip(), observed.strip())
+
+        observed = BMGInference().to_dot([gte_1_y()], {})
+        expected = """
+digraph "graph" {
+  N0[label=0.5];
+  N1[label=Bernoulli];
+  N2[label=Sample];
+  N3[label=True];
+  N4[label=Query];
+  N0 -> N1;
+  N1 -> N2;
+  N3 -> N4;
+}
+"""
         self.assertEqual(expected.strip(), observed.strip())


### PR DESCRIPTION
Summary: As noted in previous diffs in this stack, it is possible to realize comparison operators involving only bools as IF nodes in BMG. In this diff I add support for an optimized `<=` operator on Booleans.

Reviewed By: wtaha

Differential Revision: D26654406

