### PR TITLE
Implement correct edge requirement on Dirichlet input

### DIFF
--- a/src/beanmachine/ppl/compiler/bmg_nodes.py
+++ b/src/beanmachine/ppl/compiler/bmg_nodes.py
@@ -1267,18 +1267,31 @@ class DirichletNode(DistributionNode):
         self.inputs[0] = p
 
     def _compute_graph_type(self) -> BMGLatticeType:
+        # TODO: Fix this; it should be a simplex
         return BMGTensor
 
     def _compute_inf_type(self) -> BMGLatticeType:
+        # TODO: Fix this; it should be a simplex
         return BMGTensor
 
     @property
     def requirements(self) -> List[Requirement]:
-        # The input to a Direchlet must be a tensor.
-        # TODO: We do not yet support Dirichlet in BMG; when we do
-        # verify that this is correct. Also, we may wish at that
-        # time to also note that the sample type is a simplex.
-        return [BMGTensor]
+        # BMG's Dirichlet node requires that the input be exactly one
+        # vector of positive reals, and the length of the vector is
+        # the number of elements in the simplex we produce. We can
+        # express that restriction as a positive real matrix with
+        # row count equal to 1 and column count equal to the final
+        # dimension of the size.
+        #
+        # The "max" is needed to handle the degenerate case of
+        # Dirichlet(tensor([])) -- in this case we will say that we require
+        # a single positive real and that the requirement cannot be met.
+
+        required_rows = 1
+        size = self.size
+        dimensions = len(size)
+        required_columns = max(1, size[dimensions - 1]) if dimensions > 0 else 1
+        return [PositiveReal.with_dimensions(required_rows, required_columns)]
 
     @property
     def size(self) -> torch.Size:

--- a/src/beanmachine/ppl/compiler/bmg_types.py
+++ b/src/beanmachine/ppl/compiler/bmg_types.py
@@ -544,12 +544,29 @@ simplex_precision = 1e-10
 
 
 def _type_of_matrix(v: torch.Tensor) -> BMGLatticeType:
-    # There is more than one element. Can we represent this as a
-    # two-dimensional matrix?
-    if v.numel() == 1:
+    elements = v.numel()
+
+    # If we have tensor([]) then that is not useful as a value
+    # or a matrix; just call it a tensor.
+    if elements == 0:
+        return Tensor
+
+    # If we have a single element tensor no matter what its dimensionality,
+    # treat it as a single value.
+
+    if elements == 1:
         return type_of_value(float(v))  # pyre-fixme
+
+    # We have more than one element. What's the shape?
+
     shape = v.shape
     dimensions = len(shape)
+
+    # If we have more than two dimensions then we cannot make it a matrix.
+    # CONSIDER: Suppose we have something like [[[10, 20]]]] which is 1 x 1 x 2.
+    # We could reduce that to a 1 x 2 matrix if we needed to. We might discard
+    # sizes on the right equal to one.
+
     if dimensions > 2:
         return Tensor
     r, c = _size_to_rc(shape)


### PR DESCRIPTION
Summary:
In order to generate a BMG graph we require that a Dirichlet have an input that has exactly one row and any nonzero number of columns, all with positive real values. This diff adds a requirement on the edge between a Dirichlet and its input, so that the requirements checker will either convert the input node to the required type or give an error if it cannot.

This diff just checks the requirement generation and type analysis; it does not check the error detection or node conversion. That will come in a subsequent diff.

From this portion of the generated graph you can see the type analysis all in one place.

{F419336417}

* The constant tensor is typed as `T>=MR+[2,3]`, meaning "this node is currently a tensor, but it could be successfully reduced to a 2x3 matrix (M) of positive reals (R+)."
* The `MR+[1,3]` on the edge correctly notes that a Dirichlet in BMG requires this to be a 1x3 matrix, not a 2x3 matrix.
* Every other node is *incorrectly* typed as `T>=T` meaning "currently a tensor, but could be... a tensor". This is wrong. It should say that the output of a Dirichlet is a simplex matrix. That fix will also come in a later diff.
* Similarly, the edge annotations are also wrong; they should also indicate that this edge needs to be a simplex.

Reviewed By: wtaha

Differential Revision: D26692219

