### PR TITLE
Add more tests for previous diff

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/bmg_query_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_query_test.py
@@ -4,6 +4,7 @@ import unittest
 import beanmachine.ppl as bm
 from beanmachine.ppl.inference import BMGInference
 from torch import tensor
+from torch.distributions import Bernoulli
 
 
 # Bean Machine allows queries on functionals that return constants;
@@ -29,6 +30,39 @@ from torch import tensor
 @bm.functional
 def c():
     return tensor(1.0)
+
+
+# TODO: Try multidimensional constant tensors.
+
+# Two RVIDs but they both refer to the same query node:
+
+
+@bm.random_variable
+def flip():
+    return Bernoulli(0.5)
+
+
+@bm.functional
+def flip2():
+    return flip()
+
+
+# Here's a weird case. Normally query nodes are deduplicated but it is
+# possible to end up with two distinct query nodes both referring to the
+# same constant because of an optimization.
+
+
+@bm.functional
+def always_false_1():
+    return 1 < flip()
+
+
+@bm.functional
+def always_false_2():
+    # Boolean comparision optimizer turns both of these into False,
+    # even though the queries were originally on different expressions
+    # and therefore were different nodes.
+    return flip() < 0
 
 
 class BMGQueryTest(unittest.TestCase):
@@ -68,3 +102,55 @@ n0 = g.add_constant(tensor(1.0))
         observed = samples[c()]
         expected = "tensor([[1., 1., 1., 1., 1., 1., 1., 1., 1., 1.]])"
         self.assertEqual(expected.strip(), str(observed).strip())
+
+    def test_redundant_functionals(self) -> None:
+        self.maxDiff = None
+
+        # We see from the graph that we have two distinct RVIDs but they
+        # both refer to the same query.  We need to make sure that BMG
+        # inference works, and that we get the dictionary out that we expect.
+
+        observed = BMGInference().to_dot([flip(), flip2()], {})
+        expected = """
+digraph "graph" {
+  N0[label=0.5];
+  N1[label=Bernoulli];
+  N2[label=Sample];
+  N3[label=Query];
+  N0 -> N1;
+  N1 -> N2;
+  N2 -> N3;
+}
+"""
+        self.assertEqual(expected.strip(), str(observed).strip())
+
+        samples = BMGInference().infer([flip(), flip2()], {}, 10)
+        f = samples[flip()]
+        f2 = samples[flip2()]
+        self.assertEqual(str(f), str(f2))
+
+        # A strange case: two queries on the same constant.
+
+        observed = BMGInference().to_dot([always_false_1(), always_false_2()], {})
+        expected = """
+digraph "graph" {
+  N0[label=0.5];
+  N1[label=Bernoulli];
+  N2[label=Sample];
+  N3[label=False];
+  N4[label=Query];
+  N5[label=Query];
+  N0 -> N1;
+  N1 -> N2;
+  N3 -> N4;
+  N3 -> N5;
+}
+"""
+        self.assertEqual(expected.strip(), str(observed).strip())
+
+        samples = BMGInference().infer([always_false_1(), always_false_2()], {}, 2)
+        af1 = samples[always_false_1()]
+        af2 = samples[always_false_2()]
+        expected = "tensor([[False, False]])"
+        self.assertEqual(expected, str(af1))
+        self.assertEqual(expected, str(af2))


### PR DESCRIPTION
Summary:
As noted in the previous diff, I've added some test cases for:

* Multiple queried RVIDs refer to the same query node
* Multiple queried RVIDs refer to different query nodes but due to optimizations, they query the same target.

I'll add more tests for things like queries on constant tensor nodes in upcoming diffs.

Reviewed By: wtaha

Differential Revision: D26672557

