### PR TITLE
Disable test which uses unsupported indexing operation

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/bm_to_bmg_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bm_to_bmg_test.py
@@ -923,7 +923,9 @@ class CompilerTest(unittest.TestCase):
         observed = to_dot(source10)
         self.assertEqual(observed.strip(), expected_dot_10.strip())
 
-    def test_to_dot_11(self) -> None:
+    def disabled_test_to_dot_11(self) -> None:
+        # TODO: This test is disabled because we do not yet support the indexing
+        # operation where we choose via a stochastic list index which tensor to use.
         self.maxDiff = None
         observed = to_dot(source11)
         self.assertEqual(observed.strip(), expected_dot_11.strip())


### PR DESCRIPTION
Summary: We have a test which analyzes a model where we choose an element from a list based on a stochastic index. That is going to break when we move to the new indexing node that requires a tensor as the collection. We will revisit this model later and decide whether compilation should succeed or not, and if so, how to make it work.

Reviewed By: wtaha

Differential Revision: D26822258

