### PR TITLE
Fix memoization of class constructors using a metaclass

### DIFF
--- a/src/beanmachine/ppl/compiler/bmg_types.py
+++ b/src/beanmachine/ppl/compiler/bmg_types.py
@@ -4,7 +4,7 @@ from abc import abstractmethod
 from typing import Any, Union
 
 import torch
-from beanmachine.ppl.utils.memoize import memoize
+from beanmachine.ppl.utils.memoize import MemoizedClass, memoize
 from torch import Size
 
 
@@ -142,8 +142,7 @@ class BroadcastMatrixType(BMGMatrixType):
 # which is a nice property to have.
 
 
-@memoize
-class BooleanMatrix(BroadcastMatrixType):
+class BooleanMatrix(BroadcastMatrixType, metaclass=MemoizedClass):
     def __init__(self, rows: int, columns: int) -> None:
         BroadcastMatrixType.__init__(self, bool_element, rows, columns)
 
@@ -151,8 +150,7 @@ class BooleanMatrix(BroadcastMatrixType):
         return BooleanMatrix(rows, columns)
 
 
-@memoize
-class NaturalMatrix(BroadcastMatrixType):
+class NaturalMatrix(BroadcastMatrixType, metaclass=MemoizedClass):
     def __init__(self, rows: int, columns: int) -> None:
         BroadcastMatrixType.__init__(self, natural_element, rows, columns)
 
@@ -160,8 +158,7 @@ class NaturalMatrix(BroadcastMatrixType):
         return NaturalMatrix(rows, columns)
 
 
-@memoize
-class ProbabilityMatrix(BroadcastMatrixType):
+class ProbabilityMatrix(BroadcastMatrixType, metaclass=MemoizedClass):
     def __init__(self, rows: int, columns: int) -> None:
         BroadcastMatrixType.__init__(self, probability_element, rows, columns)
 
@@ -169,8 +166,7 @@ class ProbabilityMatrix(BroadcastMatrixType):
         return ProbabilityMatrix(rows, columns)
 
 
-@memoize
-class PositiveRealMatrix(BroadcastMatrixType):
+class PositiveRealMatrix(BroadcastMatrixType, metaclass=MemoizedClass):
     def __init__(self, rows: int, columns: int) -> None:
         BroadcastMatrixType.__init__(self, positive_real_element, rows, columns)
 
@@ -178,8 +174,7 @@ class PositiveRealMatrix(BroadcastMatrixType):
         return PositiveRealMatrix(rows, columns)
 
 
-@memoize
-class NegativeRealMatrix(BroadcastMatrixType):
+class NegativeRealMatrix(BroadcastMatrixType, metaclass=MemoizedClass):
     def __init__(self, rows: int, columns: int) -> None:
         BroadcastMatrixType.__init__(self, negative_real_element, rows, columns)
 
@@ -187,8 +182,7 @@ class NegativeRealMatrix(BroadcastMatrixType):
         return NegativeRealMatrix(rows, columns)
 
 
-@memoize
-class RealMatrix(BroadcastMatrixType):
+class RealMatrix(BroadcastMatrixType, metaclass=MemoizedClass):
     def __init__(self, rows: int, columns: int) -> None:
         BroadcastMatrixType.__init__(self, real_element, rows, columns)
 
@@ -196,8 +190,7 @@ class RealMatrix(BroadcastMatrixType):
         return RealMatrix(rows, columns)
 
 
