### PR TITLE
Interactive sampling

### DIFF
--- a/src/beanmachine/ppl/inference/monte_carlo_samples.py
+++ b/src/beanmachine/ppl/inference/monte_carlo_samples.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, Iterator, List, Mapping, Optional, Union
 import arviz as az
 import torch
 import xarray as xr
+from beanmachine.ppl.inference.utils import merge_dicts
 from beanmachine.ppl.model.rv_identifier import RVIdentifier
 
 
@@ -170,16 +171,3 @@ class MonteCarloSamples(Mapping[RVIdentifier, torch.Tensor]):
             warmup_posterior=self.adaptive_samples,
             save_warmup=include_adapt_steps,
         )
-
-
-def merge_dicts(dicts: List[RVDict], dim: int = 0) -> RVDict:
-    """
-    A helper function that merge multiple dicts of samples into a single dictionary,
-    stacking across a new dimension
-    """
-    rv_keys = set().union(*(rv_dict.keys() for rv_dict in dicts))
-    for idx, d in enumerate(dicts):
-        if not rv_keys.issubset(d.keys()):
-            raise ValueError(f"{rv_keys - d.keys()} are missing in dict {idx}")
-
-    return {rv: torch.stack([d[rv] for d in dicts], dim=dim) for rv in rv_keys}

--- a/src/beanmachine/ppl/inference/sampler.py
+++ b/src/beanmachine/ppl/inference/sampler.py
@@ -1,0 +1,77 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+from __future__ import annotations
+
+import copy
+import itertools
+from typing import TYPE_CHECKING, Dict, Iterator, List, Optional, Union, cast
+
+import torch
+from beanmachine.ppl.inference.monte_carlo_samples import MonteCarloSamples
+from beanmachine.ppl.inference.utils import merge_dicts
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
+
+
+if TYPE_CHECKING:
+    from beanmachine.ppl.inference.abstract_mh_infer import AbstractMHInference
+
+RVDict = Dict[RVIdentifier, torch.Tensor]
+
+
+class Sampler(Iterator[RVDict]):
+    def __init__(
+        self,
+        kernel: AbstractMHInference,
+        queries: List[RVIdentifier],
+        observations: RVDict,
+        num_samples: Optional[int] = None,
+        num_adaptive_samples: int = 0,
+        initialize_from_prior: bool = False,
+        return_adaptive_samples: bool = False,
+    ):
+        if num_samples is None:
+            self._iterations = itertools.count(0)
+        else:
+            self._iterations = iter(range(num_samples + num_adaptive_samples))
+        self.num_adaptive_samples = num_adaptive_samples
+        self.iteration = None
+
+        # initialize kernel
+        self.kernel = copy.copy(kernel)
+        self.kernel.queries_ = queries
+        self.kernel.observations_ = observations
+        self.kernel.initialize_world(initialize_from_prior)
+        self.kernel.world_.set_initialize_from_prior(True)
+
+        if not return_adaptive_samples:
+            for _ in range(self.num_adaptive_samples):
+                next(self)
+
+    def __next__(self) -> RVDict:
+        """
+        Run a single MCMC iteration and return a dict containing the queried samples
+        """
+        # this will propagate StopIteration from self._iterations
+        self.iteration = next(self._iterations)
+        return self.kernel._single_iteration_run(
+            self.iteration, self.num_adaptive_samples
+        )
+
+    @staticmethod
+    def to_monte_carlo_samples(
+        sample_list: Union[List[RVDict], List[List[RVDict]]],
+        num_adaptive_samples: int = 0,
+    ) -> MonteCarloSamples:
+        """
+        A helper function that convert a list of dicts of random variables generated
+        from a Sampler to a single MonteCarloSamples instance. Samples from multiple
+        chains can also be merged using this method by providing a list of lists, each
+        correspond to the result from a single chain.
+        """
+        if all(isinstance(sample, dict) for sample in sample_list):
+            # the cast is necessary to silent Pyre though it does nothing in run time
+            sample_list = [cast(List[RVDict], sample_list)]
+        chain_list = [
+            merge_dicts(chain) for chain in cast(List[List[RVDict]], sample_list)
+        ]
+        return MonteCarloSamples(chain_list, num_adaptive_samples)

