### PR TITLE
Move bool comparison rewriter to own module

### DIFF
--- a/src/beanmachine/ppl/compiler/fix_bool_comparisons.py
+++ b/src/beanmachine/ppl/compiler/fix_bool_comparisons.py
@@ -1,0 +1,111 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+from typing import Optional
+
+from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
+from beanmachine.ppl.compiler.bmg_nodes import (
+    BMGNode,
+    ComparisonNode,
+    EqualNode,
+    GreaterThanEqualNode,
+    NotEqualNode,
+)
+from beanmachine.ppl.compiler.bmg_types import Boolean, One, Zero, supremum
+
+
+class BoolComparisonFixer:
+    """This class takes a Bean Machine Graph builder and replaces all comparison
+    operators whose operands are bool with semantically equivalent IF nodes."""
+
+    bmg: BMGraphBuilder
+
+    def __init__(self, bmg: BMGraphBuilder) -> None:
+        self.bmg = bmg
+
+    def _is_bool_comparison(self, node: BMGNode) -> bool:
+        return (
+            isinstance(node, ComparisonNode)
+            and supremum(node.left.inf_type, node.right.inf_type, Boolean) == Boolean
+        )
+
+    def _replace_bool_equals(self, node: EqualNode) -> BMGNode:
+        # 1 == y        -->  y
+        # x == 1        -->  x
+        # 0 == y        -->  not y
+        # x == 0        -->  not x
+        # x == y        -->  if x then y else not y
+        if node.left.inf_type == One:
+            return node.right
+        if node.right.inf_type == One:
+            return node.left
+        if node.left.inf_type == Zero:
+            return self.bmg.add_complement(node.right)
+        if node.right.inf_type == Zero:
+            return self.bmg.add_complement(node.left)
+        alt = self.bmg.add_complement(node.right)
+        return self.bmg.add_if_then_else(node.left, node.right, alt)
+
+    def _replace_bool_not_equals(self, node: NotEqualNode) -> BMGNode:
+        # 1 != y        -->  not y
+        # x != 1        -->  not x
+        # 0 != y        -->  y
+        # x != 0        -->  x
+        # x != y        -->  if x then not y else y
+        if node.left.inf_type == One:
+            return self.bmg.add_complement(node.right)
+        if node.right.inf_type == One:
+            return self.bmg.add_complement(node.left)
+        if node.left.inf_type == Zero:
+            return node.right
+        if node.right.inf_type == Zero:
+            return node.left
+        cons = self.bmg.add_complement(node.right)
+        return self.bmg.add_if_then_else(node.left, cons, node.right)
+
+    def _replace_bool_gte(self, node: GreaterThanEqualNode) -> BMGNode:
+        # 1 >= y        -->  true
+        # x >= 1        -->  x
+        # 0 >= y        -->  not y
+        # x >= 0        -->  true
+        # x >= y        -->  if x then true else not y
+        if node.left.inf_type == One:
+            return self.bmg.add_constant_of_type(True, Boolean)
+        if node.right.inf_type == One:
+            return node.left
+        if node.left.inf_type == Zero:
+            return self.bmg.add_complement(node.right)
+        if node.right.inf_type == Zero:
+            return self.bmg.add_constant_of_type(True, Boolean)
+        cons = self.bmg.add_constant_of_type(True, Boolean)
+        alt = self.bmg.add_complement(node.right)
+        return self.bmg.add_if_then_else(node.left, cons, alt)
+
+    def _replace_bool_comparison(self, node: ComparisonNode) -> Optional[BMGNode]:
+        # TODO: x > y   -->  if x then not y else false
+        # TODO: x < y   -->  if x then false else y
+        # TODO: x <= y  -->  if x then y else true
+        if isinstance(node, EqualNode):
+            return self._replace_bool_equals(node)
+        if isinstance(node, NotEqualNode):
+            return self._replace_bool_not_equals(node)
+        if isinstance(node, GreaterThanEqualNode):
+            return self._replace_bool_gte(node)
+
+        return None
+
+    def fix_bool_comparisons(self) -> None:
+        replacements = {}
+        nodes = self.bmg._traverse_from_roots()
+        for node in nodes:
+            for i in range(len(node.inputs)):
+                c = node.inputs[i]
+                if not self._is_bool_comparison(c):
+                    continue
+                if c in replacements:
+                    node.inputs[i] = replacements[c]
+                    continue
+                assert isinstance(c, ComparisonNode)
+                replacement = self._replace_bool_comparison(c)
+                if replacement is not None:
+                    replacements[c] = replacement
+                    node.inputs[i] = replacement

--- a/src/beanmachine/ppl/compiler/fix_problems.py
+++ b/src/beanmachine/ppl/compiler/fix_problems.py
@@ -38,6 +38,7 @@ from beanmachine.ppl.compiler.bmg_types import (
 )
 from beanmachine.ppl.compiler.error_report import ErrorReport, Violation
 from beanmachine.ppl.compiler.fix_additions import AdditionFixer
+from beanmachine.ppl.compiler.fix_bool_comparisons import BoolComparisonFixer
 from beanmachine.ppl.compiler.fix_observations import ObservationsFixer
 from beanmachine.ppl.compiler.fix_observe_true import ObserveTrueFixer
 from beanmachine.ppl.compiler.fix_tensor_ops import TensorOpsFixer
