### PR TITLE
Move computation of edge labels into graph_labels module

### DIFF
--- a/src/beanmachine/ppl/compiler/fix_requirements.py
+++ b/src/beanmachine/ppl/compiler/fix_requirements.py
@@ -12,6 +12,7 @@ import beanmachine.ppl.compiler.bmg_nodes as bn
 import beanmachine.ppl.compiler.bmg_types as bt
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
 from beanmachine.ppl.compiler.error_report import ErrorReport, Violation
+from beanmachine.ppl.compiler.graph_labels import get_edge_labels
 from torch import Tensor
 
 
@@ -391,7 +392,11 @@ class RequirementsFixer:
         nodes = self.bmg._traverse_from_roots()
         for node in nodes:
             requirements = node.requirements
+            # TODO: The edge labels used to visualize the graph in DOT
+            # are not necessarily the best ones for displaying errors.
+            # Consider fixing this.
+            edges = get_edge_labels(node)
             for i in range(len(requirements)):
                 node.inputs[i] = self.meet_requirement(
-                    node.inputs[i], requirements[i], node, node.edges[i]
+                    node.inputs[i], requirements[i], node, edges[i]
                 )

--- a/src/beanmachine/ppl/compiler/fix_unsupported.py
+++ b/src/beanmachine/ppl/compiler/fix_unsupported.py
@@ -7,6 +7,7 @@ from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
 from beanmachine.ppl.compiler.bmg_types import PositiveReal
 from beanmachine.ppl.compiler.error_report import BMGError, UnsupportedNode
 from beanmachine.ppl.compiler.fix_problem import ProblemFixerBase
+from beanmachine.ppl.compiler.graph_labels import get_edge_label
 
 
 class UnsupportedNodeFixer(ProblemFixerBase):
@@ -78,4 +79,7 @@ class UnsupportedNodeFixer(ProblemFixerBase):
         return not n._supported_in_bmg()
 
     def _get_error(self, n: bn.BMGNode, index: int) -> Optional[BMGError]:
-        return UnsupportedNode(n.inputs[index], n, n.edges[index])
+        # TODO: The edge labels used to visualize the graph in DOT
+        # are not necessarily the best ones for displaying errors.
+        # Consider fixing this.
+        return UnsupportedNode(n.inputs[index], n, get_edge_label(n, index))

--- a/src/beanmachine/ppl/compiler/gen_dot.py
+++ b/src/beanmachine/ppl/compiler/gen_dot.py
@@ -5,7 +5,7 @@ Visualize the contents of a builder in the DOT graph language.
 
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
 from beanmachine.ppl.compiler.fix_problems import fix_problems
-from beanmachine.ppl.compiler.graph_labels import get_node_label
+from beanmachine.ppl.compiler.graph_labels import get_edge_labels, get_node_label
 from beanmachine.ppl.utils.dotbuilder import DotBuilder
 
 
@@ -41,7 +41,9 @@ def to_dot(
         if inf_types:
             node_label += ">=" + node.inf_type.short_name
         db.with_node(n, node_label)
-        for (i, edge_name, req) in zip(node.inputs, node.edges, node.requirements):
+        for (i, edge_name, req) in zip(
+            node.inputs, get_edge_labels(node), node.requirements
+        ):
             if label_edges:
                 edge_label = edge_name
                 if edge_requirements:

--- a/src/beanmachine/ppl/compiler/tests/error_report_test.py
+++ b/src/beanmachine/ppl/compiler/tests/error_report_test.py
@@ -12,7 +12,7 @@ class ErrorReportTest(unittest.TestCase):
         bmg = BMGraphBuilder()
         r = bmg.add_real(-2.5)
         b = bmg.add_bernoulli(r)
-        v = Violation(r, b.requirements[0], b, b.edges[0])
+        v = Violation(r, b.requirements[0], b, "probability")
         e = ErrorReport()
         e.add_error(v)
         expected = """


### PR DESCRIPTION
Summary: This diff completes the refactoring started and continued in the previous two diffs. Computation of edge labels is no longer a concern of the node classes, but rather is in its own module.

Reviewed By: wtaha

Differential Revision: D27418490

