### PR TITLE
A module for hints for the Beanstalk compiler

### DIFF
--- a/src/beanmachine/ppl/utils/hint.py
+++ b/src/beanmachine/ppl/utils/hint.py
@@ -1,0 +1,14 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+"""Operations that are intended as hints to the Beanstalk compiler"""
+
+import math
+
+import torch
+
+
+def math_log1mexp(x):
+    return math.log(1.0 - math.exp(x))
+
+
+def log1mexp(x):
+    return torch.log(1.0 - torch.exp(x))

--- a/src/beanmachine/ppl/utils/tests/hint_test.py
+++ b/src/beanmachine/ppl/utils/tests/hint_test.py
@@ -1,0 +1,33 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+"""Tests for hint.py"""
+
+import unittest
+
+import torch
+from beanmachine.ppl.utils.hint import log1mexp, math_log1mexp
+
+
+class HintTest(unittest.TestCase):
+    """Tests for beanmachine/utils/hint.py."""
+
+    def test_hint_math(self) -> None:
+        """Smoke test for math_log1mexp"""
+        math_observed = math_log1mexp(-15)
+        math_expected = -2.9802e-07
+        self.assertAlmostEqual(
+            math_observed,
+            math_expected,
+            delta=1e-8,
+            msg="Unexpected result for hint.math_log1mexp",
+        )
+
+    def test_hint_torch(self) -> None:
+        """Smoke test for log1mexp"""
+        observed = log1mexp(torch.tensor(-15))
+        expected = torch.tensor(-2.9802e-07)
+        self.assertAlmostEqual(
+            observed,
+            expected,
+            delta=torch.tensor(1e-8),
+            msg="Unexpected result for hint.log1mexp",
+        )


### PR DESCRIPTION
Summary: In the context of the first sprint for end-2-end CLARA model the idea of having a way to certain functions for special processing by the Beanstalk compiler came up. This diff introduces such a module, called Hints. It also populates this module with two versions of the one function that we need to provide a hint about at this point.

Reviewed By: ericlippert

Differential Revision: D26760726

