### PR TITLE
Fix statsmodel function call in diagnostic test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,5 +15,7 @@ filterwarnings = [
     # pandas sometimes complains about binary compatibility with numpy
     "default:numpy.ufunc size changed, may indicate binary incompatibility.*:RuntimeWarning",
     # flowtorch warnings
-    "ignore:DenseAutoregressive input_dim = 1. Consider using an affine transformation instead.*:UserWarning"
+    "ignore:DenseAutoregressive input_dim = 1. Consider using an affine transformation instead.*:UserWarning",
+    # statsmodels's deprecation warning
+    "default:the 'unbiased'' keyword is deprecated, use 'adjusted' instead.*:FutureWarning"
 ]

--- a/src/beanmachine/ppl/diagnostics/tests/diagnostics_test.py
+++ b/src/beanmachine/ppl/diagnostics/tests/diagnostics_test.py
@@ -120,7 +120,7 @@ class DiagnosticsTest(unittest.TestCase):
             for i in range(num_samples):
                 expected_acf = acf(
                     query_samples[:, i].detach().numpy(),
-                    adjusted=True,
+                    unbiased=True,
                     nlags=num_samples - 1,
                     fft=False,
                 )


### PR DESCRIPTION
Summary:
This diff address the broken diagnostic tests resulting from calling `statsmodels.tsa.stattools.acf` with a parameter that's only available in a newer version of statsmodel (see [TestX page](https://www.internalfb.com/intern/test/562949984776119?ref_report_id=0) for details.)

We might want to deprecate our diagnostic module, so instead of upgrading our internal statsmodel package, as a temporary solution, I'm changing the function call to use the legacy API instead.

 ---

I remembered that diagnostic test has been broken since I joined the team, so I just assumed that they were bad quality tests and never checked what caused the problem. Turns out that it was my own diff (D23400875 (https://github.com/facebookincubator/beanmachine/commit/d17a7d7836aff5cd22f2d2dd3493da9f734501b7)) that introduced this error (sorry {emoji:1f622}). It was among the first few diffs that I made while ramping up and I totally forgot about it

Differential Revision: D27315980

