### PR TITLE
Fix logic in graph builder inference to support queries on constants

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/bmg_query_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_query_test.py
@@ -64,8 +64,7 @@ n0 = g.add_constant(tensor(1.0))
         """
         self.assertEqual(expected.strip(), observed.strip())
 
-        # TODO: This part of the test is disabled because it raises
-        # an exception when we add a query on a constant.
-        # observed = BMGInference().infer([c()], {}, 1)[c()]
-        # expected = """ """
-        # self.assertEqual(str(expected).strip(), observed.strip())
+        samples = BMGInference().infer([c()], {}, 10)
+        observed = samples[c()]
+        expected = "tensor([[1., 1., 1., 1., 1., 1., 1., 1., 1., 1.]])"
+        self.assertEqual(expected.strip(), str(observed).strip())


### PR DESCRIPTION
Summary:
There are two problems fixed here. The immediate problem is that BMG does not support querying a constant node, but there are times when you want to do so -- for debugging or testing for instance.  Or when an optimization causes an expression to become a constant.

This problem is now fixed; we avoid the crash caused by adding a query on a constant node by skipping that, and the infer API just creates a vector of the constant value to put in the results.

The larger problem though was that the gear used to track queries in the graph builder was confusing, poorly designed, and wrong. As is often the case, the correct code is easier to follow than the incorrect code.

We now maintain:

* A map from queried RVIDs to the (not necessarily unique) Query nodes in the accumulated graph.
* A map from "normal" nodes to BMG graph node ids.
* A map from query nodes to BMG column indices.

When we run inference and get back a two-dimensional list of samples -- one column per queried node -- we then have enough information to make a map from RVID to column values, which is what we need.

Reviewed By: wtaha

Differential Revision: D26671305

