### PR TITLE
Attribute remaining compiler time in perf report

### DIFF
--- a/src/beanmachine/ppl/compiler/profiler.py
+++ b/src/beanmachine/ppl/compiler/profiler.py
@@ -11,6 +11,8 @@ graph_infer = "graph_infer"
 build_bmg_graph = "build_bmg_graph"
 transpose_samples = "transpose_samples"
 build_mcsamples = "build_mcsamples"
+deserialize_perf_report = "deserialize_perf_report"
+import_fix_problems = "import_fix_problems"
 
 
 class Event:

--- a/src/beanmachine/ppl/compiler/tests/perf_report_test.py
+++ b/src/beanmachine/ppl/compiler/tests/perf_report_test.py
@@ -76,6 +76,7 @@ bmg_profiler_report: nmc_infer:(1) -- ms
 
 profiler_report: accumulate:(1) -- ms
 infer:(1) -- ms
+  import_fix_problems:(--) -- ms
   fix_problems:(1) -- ms
     TensorOpsFixer:(1) -- ms
     AdditionFixer:(1) -- ms
@@ -87,6 +88,7 @@ infer:(1) -- ms
     unattributed: -- ms
   build_bmg_graph:(1) -- ms
   graph_infer:(1) -- ms
+  deserialize_perf_report:(--) -- ms
   transpose_samples:(1) -- ms
   build_mcsamples:(1) -- ms
   unattributed: -- ms


### PR DESCRIPTION
Summary:
I made the newb mistake of failing to measure the time it takes to deserialize the massive block of JSON that BMG sends back as its performance data when presenting said performance data.

When presenting numbers describing time spent in inference and compilation, remember to subtract off this time, since that burden will not be imposed upon our normal users.

There is a large (1.7 second) unexplained performance burden imposed by importing the problem fixer module. It is not clear to me why that is. (And the fact that we have a mutual dependency between the problem fixer and the graph accumulator is a known architectural problem that I have not had time to fix.)  At least we are now tracking it.

Reviewed By: wtaha

Differential Revision: D27345329

