### PR TITLE
Add optional input to BMG inference to choose inference algorithm

### DIFF
--- a/src/beanmachine/ppl/compiler/bm_graph_builder.py
+++ b/src/beanmachine/ppl/compiler/bm_graph_builder.py
@@ -53,7 +53,7 @@ from typing import Any, Callable, Dict, List, Set
 
 # TODO: For reasons unknown, Pyre is unable to find type information about
 # TODO: beanmachine.graph from beanmachine.ppl.  I'll figure out why later;
-# TODO: for now, we'll just turn off error checking in this mModuleNotFoundError
+# TODO: for now, we'll just turn off error checking in this module.
 # pyre-ignore-all-errors
 # TODO: It is somewhat confusing to import a type named "Graph" here;
 # Consider renaming it to NativeGraph or some other more descriptive
@@ -1966,8 +1966,7 @@ g = graph.Graph()
         fix_problems(self, self._fix_observe_true).raise_errors()
 
     def infer(
-        self,
-        num_samples: int,
+        self, num_samples: int, inference_type: InferenceType = InferenceType.NMC
     ) -> MonteCarloSamples:
         # TODO: Add num_chains to API
         # TODO: Add inference kind to API
@@ -2017,7 +2016,7 @@ g = graph.Graph()
 
         # BMG requires that we have at least one query.
         if len(query_to_query_id) != 0:
-            raw = g.infer(num_samples, InferenceType.NMC)
+            raw = g.infer(num_samples, inference_type)
             # Suppose we have two queries and three samples; the shape we get
             # from BMG is:
             #

--- a/src/beanmachine/ppl/compiler/bmg_nodes.py
+++ b/src/beanmachine/ppl/compiler/bmg_nodes.py
@@ -45,7 +45,7 @@ from torch.distributions.utils import broadcast_all
 
 # TODO: For reasons unknown, Pyre is unable to find type information about
 # TODO: beanmachine.graph from beanmachine.ppl.  I'll figure out why later;
-# TODO: for now, we'll just turn off error checking in this mModuleNotFoundError
+# TODO: for now, we'll just turn off error checking in this module.
 # pyre-ignore-all-errors
 
 # TODO: Extract inf type, graph type and requirements computations to own module

--- a/src/beanmachine/ppl/inference/bmg_inference.py
+++ b/src/beanmachine/ppl/inference/bmg_inference.py
@@ -5,11 +5,18 @@ inferences on Bean Machine models."""
 
 from typing import Dict, List
 
+from beanmachine.graph import InferenceType
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
 from beanmachine.ppl.inference.abstract_infer import _verify_queries_and_observations
 from beanmachine.ppl.inference.monte_carlo_samples import MonteCarloSamples
 from beanmachine.ppl.model.rv_identifier import RVIdentifier
 from torch import Tensor
+
+
+# TODO: For reasons unknown, Pyre is unable to find type information about
+# TODO: beanmachine.graph from beanmachine.ppl.  I'll figure out why later;
+# TODO: for now, we'll just turn off error checking in this module.
+# pyre-ignore-all-errors
 
 
 class BMGInference:
@@ -33,11 +40,14 @@ class BMGInference:
         queries: List[RVIdentifier],
         observations: Dict[RVIdentifier, Tensor],
         num_samples: int,
+        inference_type: InferenceType = InferenceType.NMC,
     ) -> MonteCarloSamples:
         # TODO: Add num_chains
         # TODO: Add verbose level
         # TODO: Add logging
-        return self._accumulate_graph(queries, observations).infer(num_samples)
+        return self._accumulate_graph(queries, observations).infer(
+            num_samples, inference_type
+        )
 
     def to_dot(
         self,


### PR DESCRIPTION
Summary: BMG supports both NMC and rejection sampling inference, but in the public API we did not expose that choice to the user. We do now with an optional input that defaults to NMC.

Reviewed By: wtaha

Differential Revision: D26728551

