### PR TITLE
Avoid querying constants in generated code

### DIFF
--- a/src/beanmachine/ppl/compiler/bmg_nodes.py
+++ b/src/beanmachine/ppl/compiler/bmg_nodes.py
@@ -3544,10 +3544,20 @@ class Query(BMGNode):
         return g.query(d[self.operator])
 
     def _to_python(self, d: Dict["BMGNode", int]) -> str:
-        return f"g.query(n{d[self.operator]})"
+        # BMG does not allow a query on a constant, but it is possible
+        # to end up with one in the graph. Suppress those from codegen.
+        q = self.operator
+        if isinstance(q, ConstantNode):
+            return ""
+        return f"g.query(n{d[q]})"
 
     def _to_cpp(self, d: Dict["BMGNode", int]) -> str:
-        return f"g.query(n{d[self.operator]});"
+        # BMG does not allow a query on a constant, but it is possible
+        # to end up with one in the graph. Suppress those from codegen.
+        q = self.operator
+        if isinstance(q, ConstantNode):
+            return ""
+        return f"g.query(n{d[q]});"
 
     def support(self) -> Iterator[Any]:
         return []

--- a/src/beanmachine/ppl/compiler/tests/bmg_query_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_query_test.py
@@ -44,25 +44,23 @@ digraph "graph" {
 }"""
         self.assertEqual(expected.strip(), observed.strip())
 
-        # TODO: This is wrong; we need to ensure that we do NOT
-        # TODO: emit the g.query(n0) when the node is a constant.
+        # We do not emit the query instruction when the queried node
+        # is a constant.
         observed = BMGInference().to_cpp([c()], {})
         expected = """
 graph::Graph g;
 uint n0 = g.add_constant(torch::from_blob((float[]){1.0}, {}));
-g.query(n0);
          """
         self.assertEqual(expected.strip(), observed.strip())
 
-        # TODO: This is wrong; we need to ensure that we do NOT
-        # TODO: emit the g.query(n0) when the node is a constant.
+        # We do not emit the query instruction when the queried node
+        # is a constant.
         observed = BMGInference().to_python([c()], {})
         expected = """
 from beanmachine import graph
 from torch import tensor
 g = graph.Graph()
 n0 = g.add_constant(tensor(1.0))
-g.query(n0)
         """
         self.assertEqual(expected.strip(), observed.strip())
 


### PR DESCRIPTION
Summary:
BMG does not allow a query on a constant, but it is possible to end up in a situation where we have exactly that -- because a user is testing or debugging a model, due to a mistake, or due to an optimization. In none of those scenarios should we generate bad code.

I've suppressed the generation of a query in the event that we generate code for a model that has a query on a constant.

Inference on a model containing a query on a constant is still broken; I'll fix that in an upcoming diff.

Reviewed By: wtaha

Differential Revision: D26665772