-@memoize
-class SimplexMatrix(BMGMatrixType):
+class SimplexMatrix(BMGMatrixType, metaclass=MemoizedClass):
     def __init__(self, rows: int, columns: int) -> None:
         BMGMatrixType.__init__(
             self,
@@ -212,8 +205,7 @@ class SimplexMatrix(BMGMatrixType):
         return SimplexMatrix(rows, columns)
 
 
-@memoize
-class OneHotMatrix(BMGMatrixType):
+class OneHotMatrix(BMGMatrixType, metaclass=MemoizedClass):
     def __init__(self, rows: int, columns: int) -> None:
         short_name = "OH" if rows == 1 and columns == 1 else f"OH[{rows},{columns}]"
         long_name = (
@@ -227,8 +219,7 @@ class OneHotMatrix(BMGMatrixType):
         return OneHotMatrix(rows, columns)
 
 
-@memoize
-class ZeroMatrix(BMGMatrixType):
+class ZeroMatrix(BMGMatrixType, metaclass=MemoizedClass):
     def __init__(self, rows: int, columns: int) -> None:
         short_name = "Z" if rows == 1 and columns == 1 else f"Z[{rows},{columns}]"
         long_name = (

--- a/src/beanmachine/ppl/utils/memoize.py
+++ b/src/beanmachine/ppl/utils/memoize.py
@@ -99,3 +99,70 @@ def memoize(f):
     else:
         f._wrapper = wrapper
     return wrapper
+
+
+# In Python, how do we memoize a constructor to ensure that instances of
+# a class with the same constructor arguments are reference-equal? We could
+# put the @memoize attribute on the class, but this leads to many problems.
+#
+# ASIDE: What problems? And why?
+#
+# A class is a function that constructs instances; a decorator is a function
+# from functions to functions. "@memoize class C: ..." passes the instance-
+# construction function to the decorator and assigns the result to C; this means
+# that C is no longer a *type*; it is the *function* returned by the decorator.
+# This in turn means that "instanceof(c, C)" no longer works because C is not a type.
+# Similarly C cannot be a base class because it is not a type. And so on.
+#
+# END ASIDE
+#
+# The correct way to do this in Python is to create a metaclass. A class is a factory
+# for instances; a metaclass is a factory for classes. We can create a metaclass which
+# produces classes that are memoized.
+#
+# The default metaclass in Python is "type"; if you call "type(name, bases, attrs)"
+# where name is the name of the new type, bases is a tuple of base types, and attrs
+# is a dictionary of name-value pairs, then you get back a new class with that name,
+# base classes, and attributes.  We can derive from type to make new metaclasses:
+
+
+class MemoizedClass(type):
+    # __new__ is called when the metaclass creates a new class.
+    # metacls is the "self" of the metaclass
+    # name is the name of the class we're creating
+    # bases is a tuple of base types
+    # attrs is a dictionary of attributes
+    def __new__(
+        metacls, name: str, bases: Tuple[type, ...], attrs: Dict[str, Any]
+    ) -> type:
+        # The memoized values will be stored in a per-class dictionary called
+        # _cache, so make sure that the attributes dictionary has that.
+        if "_cache" not in attrs:
+            attrs["_cache"] = {}
+        # That's the only special thing we need to do, so defer the actual
+        # type creation to the "type" metaclass -- our base type.
+        return super(MemoizedClass, metacls).__new__(metacls, name, bases, attrs)
+
+    # A class is a function which constructs instances; when that function is
+    # called to construct an instance, the __call__ handler is invoked in the
+    # metaclass. By default type.__call__ simply creates a new instance. We
+    # can replace that behavior by overriding the __call__ handler to do something
+    # else.
+    #
+    # cls is the class that we are trying to create an instance of; *args is
+    # the argument list passed to the constructor.
+    def __call__(cls, *args):
+        # TODO: We do not collect statistics on memoization use here.
+        # TODO: We do not canonicalize arguments as the memoizer does above.
+        if args not in cls._cache:
+            # This is the first time we've constructed this class with these
+            # arguments. Defer to the __call__ behavior of "type", which is the
+            # superclass of this metaclass.
+            new_instance = super(MemoizedClass, cls).__call__(*args)
+            cls._cache[args] = new_instance
+            return new_instance
+        return cls._cache[args]
+
+
+# You then use this as
+# class Foo(FooBase, metaclass=MemoizedClass): ...


### PR DESCRIPTION
Summary:
We wish to ensure the invariant that the `BooleanMatrix(1, 1)` object used to track the type information about graph nodes is reference equal to every such construction. I previously enforced this invariant by putting a memoize decorator on the `BooleanMatrix` class, but learned recently that this is wrong, wrong, wrong.

The reason it is wrong is because when you memoize a class, you are basically saying that `BooleanMatrix` is no longer a class; it is the *function* returned by the memoize decorator, and that thing is not a valid argument to `instanceof`, it is not a valid base class, and so on.

In an upcoming diff I will need to do `instanceof` testing on these objects, so I need to fix this now.

The correct thing to do when memoizing a constructor is to make a memoizer metaclass. This is a tricky technique for the novice to intermediate Python programmer so I have left a short but detailed tutorial in the comments.

Reviewed By: wtaha

Differential Revision: D26792222

