### PR TITLE
Start testing Dirichlet distribution in BMG

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/dirichlet_test.py
+++ b/src/beanmachine/ppl/compiler/tests/dirichlet_test.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+# Dirichlet compiler tests
+
+import unittest
+
+from beanmachine.graph import (
+    AtomicType,
+    DistributionType,
+    Graph,
+    InferenceType,
+    OperatorType,
+    ValueType,
+    VariableType,
+)
+from torch import tensor
+
+
+# Support for Dirichlet distributions has recently been added to BMG;
+# this is the first time that the compiler will have to deal with
+# tensor-valued quantities directly so we anticipate having a number
+# of problems to solve in type analysis and code generation that have
+# been put off until now.
+#
+# We'll start by just taking the BMG code for a spin directly and see
+# what gives errors and what gives results.
+
+dirichlet = DistributionType.DIRICHLET
+simplex = VariableType.COL_SIMPLEX_MATRIX
+broadcast = VariableType.BROADCAST_MATRIX
+real = AtomicType.REAL
+prob = AtomicType.PROBABILITY
+sample = OperatorType.SAMPLE
+s3x1 = ValueType(simplex, prob, 3, 1)
+r3x1 = ValueType(broadcast, real, 3, 1)
+nmc = InferenceType.NMC
+rejection = InferenceType.REJECTION
+
+
+class DirichletTest(unittest.TestCase):
+    def test_dirichlet_negative(self) -> None:
+        self.maxDiff = None
+        g = Graph()
+        m1 = tensor([1.5, 1.0, 2.0])
+        cm1 = g.add_constant_pos_matrix(m1)
+        m2 = tensor([[1.5, 1.0], [2.0, 1.5]])
+        cm2 = g.add_constant_pos_matrix(m2)
+        two = g.add_constant(2)
+        # Input must be a positive real matrix with one column.
+        with self.assertRaises(ValueError):
+            g.add_distribution(dirichlet, s3x1, [two])
+        with self.assertRaises(ValueError):
+            g.add_distribution(dirichlet, s3x1, [cm2])
+        # Must be only one input
+        with self.assertRaises(ValueError):
+            g.add_distribution(dirichlet, s3x1, [cm1, two])
+        # Output type must be simplex
+        with self.assertRaises(ValueError):
+            g.add_distribution(dirichlet, r3x1, [cm1])
+
+    def test_dirichlet_sample(self) -> None:
+        self.maxDiff = None
+        g = Graph()
+        m1 = tensor([1.5, 1.0, 2.0])
+        cm1 = g.add_constant_pos_matrix(m1)
+        d = g.add_distribution(dirichlet, s3x1, [cm1])
+        ds = g.add_operator(sample, [d])
+        g.query(ds)
+        samples = g.infer(1, rejection)
+        # samples has form [[array([[a1],[a2],[a3]])]]
+        result = tensor(samples[0][0]).reshape([3])
+        # We get a three-element simplex, so it should sum to 1.0.
+        self.assertAlmostEqual(1.0, float(sum(result)))


### PR DESCRIPTION
Summary:
The compiler will need to generate BMG graphs for models which contain Dirichlet distributions; here I'm just making simpler versions of Lily's recent C++ tests to show what code we'll need to generate, and to give me a test bed from which to experiment.

Coming up next: we'll represent constant positive matrices in the accumulated graph and see if we can correctly generate code for them.

Reviewed By: wtaha

Differential Revision: D26674766

