### PR TITLE
Remove get_wrapper

### DIFF
--- a/src/beanmachine/ppl/inference/abstract_mh_infer.py
+++ b/src/beanmachine/ppl/inference/abstract_mh_infer.py
@@ -10,7 +10,7 @@ import torch.distributions as dist
 from beanmachine.ppl.inference.abstract_infer import AbstractMCInference, VerboseLevel
 from beanmachine.ppl.inference.utils import Block, BlockType
 from beanmachine.ppl.model.rv_identifier import RVIdentifier
-from beanmachine.ppl.model.utils import LogLevel, get_wrapper
+from beanmachine.ppl.model.utils import LogLevel
 from beanmachine.ppl.world.variable import TransformType
 from torch import Tensor, tensor
 from tqdm.auto import tqdm
@@ -148,7 +148,7 @@ class AbstractMHInference(AbstractMCInference, metaclass=ABCMeta):
         """
         markov_blanket = set({block.first_node})
         markov_blanket_func = {}
-        markov_blanket_func[get_wrapper(block.first_node.function)] = [block.first_node]
+        markov_blanket_func[block.first_node.wrapper] = [block.first_node]
         pos_proposal_log_updates, neg_proposal_log_updates = tensor(0.0), tensor(0.0)
         children_log_updates, nodes_log_updates = tensor(0.0), tensor(0.0)
         # We will go through all family of random variable in the block. Note
@@ -219,9 +219,9 @@ class AbstractMHInference(AbstractMCInference, metaclass=ABCMeta):
                     # We create a dictionary from node family to the node itself
                     # as the match with block happens at the family level and
                     # this makes the lookup much faster.
-                    if get_wrapper(new_node.function) not in markov_blanket_func:
-                        markov_blanket_func[get_wrapper(new_node.function)] = []
-                    markov_blanket_func[get_wrapper(new_node.function)].append(new_node)
+                    if new_node.wrapper not in markov_blanket_func:
+                        markov_blanket_func[new_node.wrapper] = []
+                    markov_blanket_func[new_node.wrapper].append(new_node)
                 markov_blanket |= new_nodes_to_be_added
 
         proposal_log_updates = pos_proposal_log_updates + neg_proposal_log_updates

--- a/src/beanmachine/ppl/inference/compositional_infer.py
+++ b/src/beanmachine/ppl/inference/compositional_infer.py
@@ -15,7 +15,6 @@ from beanmachine.ppl.inference.proposer.single_site_uniform_proposer import (
     SingleSiteUniformProposer,
 )
 from beanmachine.ppl.model.rv_identifier import RVIdentifier
-from beanmachine.ppl.model.utils import get_wrapper
 from beanmachine.ppl.world.utils import is_constraint_eq
 
 
@@ -77,7 +76,7 @@ class CompositionalInference(AbstractMHInference):
         if node in self.proposers_per_rv_:
             return self.proposers_per_rv_[node]
 
-        wrapped_fn = get_wrapper(node.function)
+        wrapped_fn = node.wrapper
         if wrapped_fn in self.proposers_per_family_:
             proposer_inst = self.proposers_per_family_[wrapped_fn]
             self.proposers_per_rv_[node] = copy.deepcopy(proposer_inst)

--- a/src/beanmachine/ppl/inference/tests/compositional_infer_test.py
+++ b/src/beanmachine/ppl/inference/tests/compositional_infer_test.py
@@ -18,7 +18,6 @@ from beanmachine.ppl.inference.proposer.single_site_uniform_proposer import (
     SingleSiteUniformProposer,
 )
 from beanmachine.ppl.inference.utils import Block, BlockType
-from beanmachine.ppl.model.utils import get_wrapper
 from beanmachine.ppl.world.utils import BetaDimensionTransform, get_default_transforms
 from beanmachine.ppl.world.variable import TransformType, Variable
 from beanmachine.ppl.world.world import World
@@ -243,7 +242,7 @@ class CompositionalInferenceTest(unittest.TestCase):
                 first_nodes.append(block.first_node)
                 self.assertEqual(
                     block.block,
-                    list(map(get_wrapper, [foo_0_key.function, bar_0_key.function])),
+                    [foo_0_key.wrapper, bar_0_key.wrapper],
                 )
             if block.type == BlockType.SINGLENODE:
                 self.assertEqual(block.block, [])
@@ -256,7 +255,7 @@ class CompositionalInferenceTest(unittest.TestCase):
             Block(
                 first_node=foo_0_key,
                 type=BlockType.SEQUENTIAL,
-                block=list(map(get_wrapper, [foo_0_key.function, bar_0_key.function])),
+                block=[foo_0_key.wrapper, bar_0_key.wrapper],
             )
         )
 

--- a/src/beanmachine/ppl/model/statistical_model.py
+++ b/src/beanmachine/ppl/model/statistical_model.py
@@ -1,5 +1,4 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
-import inspect
 import warnings
 from functools import wraps
 
@@ -69,11 +68,6 @@ class StatisticalModel(object):
             else:
                 return func_key
 
-        if inspect.ismethod(f):
-            meth_name = f.__name__ + "_wrapper"
-            setattr(f.__self__, meth_name, wrapper)
-        else:
-            f._wrapper = wrapper
         wrapper.is_functional = False
         wrapper.is_random_variable = True
         return wrapper
@@ -102,11 +96,6 @@ class StatisticalModel(object):
             else:
                 return StatisticalModel.get_func_key(wrapper, args)
 
-        if inspect.ismethod(f):
-            meth_name = f.__name__ + "_wrapper"
-            setattr(f.__self__, meth_name, wrapper)
-        else:
-            f._wrapper = wrapper
         wrapper.is_functional = True
         wrapper.is_random_variable = False
         return wrapper

--- a/src/beanmachine/ppl/model/utils.py
+++ b/src/beanmachine/ppl/model/utils.py
@@ -1,18 +1,8 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
-import inspect
 import logging
 from enum import Enum
 
 import torch
-
-
-def get_wrapper(f):
-    """
-    Gets wrapped function given a Python callable
-    """
-    if inspect.ismethod(f):
-        return getattr(f.__self__, f.__name__ + "_wrapper")
-    return f._wrapper
 
 
 class LogLevel(Enum):

--- a/src/beanmachine/ppl/world/world.py
+++ b/src/beanmachine/ppl/world/world.py
@@ -6,7 +6,6 @@ from typing import Dict, List, Optional, Set, Tuple
 
 import torch
 from beanmachine.ppl.model.rv_identifier import RVIdentifier
-from beanmachine.ppl.model.utils import get_wrapper
 from beanmachine.ppl.utils.dotbuilder import print_graph
 from beanmachine.ppl.world.diff import Diff
 from beanmachine.ppl.world.diff_stack import DiffStack
@@ -164,7 +163,7 @@ class World(object):
         :param node: the node to look up
         :returns: whether the node has transform enabled or not
         """
