### PR TITLE
Implement compiler nodes for all constant matrix types

### DIFF
--- a/src/beanmachine/ppl/compiler/bm_graph_builder.py
+++ b/src/beanmachine/ppl/compiler/bm_graph_builder.py
@@ -71,8 +71,13 @@ from beanmachine.ppl.compiler.bmg_nodes import (
     CategoricalNode,
     Chi2Node,
     ComplementNode,
+    ConstantBooleanMatrixNode,
+    ConstantNaturalMatrixNode,
+    ConstantNegativeRealMatrixNode,
     ConstantNode,
     ConstantPositiveRealMatrixNode,
+    ConstantProbabilityMatrixNode,
+    ConstantRealMatrixNode,
     ConstantTensorNode,
     DirichletNode,
     DistributionNode,
@@ -133,7 +138,12 @@ from beanmachine.ppl.compiler.bmg_types import (
     Probability,
     Real,
     Zero,
+    bool_element,
+    natural_element,
+    negative_real_element,
     positive_real_element,
+    probability_element,
+    real_element,
 )
 from beanmachine.ppl.inference.abstract_infer import _verify_queries_and_observations
 from beanmachine.ppl.inference.monte_carlo_samples import MonteCarloSamples
@@ -498,8 +508,18 @@ class BMGraphBuilder:
     def add_constant_of_matrix_type(
         self, value: Any, node_type: BMGMatrixType
     ) -> ConstantNode:
+        if node_type.element_type == real_element:
+            return self.add_real_matrix(value)
         if node_type.element_type == positive_real_element:
             return self.add_pos_real_matrix(value)
+        if node_type.element_type == negative_real_element:
+            return self.add_neg_real_matrix(value)
+        if node_type.element_type == probability_element:
+            return self.add_probability_matrix(value)
+        if node_type.element_type == natural_element:
+            return self.add_natural_matrix(value)
+        if node_type.element_type == bool_element:
+            return self.add_boolean_matrix(value)
         raise NotImplementedError(
             "add_constant_of_matrix_type not yet "
             + f"implemented for {node_type.long_name}"
@@ -551,9 +571,44 @@ class BMGraphBuilder:
         return node
 
     @memoize
+    def add_boolean_matrix(self, value: Tensor) -> ConstantBooleanMatrixNode:
+        assert len(value.size()) <= 2
+        node = ConstantBooleanMatrixNode(value)
+        self.add_node(node)
+        return node
+
+    @memoize
+    def add_natural_matrix(self, value: Tensor) -> ConstantNaturalMatrixNode:
+        assert len(value.size()) <= 2
+        node = ConstantNaturalMatrixNode(value)
+        self.add_node(node)
+        return node
+
+    @memoize
+    def add_probability_matrix(self, value: Tensor) -> ConstantProbabilityMatrixNode:
+        assert len(value.size()) <= 2
+        node = ConstantProbabilityMatrixNode(value)
+        self.add_node(node)
+        return node
+
+    @memoize
     def add_pos_real_matrix(self, value: Tensor) -> ConstantPositiveRealMatrixNode:
         assert len(value.size()) <= 2
         node = ConstantPositiveRealMatrixNode(value)
+        self.add_node(node)
+        return node
+
+    @memoize
+    def add_neg_real_matrix(self, value: Tensor) -> ConstantPositiveRealMatrixNode:
+        assert len(value.size()) <= 2
+        node = ConstantNegativeRealMatrixNode(value)
+        self.add_node(node)
+        return node
+
+    @memoize
+    def add_real_matrix(self, value: Tensor) -> ConstantRealMatrixNode:
+        assert len(value.size()) <= 2
+        node = ConstantRealMatrixNode(value)
         self.add_node(node)
         return node
 

--- a/src/beanmachine/ppl/compiler/bmg_nodes.py
+++ b/src/beanmachine/ppl/compiler/bmg_nodes.py
@@ -360,6 +360,13 @@ def _value_to_cpp_eigen(value: Tensor, variable: str) -> str:
     return f"Eigen::MatrixXd {variable}({c}, {r})\n{variable} << {values};\n"
 
 
+def _matrix_value_to_python(value: Tensor) -> str:
+    r, c = _size_to_rc(value.size())
+    v = value.reshape(r, c).transpose(0, 1)
+    t = ConstantTensorNode._tensor_to_python(v)
+    return f"tensor({t})"
+
+
 # When constructing the support of various nodes we are often
 # having to remove duplicates from a set of possible values.
 # Unfortunately, it is not easy to do so with torch tensors.
@@ -737,9 +744,145 @@ class ConstantPositiveRealMatrixNode(ConstantTensorNode):
 
     def _to_python(self, d: Dict["BMGNode", int]) -> str:
         n = d[self]
-        v = self._value_to_python()
-        # TODO: Do we have to take the transpose of the tensor here?
+        v = _matrix_value_to_python(self.value)
         return f"n{n} = g.add_constant_pos_matrix({v})"
+
+    @property
+    def is_matrix(self) -> bool:
+        return True
+
+
+class ConstantRealMatrixNode(ConstantTensorNode):
+    def __init__(self, value: Tensor):
+        assert len(value.size()) <= 2
+        ConstantTensorNode.__init__(self, value)
+
+    def _compute_graph_type(self) -> BMGLatticeType:
+        return Real.with_size(self.size)
+
+    def _add_to_graph(self, g: Graph, d: Dict[BMGNode, int]) -> int:
+        r, c = _size_to_rc(self.value.size())
+        return g.add_constant_real_matrix(self.value.reshape(r, c).transpose(0, 1))
+
+    def _to_cpp(self, d: Dict["BMGNode", int]) -> str:
+        n = d[self]
+        v = _value_to_cpp_eigen(self.value, f"m{n}")
+        return f"{v}uint n{n} = g.add_constant_real_matrix(m{n});"
+
+    def _to_python(self, d: Dict["BMGNode", int]) -> str:
+        n = d[self]
+        v = _matrix_value_to_python(self.value)
+        return f"n{n} = g.add_constant_real_matrix({v})"
+
+    @property
+    def is_matrix(self) -> bool:
+        return True
+
+
+class ConstantNegativeRealMatrixNode(ConstantTensorNode):
+    def __init__(self, value: Tensor):
+        assert len(value.size()) <= 2
+        ConstantTensorNode.__init__(self, value)
+
+    def _compute_graph_type(self) -> BMGLatticeType:
+        return NegativeReal.with_size(self.size)
+
+    def _add_to_graph(self, g: Graph, d: Dict[BMGNode, int]) -> int:
+        r, c = _size_to_rc(self.value.size())
+        return g.add_constant_neg_matrix(self.value.reshape(r, c).transpose(0, 1))
+
+    def _to_cpp(self, d: Dict["BMGNode", int]) -> str:
+        n = d[self]
+        v = _value_to_cpp_eigen(self.value, f"m{n}")
+        return f"{v}uint n{n} = g.add_constant_neg_matrix(m{n});"
+
+    def _to_python(self, d: Dict["BMGNode", int]) -> str:
+        n = d[self]
+        v = _matrix_value_to_python(self.value)
+        return f"n{n} = g.add_constant_neg_matrix({v})"
+
+    @property
+    def is_matrix(self) -> bool:
+        return True
+
+
+class ConstantProbabilityMatrixNode(ConstantTensorNode):
+    def __init__(self, value: Tensor):
+        assert len(value.size()) <= 2
+        ConstantTensorNode.__init__(self, value)
+
+    def _compute_graph_type(self) -> BMGLatticeType:
+        return Probability.with_size(self.size)
+
+    def _add_to_graph(self, g: Graph, d: Dict[BMGNode, int]) -> int:
+        r, c = _size_to_rc(self.value.size())
+        return g.add_constant_probability_matrix(
+            self.value.reshape(r, c).transpose(0, 1)
+        )
+
+    def _to_cpp(self, d: Dict["BMGNode", int]) -> str:
+        n = d[self]
+        v = _value_to_cpp_eigen(self.value, f"m{n}")
+        return f"{v}uint n{n} = g.add_constant_probability_matrix(m{n});"
+
+    def _to_python(self, d: Dict["BMGNode", int]) -> str:
+        n = d[self]
+        v = _matrix_value_to_python(self.value)
+        return f"n{n} = g.add_constant_probability_matrix({v})"
+
+    @property
+    def is_matrix(self) -> bool:
+        return True
+
+
+class ConstantNaturalMatrixNode(ConstantTensorNode):
+    def __init__(self, value: Tensor):
+        assert len(value.size()) <= 2
+        ConstantTensorNode.__init__(self, value)
+
+    def _compute_graph_type(self) -> BMGLatticeType:
+        return Natural.with_size(self.size)
+
+    def _add_to_graph(self, g: Graph, d: Dict[BMGNode, int]) -> int:
+        r, c = _size_to_rc(self.value.size())
+        return g.add_constant_natural_matrix(self.value.reshape(r, c).transpose(0, 1))
+
+    def _to_cpp(self, d: Dict["BMGNode", int]) -> str:
+        n = d[self]
+        v = _value_to_cpp_eigen(self.value, f"m{n}")
+        return f"{v}uint n{n} = g.add_constant_natural_matrix(m{n});"
+
+    def _to_python(self, d: Dict["BMGNode", int]) -> str:
+        n = d[self]
+        v = _matrix_value_to_python(self.value)
+        return f"n{n} = g.add_constant_natural_matrix({v})"
+
+    @property
+    def is_matrix(self) -> bool:
+        return True
+
+
+class ConstantBooleanMatrixNode(ConstantTensorNode):
+    def __init__(self, value: Tensor):
+        assert len(value.size()) <= 2
+        ConstantTensorNode.__init__(self, value)
+
+    def _compute_graph_type(self) -> BMGLatticeType:
+        return Boolean.with_size(self.size)
+
+    def _add_to_graph(self, g: Graph, d: Dict[BMGNode, int]) -> int:
+        r, c = _size_to_rc(self.value.size())
+        return g.add_constant_bool_matrix(self.value.reshape(r, c).transpose(0, 1))
+
+    def _to_cpp(self, d: Dict["BMGNode", int]) -> str:
+        n = d[self]
+        v = _value_to_cpp_eigen(self.value, f"m{n}")
+        return f"{v}uint n{n} = g.add_constant_bool_matrix(m{n});"
+
+    def _to_python(self, d: Dict["BMGNode", int]) -> str:
+        n = d[self]
+        v = _matrix_value_to_python(self.value)
+        return f"n{n} = g.add_constant_bool_matrix({v})"
 
     @property
     def is_matrix(self) -> bool:

--- a/src/beanmachine/ppl/compiler/tests/dirichlet_test.py
+++ b/src/beanmachine/ppl/compiler/tests/dirichlet_test.py
@@ -223,15 +223,18 @@ uint n4 = g.add_constant_pos_matrix(m4);
         observed = bmg.to_cpp()
         self.assertEqual(expected.strip(), observed.strip())
 
+        # Notice that constant matrices are always expressed as a
+        # 2-d matrix, and we transpose them so that they are column-major.
+
         expected = """
 from beanmachine import graph
 from torch import tensor
 g = graph.Graph()
-n0 = g.add_constant_pos_matrix(tensor(1.0))
+n0 = g.add_constant_pos_matrix(tensor([[1.0]]))
 
-n2 = g.add_constant_pos_matrix(tensor([1.0,1.5]))
+n2 = g.add_constant_pos_matrix(tensor([[1.0],[1.5]]))
 
-n4 = g.add_constant_pos_matrix(tensor([[1.0,1.5],[2.0,2.5]]))
+n4 = g.add_constant_pos_matrix(tensor([[1.0,2.0],[1.5,2.5]]))
         """
         observed = bmg.to_python()
         self.assertEqual(expected.strip(), observed.strip())
@@ -466,7 +469,7 @@ digraph "graph" {
 from beanmachine import graph
 from torch import tensor
 g = graph.Graph()
-n0 = g.add_constant_pos_matrix(tensor([2.5,3.0]))
+n0 = g.add_constant_pos_matrix(tensor([[2.5],[3.0]]))
 n1 = g.add_distribution(
   graph.DistributionType.DIRICHLET,
   graph.ValueType(

--- a/src/beanmachine/ppl/compiler/tests/index_test.py
+++ b/src/beanmachine/ppl/compiler/tests/index_test.py
@@ -26,12 +26,12 @@ def real():
 
 @bm.random_variable
 def pos_real():
-    return Normal(0.0, tensor([1.5, 1.5])[flip()])
+    return Normal(0.0, tensor([1.5, 2.5])[flip()])
 
 
 @bm.random_variable
 def neg_real():
-    return Bernoulli(tensor([-1.5, -1.5])[flip()].log())
+    return Bernoulli(tensor([-1.5, -2.5])[flip()].exp())
 
 
 @bm.random_variable
@@ -39,23 +39,26 @@ def prob():
     return Bernoulli(tensor([0.5, 0.25])[flip()])
 
 
-@bm.functional
+@bm.random_variable
 def natural():
-    return Binomial(0.5, tensor([2, 3])[flip()])
+    return Binomial(tensor([2, 3])[flip()], 0.75)
 
 
 class IndexTest(unittest.TestCase):
     def test_index_constant_vector_stochastic_index(self) -> None:
         self.maxDiff = None
 
-        observed = BMGInference().to_dot([pos_real()], {})
+        observed = BMGInference().to_dot(
+            [pos_real(), real(), neg_real(), prob(), natural()],
+            {},
+        )
         expected = """
 digraph "graph" {
   N00[label=0.5];
   N01[label=Bernoulli];
   N02[label=Sample];
   N03[label=0.0];
-  N04[label="[1.5,1.5]"];
+  N04[label="[1.5,2.5]"];
   N05[label=1];
   N06[label=0];
   N07[label=if];
@@ -63,6 +66,29 @@ digraph "graph" {
   N09[label=Normal];
   N10[label=Sample];
   N11[label=Query];
+  N12[label="[1.5,-1.5]"];
+  N13[label=index];
+  N14[label=1.0];
+  N15[label=Normal];
+  N16[label=Sample];
+  N17[label=Query];
+  N18[label="[-1.5,-2.5]"];
+  N19[label=index];
+  N20[label=Exp];
+  N21[label=Bernoulli];
+  N22[label=Sample];
+  N23[label=Query];
+  N24[label="[0.5,0.25]"];
+  N25[label=index];
+  N26[label=Bernoulli];
+  N27[label=Sample];
+  N28[label=Query];
+  N29[label="[2,3]"];
+  N30[label=index];
+  N31[label=0.75];
+  N32[label=Binomial];
+  N33[label=Sample];
+  N34[label=Query];
   N00 -> N01;
   N01 -> N02;
   N02 -> N07;
@@ -71,15 +97,32 @@ digraph "graph" {
   N05 -> N07;
   N06 -> N07;
   N07 -> N08;
+  N07 -> N13;
+  N07 -> N19;
+  N07 -> N25;
+  N07 -> N30;
   N08 -> N09;
   N09 -> N10;
   N10 -> N11;
+  N12 -> N13;
+  N13 -> N15;
+  N14 -> N15;
+  N15 -> N16;
+  N16 -> N17;
+  N18 -> N19;
+  N19 -> N20;
+  N20 -> N21;
+  N21 -> N22;
+  N22 -> N23;
+  N24 -> N25;
+  N25 -> N26;
+  N26 -> N27;
+  N27 -> N28;
+  N29 -> N30;
+  N30 -> N32;
+  N31 -> N32;
+  N32 -> N33;
+  N33 -> N34;
 }
 """
         self.assertEqual(expected.strip(), observed.strip())
-
-        # TODO: real
-        # TODO: neg_real
-        # TODO: prob
-        # TODO: natural
-        # TODO: Boolean


### PR DESCRIPTION
Summary:
BMG has nodes representing constant 2d real, negative real, positive real, probability, natural and Boolean matrices; this diff adds all the previously unsupported node types to the graph accumulator and implements conversion logic to create the kind of matrix we need for any particular purpose.

The test case demonstrates that we can create an index which draws from a matrix of reals, negative reals, positive reals, probabilities or naturals in order to route an element of that matrix to an input expecting that type, where the index is a coin flip.

{F482071548}

I also made the code generation output more consistent: when dumping python or C++ code that creates a graph, we always format tensors that will be used to create constant matrixes as a 2-d matrix in column major form.

Reviewed By: wtaha

Differential Revision: D26932342

