### PR TITLE
Add accidentally-missing INDEX constant to BMG Python bindings

### DIFF
--- a/src/beanmachine/graph/pybindings.cpp
+++ b/src/beanmachine/graph/pybindings.cpp
@@ -57,7 +57,8 @@ PYBIND11_MODULE(graph, module) {
       .value("LOG", OperatorType::LOG)
       .value("POW", OperatorType::POW)
       .value("MATRIX_MULTIPLY", OperatorType::MATRIX_MULTIPLY)
-      .value("TO_PROBABILITY", OperatorType::TO_PROBABILITY);
+      .value("TO_PROBABILITY", OperatorType::TO_PROBABILITY)
+      .value("INDEX", OperatorType::INDEX);
 
   py::enum_<DistributionType>(module, "DistributionType")
       .value("TABULAR", DistributionType::TABULAR)


### PR DESCRIPTION
Summary: Looks like we forgot to add an entry in the interop library when adding the index operator.

Reviewed By: wtaha

Differential Revision: D26821077

