### PR TITLE
Add "any" requirement to input edge requirements

### DIFF
--- a/src/beanmachine/ppl/compiler/bmg_nodes.py
+++ b/src/beanmachine/ppl/compiler/bmg_nodes.py
@@ -34,6 +34,7 @@ from beanmachine.ppl.compiler.bmg_types import (
     supremum,
     type_of_value,
     upper_bound,
+    AnyRequirement,
 )
 from beanmachine.ppl.compiler.internal_error import InternalError
 from beanmachine.ppl.utils.item_counter import ItemCounter
@@ -46,6 +47,10 @@ from torch.distributions.utils import broadcast_all
 # TODO: beanmachine.graph from beanmachine.ppl.  I'll figure out why later;
 # TODO: for now, we'll just turn off error checking in this mModuleNotFoundError
 # pyre-ignore-all-errors
+
+# TODO: Extract inf type, graph type and requirements computations to own module
+# TODO: Add assertions which ensure that type requirements are never "fake" types
+# like Zero or OneHot.  Also assert that a requirement is never Malformed.
 
 
 def prod(x):
@@ -3534,7 +3539,7 @@ class Observation(BMGNode):
 
     @property
     def requirements(self) -> List[Requirement]:
-        return [self.inf_type]
+        return [AnyRequirement()]
 
     @property
     def size(self) -> torch.Size:
@@ -3604,7 +3609,7 @@ class Query(BMGNode):
 
     @property
     def requirements(self) -> List[Requirement]:
-        return [self.graph_type]
+        return [AnyRequirement()]
 
     @property
     def size(self) -> torch.Size:

--- a/src/beanmachine/ppl/compiler/tests/bmg_types_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_types_test.py
@@ -179,7 +179,7 @@ digraph "graph" {
   N04 -> N05[label="right:P"];
   N05 -> N06[label="mu:R"];
   N05 -> N07[label="probability:P"];
-  N05 -> N10[label="operator:M"];
+  N05 -> N10[label="operator:any"];
   N06 -> N08[label="operand:R"];
   N07 -> N09[label="operand:B"];
 }"""

--- a/src/beanmachine/ppl/compiler/tests/dirichlet_test.py
+++ b/src/beanmachine/ppl/compiler/tests/dirichlet_test.py
@@ -275,28 +275,28 @@ digraph "graph" {
   N31[label="Query:S[1,3]>=S[1,3]"];
   N00 -> N01[label="R+"];
   N01 -> N02[label="S[1,1]"];
-  N02 -> N03[label="S[1,1]"];
+  N02 -> N03[label=any];
   N04 -> N05[label="R+"];
   N05 -> N06[label="S[1,1]"];
-  N06 -> N07[label="S[1,1]"];
+  N06 -> N07[label=any];
   N08 -> N09[label="R+"];
   N09 -> N10[label="S[1,1]"];
-  N10 -> N11[label="S[1,1]"];
+  N10 -> N11[label=any];
   N12 -> N13[label="R+"];
   N13 -> N14[label="S[1,1]"];
-  N14 -> N15[label="S[1,1]"];
+  N14 -> N15[label=any];
   N16 -> N17[label="MR+[1,2]"];
   N17 -> N18[label="S[1,2]"];
-  N18 -> N19[label="S[1,2]"];
+  N18 -> N19[label=any];
   N20 -> N21[label="MR+[1,2]"];
   N21 -> N22[label="S[1,2]"];
-  N22 -> N23[label="S[1,2]"];
+  N22 -> N23[label=any];
   N24 -> N25[label="MR+[1,2]"];
   N25 -> N26[label="S[1,2]"];
-  N26 -> N27[label="S[1,2]"];
+  N26 -> N27[label=any];
   N28 -> N29[label="MR+[1,3]"];
   N29 -> N30[label="S[1,3]"];
-  N30 -> N31[label="S[1,3]"];
+  N30 -> N31[label=any];
 }
         """
         self.assertEqual(expected.strip(), observed.strip())
