### PR TITLE
Implement constant positive real matrix node in graph accumulator

### DIFF
--- a/src/beanmachine/ppl/compiler/bm_graph_builder.py
+++ b/src/beanmachine/ppl/compiler/bm_graph_builder.py
@@ -71,6 +71,7 @@ from beanmachine.ppl.compiler.bmg_nodes import (
     Chi2Node,
     ComplementNode,
     ConstantNode,
+    ConstantPositiveRealMatrixNode,
     ConstantTensorNode,
     DirichletNode,
     DistributionNode,
@@ -522,6 +523,13 @@ class BMGraphBuilder:
     @memoize
     def add_pos_real(self, value: float) -> PositiveRealNode:
         node = PositiveRealNode(value)
+        self.add_node(node)
+        return node
+
+    @memoize
+    def add_pos_real_matrix(self, value: Tensor) -> ConstantPositiveRealMatrixNode:
+        assert len(value.size()) <= 2
+        node = ConstantPositiveRealMatrixNode(value)
         self.add_node(node)
         return node
 

--- a/src/beanmachine/ppl/compiler/tests/dirichlet_test.py
+++ b/src/beanmachine/ppl/compiler/tests/dirichlet_test.py
@@ -14,7 +14,12 @@ from beanmachine.graph import (
     ValueType,
     VariableType,
 )
+from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
 from torch import tensor
+
+
+def tidy(s: str) -> str:
+    return "\n".join(c.strip() for c in s.strip().split("\n")).strip()
 
 
 # Support for Dirichlet distributions has recently been added to BMG;
@@ -72,3 +77,92 @@ class DirichletTest(unittest.TestCase):
         result = tensor(samples[0][0]).reshape([3])
         # We get a three-element simplex, so it should sum to 1.0.
         self.assertAlmostEqual(1.0, float(sum(result)))
+
+    def test_constant_pos_real_matrix(self) -> None:
+
+        # To make a BMG graph with a Dirichlet distribution the first thing
+        # we'll need to do is make a positive real matrix as its input.
+        # Demonstrate that we can add such a matrix to a graph builder,
+        # do a type analysis, and generate C++ and Python code that builds
+        # the graph.  Finally, actually build the graph.
+
+        self.maxDiff = None
+
+        bmg = BMGraphBuilder()
+        c1 = bmg.add_pos_real_matrix(tensor(1.0))
+        c2 = bmg.add_pos_real_matrix(tensor([1.0, 1.5]))
+        c3 = bmg.add_pos_real_matrix(tensor([[1.0, 1.5], [2.0, 2.5]]))
+        c4 = bmg.add_pos_real_matrix(tensor([1.0, 1.5]))
+
+        # These should be deduplicated
+        self.assertTrue(c4 is c2)
+
+        # Verify that we can add these nodes to the graph, do a type analysis,
+        # and survive the problem-fixing pass without generating an exception.
+        bmg.add_query(c1)
+        bmg.add_query(c2)
+        bmg.add_query(c3)
+        expected = """
+digraph "graph" {
+  N0[label="1.0:R+>=OH"];
+  N1[label="Query:R+>=OH"];
+  N2[label="[1.0,1.5]:MR+[1,2]>=MR+[1,2]"];
+  N3[label="Query:MR+[1,2]>=MR+[1,2]"];
+  N4[label="[[1.0,1.5],\\\\n[2.0,2.5]]:MR+[2,2]>=MR+[2,2]"];
+  N5[label="Query:MR+[2,2]>=MR+[2,2]"];
+  N0 -> N1;
+  N2 -> N3;
+  N4 -> N5;
+}"""
+        observed = bmg.to_dot(
+            graph_types=True,
+            inf_types=True,
+            point_at_input=True,
+            label_edges=False,
+            after_transform=True,
+        )
+        self.assertEqual(expected.strip(), observed.strip())
+
+        # We should be able to generate correct C++ and Python code to build
+        # a graph that contains only positive constant matrices. Note that the
+        # queries are not emitted into the graph because BMG does not allow
+        # a query on a constant.
+        expected = """
+graph::Graph g;
+Eigen::MatrixXd m0(1, 1)
+m0 << 1.0;
+uint n0 = g.add_constant_pos_matrix(m0);
+
+Eigen::MatrixXd m2(2, 1)
+m2 << 1.0, 1.5;
+uint n2 = g.add_constant_pos_matrix(m2);
+
+Eigen::MatrixXd m4(2, 2)
+m4 << 1.0, 1.5, 2.0, 2.5;
+uint n4 = g.add_constant_pos_matrix(m4);
+        """
+        observed = bmg.to_cpp()
+        self.assertEqual(expected.strip(), observed.strip())
+
+        expected = """
+from beanmachine import graph
+from torch import tensor
+g = graph.Graph()
+n0 = g.add_constant_pos_matrix(tensor(1.0))
+
+n2 = g.add_constant_pos_matrix(tensor([1.0,1.5]))
+
+n4 = g.add_constant_pos_matrix(tensor([[1.0,1.5],[2.0,2.5]]))
+        """
+        observed = bmg.to_python()
+        self.assertEqual(expected.strip(), observed.strip())
+
+        # Let's actually get the graph
+        g = bmg.to_bmg()
+        expected = """
+Node 0 type 1 parents [ ] children [ ] matrix<positive real> 1
+Node 1 type 1 parents [ ] children [ ] matrix<positive real>   1 1.5
+Node 2 type 1 parents [ ] children [ ] matrix<positive real>   1 1.5
+ 2 2.5"""
+        observed = g.to_string()
+        self.assertEqual(tidy(expected), tidy(observed))


### PR DESCRIPTION
Summary:
The graph accumulator can now represent a positive real matrix. This is necessary for making the Dirichlet distribution work, as BMG requires that we mark constant tensor nodes that are inputs to Dirichlet as being positive real.

Coming up next: I will make the Dirichlet node state a requirement that its input be a one-row positive real matrix. We'll test that, and then work on making it codegen correctly.

Reviewed By: wtaha

Differential Revision: D26678750

