### PR TITLE
Add support for C++ code generation on dirichlet models

### DIFF
--- a/src/beanmachine/ppl/compiler/bmg_nodes.py
+++ b/src/beanmachine/ppl/compiler/bmg_nodes.py
@@ -1375,7 +1375,15 @@ class DirichletNode(DistributionNode):
 )"""
 
     def _to_cpp(self, d: Dict["BMGNode", int]) -> str:
-        raise NotImplementedError("DirichletNode._to_cpp not yet implemented")
+        return f"""uint n{d[self]} = g.add_distribution(
+  graph::DistributionType::DIRICHLET,
+  graph::ValueType(
+    graph::VariableType::COL_SIMPLEX_MATRIX,
+    graph::AtomicType::PROBABILITY,
+    {self._required_columns},
+    1
+  )
+  std::vector<uint>({{n{d[self.concentration]}}}));"""
 
 
 class FlatNode(DistributionNode):

--- a/src/beanmachine/ppl/compiler/tests/dirichlet_test.py
+++ b/src/beanmachine/ppl/compiler/tests/dirichlet_test.py
@@ -448,3 +448,26 @@ n2 = g.add_operator(graph.OperatorType.SAMPLE, [n1])
 g.query(n2)
         """
         self.assertEqual(expected.strip(), observed.strip())
+
+    def test_dirichlet_to_cpp(self) -> None:
+        self.maxDiff = None
+
+        observed = BMGInference().to_cpp([d2a()], {})
+        expected = """
+graph::Graph g;
+Eigen::MatrixXd m0(2, 1)
+m0 << 2.5, 3.0;
+uint n0 = g.add_constant_pos_matrix(m0);
+uint n1 = g.add_distribution(
+  graph::DistributionType::DIRICHLET,
+  graph::ValueType(
+    graph::VariableType::COL_SIMPLEX_MATRIX,
+    graph::AtomicType::PROBABILITY,
+    2,
+    1
+  )
+  std::vector<uint>({n0}));
+uint n2 = g.add_operator(
+  graph::OperatorType::SAMPLE, std::vector<uint>({n1}));
+g.query(n2);"""
+        self.assertEqual(expected.strip(), observed.strip())


### PR DESCRIPTION
Summary: The compiler can output a C++ program which generates the BMG graph associated with a model; it can now do so for models containing Dirichlet distributions.

Reviewed By: wtaha

Differential Revision: D26738691

