### PR TITLE
Add more performance tracking to NMC inference

### DIFF
--- a/src/beanmachine/graph/profiler.h
+++ b/src/beanmachine/graph/profiler.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <chrono>
+#include <map>
 #include <stack>
 #include <vector>
 
@@ -13,8 +14,17 @@ enum class ProfilerEvent {
   NMC_INFER,
   NMC_INFER_INITIALIZE,
   NMC_INFER_COLLECT_SAMPLES,
+  NMC_INFER_COLLECT_SAMPLE,
   NMC_STEP,
   NMC_STEP_DIRICHLET,
+  NMC_COMPUTE_GRADS,
+  NMC_EVAL,
+  NMC_CLEAR_GRADS,
+  NMC_CREATE_PROP,
+  NMC_CREATE_PROP_DIR,
+  NMC_SAMPLE,
+  NMC_SAVE_OLD,
+  NMC_RESTORE_OLD,
 };
 
 struct Event {
@@ -26,6 +36,9 @@ struct Event {
 struct ProfilerData {
   std::vector<Event> events;
   std::stack<ProfilerEvent> in_flight;
+  // Map from node id of a stochastic node to the number of
+  // deterministic descendent nodes in the support.
+  std::map<unsigned int, unsigned int> det_supp_count;
   ProfilerData();
   void begin(ProfilerEvent kind);
   void finish(ProfilerEvent kind);

--- a/src/beanmachine/ppl/compiler/performance_report.py
+++ b/src/beanmachine/ppl/compiler/performance_report.py
@@ -7,7 +7,23 @@ from beanmachine.ppl.compiler.profiler import event_list_to_report
 
 class PerformanceReport:
     json: Optional[str] = None
-    # TODO: Add a __str__ function
+
+    def _str(self, indent: str) -> str:
+        s = ""
+        for k, v in vars(self).items():
+            if k == "json" or k == "profiler_data":
+                continue
+            s += indent + k + ":"
+            if isinstance(v, PerformanceReport):
+                s += "\n" + v._str(indent + "  ")
+            elif isinstance(v, list):
+                s += " [" + ",".join(str(i) for i in v) + "]\n"
+            else:
+                s += " " + str(v) + "\n"
+        return s
+
+    def __str__(self) -> str:
+        return self._str("")
 
 
 def _to_perf_rep(v: Any) -> Any:


### PR DESCRIPTION
Summary:
In this diff:

* We have now almost fully attributed the time spent in NMC inference.
* We can now dump the entire performance report as a single string.
* Perf report includes a breakdown of how many of each kind of node in the graph (operator, constant, distribution, factor)

Reviewed By: wtaha

Differential Revision: D27165258

