### PR TITLE
Add support for python code generation on dirichlet models

### DIFF
--- a/src/beanmachine/ppl/compiler/bmg_nodes.py
+++ b/src/beanmachine/ppl/compiler/bmg_nodes.py
@@ -1363,7 +1363,16 @@ class DirichletNode(DistributionNode):
         )
 
     def _to_python(self, d: Dict["BMGNode", int]) -> str:
-        raise NotImplementedError("DirichletNode._to_python not yet implemented")
+        return f"""n{d[self]} = g.add_distribution(
+  graph.DistributionType.DIRICHLET,
+  graph.ValueType(
+    graph.VariableType.COL_SIMPLEX_MATRIX,
+    graph.AtomicType.PROBABILITY,
+    {self._required_columns},
+    1,
+  ),
+  [n{d[self.concentration]}],
+)"""
 
     def _to_cpp(self, d: Dict["BMGNode", int]) -> str:
         raise NotImplementedError("DirichletNode._to_cpp not yet implemented")

--- a/src/beanmachine/ppl/compiler/tests/dirichlet_test.py
+++ b/src/beanmachine/ppl/compiler/tests/dirichlet_test.py
@@ -424,3 +424,27 @@ digraph "graph" {
         results = BMGInference().infer([d3()], {}, 20, rejection)
         samples = results[d3()]
         self.assertEqual(Size([1, 20, 1, 3]), samples.size())
+
+    def test_dirichlet_to_python(self) -> None:
+        self.maxDiff = None
+
+        observed = BMGInference().to_python([d2a()], {})
+        expected = """
+from beanmachine import graph
+from torch import tensor
+g = graph.Graph()
+n0 = g.add_constant_pos_matrix(tensor([2.5,3.0]))
+n1 = g.add_distribution(
+  graph.DistributionType.DIRICHLET,
+  graph.ValueType(
+    graph.VariableType.COL_SIMPLEX_MATRIX,
+    graph.AtomicType.PROBABILITY,
+    2,
+    1,
+  ),
+  [n0],
+)
+n2 = g.add_operator(graph.OperatorType.SAMPLE, [n1])
+g.query(n2)
+        """
+        self.assertEqual(expected.strip(), observed.strip())


### PR DESCRIPTION
Summary:
The compiler can output a Python program which generates the BMG graph associated with a model; it can now do so for models containing Dirichlet distributions.

C++ code generation will be in the next diff.

Reviewed By: wtaha

Differential Revision: D26738294

