### PR TITLE
Deprecate existing index node class

### DIFF
--- a/src/beanmachine/ppl/compiler/bm_graph_builder.py
+++ b/src/beanmachine/ppl/compiler/bm_graph_builder.py
@@ -88,7 +88,7 @@ from beanmachine.ppl.compiler.bmg_nodes import (
     GreaterThanNode,
     HalfCauchyNode,
     IfThenElseNode,
-    IndexNode,
+    IndexNodeDeprecated,
     LessThanEqualNode,
     LessThanNode,
     Log1mexpNode,
@@ -1031,16 +1031,15 @@ class BMGraphBuilder:
             return input.value ** exponent.value
         return self.add_power(input, exponent)
 
-    # TODO: Indexes and maps are slightly tricky; add some comments here
-    # explaining what's going on.
+    # TODO: Remove this.
 
     @memoize
-    def add_index(self, left: MapNode, right: BMGNode) -> BMGNode:
+    def add_index_deprecated(self, left: MapNode, right: BMGNode) -> BMGNode:
         # TODO: Is there a better way to say "if list length is 1" that bails out
         # TODO: if it is greater than 1?
         if len(list(right.support())) == 1:
             return left[right]
-        node = IndexNode(left, right)
+        node = IndexNodeDeprecated(left, right)
         self.add_node(node)
         return node
 
@@ -1055,7 +1054,7 @@ class BMGraphBuilder:
             result = left[right]
             return result.value if isinstance(result, ConstantNode) else result
         m = self.collection_to_map(left)
-        return self.add_index(m, right)
+        return self.add_index_deprecated(m, right)
 
     @memoize
     def add_negate(self, operand: BMGNode) -> BMGNode:
@@ -1369,8 +1368,9 @@ class BMGraphBuilder:
                 return self.add_if_then_else(choice, second_value, first_value)
 
         # Otherwise, just make a map node.
+        # TODO: Fix this. We need a better abstraction that is supported by BMG.
         map_node = self.add_map(*key_value_pairs)
-        index_node = self.add_index(map_node, choice)
+        index_node = self.add_index_deprecated(map_node, choice)
         return index_node
 
     def _handle_random_variable_call_checked(

--- a/src/beanmachine/ppl/compiler/bmg_nodes.py
+++ b/src/beanmachine/ppl/compiler/bmg_nodes.py
@@ -2538,7 +2538,13 @@ class MapNode(BMGNode):
         raise ValueError("Key not found in map")
 
 
-class IndexNode(BinaryOperatorNode):
+class IndexNodeDeprecated(BinaryOperatorNode):
+
+    # TODO: The index / map node combination that we originally envisioned
+    # does not work well with BMGs indexing operator; we will eventually
+    # remove it. Until then, just mark it as deprecated to minimize
+    # disruption while we get indexing support working.
+
     """This represents a stochastic choice of multiple options; the left
     operand must be a map, and the right is the stochastic value used to
     choose an element from the map."""

--- a/src/beanmachine/ppl/compiler/fix_problems.py
+++ b/src/beanmachine/ppl/compiler/fix_problems.py
@@ -13,7 +13,7 @@ from beanmachine.ppl.compiler.bmg_nodes import (
     BMGNode,
     ConstantNode,
     DistributionNode,
-    IndexNode,
+    IndexNodeDeprecated,
     MapNode,
     MultiplicationNode,
     Observation,
@@ -126,7 +126,7 @@ class RequirementsFixer:
         # TODO: (2) until we do support map nodes in BMG, we should add an
         # TODO: error reporting pass to this code that detects map nodes
         # TODO: and gives an unsupported node type error.
-        assert isinstance(consumer, IndexNode)
+        assert isinstance(consumer, IndexNodeDeprecated)
         assert requirement == node.inf_type
         return node
 

--- a/src/beanmachine/ppl/compiler/tests/bm_graph_builder_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bm_graph_builder_test.py
@@ -1483,6 +1483,7 @@ Node 9 type 3 parents [ 8 ] children [ ] real 0"""
         self.assertEqual(bmg.add_log1mexp(s).size, Size([2]))
 
     def test_maps(self) -> None:
+        # TODO: Eliminate map nodes and delete this test
         bmg = BMGraphBuilder()
 
         t0 = bmg.add_constant_tensor(tensor(0.0))
@@ -1495,7 +1496,7 @@ Node 9 type 3 parents [ 8 ] children [ ] real 0"""
         s3 = bmg.add_sample(bern)
         a = bmg.add_addition(s2, t2)
         m = bmg.add_map(t0, s1, t1, a)
-        i = bmg.add_index(m, s3)
+        i = bmg.add_index_deprecated(m, s3)
         self.assertEqual(
             SetOfTensors(i.support()),
             SetOfTensors([tensor(0.0), tensor(1.0), tensor(2.0), tensor(3.0)]),

--- a/src/beanmachine/ppl/utils/probabilistic.py
+++ b/src/beanmachine/ppl/utils/probabilistic.py
@@ -6,6 +6,7 @@ from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
 from beanmachine.ppl.compiler.bmg_nodes import BMGNode
 
 
+# TODO: Eliminate this decorator. It is only used in the non-JIT compiler workflow.
 def probabilistic(bmg: BMGraphBuilder):
     """
     Decorator to be used to make sample function probabilistic
@@ -25,7 +26,7 @@ def probabilistic(bmg: BMGraphBuilder):
                         key_value_pairs.append(bmg.add_constant(key))
                         key_value_pairs.append(value)
                     map_node = bmg.add_map(*key_value_pairs)
-                    index_node = bmg.add_index(map_node, arg)
+                    index_node = bmg.add_index_deprecated(map_node, arg)
                     return index_node
             # If we got here, there were no distribution arguments.
             return f(*args)


### PR DESCRIPTION
Summary:
The ideas we originally had about how indexing into a map might work in BMG are not compatible with the new indexing operation that has been added to BMG.

Eventually I will delete the index and map code, but for now I'm just going to mark the existing indexing node as deprecated and create a new one that has the correct semantics.

Reviewed By: wtaha

Differential Revision: D26764436

