### PR TITLE
Move generation of sample nodes out of lifted code and into graph accumulator

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/comparison_rewriting_test.py
+++ b/src/beanmachine/ppl/compiler/tests/comparison_rewriting_test.py
@@ -70,7 +70,7 @@ def y_helper(bmg):
         r8 = bmg.handle_addition(a9, a11)
         r12 = {}
         r2 = bmg.handle_function(StudentT, r8, r12)
-        return bmg.handle_sample(r2)
+        return r2
     return y
 """
         self.assertEqual(observed.strip(), expected.strip())

--- a/src/beanmachine/ppl/compiler/tests/jit_test.py
+++ b/src/beanmachine/ppl/compiler/tests/jit_test.py
@@ -171,6 +171,21 @@ def assertions_are_removed():
     return Bernoulli(0.5)
 
 
+@bm.random_variable
+def flip_with_comprehension():
+    _ = [0 for x in []]
+    return Bernoulli(0.5)
+
+
+@bm.random_variable
+def flip_with_nested_function():
+    def x():
+        return 0.5
+
+    x()
+    return Bernoulli(0.5)
+
+
 class JITTest(unittest.TestCase):
     def test_function_transformation_1(self) -> None:
         """Unit tests for JIT functions"""
@@ -212,7 +227,7 @@ def norm_helper(bmg):
         a7 = dict(scale=a8)
         r4 = dict(**a5, **a7)
         r2 = bmg.handle_function(Normal, r3, r4)
-        return bmg.handle_sample(r2)
+        return r2
     return norm
 """
         self.assertEqual(observed.strip(), expected.strip())
@@ -551,3 +566,17 @@ digraph "graph" {
 
         # The side effect is not caused.
         self.assertEqual(observable_side_effect, 0)
+
+    def test_nested_functions_and_comprehensions(self) -> None:
+        self.maxDiff = None
+
+        # We had a bug where a nested function or comprehension inside a
+        # random_variable would crash while accumulating the graph;
+        # this test regresses that bug by simply verifying that we do
+        # not crash in those scenarios now.
+
+        bmg = BMGraphBuilder()
+        bmg.accumulate_graph([flip_with_nested_function()], {})
+
+        bmg = BMGraphBuilder()
+        bmg.accumulate_graph([flip_with_comprehension()], {})


### PR DESCRIPTION
Summary:
In the original compiler workflow we lift *all* the random variable functions in a module by instrumenting them with callbacks into the graph builder. Since the graph builder in this scenario is entirely "reacting" to the execution of the lifted module, we needed to insert calls to handle_sample into the lifted code to ensure that the graph accumulator accumulated a sample node on every unique random variable.

In the jit-based workflow the graph accumulator is "driving" the execution of the lifted model; it knows every time an RVID is being mapped to a call to a lifted function, and so there is no need for the lifted function itself to invoke handle_sample before every return. The graph accumulator itself can do so.

Eliminating the generation of handle_sample calls on every return statement inside a random_variable eliminates a bug.  If we have a nested function inside an random_variable:

    random_variable
    def flip():
      def half():
        return 0.5
      return Bernoulli(half())

then this was being rewritten to the equivalent of:

    def flip():
      def half():
        return handle_sample(0.5)
      ...

which is plainly wrong; we must not attempt to sample from the distribution "0.5".  Doing so was crashing during graph accumulation.

Since query comprehensions are rewritten into nested functions, we were also causing crashes during accumulation of any random_variable containing a comprehension.

By moving the call to handle_sample to the graph accumulator itself, we guarantee that we are only inserting a sample when we are processing the value returned by a random_variable.  And we simplify the lifted code.

We still have test cases for the original workflow; once those are all modernized we can eliminate the flag that decides whether to generate handle_sample on returns or not.

Reviewed By: kshah1997

Differential Revision: D26925640

