### PR TITLE
Temporary solution to make NMC work with Dirichlet Prior and Index Operator.

### DIFF
--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -737,5 +737,16 @@ struct Graph {
       common_transformations;
 };
 
+/*
+A temporary solution to use NMC sampler on Dirichlet sample.
+*/
+void nmc_step_for_dirichlet(
+    Node* tgt_node,
+    const std::vector<uint>& det_nodes,
+    const std::vector<uint>& sto_nodes,
+    const std::vector<Node*>& node_ptrs,
+    std::vector<NodeValue>& old_values,
+    std::mt19937& gen);
+
 } // namespace graph
 } // namespace beanmachine

--- a/src/beanmachine/graph/operator/gradient.cpp
+++ b/src/beanmachine/graph/operator/gradient.cpp
@@ -2,6 +2,7 @@
 #include <cmath>
 
 #include "beanmachine/graph/operator/controlop.h"
+#include "beanmachine/graph/operator/linalgop.h"
 #include "beanmachine/graph/operator/multiaryop.h"
 #include "beanmachine/graph/operator/unaryop.h"
 
@@ -240,6 +241,12 @@ void IfThenElse::compute_gradients() {
     grad1 = in_nodes[2]->grad1;
     grad2 = in_nodes[2]->grad2;
   }
+}
+
+void Index::compute_gradients() {
+  assert(in_nodes.size() == 2);
+  grad1 = in_nodes[0]->Grad1.coeff(in_nodes[1]->value._natural);
+  grad2 = in_nodes[0]->Grad2.coeff(in_nodes[1]->value._natural);
 }
 
 } // namespace oper

--- a/src/beanmachine/graph/operator/linalgop.h
+++ b/src/beanmachine/graph/operator/linalgop.h
@@ -34,10 +34,7 @@ class Index : public Operator {
 
   void eval(std::mt19937& gen) override;
   void backward() override;
-  void compute_gradients() override {
-    throw std::runtime_error(
-        "INDEX does not support forward gradient propagation.");
-  }
+  void compute_gradients() override;
 
   static std::unique_ptr<Operator> new_op(
       const std::vector<graph::Node*>& in_nodes) {

--- a/src/beanmachine/graph/operator/stochasticop.cpp
+++ b/src/beanmachine/graph/operator/stochasticop.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
 
 #include "beanmachine/graph/operator/stochasticop.h"
+#include "beanmachine/graph/graph.h"
 
 namespace beanmachine {
 namespace oper {
@@ -78,6 +79,8 @@ Sample::Sample(const std::vector<graph::Node*>& in_nodes)
   // the type of value of a SAMPLE node is obviously the sample type
   // of the distribution parent
   value = graph::NodeValue(dist->sample_type);
+  unconstrained_value = graph::NodeValue(graph::ValueType(
+      dist->sample_type.variable_type, graph::AtomicType::REAL, 1, 0));
 }
 
 IIdSample::IIdSample(const std::vector<graph::Node*>& in_nodes)
@@ -132,6 +135,8 @@ IIdSample::IIdSample(const std::vector<graph::Node*>& in_nodes)
       throw std::invalid_argument("Invalid sample type for for iid sample. ");
   }
   value = graph::NodeValue(vtype);
+  unconstrained_value = graph::NodeValue(graph::ValueType(
+      dist->sample_type.variable_type, graph::AtomicType::REAL, 1, 0));
   return;
 }
 


### PR DESCRIPTION
Summary:
This is a temporary solution to unblock the CLARA model, which has Dirichlet priors.
- added forward gradient prop for Index
- added a temporary logic in NMC to loop over transformed Dirichlet sample node.

Reviewed By: wtaha

Differential Revision: D26694851

