### PR TITLE
Improve optimization when creating if-then-else nodes

### DIFF
--- a/src/beanmachine/ppl/compiler/bm_graph_builder.py
+++ b/src/beanmachine/ppl/compiler/bm_graph_builder.py
@@ -1003,7 +1003,10 @@ class BMGraphBuilder:
     def add_if_then_else(
         self, condition: BMGNode, consequence: BMGNode, alternative: BMGNode
     ) -> BMGNode:
-        if isinstance(condition, bn.BooleanNode):
+        if (
+            isinstance(condition, bn.ConstantNode)
+            and bt.supremum(condition.inf_type, bt.Boolean) == bt.Boolean
+        ):
             return consequence if condition.value else alternative
         node = bn.IfThenElseNode(condition, consequence, alternative)
         self.add_node(node)


### PR DESCRIPTION
Summary:
When we create an if-then-else node, we check to see if the condition is a constant bool, and if it is, then we skip creating the node entirely -- we just hand out the consequence or alternative.

We could be more aggressive with this optimization; for example, a constant natural zero could be treated as a bool False. We now do so; instead of checking for the condition being a constant Boolean, we check to see if it is a constant whose value fits into a Boolean.

Reviewed By: wtaha

Differential Revision: D27148562

