### PR TITLE
Implement to_dot on BMG

### DIFF
--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -499,6 +499,7 @@ struct Graph {
   Graph(const Graph& other);
   ~Graph() {}
   std::string to_string() const;
+  std::string to_dot() const;
   // Graph builder APIs -> return the node number
   uint add_constant(bool value);
   uint add_constant(double value);

--- a/src/beanmachine/graph/pybindings.cpp
+++ b/src/beanmachine/graph/pybindings.cpp
@@ -101,6 +101,7 @@ PYBIND11_MODULE(graph, module) {
   py::class_<Graph>(module, "Graph")
       .def(py::init())
       .def("to_string", &Graph::to_string, "string representation of the graph")
+      .def("to_dot", &Graph::to_dot, "DOT representation of the graph")
       .def(
           "add_constant",
           (uint(Graph::*)(bool)) & Graph::add_constant,

--- a/src/beanmachine/graph/tests/graph_test.py
+++ b/src/beanmachine/graph/tests/graph_test.py
@@ -241,6 +241,45 @@ class TestBayesNet(unittest.TestCase):
         g.query(GrassWet)
         g.infer(1)
 
+    def test_to_dot(self):
+        self.maxDiff = None
+        g, Rain, Sprinkler, GrassWet = self._create_graph()
+        g.query(Rain)
+        g.query(Sprinkler)
+        g.query(GrassWet)
+        g.observe(GrassWet, True)
+        observed = g.to_dot()
+        expected = """
+digraph "graph" {
+  N0[label="simplex"];
+  N1[label="simplex"];
+  N2[label="simplex"];
+  N3[label="Tabular"];
+  N4[label="~"];
+  N5[label="Tabular"];
+  N6[label="~"];
+  N7[label="Tabular"];
+  N8[label="~"];
+  N0 -> N3;
+  N1 -> N5;
+  N2 -> N7;
+  N3 -> N4;
+  N4 -> N5;
+  N4 -> N7;
+  N5 -> N6;
+  N6 -> N7;
+  N7 -> N8;
+  O0[label="Observation"];
+  N8 -> O0;
+  Q0[label="Query"];
+  N4 -> Q0;
+  Q1[label="Query"];
+  N6 -> Q1;
+  Q2[label="Query"];
+  N8 -> Q2;
+}"""
+        self.assertEqual(expected.strip(), observed.strip())
+
     def test_observe(self):
         g, Rain, Sprinkler, GrassWet = self._create_graph()
         g.observe(GrassWet, True)

--- a/src/beanmachine/graph/to_dot.cpp
+++ b/src/beanmachine/graph/to_dot.cpp
@@ -1,0 +1,242 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+#include <sstream>
+
+#include "beanmachine/graph/distribution/distribution.h"
+#include "beanmachine/graph/factor/factor.h"
+#include "beanmachine/graph/graph.h"
+#include "beanmachine/graph/operator/operator.h"
+
+namespace beanmachine {
+namespace graph {
+
+class DOT {
+ public:
+  std::string str() {
+    return os.str();
+  }
+
+  void start_graph() {
+    os << "digraph \"graph\" {\n";
+  }
+
+  void end_graph() {
+    os << "}\n";
+  }
+
+  void node(uint n, std::string label) {
+    os << "  N" << n << "[label=\"" << label << "\"];\n";
+  }
+
+  void scalar(NodeValue v) {
+    switch (v.type.atomic_type) {
+      case AtomicType::BOOLEAN:
+        os << v._bool;
+        break;
+      case AtomicType::NATURAL:
+        os << v._natural;
+        break;
+      case AtomicType::REAL:
+      case AtomicType::POS_REAL:
+      case AtomicType::NEG_REAL:
+      case AtomicType::PROBABILITY:
+        os << v._double;
+        break;
+      default:
+        os << "Scalar";
+        break;
+    }
+  }
+
+  void broadcast(NodeValue v) {
+    // TODO: Better display of matrices
+    os << "matrix";
+  }
+
+  void simplex(NodeValue v) {
+    // TODO: Better display of simplexes
+    os << "simplex";
+  }
+
+  void value(NodeValue v) {
+    switch (v.type.variable_type) {
+      case VariableType::SCALAR:
+        scalar(v);
+        break;
+      case VariableType::BROADCAST_MATRIX:
+        broadcast(v);
+        break;
+      case VariableType::COL_SIMPLEX_MATRIX:
+        simplex(v);
+        break;
+      default:
+        os << "Value";
+    }
+  }
+
+  void constant(uint n, NodeValue v) {
+    os << "  N" << n << "[label=\"";
+    value(v);
+    os << "\"];\n";
+  }
+
+  std::string distribution(DistributionType d) {
+    switch (d) {
+      case DistributionType::TABULAR:
+        return "Tabular";
+      case DistributionType::BERNOULLI:
+        return "Bernoulli";
+      case DistributionType::BERNOULLI_NOISY_OR:
+        return "BernoulliNO";
+      case DistributionType::BETA:
+        return "Beta";
+      case DistributionType::BINOMIAL:
+        return "Binomial";
+      case DistributionType::DIRICHLET:
+        return "Dirichlet";
+      case DistributionType::FLAT:
+        return "Flat";
+      case DistributionType::NORMAL:
+        return "Normal";
+      case DistributionType::HALF_CAUCHY:
+        return "HalfCauchy";
+      case DistributionType::STUDENT_T:
+        return "StudentT";
+      case DistributionType::BERNOULLI_LOGIT:
+        return "BernoulliLogit";
+      case DistributionType::GAMMA:
+        return "Gamma";
+      case DistributionType::BIMIXTURE:
+        return "Bimixture";
+      default:
+        return "distribution";
+    }
+  }
+
+  void distribution(uint n, DistributionType d) {
+    node(n, distribution(d));
+  }
+
+  std::string op(OperatorType o) {
+    switch (o) {
+      case OperatorType::SAMPLE:
+      case OperatorType::IID_SAMPLE:
+        return "~";
+      case OperatorType::TO_REAL:
+        return "ToReal";
+      case OperatorType::TO_POS_REAL:
+        return "ToPosReal";
+      case OperatorType::COMPLEMENT:
+        return "Complement";
+      case OperatorType::NEGATE:
+        return "Negate";
+      case OperatorType::EXP:
+        return "exp";
+      case OperatorType::EXPM1:
+        return "expm1";
+      case OperatorType::MULTIPLY:
+        return "*";
+      case OperatorType::ADD:
+        return "+";
+      case OperatorType::PHI:
+        return "Phi";
+      case OperatorType::LOGISTIC:
+        return "Logistic";
+      case OperatorType::IF_THEN_ELSE:
+        return "IfThenElse";
+      case OperatorType::LOG1PEXP:
+        return "Log1pExp";
+      case OperatorType::LOGSUMEXP:
+        return "LogSumExp";
+      case OperatorType::LOG:
+        return "Log";
+      case OperatorType::POW:
+        return "^";
+      case OperatorType::LOG1MEXP:
+        return "Log1mExp";
+      case OperatorType::MATRIX_MULTIPLY:
+        return "MatrixMultiply";
+      case OperatorType::TO_PROBABILITY:
+        return "ToProb";
+      case OperatorType::INDEX:
+        return "Index";
+      default:
+        return "Operator";
+    }
+  }
+
+  void op(uint n, OperatorType o) {
+    node(n, op(o));
+  }
+
+  void edge(uint start_n, uint end_n) {
+    os << "  N" << start_n << " -> N" << end_n << ";\n";
+  }
+
+  void observation(uint o, uint n) {
+    // TODO: Include value of observation
+    os << "  O" << o << "[label=\"Observation\"];\n";
+    os << "  N" << n << " -> O" << o << ";\n";
+  }
+
+  void query(uint q, uint n) {
+    os << "  Q" << q << "[label=\"Query\"];\n";
+    os << "  N" << n << " -> Q" << q << ";\n";
+  }
+
+ private:
+  std::ostringstream os;
+};
+
+std::string Graph::to_dot() const {
+  DOT dot;
+  dot.start_graph();
+
+  // Nodes
+  for (auto const& n : nodes) {
+    Node* node = n.get();
+    switch (node->node_type) {
+      case NodeType::CONSTANT:
+        dot.constant(node->index, node->value);
+        break;
+      case NodeType::DISTRIBUTION:
+        dot.distribution(
+            node->index,
+            static_cast<const distribution::Distribution*>(node)->dist_type);
+        break;
+      case NodeType::OPERATOR:
+        dot.op(node->index, static_cast<const oper::Operator*>(node)->op_type);
+        break;
+      case NodeType::FACTOR:
+        // TODO: Better display of factors.
+        dot.node(node->index, "Factor");
+        break;
+      default:
+        dot.node(node->index, "Node");
+        break;
+    }
+  }
+
+  // Edges
+  for (auto const& node : nodes) {
+    for (Node* child : node->out_nodes) {
+      dot.edge(node->index, child->index);
+    }
+  }
+
+  // Observations
+  uint obs = 0;
+  for (uint id : observed) {
+    dot.observation(obs, id);
+    obs += 1;
+  }
+
+  // Queries
+  for (uint q = 0; q < queries.size(); q += 1) {
+    dot.query(q, queries[q]);
+  }
+  dot.end_graph();
+  return dot.str();
+}
+
+} // namespace graph
+} // namespace beanmachine


### PR DESCRIPTION
Summary: By request I've added a to_dot visualizer to BMG; this is less compact than the to_string method's output, but can be more easily turned into a visualization of the graph.

Reviewed By: wtaha

Differential Revision: D27314812