-        return self.transforms_[get_wrapper(node.function)]
+        return self.transforms_[node.wrapper]
 
     def set_proposer(self, func_wrapper, proposer):
         """
@@ -199,7 +198,7 @@ class World(object):
         :param node: the node to look up
         :returns: the associate proposer
         """
-        return self.proposer_[get_wrapper(node.function)]
+        return self.proposer_[node.wrapper]
 
     def __str__(self) -> str:
         return (
@@ -789,4 +788,4 @@ class World(object):
         A helper function that invokes the random variable and return its value
         """
         with self:
-            return get_wrapper(node.function)(*node.arguments)
+            return node.wrapper(*node.arguments)

--- a/src/beanmachine/ppl/world/world_vars.py
+++ b/src/beanmachine/ppl/world/world_vars.py
@@ -3,7 +3,6 @@ from collections import defaultdict
 from typing import Dict, Optional, Union
 
 from beanmachine.ppl.model.rv_identifier import RVIdentifier
-from beanmachine.ppl.model.utils import get_wrapper
 from beanmachine.ppl.world.variable import Variable
 from torch import Tensor
 
@@ -32,7 +31,7 @@ class WorldVars(object):
         """
         self.data_[node] = value
         if hasattr(node, "function"):
-            self.var_funcs_[get_wrapper(node.function)].add(node)
+            self.var_funcs_[node.wrapper].add(node)
 
     def contains_node_by_func(self, node_func: str) -> bool:
         """
@@ -99,7 +98,7 @@ class WorldVars(object):
         :param node: the node to delete
         """
         del self.data_[node]
-        self.var_funcs_[get_wrapper(node.function)].remove(node)
+        self.var_funcs_[node.wrapper].remove(node)
 
     def len(self) -> int:
         """


### PR DESCRIPTION
Summary:
This diff just removes the `get_wrapper` helper that was introduced in D23722873 (https://github.com/facebookincubator/beanmachine/commit/f1a5d469a07641e0cfd709263b633ccf4231f10f).

It's no longer necessary because `RVIdentifier` now stores a reference to wrapper function itself (since D25421261 (https://github.com/facebookincubator/beanmachine/commit/cd90d6596d3d1d449c42e054e3a6867772a4bf3b)), so we no longer need to store an additional reference to wrapper on the decorated function/method.

Calling `get_wrapper(node.function)` is actually equivalent to either
- `node.wrapper.__wrapped__._wrapper` or
- `getattr(node.wrapper.__wrapped__.__self__, node.wrapper.__wrapped__.__name__ + "_wrapper")`

which is a bit redundant

This diff does not change the semantics of BM. I'm just trying to gradually refactor and clean up our code base :D

Reviewed By: feynmanliang

Differential Revision: D26698121

