### PR TITLE
Implement serializer for graph accumulator

### DIFF
--- a/src/beanmachine/ppl/compiler/bm_graph_builder.py
+++ b/src/beanmachine/ppl/compiler/bm_graph_builder.py
@@ -404,13 +404,14 @@ class BMGraphBuilder:
     # graph nodes. These scenarios should now be impossible, and we
     # should take a work item to remove this now-unnecessary code.
 
-    def add_node(self, node: BMGNode) -> None:
+    def add_node(self, node: BMGNode) -> BMGNode:
         """This adds a node we've recently created to the node set;
         it maintains the invariant that all the input nodes are also added."""
         if node not in self.nodes:
             for i in node.inputs:
                 self.add_node(i)
             self.nodes[node] = len(self.nodes)
+        return node
 
     def remove_leaf(self, node: BMGNode) -> None:
         """This removes a leaf node from the builder, and ensures that the

--- a/src/beanmachine/ppl/compiler/gen_builder.py
+++ b/src/beanmachine/ppl/compiler/gen_builder.py
@@ -1,0 +1,61 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+"""
+Convert a builder into a program that produces a graph builder.
+"""
+
+import beanmachine.ppl.compiler.bmg_nodes as bn
+from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
+
+
+class GenerateBuilder:
+    bmg: BMGraphBuilder
+
+    def __init__(self, bmg: BMGraphBuilder) -> None:
+        self.bmg = bmg
+
+    def _factory_name(self, node: bn.BMGNode) -> str:
+        return type(node).__name__
+
+    def _to_id(self, index: int) -> str:
+        return "n" + str(index)
+
+    def _input_to_arg(self, node: bn.BMGNode) -> str:
+        index = self.bmg.nodes[node]
+        return self._to_id(index)
+
+    def _inputs_to_args(self, node: bn.BMGNode) -> str:
+        if isinstance(node, bn.ConstantNode):
+            return str(node.value)
+        arglist = ", ".join(self._input_to_arg(i) for i in node.inputs)
+        if isinstance(node, bn.Observation):
+            return f"{arglist}, {str(node.value)}"
+        if isinstance(node, bn.LogSumExpNode):
+            return f"[{arglist}]"
+        if isinstance(node, bn.TensorNode):
+            return f"[{arglist}], torch.Size([{str(len(node.inputs))}])"
+        return arglist
+
+    def _generate_builder(self) -> str:
+
+        lines = [
+            "import beanmachine.ppl.compiler.bmg_nodes as bn",
+            "import torch",
+            "from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder",
+            "from torch import tensor",
+            "",
+            "bmg = BMGraphBuilder()",
+        ]
+
+        # Nodes should be sorted so that ancestors always come
+        # before descendents.
+
+        for node, index in self.bmg.nodes.items():
+            n = self._to_id(index)
+            f = self._factory_name(node)
+            a = self._inputs_to_args(node)
+            lines.append(f"{n} = bmg.add_node(bn.{f}({a}))")
+        return "\n".join(lines)
+
+
+def generate_builder(bmg: BMGraphBuilder) -> str:
+    return GenerateBuilder(bmg)._generate_builder()

--- a/src/beanmachine/ppl/compiler/tests/gen_builder_test.py
+++ b/src/beanmachine/ppl/compiler/tests/gen_builder_test.py
@@ -1,0 +1,45 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+"""Tests for gen_builder.py"""
+import unittest
+
+import beanmachine.ppl as bm
+from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
+from beanmachine.ppl.compiler.gen_builder import generate_builder
+from torch.distributions import Normal
+
+
+@bm.random_variable
+def norm(x):
+    return Normal(0.0, 1.0)
+
+
+@bm.functional
+def norm_sum():
+    return norm(1) + norm(2) + norm(3) + norm(4)
+
+
+class GenerateBuilderTest(unittest.TestCase):
+    def test_generate_builder_1(self) -> None:
+        self.maxDiff = None
+        bmg = BMGraphBuilder()
+        bmg.accumulate_graph([norm_sum()], {})
+        observed = generate_builder(bmg)
+        expected = """
+import beanmachine.ppl.compiler.bmg_nodes as bn
+import torch
+from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
+from torch import tensor
+
+bmg = BMGraphBuilder()
+n0 = bmg.add_node(bn.ConstantTensorNode(tensor(0.)))
+n1 = bmg.add_node(bn.ConstantTensorNode(tensor(1.)))
+n2 = bmg.add_node(bn.NormalNode(n0, n1))
+n3 = bmg.add_node(bn.SampleNode(n2))
+n4 = bmg.add_node(bn.SampleNode(n2))
+n5 = bmg.add_node(bn.AdditionNode(n3, n4))
+n6 = bmg.add_node(bn.SampleNode(n2))
+n7 = bmg.add_node(bn.AdditionNode(n5, n6))
+n8 = bmg.add_node(bn.SampleNode(n2))
+n9 = bmg.add_node(bn.AdditionNode(n7, n8))
+n10 = bmg.add_node(bn.Query(n9))"""
+        self.assertEqual(expected.strip(), observed.strip())


### PR DESCRIPTION
Summary:
For testing and debugging purposes it will be useful to me to be able to accumulate a graph into a graph builder, and then serialize that graph out as a program which, when executed, builds an identical graph builder.

I have also been meaning to refactor to extract the "generate some language from this accumulated graph" functions into their own modules, instead of being implemented on the node classes and graph builder class. This is a good place to start that effort.

Reviewed By: wtaha

Differential Revision: D27278225