@@ -410,6 +411,7 @@ def fix_problems(bmg: BMGraphBuilder, fix_observe_true: bool = False) -> ErrorRe
     # add(1, negate(to_real(p)).  Better to turn it into complement(p)
     # and orphan the negate(p) early.
     AdditionFixer(bmg).additions_to_complements()
+    BoolComparisonFixer(bmg).fix_bool_comparisons()
     f = UnsupportedNodeFixer(bmg)
     f.fix_unsupported_nodes()
     if f.errors.any():

--- a/src/beanmachine/ppl/compiler/fix_unsupported.py
+++ b/src/beanmachine/ppl/compiler/fix_unsupported.py
@@ -6,21 +6,11 @@ from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
 from beanmachine.ppl.compiler.bmg_nodes import (
     BMGNode,
     Chi2Node,
-    ComparisonNode,
     ConstantNode,
     DivisionNode,
-    EqualNode,
-    GreaterThanEqualNode,
-    NotEqualNode,
     UniformNode,
 )
-from beanmachine.ppl.compiler.bmg_types import (
-    Boolean,
-    One,
-    PositiveReal,
-    Zero,
-    supremum,
-)
+from beanmachine.ppl.compiler.bmg_types import PositiveReal
 from beanmachine.ppl.compiler.error_report import ErrorReport, UnsupportedNode
 
 
@@ -81,77 +71,6 @@ class UnsupportedNodeFixer:
         mult = self.bmg.add_multiplication(node.df, half)
         return self.bmg.add_gamma(mult, half)
 
-    def _is_bool_comparison(self, node: BMGNode) -> bool:
-        return (
-            isinstance(node, ComparisonNode)
-            and supremum(node.left.inf_type, node.right.inf_type, Boolean) == Boolean
-        )
-
-    def _replace_bool_equals(self, node: EqualNode) -> BMGNode:
-        # 1 == y        -->  y
-        # x == 1        -->  x
-        # 0 == y        -->  not y
-        # x == 0        -->  not x
-        # x == y        -->  if x then y else not y
-        if node.left.inf_type == One:
-            return node.right
-        if node.right.inf_type == One:
-            return node.left
-        if node.left.inf_type == Zero:
-            return self.bmg.add_complement(node.right)
-        if node.right.inf_type == Zero:
-            return self.bmg.add_complement(node.left)
-        alt = self.bmg.add_complement(node.right)
-        return self.bmg.add_if_then_else(node.left, node.right, alt)
-
-    def _replace_bool_not_equals(self, node: NotEqualNode) -> BMGNode:
-        # 1 != y        -->  not y
-        # x != 1        -->  not x
-        # 0 != y        -->  y
-        # x != 0        -->  x
-        # x != y        -->  if x then not y else y
-        if node.left.inf_type == One:
-            return self.bmg.add_complement(node.right)
-        if node.right.inf_type == One:
-            return self.bmg.add_complement(node.left)
-        if node.left.inf_type == Zero:
-            return node.right
-        if node.right.inf_type == Zero:
-            return node.left
-        cons = self.bmg.add_complement(node.right)
-        return self.bmg.add_if_then_else(node.left, cons, node.right)
-
-    def _replace_bool_gte(self, node: GreaterThanEqualNode) -> BMGNode:
-        # 1 >= y        -->  true
-        # x >= 1        -->  x
-        # 0 >= y        -->  not y
-        # x >= 0        -->  true
-        # x >= y        -->  if x then true else not y
-        if node.left.inf_type == One:
-            return self.bmg.add_constant_of_type(True, Boolean)
-        if node.right.inf_type == One:
-            return node.left
-        if node.left.inf_type == Zero:
-            return self.bmg.add_complement(node.right)
-        if node.right.inf_type == Zero:
-            return self.bmg.add_constant_of_type(True, Boolean)
-        cons = self.bmg.add_constant_of_type(True, Boolean)
-        alt = self.bmg.add_complement(node.right)
-        return self.bmg.add_if_then_else(node.left, cons, alt)
-
-    def _replace_bool_comparison(self, node: ComparisonNode) -> Optional[BMGNode]:
-        # TODO: x > y   -->  if x then not y else false
-        # TODO: x < y   -->  if x then false else y
-        # TODO: x <= y  -->  if x then y else true
-        if isinstance(node, EqualNode):
-            return self._replace_bool_equals(node)
-        if isinstance(node, NotEqualNode):
-            return self._replace_bool_not_equals(node)
-        if isinstance(node, GreaterThanEqualNode):
-            return self._replace_bool_gte(node)
-
-        return None
-
     def _replace_unsupported_node(self, node: BMGNode) -> Optional[BMGNode]:
         # TODO:
         # Not -> Complement
@@ -162,9 +81,6 @@ class UnsupportedNodeFixer:
             return self._replace_division(node)
         if isinstance(node, UniformNode):
             return self._replace_uniform(node)
-        if self._is_bool_comparison(node):
-            assert isinstance(node, ComparisonNode)
-            return self._replace_bool_comparison(node)
         return None
 
     def fix_unsupported_nodes(self) -> None:


### PR DESCRIPTION
Summary:
I realized that I made a mistake when putting the bool comparison rewriter into the unsupported node rewriter: the bool comparison rewriter code is going to grow to be larger than the rest of the unsupported node rewriters put together.

It does a clear, specific task so that responsibility should go in a class of its own.  I've extracted the code to its own module.

Reviewed By: wtaha

Differential Revision: D26654872

