### PR TITLE
Add simple profiling to BMG C++ codebase

### DIFF
--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <tuple>
 #include <vector>
+#include "beanmachine/graph/profiler.h"
 
 #define NATURAL_TYPE unsigned long long int
 
@@ -740,12 +741,23 @@ struct Graph {
   std::map<TransformType, std::unique_ptr<Transformation>>
       common_transformations;
 
+  ProfilerData profiler_data;
   bool _collect_performance_data = false;
   std::string _performance_report;
   void _produce_performance_report(
       uint num_samples,
       InferenceType algorithm,
       uint seed);
+  void pd_begin(ProfilerEvent kind) {
+    if (_collect_performance_data) {
+      profiler_data.begin(kind);
+    }
+  }
+  void pd_finish(ProfilerEvent kind) {
+    if (_collect_performance_data) {
+      profiler_data.finish(kind);
+    }
+  }
 };
 
 /*

--- a/src/beanmachine/graph/nmc.cpp
+++ b/src/beanmachine/graph/nmc.cpp
@@ -8,6 +8,7 @@
 #include "beanmachine/graph/distribution/distribution.h"
 #include "beanmachine/graph/graph.h"
 #include "beanmachine/graph/operator/stochasticop.h"
+#include "beanmachine/graph/profiler.h"
 #include "beanmachine/graph/proposer/proposer.h"
 #include "beanmachine/graph/util.h"
 
@@ -15,8 +16,10 @@ namespace beanmachine {
 namespace graph {
 
 void Graph::nmc(uint num_samples, std::mt19937& gen) {
+  pd_begin(ProfilerEvent::NMC_INFER);
   // convert the smart pointers in nodes to dumb pointers in node_ptrs
   // for faster access
+  pd_begin(ProfilerEvent::NMC_INFER_INITIALIZE);
   std::vector<Node*> node_ptrs;
   for (uint node_id = 0; node_id < nodes.size(); node_id++) {
     node_ptrs.push_back(nodes[node_id].get());
@@ -61,6 +64,8 @@ void Graph::nmc(uint num_samples, std::mt19937& gen) {
     }
   }
 
+  pd_finish(ProfilerEvent::NMC_INFER_INITIALIZE);
+  pd_begin(ProfilerEvent::NMC_INFER_COLLECT_SAMPLES);
   std::vector<NodeValue> old_values = std::vector<NodeValue>(nodes.size());
   assert(old_values.size() > 0); // keep linter happy
   // sampling outer loop
@@ -157,6 +162,8 @@ void Graph::nmc(uint num_samples, std::mt19937& gen) {
     }
     collect_sample();
   }
+  pd_finish(ProfilerEvent::NMC_INFER_COLLECT_SAMPLES);
+  pd_finish(ProfilerEvent::NMC_INFER);
 }
 
 /*

--- a/src/beanmachine/graph/perf_report.cpp
+++ b/src/beanmachine/graph/perf_report.cpp
@@ -5,6 +5,7 @@
 #include <sstream>
 #include <stack>
 #include <string>
+#include <variant>
 
 #include "beanmachine/graph/graph.h"
 
@@ -18,33 +19,102 @@ class JSON {
   std::string str() {
     return os.str();
   }
+
   void start_object() {
     os << "{\n";
     needs_comma.push(false);
   }
+
   void end_object() {
     os << "\n}";
     needs_comma.pop();
   }
-  void member(std::string name, std::string value) {
-    comma();
-    os << "\"" << name << "\" : \"" << value << "\"";
+
+  void start_array() {
+    os << "[\n";
+    needs_comma.push(false);
   }
 
-  void member(std::string name, system_clock::time_point value) {
-    auto t = system_clock::to_time_t(value);
+  void end_array() {
+    os << "\n]";
+    needs_comma.pop();
+  }
+
+  void text(std::string v) {
+    os << "\"" << v << "\"";
+  }
+
+  void boolean(bool v) {
+    os << (v ? "true" : "false");
+  }
+
+  void date(system_clock::time_point v) {
+    auto t = system_clock::to_time_t(v);
     auto lt = localtime(&t);
     auto timestamp = std::put_time(lt, "%Y-%m-%d %H:%M:%S");
-    comma();
-    os << "\"" << name << "\" : \"" << timestamp << "\"";
+    os << "\"" << timestamp << "\"";
   }
 
-  void member(std::string name, uint value) {
-    comma();
-    os << "\"" << name << "\" : " << value << "\n";
+  void ticks(high_resolution_clock::time_point v) {
+    number(v.time_since_epoch().count());
   }
 
- private:
+  void number(long v) {
+    os << v;
+  }
+
+  void member(std::string name) {
+    comma();
+    os << "\"" << name << "\" : ";
+  }
+
+  void boolean(std::string name, bool v) {
+    member(name);
+    boolean(v);
+  }
+
+  void text(std::string name, std::string v) {
+    member(name);
+    text(v);
+  }
+
+  void date(std::string name, system_clock::time_point v) {
+    member(name);
+    date(v);
+  }
+
+  void ticks(std::string name, high_resolution_clock::time_point v) {
+    member(name);
+    ticks(v);
+  }
+
+  void number(std::string name, long v) {
+    member(name);
+    number(v);
+  }
+
+  void event(ProfilerEvent v) {
+    switch (v) {
+      case ProfilerEvent::NMC_INFER:
+        text("nmc_infer");
+        break;
+      case ProfilerEvent::NMC_INFER_COLLECT_SAMPLES:
+        text("collect_samples");
+        break;
+      case ProfilerEvent::NMC_INFER_INITIALIZE:
+        text("initialize");
+        break;
+      default:
+        number((int)v);
+        break;
+    }
+  }
+
+  void event(std::string name, ProfilerEvent v) {
+    member(name);
+    event(v);
+  }
+
   void comma() {
     if (needs_comma.top()) {
       os << ",\n";
@@ -53,6 +123,8 @@ class JSON {
       needs_comma.push(true);
     }
   }
+
+ private:
   std::ostringstream os;
   std::stack<bool> needs_comma;
 };
@@ -79,13 +151,26 @@ void Graph::_produce_performance_report(
     edge_count += nodes[node_id]->in_nodes.size();
   }
   js.start_object();
-  js.member("title", "Bean Machine Graph performance report");
-  js.member("generated_at", system_clock::now());
-  js.member("num_samples", num_samples);
-  js.member("algorithm", (uint)algorithm);
-  js.member("seed", seed);
-  js.member("node_count", nodes.size());
-  js.member("edge_count", edge_count);
+  js.text("title", "Bean Machine Graph performance report");
+  js.date("generated_at", system_clock::now());
+  js.number("num_samples", num_samples);
+  js.number("algorithm", (uint)algorithm);
+  js.number("seed", seed);
+  js.number("node_count", nodes.size());
+  js.number("edge_count", edge_count);
+  js.number("edge_count", edge_count);
+  js.member("profiler_data");
+  js.start_array();
+  for (auto e : profiler_data.events) {
+    js.comma();
+    js.start_object();
+    js.boolean("begin", e.begin);
+    js.event("event", e.kind);
+    js.ticks("timestamp", e.timestamp);
+    js.end_object();
+  }
+
+  js.end_array();
   js.end_object();
   _performance_report = js.str();
 }

--- a/src/beanmachine/graph/profiler.cpp
+++ b/src/beanmachine/graph/profiler.cpp
@@ -1,0 +1,31 @@
+// (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+
+#include "beanmachine/graph/profiler.h"
+
+using namespace std::chrono;
+
+namespace beanmachine {
+namespace graph {
+
+ProfilerData::ProfilerData() {}
+
+void ProfilerData::begin(ProfilerEvent kind) {
+  auto t = high_resolution_clock::now();
+  events.push_back({true, kind, t});
+  in_flight.push(kind);
+}
+
+void ProfilerData::finish(ProfilerEvent kind) {
+  auto t = high_resolution_clock::now();
+  while (!in_flight.empty()) {
+    ProfilerEvent top = in_flight.top();
+    in_flight.pop();
+    events.push_back({false, top, t});
+    if (top == kind) {
+      break;
+    }
+  }
+}
+
+} // namespace graph
+} // namespace beanmachine

--- a/src/beanmachine/graph/profiler.h
+++ b/src/beanmachine/graph/profiler.h
@@ -1,0 +1,33 @@
+// (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <chrono>
+#include <stack>
+#include <vector>
+
+namespace beanmachine {
+namespace graph {
+
+enum class ProfilerEvent {
+  NMC_INFER,
+  NMC_INFER_INITIALIZE,
+  NMC_INFER_COLLECT_SAMPLES,
+};
+
+struct Event {
+  bool begin;
+  ProfilerEvent kind;
+  std::chrono::high_resolution_clock::time_point timestamp;
+};
+
+struct ProfilerData {
+  std::vector<Event> events;
+  std::stack<ProfilerEvent> in_flight;
+  ProfilerData();
+  void begin(ProfilerEvent kind);
+  void finish(ProfilerEvent kind);
+};
+
+} // namespace graph
+} // namespace beanmachine

--- a/src/beanmachine/ppl/compiler/bm_graph_builder.py
+++ b/src/beanmachine/ppl/compiler/bm_graph_builder.py
@@ -59,12 +59,12 @@ from typing import Any, Callable, Dict, List, Set, Tuple
 
 import beanmachine.ppl.compiler.bmg_nodes as bn
 import beanmachine.ppl.compiler.bmg_types as bt
+import beanmachine.ppl.compiler.performance_report as pr
 import beanmachine.ppl.compiler.profiler as prof
 import numpy as np
 import torch.distributions as dist
 from beanmachine.graph import Graph, InferenceType
 from beanmachine.ppl.compiler.bmg_nodes import BMGNode, ConstantNode
-from beanmachine.ppl.compiler.performance_report import PerformanceReport
 from beanmachine.ppl.inference.abstract_infer import _verify_queries_and_observations
 from beanmachine.ppl.inference.monte_carlo_samples import MonteCarloSamples
 from beanmachine.ppl.model.rv_identifier import RVIdentifier
@@ -2095,13 +2095,13 @@ g = graph.Graph()
 
     def _infer(
         self, num_samples: int, inference_type: InferenceType, produce_report: bool
-    ) -> Tuple[MonteCarloSamples, PerformanceReport]:
+    ) -> Tuple[MonteCarloSamples, pr.PerformanceReport]:
         # TODO: Add num_chains to API
         # TODO: Test duplicated observations.
         # TODO: Test duplicated queries.
         # TODO: Move this logic to BMGInference
 
-        report = PerformanceReport()
+        report = pr.PerformanceReport()
         self.pd.begin(prof.infer)
         self._fix_problems()
 
@@ -2161,7 +2161,8 @@ g = graph.Graph()
             raw = g.infer(num_samples, inference_type)
             self.pd.finish(prof.graph_infer)
             if produce_report:
-                report = PerformanceReport(json=g.performance_report())
+                js = g.performance_report()
+                report = pr.json_to_perf_report(js)
             assert len(raw) == num_samples
             assert len(raw[0]) == bmg_query_count
             samples = self._transpose_samples(raw)

--- a/src/beanmachine/ppl/compiler/performance_report.py
+++ b/src/beanmachine/ppl/compiler/performance_report.py
@@ -1,18 +1,29 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import json as json_
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 
 class PerformanceReport:
-    json: Optional[str]
+    json: Optional[str] = None
 
-    def __init__(self, d: Optional[Dict[Any, Any]] = None, json: Optional[str] = None):
-        self.json = json
-        if json is not None:
-            d = json_.loads(json)
-        if d is not None:
-            for key, value in d.items():
-                # TODO: Recurse on dictionaries in lists also
-                if isinstance(value, dict):
-                    value = PerformanceReport(d=value)
-                setattr(self, key, value)
+
+def _to_perf_rep(v: Any) -> Any:
+    if isinstance(v, dict):
+        p = PerformanceReport()
+        for key, value in v.items():
+            value = _to_perf_rep(value)
+            setattr(p, key, value)
+        return p
+    if isinstance(v, list):
+        for i in range(len(v)):
+            v[i] = _to_perf_rep(v[i])
+        return v
+    return v
+
+
+def json_to_perf_report(json: str) -> PerformanceReport:
+    d = json_.loads(json)
+    p = _to_perf_rep(d)
+    assert isinstance(p, PerformanceReport)
+    p.json = json
+    return p

--- a/src/beanmachine/ppl/compiler/tests/perf_report_test.py
+++ b/src/beanmachine/ppl/compiler/tests/perf_report_test.py
@@ -33,3 +33,5 @@ class PerfReportTest(unittest.TestCase):
         self.assertLess(0, report.profiler_report.accumulate.total_time)
         self.assertLess(0, report.profiler_report.infer.total_time)
         self.assertLess(0, report.profiler_report.infer.graph_infer.total_time)
+        self.assertLess(0, len(report.profiler_data))
+        self.assertLess(0, report.profiler_data[0].timestamp)


### PR DESCRIPTION
Summary:
In previous diffs I added simple profiling to the Python codebase and transmission of performance stats from C++ to Python. In this diff I port my mini-profiler to C++ and send profiling information over to the Python side; I do not yet decode it into a more readable report.

There are a number of other miscellaneous changes in support here which I would normally break out into separate diffs, but in the interest of expediency are all in one diff:

* Serialization and deserialization of performance statistics now includes supporting JSON list
* JSON serialization code now breaks out every value encoding into its own clearly-named helper function.
* And other minor improvements

Reviewed By: wtaha

Differential Revision: D27028011