@@ -363,7 +363,7 @@ digraph "graph" {
   N3[label="Query:S[1,2]>=S[1,2]"];
   N0 -> N1[label="MR+[1,2]"];
   N1 -> N2[label="S[1,2]"];
-  N2 -> N3[label="S[1,2]"];
+  N2 -> N3[label=any];
 }
         """
 
@@ -396,7 +396,7 @@ digraph "graph" {
   N3[label="Query:S[1,1]>=S[1,1]"];
   N0 -> N1[label="R+"];
   N1 -> N2[label="S[1,1]"];
-  N2 -> N3[label="S[1,1]"];
+  N2 -> N3[label=any];
 }"""
 
         self.assertEqual(expected.strip(), observed.strip())

--- a/src/beanmachine/ppl/compiler/tests/fix_problems_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_problems_test.py
@@ -8,9 +8,7 @@ from torch import tensor
 
 
 class FixProblemsTest(unittest.TestCase):
-    def test_fix_problems_1(self) -> None:
-        """test_fix_problems_1"""
-
+    def test_fix_problems_01(self) -> None:
         # Problems that need to be fixed:
         #
         # * Single-valued tensors are used in contexts where scalars are needed.
@@ -64,7 +62,7 @@ digraph "graph" {
   N04 -> N05[label="right:P"];
   N05 -> N06[label="mu:R"];
   N05 -> N07[label="probability:P"];
-  N05 -> N10[label="operator:M"];
+  N05 -> N10[label="operator:any"];
   N06 -> N08[label="operand:R"];
   N07 -> N09[label="operand:B"];
 }"""
@@ -97,7 +95,7 @@ digraph "graph" {
   N03 -> N04[label="operand:P"];
   N04 -> N05[label="right:P"];
   N05 -> N07[label="probability:P"];
-  N05 -> N10[label="operator:P"];
+  N05 -> N10[label="operator:any"];
   N05 -> N13[label="operand:<=R"];
   N06 -> N08[label="operand:R"];
   N07 -> N09[label="operand:B"];
@@ -996,18 +994,18 @@ digraph "graph" {
   N15[label="1.0:R+>=OH"];
   N00 -> N08[label="mu:R"];
   N04 -> N05[label="operand:B"];
-  N05 -> N10[label="operand:B"];
+  N05 -> N10[label="operand:any"];
   N06 -> N07[label="operand:N"];
-  N07 -> N11[label="operand:N"];
+  N07 -> N11[label="operand:any"];
   N08 -> N09[label="operand:R"];
-  N09 -> N12[label="operand:R"];
+  N09 -> N12[label="operand:any"];
   N13 -> N04[label="probability:P"];
   N13 -> N06[label="probability:P"];
   N14 -> N06[label="count:N"];
   N15 -> N08[label="sigma:R+"];
 }
 """
-        self.assertEqual(observed.strip(), expected.strip())
+        self.assertEqual(expected.strip(), observed.strip())
 
     def test_fix_problems_14(self) -> None:
         """test_fix_problems_14"""


### PR DESCRIPTION
Summary:
Our type analysis places type requirements on the input edges coming into a node; I recently needed to express the notion of "no requirement on this edge, any input is acceptable" and I did it wrong.

What I did wrong was express this as "whatever type the node is now, is the type it is required to be".  But a malformed node has type "malformed" and it is never correct to say that a node is required to be malformed.  This caused a bad code path to become possible in requirement checking; thanks to Walid for finding a reproducer.

The right thing to do is to have a requirements object that explicitly represents "anything is good".  I've done so, and reworked the type hierarchy of requirements objects as a result.

There is still more work to do here, as noted in the TODO comments. I'm redoing how memoization works in this module, and when I do I will memoize construction of requirements objects.  Longer term, we need to:

* create assertions which establish invariants such as "every type requirement must name a type which actually exists in the BMG type system" -- no "malformed" or "all zero" requirements should be allowed; those are bugs.
* extract node type inference and edge type requirement computation to its own module that deals exclusively with this topic, rather than embedding that logic in every node class. Putting it in the node classes smears the logic out over a large area and makes it difficult to apply a different typing discipline should we need to in the future.

Reviewed By: wtaha

Differential Revision: D26802638

