### PR TITLE
Add profiling events to each NMC step

### DIFF
--- a/src/beanmachine/graph/nmc.cpp
+++ b/src/beanmachine/graph/nmc.cpp
@@ -277,6 +277,7 @@ class Graph::NMC {
       Node* tgt_node,
       const std::vector<Node*>& det_nodes,
       const std::vector<Node*>& sto_nodes) {
+    g->pd_begin(ProfilerEvent::NMC_STEP);
     // We are given an unobserved stochastic "target" node and we wish
     // to compute a new value for it. The basic idea of the algorithm is:
     //
@@ -321,6 +322,7 @@ class Graph::NMC {
     clear_gradients(det_nodes);
     tgt_node->grad1 = 0;
     tgt_node->grad2 = 0;
+    g->pd_finish(ProfilerEvent::NMC_STEP);
   }
 
   /*
@@ -333,6 +335,7 @@ class Graph::NMC {
       Node* tgt_node,
       const std::vector<Node*>& det_nodes,
       const std::vector<Node*>& sto_nodes) {
+    g->pd_begin(ProfilerEvent::NMC_STEP_DIRICHLET);
     uint K = tgt_node->value._matrix.size();
     auto src_node = static_cast<oper::StochasticOperator*>(tgt_node);
     // @lint-ignore CLANGTIDY
@@ -393,7 +396,8 @@ class Graph::NMC {
       clear_gradients(det_nodes);
       tgt_node->grad1 = 0;
       tgt_node->grad2 = 0;
-    }
+    } // k
+    g->pd_finish(ProfilerEvent::NMC_STEP_DIRICHLET);
   }
 };
 

--- a/src/beanmachine/graph/perf_report.cpp
+++ b/src/beanmachine/graph/perf_report.cpp
@@ -104,6 +104,13 @@ class JSON {
       case ProfilerEvent::NMC_INFER_INITIALIZE:
         text("initialize");
         break;
+      case ProfilerEvent::NMC_STEP:
+        text("step");
+        break;
+      case ProfilerEvent::NMC_STEP_DIRICHLET:
+        text("step_dirichlet");
+        break;
+
       default:
         number((int)v);
         break;

--- a/src/beanmachine/graph/profiler.h
+++ b/src/beanmachine/graph/profiler.h
@@ -13,6 +13,8 @@ enum class ProfilerEvent {
   NMC_INFER,
   NMC_INFER_INITIALIZE,
   NMC_INFER_COLLECT_SAMPLES,
+  NMC_STEP,
+  NMC_STEP_DIRICHLET,
 };
 
 struct Event {


### PR DESCRIPTION
Summary: I've added a profiling event to each NMC step so that we can get an idea of how many steps there are per sample, and how many of them are Dirichlet vs normal steps.

Reviewed By: wtaha

Differential Revision: D27105622

