### PR TITLE
Add nicer error reporting to samples dictionary

### DIFF
--- a/src/beanmachine/ppl/inference/monte_carlo_samples.py
+++ b/src/beanmachine/ppl/inference/monte_carlo_samples.py
@@ -97,6 +97,13 @@ class MonteCarloSamples(Mapping[RVIdentifier, torch.Tensor]):
             chain should be included with the healthy samples.
         :returns: samples drawn during inference for the specified variable
         """
+
+        if not isinstance(rv, RVIdentifier):
+            raise TypeError(
+                "The key is required to be a random variable "
+                + f"but is of type {type(rv).__name__}."
+            )
+
         samples = self.samples[rv]
 
         if include_adapt_steps:

--- a/src/beanmachine/ppl/inference/tests/inference_error_reporting_test.py
+++ b/src/beanmachine/ppl/inference/tests/inference_error_reporting_test.py
@@ -3,6 +3,7 @@ import unittest
 
 import beanmachine.ppl as bm
 from torch import tensor
+from torch.distributions import Bernoulli
 
 
 @bm.random_variable
@@ -18,6 +19,11 @@ def g(n):
 @bm.functional
 def h():
     return 123  # BAD; needs to be a tensor
+
+
+@bm.random_variable
+def flip():
+    return Bernoulli(0.5)
 
 
 class InferenceErrorReportingTest(unittest.TestCase):
@@ -99,4 +105,12 @@ class InferenceErrorReportingTest(unittest.TestCase):
         self.assertEqual(
             str(ex.exception),
             "A random_variable is required to return a distribution.",
+        )
+
+        # The lookup key to the samples object is required to be an RVID.
+        with self.assertRaises(TypeError) as ex:
+            mh.infer([flip()], {}, 10)[flip]
+        self.assertEqual(
+            str(ex.exception),
+            "The key is required to be a random variable but is of type function.",
         )


### PR DESCRIPTION
Summary: It's easy to make a typo when you're indexing into the samples dictionary returned by inference, but the error message you get is unhelpful. I've added type error checking to the entrypoint.

Reviewed By: wtaha

Differential Revision: D26759192

