### PR TITLE
Turn on support for Dirichlet distribution to find requirement errors

### DIFF
--- a/src/beanmachine/ppl/compiler/bmg_nodes.py
+++ b/src/beanmachine/ppl/compiler/bmg_nodes.py
@@ -1312,6 +1312,18 @@ class DirichletNode(DistributionNode):
         # TODO: n() is a sample that returns a Dirichlet.
         raise ValueError("Dirichlet distribution does not have finite support.")
 
+    def _supported_in_bmg(self) -> bool:
+        return True
+
+    def _add_to_graph(self, g: Graph, d: Dict[BMGNode, int]) -> int:
+        raise NotImplementedError("DirichletNode._add_to_graph not yet implemented")
+
+    def _to_python(self, d: Dict["BMGNode", int]) -> str:
+        raise NotImplementedError("DirichletNode._to_python not yet implemented")
+
+    def _to_cpp(self, d: Dict["BMGNode", int]) -> str:
+        raise NotImplementedError("DirichletNode._to_cpp not yet implemented")
+
 
 class FlatNode(DistributionNode):
 

--- a/src/beanmachine/ppl/compiler/tests/clara_categorical_test.py
+++ b/src/beanmachine/ppl/compiler/tests/clara_categorical_test.py
@@ -3,7 +3,7 @@
 
 # This is a simplified version of the CLARA model which uses categorical
 # distributions. We do not support compiling this to BMG yet because
-# we do not have categorical or Dirichlet distributions in BMG or
+# we do not have categorical distributions in BMG or
 # stochastic control flows other than if-then-else.
 #
 # This module tests whether we can (1) accumulate a graph for this
@@ -188,7 +188,7 @@ digraph "graph" {
 """
         self.assertEqual(expected.strip(), observed.strip())
 
-        # TODO: We do not yet support Dirichlet, Categorical
+        # TODO: We do not yet support Categorical
         # or map/index nodes in BMG.  Revisit this test when we do.
         # TODO: Raise a better error than a generic ValueError
         # TODO: These error messages are needlessly repetitive.
@@ -208,14 +208,6 @@ The unsupported node is the operand of a Sample.
 The model uses a Categorical operation unsupported by Bean Machine Graph.
 The unsupported node is the operand of a Sample.
 The model uses a Categorical operation unsupported by Bean Machine Graph.
-The unsupported node is the operand of a Sample.
-The model uses a Dirichlet operation unsupported by Bean Machine Graph.
-The unsupported node is the operand of a Sample.
-The model uses a Dirichlet operation unsupported by Bean Machine Graph.
-The unsupported node is the operand of a Sample.
-The model uses a Dirichlet operation unsupported by Bean Machine Graph.
-The unsupported node is the operand of a Sample.
-The model uses a Dirichlet operation unsupported by Bean Machine Graph.
 The unsupported node is the operand of a Sample.
 The model uses a index operation unsupported by Bean Machine Graph.
 The unsupported node is the probability of a Categorical.


### PR DESCRIPTION
Summary:
The problem-fixing phase of the compiler runs after the graph has been accumulated but before it is emitted as a BMG graph; it seeks to find and fix problems that prevent BMG graph generation, or to produce an error if a problem cannot be fixed.

The problem fixer itself runs a series of passes; earlier passes must complete successfully to establish invariants required by later passes. In particular, we do not do any requirements checking of a graph which contains nodes that have no representation in BMG.

Since previously we had no representation of Dirichlet in BMG, we automatically produced an "unsupported node" error if there was one.  I've marked that node as supported, so the unsupported node errors go away and we now make it to the "requirements checking" phase.

In this diff I demonstrate that we correctly generate error messages when an input requirement of a Dirichlet cannot be met.

However:

* We do not yet ensure that an input requirement that CAN be met IS met.
* We do not generate Python or C++ code for a valid BMG graph generation program
* We do not generate a valid BMG graph

Those will all come in subsequent diffs.

Reviewed By: wtaha

Differential Revision: D26696602

