### PR TITLE
Create perf testing API for Bean Machine Graph

### DIFF
--- a/src/beanmachine/graph/graph.cpp
+++ b/src/beanmachine/graph/graph.cpp
@@ -852,6 +852,7 @@ Graph::infer(uint num_samples, InferenceType algorithm, uint seed) {
   log_prob_vals.clear();
   log_prob_allchains.clear();
   _infer(num_samples, algorithm, seed);
+  _produce_performance_report();
   return samples;
 }
 
@@ -1022,6 +1023,21 @@ Graph::Graph(const Graph& other) {
   agg_type = other.agg_type;
   agg_samples = other.agg_samples;
   infer_config = other.infer_config;
+}
+
+void Graph::collect_performance_data(bool b) {
+  _collect_performance_data = b;
+}
+
+std::string Graph::performance_report() {
+  return _performance_report;
+}
+
+void Graph::_produce_performance_report() {
+  _performance_report = "";
+  if (!_collect_performance_data)
+    return;
+  _performance_report = "Bean Machine Graph performance report\n";
 }
 
 } // namespace graph

--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -688,6 +688,9 @@ struct Graph {
   Node* check_node(uint node_id, NodeType node_type);
   uint thread_index;
 
+  void collect_performance_data(bool b);
+  std::string performance_report();
+
  private:
   uint add_node(std::unique_ptr<Node> node, std::vector<uint> parents);
   std::vector<Node*> convert_parent_ids(const std::vector<uint>& parents) const;
@@ -736,6 +739,10 @@ struct Graph {
   std::vector<std::vector<double>> log_prob_allchains;
   std::map<TransformType, std::unique_ptr<Transformation>>
       common_transformations;
+
+  bool _collect_performance_data = false;
+  std::string _performance_report;
+  void _produce_performance_report();
 };
 
 /*

--- a/src/beanmachine/graph/pybindings.cpp
+++ b/src/beanmachine/graph/pybindings.cpp
@@ -303,7 +303,16 @@ PYBIND11_MODULE(graph, module) {
       .def(
           "get_log_prob",
           &Graph::get_log_prob,
-          "get the log probabilities of all chains");
+          "get the log probabilities of all chains")
+      .def(
+          "collect_performance_data",
+          &Graph::collect_performance_data,
+          "collect performance data",
+          py::arg("b"))
+      .def(
+          "performance_report",
+          &Graph::performance_report,
+          "performance report");
 }
 
 } // namespace graph

--- a/src/beanmachine/ppl/compiler/tests/perf_report_test.py
+++ b/src/beanmachine/ppl/compiler/tests/perf_report_test.py
@@ -1,0 +1,27 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import unittest
+
+import beanmachine.ppl as bm
+from beanmachine.ppl.inference import BMGInference
+from torch import tensor
+from torch.distributions import Bernoulli, Beta
+
+
+@bm.random_variable
+def coin():
+    return Beta(2.0, 2.0)
+
+
+@bm.random_variable
+def flip():
+    return Bernoulli(coin())
+
+
+class PerfReportTest(unittest.TestCase):
+    def test_bmg_performance_report_1(self) -> None:
+        self.maxDiff = None
+        queries = [coin()]
+        observations = {flip(): tensor(1.0)}
+        _, report = BMGInference()._infer(queries, observations, 1000)
+        expected = """Bean Machine Graph performance report"""
+        self.assertEqual(expected.strip(), report.strip())

--- a/src/beanmachine/ppl/inference/bmg_inference.py
+++ b/src/beanmachine/ppl/inference/bmg_inference.py
@@ -3,7 +3,7 @@
 """An inference engine which uses Bean Machine Graph to make
 inferences on Bean Machine models."""
 
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 from beanmachine.graph import InferenceType
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
@@ -34,6 +34,17 @@ class BMGInference:
         bmg._fix_observe_true = self._fix_observe_true
         bmg.accumulate_graph(queries, observations)
         return bmg
+
+    def _infer(
+        self,
+        queries: List[RVIdentifier],
+        observations: Dict[RVIdentifier, Tensor],
+        num_samples: int,
+        inference_type: InferenceType = InferenceType.NMC,
+    ) -> Tuple[MonteCarloSamples, str]:
+        return self._accumulate_graph(queries, observations)._infer(
+            num_samples, inference_type, True
+        )
 
     def infer(
         self,


### PR DESCRIPTION
Summary:
I've created a small back-channel API for doing arbitrary debug reporting of BMG state; I intend to use this for quick-and-dirty profiling.  I've added Beanstalk APIs to get this information from BMGInference as well.

As of yet we are not collecting any data. This is just getting the infrastructure in place.

The BMG API is straightforward; there are two public methods:

    void collect_performance_data(bool)
    string performance_report()

The first toggles whether or not performance data is collected; the second returns that data as a string. I will probably make it a JSON string in the next diff.

Those methods are exposed via Python interop.

The `infer` method of `BMGInference` returns a collection of samples. I've added an `_infer` method that returns a (samples, string)` pair. It instructs BMG to collect performance data, and then returns the resulting string.

(Yes I know this business of having BMGInference defer inference to BMGraphBuilder is bad architecture. I haven't had time to fix it.  We'll eventually move all that logic into BMGInference where it belongs.)

Reviewed By: wtaha

Differential Revision: D26968427

