### PR TITLE
Fix bug for r-hat calculations with low variance

### DIFF
--- a/src/beanmachine/ppl/diagnostics/common_statistics.py
+++ b/src/beanmachine/ppl/diagnostics/common_statistics.py
@@ -46,7 +46,7 @@ def _compute_var(query_samples: Tensor) -> Tuple[Tensor, Tensor]:
         b = 0
     w = torch.mean(torch.var(query_samples, dim=1), dim=0)
     var_hat = (n_samples - 1) / n_samples * w + (1 / n_samples) * b
-    return w, var_hat.clamp(min=1e-3)
+    return w, var_hat.clamp(min=1e-10)
 
 
 def r_hat(query_samples: Tensor) -> Optional[Tensor]:


### PR DESCRIPTION
Summary: In some use cases (such as BMA), the variance can be around 1e-8

Reviewed By: jpchen

Differential Revision: D27104754

