### PR TITLE
Add analysis of BMG profiling report to performance report

### DIFF
--- a/src/beanmachine/graph/perf_report.cpp
+++ b/src/beanmachine/graph/perf_report.cpp
@@ -165,7 +165,7 @@ void Graph::_produce_performance_report(
     js.comma();
     js.start_object();
     js.boolean("begin", e.begin);
-    js.event("event", e.kind);
+    js.event("kind", e.kind);
     js.ticks("timestamp", e.timestamp);
     js.end_object();
   }

--- a/src/beanmachine/ppl/compiler/bm_graph_builder.py
+++ b/src/beanmachine/ppl/compiler/bm_graph_builder.py
@@ -2163,6 +2163,9 @@ g = graph.Graph()
             if produce_report:
                 js = g.performance_report()
                 report = pr.json_to_perf_report(js)
+                report.bmg_profiler_report = prof.event_list_to_report(
+                    report.profiler_data
+                )
             assert len(raw) == num_samples
             assert len(raw[0]) == bmg_query_count
             samples = self._transpose_samples(raw)

--- a/src/beanmachine/ppl/compiler/profiler.py
+++ b/src/beanmachine/ppl/compiler/profiler.py
@@ -112,28 +112,32 @@ class ProfilerData:
         return total_time
 
     def to_report(self) -> ProfileReport:
-        root = ProfileReport()
-        current = root
-        begins = []
-        for e in self.events:
-            if e.begin:
-                if e.kind in current.children:
-                    p = current.children[e.kind]
-                else:
-                    p = ProfileReport()
-                    p.parent = current
-                    current.children[e.kind] = p
-                    setattr(current, e.kind, p)
-                p.calls += 1
-                current = p
-                begins.append(e)
+        return event_list_to_report(self.events)
+
+
+def event_list_to_report(events) -> ProfileReport:
+    root = ProfileReport()
+    current = root
+    begins = []
+    for e in events:
+        if e.begin:
+            if e.kind in current.children:
+                p = current.children[e.kind]
             else:
-                assert len(begins) > 0
-                b = begins[-1]
-                assert e.kind == b.kind
-                current.total_time += e.timestamp - b.timestamp
-                begins.pop()
-                current = current.parent
-        assert len(begins) == 0
-        assert current == root
-        return root
+                p = ProfileReport()
+                p.parent = current
+                current.children[e.kind] = p
+                setattr(current, e.kind, p)
+            p.calls += 1
+            current = p
+            begins.append(e)
+        else:
+            assert len(begins) > 0
+            b = begins[-1]
+            assert e.kind == b.kind
+            current.total_time += e.timestamp - b.timestamp
+            begins.pop()
+            current = current.parent
+    assert len(begins) == 0
+    assert current == root
+    return root

--- a/src/beanmachine/ppl/compiler/tests/perf_report_test.py
+++ b/src/beanmachine/ppl/compiler/tests/perf_report_test.py
@@ -35,3 +35,9 @@ class PerfReportTest(unittest.TestCase):
         self.assertLess(0, report.profiler_report.infer.graph_infer.total_time)
         self.assertLess(0, len(report.profiler_data))
         self.assertLess(0, report.profiler_data[0].timestamp)
+        self.assertNotEqual("", str(report.bmg_profiler_report))
+        self.assertLess(0, report.bmg_profiler_report.nmc_infer.total_time)
+        self.assertLess(0, report.bmg_profiler_report.nmc_infer.initialize.total_time)
+        self.assertLess(
+            0, report.bmg_profiler_report.nmc_infer.collect_samples.total_time
+        )


### PR DESCRIPTION
Summary:
The performance report now runs the raw data from the BMG profiler through the same analyzer used for compiler profiling.

See the test case for how to read the data out of the performance report: attribute `bmg_profiler_report` can be turned into a string or interrogated programmatically.

Reviewed By: wtaha

Differential Revision: D27060543

