### PR TITLE
Rename add_constant_matrix overloads

### DIFF
--- a/src/beanmachine/graph/graph.cpp
+++ b/src/beanmachine/graph/graph.cpp
@@ -562,15 +562,15 @@ uint Graph::add_constant_neg_real(double value) {
   return add_constant(NodeValue(AtomicType::NEG_REAL, value));
 }
 
-uint Graph::add_constant_matrix(Eigen::MatrixXb& value) {
+uint Graph::add_constant_bool_matrix(Eigen::MatrixXb& value) {
   return add_constant(NodeValue(value));
 }
 
-uint Graph::add_constant_matrix(Eigen::MatrixXd& value) {
+uint Graph::add_constant_real_matrix(Eigen::MatrixXd& value) {
   return add_constant(NodeValue(value));
 }
 
-uint Graph::add_constant_matrix(Eigen::MatrixXn& value) {
+uint Graph::add_constant_natural_matrix(Eigen::MatrixXn& value) {
   return add_constant(NodeValue(value));
 }
 

--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -506,9 +506,9 @@ struct Graph {
   uint add_constant_probability(double value);
   uint add_constant_pos_real(double value);
   uint add_constant_neg_real(double value);
-  uint add_constant_matrix(Eigen::MatrixXb& value);
-  uint add_constant_matrix(Eigen::MatrixXd& value);
-  uint add_constant_matrix(Eigen::MatrixXn& value);
+  uint add_constant_bool_matrix(Eigen::MatrixXb& value);
+  uint add_constant_real_matrix(Eigen::MatrixXd& value);
+  uint add_constant_natural_matrix(Eigen::MatrixXn& value);
   uint add_constant_pos_matrix(Eigen::MatrixXd& value);
   uint add_constant_neg_matrix(Eigen::MatrixXd& value);
   uint add_constant_probability_matrix(Eigen::MatrixXd& value);

--- a/src/beanmachine/graph/operator/tests/gradient_test.cpp
+++ b/src/beanmachine/graph/operator/tests/gradient_test.cpp
@@ -291,7 +291,7 @@ TEST(testgradient, backward_vector_linearmodel) {
   Xmat << 1.0, 0.5, 1.0, -1.5, 1.0, 2.1;
   for (uint i = 0; i < 3; ++i) {
     Eigen::MatrixXd x = Xmat.row(i);
-    uint x_i = g.add_constant_matrix(x);
+    uint x_i = g.add_constant_real_matrix(x);
     uint mu_i = g.add_operator(
         OperatorType::MATRIX_MULTIPLY, std::vector<uint>{x_i, betas});
     uint dist_i = g.add_distribution(

--- a/src/beanmachine/graph/operator/tests/operator_test.cpp
+++ b/src/beanmachine/graph/operator/tests/operator_test.cpp
@@ -687,9 +687,9 @@ TEST(testoperator, matrix_multiply) {
       std::invalid_argument);
   Eigen::MatrixXd m1(3, 2);
   m1 << 0.3, -0.1, 1.2, 0.9, -2.6, 0.8;
-  auto cm1 = g.add_constant_matrix(m1);
+  auto cm1 = g.add_constant_real_matrix(m1);
   Eigen::MatrixXb m2 = Eigen::MatrixXb::Random(1, 2);
-  auto cm2 = g.add_constant_matrix(m2);
+  auto cm2 = g.add_constant_bool_matrix(m2);
   // requires real/pos_real/neg_real/probability types
   EXPECT_THROW(
       g.add_operator(
@@ -806,7 +806,7 @@ TEST(testoperator, index) {
       std::invalid_argument);
   Eigen::MatrixXd m1(2, 1);
   m1 << 2.0, -1.0;
-  auto cm1 = g.add_constant_matrix(m1);
+  auto cm1 = g.add_constant_real_matrix(m1);
   EXPECT_THROW(
       g.add_operator(OperatorType::INDEX, std::vector<uint>{cm1}),
       std::invalid_argument);

--- a/src/beanmachine/graph/pybindings.cpp
+++ b/src/beanmachine/graph/pybindings.cpp
@@ -137,18 +137,19 @@ PYBIND11_MODULE(graph, module) {
           "add a Node with a constant negative real (<=0) value",
           py::arg("value"))
       .def(
-          "add_constant_matrix",
-          (uint(Graph::*)(Eigen::MatrixXd&)) & Graph::add_constant_matrix,
+          "add_constant_real_matrix",
+          (uint(Graph::*)(Eigen::MatrixXd&)) & Graph::add_constant_real_matrix,
           "add a Node with a constant real-valued matrix",
           py::arg("value"))
       .def(
-          "add_constant_matrix",
-          (uint(Graph::*)(Eigen::MatrixXb&)) & Graph::add_constant_matrix,
-          "add a Node with a constant boolean-valued matrix",
+          "add_constant_bool_matrix",
+          (uint(Graph::*)(Eigen::MatrixXb&)) & Graph::add_constant_bool_matrix,
+          "add a Node with a constant Boolean-valued matrix",
           py::arg("value"))
       .def(
-          "add_constant_matrix",
-          (uint(Graph::*)(Eigen::MatrixXn&)) & Graph::add_constant_matrix,
+          "add_constant_natural_matrix",
+          (uint(Graph::*)(Eigen::MatrixXn&)) &
+              Graph::add_constant_natural_matrix,
           "add a Node with a constant natural-valued matrix",
           py::arg("value"))
       .def(

--- a/src/beanmachine/graph/tests/graph_test.cpp
+++ b/src/beanmachine/graph/tests/graph_test.cpp
@@ -157,16 +157,16 @@ TEST(testgraph, clone_graph) {
   Eigen::MatrixXd m1 = Eigen::MatrixXd::Identity(2, 2);
   g.add_constant_pos_matrix(m1);
   Eigen::MatrixXd m2 = Eigen::MatrixXd::Random(2, 2);
-  g.add_constant_matrix(m2);
+  g.add_constant_real_matrix(m2);
   Eigen::MatrixXd m3(2, 1);
   m3 << 0.2, 0.8;
   g.add_constant_col_simplex_matrix(m3);
   Eigen::MatrixXb m4(1, 2);
   m4 << true, false;
-  g.add_constant_matrix(m4);
+  g.add_constant_bool_matrix(m4);
   Eigen::MatrixXn m5(2, 1);
   m5 << 1, 2;
-  g.add_constant_matrix(m5);
+  g.add_constant_natural_matrix(m5);
   // distributions
   uint d_bernoulli = g.add_distribution(
       graph::DistributionType::BERNOULLI,

--- a/src/beanmachine/graph/tests/graph_test.py
+++ b/src/beanmachine/graph/tests/graph_test.py
@@ -74,7 +74,7 @@ class TestBayesNet(unittest.TestCase):
             )
         self.assertTrue("only supports boolean parents" in str(cm.exception))
 
-        c3 = g.add_constant_matrix(np.array([1.1, -0.1]))
+        c3 = g.add_constant_real_matrix(np.array([1.1, -0.1]))
         with self.assertRaises(ValueError) as cm:
             g.add_distribution(
                 graph.DistributionType.TABULAR, graph.AtomicType.BOOLEAN, [c3]

--- a/src/beanmachine/graph/tests/operator_test.py
+++ b/src/beanmachine/graph/tests/operator_test.py
@@ -29,12 +29,9 @@ class TestOperators(unittest.TestCase):
         c8 = g.add_constant_neg_real(-1.25)
         c9 = g.add_constant_pos_real(1.25)
         # add const matrices, operators on matrix to be added
-        g.add_constant_matrix(np.array([[True, False], [False, True]]))
-        g.add_constant_matrix(np.array([[-0.1, 0.0], [2.0, -1.0]]))
-        # TODO: This adds a real-valued matrix, not a natural-valued matrix
-        # as was likely intended. Figure out how to fix that.  See line
-        # marked "Node 11" at the bottom of this function.
-        g.add_constant_matrix(np.array([[1, 2], [0, 999]]))
+        g.add_constant_bool_matrix(np.array([[True, False], [False, True]]))
+        g.add_constant_real_matrix(np.array([[-0.1, 0.0], [2.0, -1.0]]))
+        g.add_constant_natural_matrix(np.array([[1, 2], [0, 999]]))
         g.add_constant_pos_matrix(np.array([[0.1, 0.0], [2.0, 1.0]]))
         g.add_constant_neg_matrix(np.array(([-0.3, -0.4])))
         g.add_constant_probability_matrix(np.array([0.1, 0.9]))
@@ -156,7 +153,7 @@ Node 9 type 1 parents [ ] children [ ] matrix<boolean> 1 0
 0 1
 Node 10 type 1 parents [ ] children [ ] matrix<real> -0.1    0
 2   -1
-Node 11 type 1 parents [ ] children [ ] matrix<real>   1   2
+Node 11 type 1 parents [ ] children [ ] matrix<natural>   1   2
 0 999
 Node 12 type 1 parents [ ] children [ ] matrix<positive real> 0.1   0
 2   1


### PR DESCRIPTION
Summary: C++ style method overloading makes it difficult to interoperate with Python. I've renamed the three `add_constant_matrix` methods in BMG to `add_constant_real_matrix`, `add_constant_natural_matrix` and `add_constant_bool_matrix`. This is consistent with the existing `add_constant_neg_real_matrix` and so on.

Reviewed By: wtaha

Differential Revision: D26901320