--- a/src/beanmachine/ppl/inference/tests/sampler_test.py
+++ b/src/beanmachine/ppl/inference/tests/sampler_test.py
@@ -1,0 +1,62 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import unittest
+
+import beanmachine.ppl as bm
+import torch
+import torch.distributions as dist
+
+
+class SamplerTest(unittest.TestCase):
+    class SampleModel:
+        @bm.random_variable
+        def foo(self):
+            return dist.Uniform(torch.tensor(0.0), torch.tensor(1.0))
+
+        @bm.random_variable
+        def bar(self):
+            return dist.Normal(self.foo(), torch.tensor(1.0))
+
+    def test_sampler_smoke(self):
+        model = self.SampleModel()
+        num_samples = 10
+        sampler = bm.SingleSiteAncestralMetropolisHastings().sampler(
+            [model.foo()],
+            {model.bar(): torch.tensor(0.8)},
+            num_samples,
+            num_adaptive_samples=num_samples,
+        )
+        samples = []
+        for sample in sampler:
+            self.assertIn(model.foo(), sample)
+            # only a single sample is returned at a time
+            self.assertEqual(sample[model.foo()].numel(), 1)
+            samples.append(sample)
+        self.assertEqual(len(samples), num_samples)
+        samples = sampler.to_monte_carlo_samples(samples)
+        self.assertIn(model.foo(), samples)
+        self.assertIsInstance(samples[model.foo()], torch.Tensor)
+        self.assertEqual(samples[model.foo()].shape, (1, num_samples))
+
+    def test_infinite_sampler(self):
+        model = self.SampleModel()
+        sampler = bm.SingleSiteRandomWalk().sampler(
+            [model.foo()], {model.bar(): torch.tensor(0.4)}
+        )
+        for _ in range(10):
+            sample = next(sampler)
+            self.assertIn(model.foo(), sample)
+
+    def test_multiple_samplers(self):
+        model = self.SampleModel()
+        num_chains = 2
+        num_samples = 10
+        samplers = [
+            bm.SingleSiteAncestralMetropolisHastings().sampler(
+                [model.foo()], {model.bar(): torch.tensor(0.3)}, num_samples
+            )
+            for _ in range(num_chains)
+        ]
+        chains = [list(sampler) for sampler in samplers]
+        samples = samplers[0].to_monte_carlo_samples(chains)
+        self.assertIn(model.foo(), samples)
+        self.assertEqual(samples[model.foo()].shape, (num_chains, num_samples))

--- a/src/beanmachine/ppl/inference/utils.py
+++ b/src/beanmachine/ppl/inference/utils.py
@@ -1,10 +1,13 @@
 # Copyright (c) Facebook, Inc. and its affiliates
 from dataclasses import dataclass
 from enum import Enum
-from typing import List
+from typing import Dict, List
 
+import torch
 from beanmachine.ppl.model.rv_identifier import RVIdentifier
-from torch import Tensor, tensor
+
+
+RVDict = Dict[RVIdentifier, torch.Tensor]
 
 
 class BlockType(Enum):
@@ -30,12 +33,25 @@ class Block:
     block: List[str]
 
 
-def safe_log_prob_sum(distrib, value: Tensor) -> Tensor:
+def safe_log_prob_sum(distrib, value: torch.Tensor) -> torch.Tensor:
     "Computes log_prob, converting out of support exceptions to -Infinity."
     try:
         return distrib.log_prob(value).sum()
     except (RuntimeError, ValueError) as e:
         if not distrib.support.check(value):
-            return tensor(float("-Inf")).to(value.device)
+            return torch.tensor(float("-Inf")).to(value.device)
         else:
             raise e
+
+
+def merge_dicts(dicts: List[RVDict], dim: int = 0) -> RVDict:
+    """
+    A helper function that merge multiple dicts of samples into a single dictionary,
+    stacking across a new dimension
+    """
+    rv_keys = set().union(*(rv_dict.keys() for rv_dict in dicts))
+    for idx, d in enumerate(dicts):
+        if not rv_keys.issubset(d.keys()):
+            raise ValueError(f"{rv_keys - d.keys()} are missing in dict {idx}")
+
+    return {rv: torch.stack([d[rv] for d in dicts], dim=dim) for rv in rv_keys}


### PR DESCRIPTION
Summary:
This diff introduces the interactive sampling API via a "Sampler" class.

The change in this diff is actually quite small. I basically refactor and exposes the single iteration run into a method of `AbstractMHInference` and use it from both the regular `AbstractMHInference.infer` and in the `Sampler.__next__`.

The reason for creating a new class instead of using Python's native generator object (function with `yield`) is that native generators are not pickle-able. By creating our own class, we can control how to save and reload the state in case we want to reuse a converged sampler in a new session. (Currently the `Sampler` class is not fully pickle-able yet due to an issue in pickling `world`, but we can enable this in a future diff)

In the future we might want to move the "state" out of any of the `AbstractMHInference` classes and pass things like world, queries and observations as inputs to single iteration run.  Currently the state of a sampler is still kept in a "kernel" instance, which could be a bit unintuitive.

I'm also adding a helper function to the `Sampler` class so that users can easily re-create a `MonteCarloSamples` instance if they need to. More examples on how to use the sampler can be found in N493647.

Related doc: https://fb.quip.com/Nb3TATvObVlD

I'm open to rename the class to something else or rewrite this diff completely, so feel free to make any suggestions or comments :)

Reviewed By: jpchen, neerajprad

Differential Revision: D26934961

