### PR TITLE
Generate positive real matrix nodes in problem fixing pass for Dirichlet

### DIFF
--- a/src/beanmachine/ppl/compiler/bm_graph_builder.py
+++ b/src/beanmachine/ppl/compiler/bm_graph_builder.py
@@ -121,6 +121,7 @@ from beanmachine.ppl.compiler.bmg_nodes import (
 )
 from beanmachine.ppl.compiler.bmg_types import (
     BMGLatticeType,
+    BMGMatrixType,
     Boolean,
     Natural,
     NegativeReal,
@@ -129,6 +130,7 @@ from beanmachine.ppl.compiler.bmg_types import (
     Probability,
     Real,
     Zero,
+    positive_real_element,
 )
 from beanmachine.ppl.inference.abstract_infer import _verify_queries_and_observations
 from beanmachine.ppl.inference.monte_carlo_samples import MonteCarloSamples
@@ -486,6 +488,16 @@ class BMGraphBuilder:
             return self.add_constant_tensor(value)
         raise TypeError("value must be a bool, real or tensor")
 
+    def add_constant_of_matrix_type(
+        self, value: Any, node_type: BMGMatrixType
+    ) -> ConstantNode:
+        if node_type.element_type == positive_real_element:
+            return self.add_pos_real_matrix(value)
+        raise NotImplementedError(
+            "add_constant_of_matrix_type not yet "
+            + f"implemented for {node_type.long_name}"
+        )
+
     def add_constant_of_type(
         self, value: Any, node_type: BMGLatticeType
     ) -> ConstantNode:
@@ -507,7 +519,11 @@ class BMGraphBuilder:
             if isinstance(value, Tensor):
                 return self.add_constant_tensor(value)
             return self.add_constant_tensor(tensor(value))
-        raise TypeError("node type must be a valid BMG type")
+        if isinstance(node_type, BMGMatrixType):
+            return self.add_constant_of_matrix_type(value, node_type)
+        raise NotImplementedError(
+            "add_constant_of_type not yet " + f"implemented for {node_type.long_name}"
+        )
 
     @memoize
     def add_real(self, value: float) -> RealNode:

--- a/src/beanmachine/ppl/compiler/error_report.py
+++ b/src/beanmachine/ppl/compiler/error_report.py
@@ -7,7 +7,11 @@ from abc import ABC
 from typing import List
 
 from beanmachine.ppl.compiler.bmg_nodes import BMGNode, Observation
-from beanmachine.ppl.compiler.bmg_types import BMGLatticeType, Requirement, UpperBound
+from beanmachine.ppl.compiler.bmg_types import (
+    BMGLatticeType,
+    Requirement,
+    requirement_to_type,
+)
 
 
 class BMGError(ABC):
@@ -30,8 +34,10 @@ class Violation(BMGError):
 
     def __str__(self) -> str:
         r = self.requirement
-        t = r.bound if isinstance(r, UpperBound) else r
+        t = requirement_to_type(r)
         assert isinstance(t, BMGLatticeType)
+        # TODO: Fix this error message for the case where we require
+        # a matrix but we can only get a scalar value
         msg = (
             f"The {self.edge} of a {self.consumer.label} "
             + f"is required to be a {t.long_name} "

--- a/src/beanmachine/ppl/compiler/tests/bmg_types_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_types_test.py
@@ -24,8 +24,8 @@ from beanmachine.ppl.compiler.bmg_types import (
     Zero,
     ZeroMatrix,
     bottom,
-    meets_requirement,
     supremum,
+    type_meets_requirement,
     type_of_value,
     upper_bound,
 )
@@ -128,13 +128,13 @@ class BMGTypesTest(unittest.TestCase):
             Tensor, type_of_value(tensor([[[0, 0], [0, 0]], [[0, 0], [0, 0]]]))
         )
 
-    def test_meets_requirement(self) -> None:
-        """test_meets_requirement"""
-        self.assertFalse(meets_requirement(Natural, Boolean))
-        self.assertTrue(meets_requirement(Natural, Natural))
-        self.assertTrue(meets_requirement(Boolean, upper_bound(Natural)))
-        self.assertTrue(meets_requirement(Natural, upper_bound(Natural)))
-        self.assertFalse(meets_requirement(PositiveReal, upper_bound(Natural)))
+    def test_type_meets_requirement(self) -> None:
+        """test_type_meets_requirement"""
+        self.assertFalse(type_meets_requirement(Natural, Boolean))
+        self.assertTrue(type_meets_requirement(Natural, Natural))
+        self.assertTrue(type_meets_requirement(Boolean, upper_bound(Natural)))
+        self.assertTrue(type_meets_requirement(Natural, upper_bound(Natural)))
+        self.assertFalse(type_meets_requirement(PositiveReal, upper_bound(Natural)))
 
     def test_types_in_dot(self) -> None:
         """test_types_in_dot"""


### PR DESCRIPTION
Summary:
This is a surprisingly long and complex diff caused by an unlikely but possible situation.

The input to a Dirichlet in BMG *must* be a matrix, even if there is only one value in that matrix. It is not legal for the input to be a single-valued positive real node.  (It is of course silly to have a Dirichlet with only one column in the matrix because that is the distribution whose value is always [1], no matter what the value of that input is. But it is legal, and so we must support it.)

I did not anticipate this when I designed the type analyzer; my assumption was that we would never need to distinguish between "we have a single constant value 1" and "we have the matrix constant value [1]" in the type system.  This assumption was wrong; we do need to track that.

The type analyzer works by attaching "requirements" to each edge in the graph.  I've had to add a new requirement kind "always matrix".  We attach the "always matrix" requirement to the input edge of a Dirichlet.

This then means that we must also have some way of disambiguating between graph nodes which produce a single positive real value and graph nodes which always produce a matrix of positive reals. I've added an `is_matrix` property to `BMGNode` which we can then override as we add more nodes that are matrix-valued.

All this then led to a number of knock-on effects where I had to do some redesign of the requirements checking logic.  I've split it into two helper methods, `node_meets_requirement` and `type_meets_requirement`, as those were now logically different operations.

As noted in the code, the logic in the operator rewriting is not quite right yet; it will be possible to end up in a situation where we have, say, a sum of positive reals being fed into the input of a Dirichlet, and we do not correctly give an error saying that no, that needs to be a matrix.  However, I'll deal with that in a later diff.

I also cleaned up some out-of-date comments in bmg_types.py.

Actually generating Python code, C++ code, or the graph nodes is not yet implemented. That will come in subsequent diffs.

Reviewed By: wtaha

Differential Revision: D26702297

