### PR TITLE
BMG performance report now returns data via JSON

### DIFF
--- a/src/beanmachine/graph/graph.cpp
+++ b/src/beanmachine/graph/graph.cpp
@@ -852,7 +852,7 @@ Graph::infer(uint num_samples, InferenceType algorithm, uint seed) {
   log_prob_vals.clear();
   log_prob_allchains.clear();
   _infer(num_samples, algorithm, seed);
-  _produce_performance_report();
+  _produce_performance_report(num_samples, algorithm, seed);
   return samples;
 }
 
@@ -1023,21 +1023,6 @@ Graph::Graph(const Graph& other) {
   agg_type = other.agg_type;
   agg_samples = other.agg_samples;
   infer_config = other.infer_config;
-}
-
-void Graph::collect_performance_data(bool b) {
-  _collect_performance_data = b;
-}
-
-std::string Graph::performance_report() {
-  return _performance_report;
-}
-
-void Graph::_produce_performance_report() {
-  _performance_report = "";
-  if (!_collect_performance_data)
-    return;
-  _performance_report = "Bean Machine Graph performance report\n";
 }
 
 } // namespace graph

--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -742,7 +742,10 @@ struct Graph {
 
   bool _collect_performance_data = false;
   std::string _performance_report;
-  void _produce_performance_report();
+  void _produce_performance_report(
+      uint num_samples,
+      InferenceType algorithm,
+      uint seed);
 };
 
 /*

--- a/src/beanmachine/graph/perf_report.cpp
+++ b/src/beanmachine/graph/perf_report.cpp
@@ -1,0 +1,93 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+#include <chrono>
+#include <ctime>
+#include <iomanip>
+#include <sstream>
+#include <stack>
+#include <string>
+
+#include "beanmachine/graph/graph.h"
+
+using namespace std::chrono;
+
+namespace beanmachine {
+namespace graph {
+
+class JSON {
+ public:
+  std::string str() {
+    return os.str();
+  }
+  void start_object() {
+    os << "{\n";
+    needs_comma.push(false);
+  }
+  void end_object() {
+    os << "\n}";
+    needs_comma.pop();
+  }
+  void member(std::string name, std::string value) {
+    comma();
+    os << "\"" << name << "\" : \"" << value << "\"";
+  }
+
+  void member(std::string name, system_clock::time_point value) {
+    auto t = system_clock::to_time_t(value);
+    auto lt = localtime(&t);
+    auto timestamp = std::put_time(lt, "%Y-%m-%d %H:%M:%S");
+    comma();
+    os << "\"" << name << "\" : \"" << timestamp << "\"";
+  }
+
+  void member(std::string name, uint value) {
+    comma();
+    os << "\"" << name << "\" : " << value << "\n";
+  }
+
+ private:
+  void comma() {
+    if (needs_comma.top()) {
+      os << ",\n";
+    } else {
+      needs_comma.pop();
+      needs_comma.push(true);
+    }
+  }
+  std::ostringstream os;
+  std::stack<bool> needs_comma;
+};
+
+void Graph::collect_performance_data(bool b) {
+  _collect_performance_data = b;
+}
+
+std::string Graph::performance_report() {
+  return _performance_report;
+}
+
+void Graph::_produce_performance_report(
+    uint num_samples,
+    InferenceType algorithm,
+    uint seed) {
+  _performance_report = "";
+  JSON js;
+  if (!_collect_performance_data)
+    return;
+
+  uint edge_count = 0;
+  for (uint node_id = 0; node_id < nodes.size(); node_id++) {
+    edge_count += nodes[node_id]->in_nodes.size();
+  }
+  js.start_object();
+  js.member("title", "Bean Machine Graph performance report");
+  js.member("generated_at", system_clock::now());
+  js.member("num_samples", num_samples);
+  js.member("algorithm", (uint)algorithm);
+  js.member("seed", seed);
+  js.member("node_count", nodes.size());
+  js.member("edge_count", edge_count);
+  js.end_object();
+  _performance_report = js.str();
+}
+} // namespace graph
+} // namespace beanmachine

--- a/src/beanmachine/ppl/compiler/bm_graph_builder.py
+++ b/src/beanmachine/ppl/compiler/bm_graph_builder.py
@@ -64,6 +64,7 @@ import numpy as np
 import torch.distributions as dist
 from beanmachine.graph import Graph, InferenceType
 from beanmachine.ppl.compiler.bmg_nodes import BMGNode, ConstantNode
+from beanmachine.ppl.compiler.performance_report import PerformanceReport
 from beanmachine.ppl.inference.abstract_infer import _verify_queries_and_observations
 from beanmachine.ppl.inference.monte_carlo_samples import MonteCarloSamples
 from beanmachine.ppl.model.rv_identifier import RVIdentifier
@@ -1999,7 +2000,7 @@ g = graph.Graph()
 
     def _infer(
         self, num_samples: int, inference_type: InferenceType, produce_report: bool
-    ) -> Tuple[MonteCarloSamples, str]:
+    ) -> Tuple[MonteCarloSamples, PerformanceReport]:
         # TODO: Add num_chains to API
         # TODO: Test duplicated observations.
         # TODO: Test duplicated queries.
@@ -2007,7 +2008,7 @@ g = graph.Graph()
         self._fix_problems()
         g = Graph()
 
-        report = ""
+        report = PerformanceReport()
         node_to_graph_id: Dict[BMGNode, int] = {}
         query_to_query_id: Dict[bn.Query, int] = {}
         bmg_query_count = 0
@@ -2053,7 +2054,8 @@ g = graph.Graph()
         if len(query_to_query_id) != 0:
             g.collect_performance_data(produce_report)
             raw = g.infer(num_samples, inference_type)
-            report = g.performance_report()
+            if produce_report:
+                report = PerformanceReport(json=g.performance_report())
             assert len(raw) == num_samples
             assert len(raw[0]) == bmg_query_count
 

--- a/src/beanmachine/ppl/compiler/performance_report.py
+++ b/src/beanmachine/ppl/compiler/performance_report.py
@@ -1,0 +1,18 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import json as json_
+from typing import Any, Dict, Optional
+
+
+class PerformanceReport:
+    json: Optional[str]
+
+    def __init__(self, d: Optional[Dict[Any, Any]] = None, json: Optional[str] = None):
+        self.json = json
+        if json is not None:
+            d = json_.loads(json)
+        if d is not None:
+            for key, value in d.items():
+                # TODO: Recurse on dictionaries in lists also
+                if isinstance(value, dict):
+                    value = PerformanceReport(d=value)
+                setattr(self, key, value)

--- a/src/beanmachine/ppl/compiler/tests/perf_report_test.py
+++ b/src/beanmachine/ppl/compiler/tests/perf_report_test.py
@@ -22,6 +22,11 @@ class PerfReportTest(unittest.TestCase):
         self.maxDiff = None
         queries = [coin()]
         observations = {flip(): tensor(1.0)}
-        _, report = BMGInference()._infer(queries, observations, 1000)
-        expected = """Bean Machine Graph performance report"""
-        self.assertEqual(expected.strip(), report.strip())
+        num_samples = 1000
+        _, report = BMGInference()._infer(queries, observations, num_samples)
+
+        self.assertEqual("Bean Machine Graph performance report", report.title)
+        self.assertEqual(3, report.algorithm)
+        self.assertEqual(num_samples, report.num_samples)
+        self.assertEqual(5, report.node_count)
+        self.assertEqual(5, report.edge_count)

--- a/src/beanmachine/ppl/inference/bmg_inference.py
+++ b/src/beanmachine/ppl/inference/bmg_inference.py
@@ -7,6 +7,7 @@ from typing import Dict, List, Tuple
 
 from beanmachine.graph import InferenceType
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
+from beanmachine.ppl.compiler.performance_report import PerformanceReport
 from beanmachine.ppl.inference.abstract_infer import _verify_queries_and_observations
 from beanmachine.ppl.inference.monte_carlo_samples import MonteCarloSamples
 from beanmachine.ppl.model.rv_identifier import RVIdentifier
@@ -41,7 +42,7 @@ class BMGInference:
         observations: Dict[RVIdentifier, Tensor],
         num_samples: int,
         inference_type: InferenceType = InferenceType.NMC,
-    ) -> Tuple[MonteCarloSamples, str]:
+    ) -> Tuple[MonteCarloSamples, PerformanceReport]:
         return self._accumulate_graph(queries, observations)._infer(
             num_samples, inference_type, True
         )


### PR DESCRIPTION
Summary:
I've moved the BMG performance reporting code to its own cpp file, and it now uses the world's simplest JSON serializer to dump out data about the run.

We are still not actually collecting performance data beyond simple things like node and edge count, but this demonstrates that we can very easily transmit arbitrary structured data from BMG to Python to create a Python object.

On the Python side we deserialize into a Python object (while retaining the JSON should we need it) and I've created some simple tests.

Reviewed By: wtaha

Differential Revision: D26969862

