### PR TITLE
Finish making consistent interface and base class for problem fixers

### DIFF
--- a/src/beanmachine/ppl/compiler/fix_observations.py
+++ b/src/beanmachine/ppl/compiler/fix_observations.py
@@ -26,7 +26,7 @@ class ObservationsFixer:
         self.errors = ErrorReport()
         self.bmg = bmg
 
-    def fix_observations(self) -> None:
+    def fix_problems(self) -> None:
         for o in self.bmg.all_observations():
             v = o.value
             inf = type_of_value(v)

--- a/src/beanmachine/ppl/compiler/fix_problem.py
+++ b/src/beanmachine/ppl/compiler/fix_problem.py
@@ -5,13 +5,16 @@ from typing import Optional
 
 import beanmachine.ppl.compiler.bmg_nodes as bn
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
+from beanmachine.ppl.compiler.error_report import BMGError, ErrorReport
 
 
 class ProblemFixerBase(ABC):
     _bmg: BMGraphBuilder
+    errors: ErrorReport
 
     def __init__(self, bmg: BMGraphBuilder) -> None:
         self._bmg = bmg
+        self.errors = ErrorReport()
 
     @abstractmethod
     def _needs_fixing(self, n: bn.BMGNode) -> bool:
@@ -21,17 +24,39 @@ class ProblemFixerBase(ABC):
     def _get_replacement(self, n: bn.BMGNode) -> Optional[bn.BMGNode]:
         pass
 
+    def _get_error(self, n: bn.BMGNode, index: int) -> Optional[BMGError]:
+        # n.inputs[i] needed fixing but was unfixable. If that needs to
+        # produce an error, do by overriding this method
+        return None
+
     def fix_problems(self) -> None:
         replacements = {}
+        reported = set()
         nodes = self._bmg._traverse_from_roots()
         for node in nodes:
             for i in range(len(node.inputs)):
                 c = node.inputs[i]
+                # Have we already replaced this input with something?
+                # If so, no need to compute the replacement again.
                 if c in replacements:
                     node.inputs[i] = replacements[c]
                     continue
-                if self._needs_fixing(c):
-                    replacement = self._get_replacement(c)
-                    if replacement is not None:
-                        node.inputs[i] = replacement
-                        replacements[c] = replacement
+                # Does the input need fixing at all?
+                if not self._needs_fixing(c):
+                    continue
+                # The input needs fixing. Get the replacement.
+                replacement = self._get_replacement(c)
+                if replacement is not None:
+                    node.inputs[i] = replacement
+                    replacements[c] = replacement
+                    continue
+                # It needed fixing but we did not succeed. Have we already
+                # reported this error?  If so, no need to compute the error.
+                if c in reported:
+                    continue
+                # Mark the node as having been error-reported, and emit
+                # an error into the error report.
+                reported.add(c)
+                error = self._get_error(node, i)
+                if error is not None:
+                    self.errors.add_error(error)

--- a/src/beanmachine/ppl/compiler/fix_problems.py
+++ b/src/beanmachine/ppl/compiler/fix_problems.py
@@ -401,7 +401,7 @@ class RequirementsFixer:
             return self._meet_operator_requirement(node, requirement, consumer, edge)
         raise AssertionError("Unexpected node type")
 
-    def fix_unmet_requirements(self) -> None:
+    def fix_problems(self) -> None:
         nodes = self.bmg._traverse_from_roots()
         for node in nodes:
             requirements = node.requirements
@@ -423,16 +423,16 @@ def fix_problems(bmg: BMGraphBuilder, fix_observe_true: bool = False) -> ErrorRe
     AdditionFixer(bmg).fix_problems()
     BoolComparisonFixer(bmg).fix_problems()
     f = UnsupportedNodeFixer(bmg)
-    f.fix_unsupported_nodes()
+    f.fix_problems()
     if f.errors.any():
         return f.errors
     MultiaryOperatorFixer(bmg).fix_problems()
     f = RequirementsFixer(bmg)
-    f.fix_unmet_requirements()
+    f.fix_problems()
     if f.errors.any():
         return f.errors
     f = ObservationsFixer(bmg)
-    f.fix_observations()
+    f.fix_problems()
     if f.errors.any():
         return f.errors
     if fix_observe_true:

--- a/src/beanmachine/ppl/compiler/fix_unsupported.py
+++ b/src/beanmachine/ppl/compiler/fix_unsupported.py
@@ -2,31 +2,22 @@
 
 from typing import Optional
 
+import beanmachine.ppl.compiler.bmg_nodes as bn
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
-from beanmachine.ppl.compiler.bmg_nodes import (
-    BMGNode,
-    Chi2Node,
-    ConstantNode,
-    DivisionNode,
-    UniformNode,
-)
 from beanmachine.ppl.compiler.bmg_types import PositiveReal
-from beanmachine.ppl.compiler.error_report import ErrorReport, UnsupportedNode
+from beanmachine.ppl.compiler.error_report import BMGError, UnsupportedNode
+from beanmachine.ppl.compiler.fix_problem import ProblemFixerBase
 
 
-class UnsupportedNodeFixer:
+class UnsupportedNodeFixer(ProblemFixerBase):
     """This class takes a Bean Machine Graph builder and attempts to
     fix all uses of unsupported operators by replacing them with semantically
     equivalent nodes that are supported by BMG."""
 
