### PR TITLE
Fix error in type analysis of logsumexp node

### DIFF
--- a/src/beanmachine/ppl/compiler/bmg_nodes.py
+++ b/src/beanmachine/ppl/compiler/bmg_nodes.py
@@ -2170,15 +2170,18 @@ class LogSumExpNode(OperatorNode):
         # * at least two values
         # * all values the same graph type
         # * that type is R, R+ or R-.
+        #
+        # If these conditions are met then the graph type is real,
+        # otherwise it is malformed
 
         if len(self.inputs) <= 1:
             return Malformed
-        gt = self.inputs[0].graph_type
-        if gt not in {Real, NegativeReal, PositiveReal}:
+        input_gt = self.inputs[0].graph_type
+        if input_gt not in {Real, NegativeReal, PositiveReal}:
             return Malformed
-        if any(i.graph_type != gt for i in self.inputs):
+        if any(i.graph_type != input_gt for i in self.inputs):
             return Malformed
-        return gt
+        return Real
 
     def _compute_inf_type(self) -> BMGLatticeType:
         # No matter what, logsumexp produces a real.

--- a/src/beanmachine/ppl/compiler/tests/clara_tensor_cgm_no_update_test.py
+++ b/src/beanmachine/ppl/compiler/tests/clara_tensor_cgm_no_update_test.py
@@ -152,24 +152,23 @@ digraph "graph" {
   N17[label=-4.605170249938965];
   N18[label="+"];
   N19[label=LogSumExp];
-  N20[label=ToReal];
-  N21[label=Exp];
-  N22[label=ToProb];
-  N23[label=Bernoulli];
-  N24[label=Sample];
-  N25[label="Observation True"];
+  N20[label=Exp];
+  N21[label=ToProb];
+  N22[label=Bernoulli];
+  N23[label=Sample];
+  N24[label="Observation True"];
+  N25[label=Query];
   N26[label=Query];
   N27[label=Query];
-  N28[label=Query];
   N00 -> N01;
   N01 -> N02;
   N01 -> N03;
   N01 -> N04;
   N02 -> N06;
   N02 -> N13;
-  N02 -> N27;
+  N02 -> N26;
   N03 -> N08;
-  N03 -> N28;
+  N03 -> N27;
   N04 -> N15;
   N05 -> N06;
   N05 -> N08;
@@ -180,7 +179,7 @@ digraph "graph" {
   N09 -> N11;
   N10 -> N11;
   N11 -> N19;
-  N11 -> N26;
+  N11 -> N25;
   N12 -> N13;
   N13 -> N14;
   N14 -> N18;
@@ -193,10 +192,9 @@ digraph "graph" {
   N21 -> N22;
   N22 -> N23;
   N23 -> N24;
-  N24 -> N25;
 }
         """
-        self.assertEqual(observed.strip(), expected.strip())
+        self.assertEqual(expected.strip(), observed.strip())
 
         observed = BMGInference().to_cpp(queries, observations)
         expected = """
@@ -249,23 +247,21 @@ n19 = g.add_operator(
   graph::OperatorType::LOGSUMEXP,
   std::vector<uint>({n11, n18}));
 uint n20 = g.add_operator(
-  graph::OperatorType::TO_REAL, std::vector<uint>({n19}));
+  graph::OperatorType::EXP, std::vector<uint>({n19}));
 uint n21 = g.add_operator(
-  graph::OperatorType::EXP, std::vector<uint>({n20}));
-uint n22 = g.add_operator(
-  graph::OperatorType::TO_PROBABILITY, std::vector<uint>({n21}));
-uint n23 = g.add_distribution(
+  graph::OperatorType::TO_PROBABILITY, std::vector<uint>({n20}));
+uint n22 = g.add_distribution(
   graph::DistributionType::BERNOULLI,
   graph::AtomicType::BOOLEAN,
-  std::vector<uint>({n22}));
-uint n24 = g.add_operator(
-  graph::OperatorType::SAMPLE, std::vector<uint>({n23}));
-g.observe([n24], true);
+  std::vector<uint>({n21}));
+uint n23 = g.add_operator(
+  graph::OperatorType::SAMPLE, std::vector<uint>({n22}));
+g.observe([n23], true);
 g.query(n11);
 g.query(n2);
 g.query(n3);
 """
-        self.assertEqual(observed.strip(), expected.strip())
+        self.assertEqual(expected.strip(), observed.strip())
 
         observed = BMGInference().to_python(queries, observations)
         expected = """
@@ -307,17 +303,16 @@ n18 = g.add_operator(
 n19 = g.add_operator(
   graph.OperatorType.LOGSUMEXP,
   [n11, n18])
-n20 = g.add_operator(graph.OperatorType.TO_REAL, [n19])
-n21 = g.add_operator(graph.OperatorType.EXP, [n20])
-n22 = g.add_operator(graph.OperatorType.TO_PROBABILITY, [n21])
-n23 = g.add_distribution(
+n20 = g.add_operator(graph.OperatorType.EXP, [n19])
+n21 = g.add_operator(graph.OperatorType.TO_PROBABILITY, [n20])
+n22 = g.add_distribution(
   graph.DistributionType.BERNOULLI,
   graph.AtomicType.BOOLEAN,
-  [n22])
-n24 = g.add_operator(graph.OperatorType.SAMPLE, [n23])
-g.observe(n24, True)
+  [n21])
+n23 = g.add_operator(graph.OperatorType.SAMPLE, [n22])
+g.observe(n23, True)
 g.query(n11)
 g.query(n2)
 g.query(n3)
 """
-        self.assertEqual(observed.strip(), expected.strip())
+        self.assertEqual(expected.strip(), observed.strip())


### PR DESCRIPTION
Summary:
Given an accumulated graph, we attempt to find an equivalent graph which meets the node and edge requirements of BMG; this means that we need to be able to determine what is the type of a graph node, and is it valid or "malformed" according to BMG.

We were computing the type of a logsumexp node incorrectly. The correct rules are:

* Every input must have the same graph type
* That type must be real, negative real or positive real.
* If those conditions are met then the output type of logsumexp is real; otherwise it is malformed.

The rule I implemented was

* If those conditions are met then the output type is the input type, otherwise it is malformed.

That's wrong; we must never treat a logsumexp as producing a negative real just because its operands are negative reals.

The consequence of this mistake is: if we use logsumexp in a context where a real is required, but its inputs are negative reals, then we insert an unnecessary to_real node.

I've fixed the computation of the graph type, and as expected, the unnecessary to_real node in the test case disappears.

Reviewed By: wtaha

Differential Revision: D27334146