-    errors: ErrorReport
-    bmg: BMGraphBuilder
-
     def __init__(self, bmg: BMGraphBuilder) -> None:
-        self.errors = ErrorReport()
-        self.bmg = bmg
+        ProblemFixerBase.__init__(self, bmg)
 
-    def _replace_division(self, node: DivisionNode) -> Optional[BMGNode]:
+    def _replace_division(self, node: bn.DivisionNode) -> Optional[bn.BMGNode]:
         # BMG has no division node. We replace division by a constant with
         # a multiplication:
         #
@@ -37,15 +28,15 @@ class UnsupportedNodeFixer:
         # x / y --> x * (y ** (-1))
         #
         r = node.right
-        if isinstance(r, ConstantNode):
-            return self.bmg.add_multiplication(
-                node.left, self.bmg.add_constant(1.0 / r.value)
+        if isinstance(r, bn.ConstantNode):
+            return self._bmg.add_multiplication(
+                node.left, self._bmg.add_constant(1.0 / r.value)
             )
-        neg1 = self.bmg.add_constant(-1.0)
-        powr = self.bmg.add_power(r, neg1)
-        return self.bmg.add_multiplication(node.left, powr)
+        neg1 = self._bmg.add_constant(-1.0)
+        powr = self._bmg.add_power(r, neg1)
+        return self._bmg.add_multiplication(node.left, powr)
 
-    def _replace_uniform(self, node: UniformNode) -> Optional[BMGNode]:
+    def _replace_uniform(self, node: bn.UniformNode) -> Optional[bn.BMGNode]:
         # TODO: Suppose we have something like Uniform(1.0, 2.0).  Can we replace that
         # with (Flat() + 1.0) ? The problem is that if there is an observation on
         # a sample of the original uniform, we need to modify the observation to
@@ -56,56 +47,35 @@ class UnsupportedNodeFixer:
         low = node.low
         high = node.high
         if (
-            isinstance(low, ConstantNode)
+            isinstance(low, bn.ConstantNode)
             and float(low.value) == 0.0
-            and isinstance(high, ConstantNode)
+            and isinstance(high, bn.ConstantNode)
             and float(high.value) == 1.0
         ):
-            return self.bmg.add_flat()
+            return self._bmg.add_flat()
         return None
 
-    def _replace_chi2(self, node: Chi2Node) -> BMGNode:
+    def _replace_chi2(self, node: bn.Chi2Node) -> bn.BMGNode:
         # Chi2(x), which BMG does not support, is exactly equivalent
         # to Gamma(x * 0.5, 0.5), which BMG does support.
-        half = self.bmg.add_constant_of_type(0.5, PositiveReal)
-        mult = self.bmg.add_multiplication(node.df, half)
-        return self.bmg.add_gamma(mult, half)
+        half = self._bmg.add_constant_of_type(0.5, PositiveReal)
+        mult = self._bmg.add_multiplication(node.df, half)
+        return self._bmg.add_gamma(mult, half)
 
-    def _replace_unsupported_node(self, node: BMGNode) -> Optional[BMGNode]:
+    def _get_replacement(self, n: bn.BMGNode) -> Optional[bn.BMGNode]:
         # TODO:
         # Not -> Complement
         # Index/Map -> IfThenElse
-        if isinstance(node, Chi2Node):
-            return self._replace_chi2(node)
-        if isinstance(node, DivisionNode):
-            return self._replace_division(node)
-        if isinstance(node, UniformNode):
-            return self._replace_uniform(node)
+        if isinstance(n, bn.Chi2Node):
+            return self._replace_chi2(n)
+        if isinstance(n, bn.DivisionNode):
+            return self._replace_division(n)
+        if isinstance(n, bn.UniformNode):
+            return self._replace_uniform(n)
         return None
 
-    def fix_unsupported_nodes(self) -> None:
-        replacements = {}
-        reported = set()
-        nodes = self.bmg._traverse_from_roots()
-        for node in nodes:
-            for i in range(len(node.inputs)):
-                c = node.inputs[i]
-                if c._supported_in_bmg():
-                    continue
-                # We have an unsupported node. Have we already worked out its
-                # replacement node?
-                if c in replacements:
-                    node.inputs[i] = replacements[c]
-                    continue
-                # We have an unsupported node; have we already reported it as
-                # having no replacement?
-                if c in reported:
-                    continue
-                # We have an unsupported node and we don't know what to do.
-                replacement = self._replace_unsupported_node(c)
-                if replacement is None:
-                    self.errors.add_error(UnsupportedNode(c, node, node.edges[i]))
-                    reported.add(c)
-                else:
-                    replacements[c] = replacement
-                    node.inputs[i] = replacement
+    def _needs_fixing(self, n: bn.BMGNode) -> bool:
+        return not n._supported_in_bmg()
+
+    def _get_error(self, n: bn.BMGNode, index: int) -> Optional[BMGError]:
+        return UnsupportedNode(n.inputs[index], n, n.edges[index])


### PR DESCRIPTION
Summary: This diff extends the work of the previous diff so that we have the typical algorithm for problem fixing implemented in one place. For fixers that use a different traversal strategy, I have at least given them a consistent API. In the next diff we'll take advantage of that.

Reviewed By: wtaha

Differential Revision: D27282953

