### PR TITLE
Move C++ code generation to own module

### DIFF
--- a/src/beanmachine/ppl/compiler/bm_graph_builder.py
+++ b/src/beanmachine/ppl/compiler/bm_graph_builder.py
@@ -1856,6 +1856,7 @@ class BMGraphBuilder:
     # #### Output
     # ####
 
+    # TODO: This is only used by the dot generator; eliminate it.
     def _resort_nodes(self) -> Dict[BMGNode, int]:
         """This renumbers the nodes so that the ids are in topological order;
         it returns a dictionary mapping nodes to integers."""
@@ -1863,15 +1864,6 @@ class BMGraphBuilder:
         for index, node in enumerate(self._traverse_from_roots()):
             sorted_nodes[node] = index
         return sorted_nodes
-
-    def to_cpp(self) -> str:
-        """This transforms the accumulated graph into a BMG type system compliant
-        graph and then creates a C++ program which creates the graph."""
-        self._fix_problems()
-        sorted_nodes = self._resort_nodes()
-        return "graph::Graph g;\n" + "\n".join(
-            n._to_cpp(sorted_nodes) for n in sorted_nodes
-        )
 
     def _traverse_from_roots(self) -> List[BMGNode]:
         """This returns a list of the reachable graph nodes

--- a/src/beanmachine/ppl/compiler/gen_bmg_cpp.py
+++ b/src/beanmachine/ppl/compiler/gen_bmg_cpp.py
@@ -1,0 +1,190 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+from typing import Any, Dict, List
+
+import beanmachine.ppl.compiler.bmg_nodes as bn
+import torch
+from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
+from beanmachine.ppl.compiler.bmg_node_types import (
+    dist_type,
+    factor_type,
+    operator_type,
+)
+from beanmachine.ppl.compiler.bmg_types import _size_to_rc
+from beanmachine.ppl.compiler.fix_problems import fix_problems
+
+
+def _value_to_cpp_eigen(value: torch.Tensor, variable: str) -> str:
+    # Torch tensors are row major but Eigen matrices are column major;
+    # a torch Dirichlet distribution expects a row of parameters;
+    # BMG expects a column.  That's why we swap rows with columns here.
+    r, c = _size_to_rc(value.size())
+    v = value.reshape(r, c).transpose(0, 1)
+    values = ", ".join(str(element) for element in v.storage())  # pyre-ignore
+    return f"Eigen::MatrixXd {variable}({c}, {r})\n{variable} << {values};"
+
+
+def _value_to_cpp(value: Any) -> str:
+    if isinstance(value, torch.Tensor):
+        values = ",".join(str(element) for element in value.storage())  # pyre-ignore
+        dims = ",".join(str(dim) for dim in value.shape)
+        return f"torch::from_blob((float[]){{{values}}}, {{{dims}}})"
+    return str(value).lower()
+
+
+class GeneratedGraphCPP:
+    code: str
+    _code: List[str]
+    bmg: BMGraphBuilder
+    node_to_graph_id: Dict[bn.BMGNode, int]
+    query_to_query_id: Dict[bn.Query, int]
+    _observation_count: int
+
+    def __init__(self, bmg: BMGraphBuilder) -> None:
+        self.code = ""
+        self._code = ["graph::Graph g;"]
+        self.bmg = bmg
+        self.node_to_graph_id = {}
+        self.query_to_query_id = {}
+        self._observation_count = 0
+
+    def _add_observation(self, node: bn.Observation) -> None:
+        graph_id = self.node_to_graph_id[node.observed]
+        v = node.value
+        if isinstance(v, torch.Tensor):
+            o = f"o{self._observation_count}"
+            self._observation_count += 1
+            s = _value_to_cpp_eigen(v, o)
+            self._code.append(s)
+            self._code.append(f"g.observe([n{graph_id}], {o});")
+        else:
+            self._code.append(f"g.observe([n{graph_id}], {_value_to_cpp(v)});")
+
+    def _add_query(self, node: bn.Query) -> None:
+        # BMG does not allow a query on a constant, but it is possible
+        # to end up with one in the graph. Suppress those from codegen.
+        if isinstance(node.operator, bn.ConstantNode):
+            return
+        query_id = len(self.query_to_query_id)
+        self.query_to_query_id[node] = query_id
+        graph_id = self.node_to_graph_id[node.operator]
+        self._code.append(f"uint q{query_id} = g.query(n{graph_id});")
+
+    def _inputs(self, node: bn.BMGNode) -> str:
+        inputs = ", ".join("n" + str(self.node_to_graph_id[x]) for x in node.inputs)
+        return "std::vector<uint>({" + inputs + "})"
+
+    def _add_factor(self, node: bn.FactorNode) -> None:
+        graph_id = len(self.node_to_graph_id)
+        self.node_to_graph_id[node] = graph_id
+        i = self._inputs(node)
+        ft = str(factor_type(node)).replace(".", "::")
+        self._code.append(f"uint n{graph_id} = g.add_factor(")
+        self._code.append(f"  graph::{ft},")
+        self._code.append(f"  {i});")
+
+    def _add_distribution(self, node: bn.DistributionNode) -> None:
+        graph_id = len(self.node_to_graph_id)
+        self.node_to_graph_id[node] = graph_id
+        i = self._inputs(node)
+        if isinstance(node, bn.DirichletNode):
+            self._code.append(f"uint n{graph_id} = g.add_distribution(")
+            self._code.append("  graph::DistributionType::DIRICHLET,")
+            self._code.append("  graph::ValueType(")
+            self._code.append("    graph::VariableType::COL_SIMPLEX_MATRIX,")
+            self._code.append("    graph::AtomicType::PROBABILITY,")
+            self._code.append(f"    {node._required_columns},")
+            self._code.append("    1")
+            self._code.append("  ),")
+            self._code.append(f"  {i});")
+        else:
+            distr_type, elt_type = dist_type(node)
+            distr_type = str(distr_type).replace(".", "::")
+            elt_type = str(elt_type).replace(".", "::")
+            self.node_to_graph_id[node] = graph_id
+            self._code.append(f"uint n{graph_id} = g.add_distribution(")
+            self._code.append(f"  graph::{distr_type},")
+            self._code.append(f"  graph::{elt_type},")
+            self._code.append(f"  {i});")
+
+    def _add_operator(self, node: bn.OperatorNode) -> None:
+        graph_id = len(self.node_to_graph_id)
+        self.node_to_graph_id[node] = graph_id
+        i = self._inputs(node)
+        ot = str(operator_type(node)).replace(".", "::")
+        self._code.append(f"uint n{graph_id} = g.add_operator(")
+        if len(node.inputs) <= 2:
+            self._code.append(f"  graph::{ot}, {i});")
+        else:
+            self._code.append(f"  graph::{ot},")
+            self._code.append(f"  {i});")
+
+    def _add_constant(self, node: bn.ConstantNode) -> None:  # noqa
+        graph_id = len(self.node_to_graph_id)
+        self.node_to_graph_id[node] = graph_id
+        t = type(node)
+        v = node.value
+        m = ""
+        if t is bn.PositiveRealNode:
+            f = f"add_constant_pos_real({_value_to_cpp(float(v))})"
+        elif t is bn.NegativeRealNode:
+            f = f"add_constant_neg_real({_value_to_cpp(float(v))})"
+        elif t is bn.ProbabilityNode:
+            f = f"add_constant_probability({_value_to_cpp(float(v))})"
+        elif t is bn.BooleanNode:
+            f = f"add_constant({_value_to_cpp(bool(v))})"
+        elif t is bn.NaturalNode:
+            f = f"add_constant({_value_to_cpp(int(v))})"
+        elif t is bn.RealNode:
+            f = f"add_constant({_value_to_cpp(float(v))})"
+        elif t is bn.ConstantTensorNode:
+            f = f"add_constant({_value_to_cpp(v)})"
+        elif t is bn.ConstantPositiveRealMatrixNode:
+            m = _value_to_cpp_eigen(v, f"m{graph_id}")
+            f = f"add_constant_pos_matrix(m{graph_id})"
+        elif t is bn.ConstantRealMatrixNode:
+            m = _value_to_cpp_eigen(v, f"m{graph_id}")
+            f = f"add_constant_real_matrix(m{graph_id})"
+        elif t is bn.ConstantNegativeRealMatrixNode:
+            m = _value_to_cpp_eigen(v, f"m{graph_id}")
+            f = f"add_constant_neg_matrix(m{graph_id})"
+        elif t is bn.ConstantProbabilityMatrixNode:
+            m = _value_to_cpp_eigen(v, f"m{graph_id}")
+            f = f"add_constant_probability_matrix(m{graph_id})"
+        elif t is bn.ConstantNaturalMatrixNode:
+            m = _value_to_cpp_eigen(v, f"m{graph_id}")
+            f = f"add_constant_natural_matrix(m{graph_id})"
+        elif t is bn.ConstantBooleanMatrixNode:
+            m = _value_to_cpp_eigen(v, f"m{graph_id}")
+            f = f"add_constant_bool_matrix(m{graph_id})"
+        else:
+            f = "UNKNOWN"
+        if m != "":
+            self._code.append(m)
+        self._code.append(f"uint n{graph_id} = g.{f};")
+
+    def _generate_node(self, node: bn.BMGNode) -> None:
+        if isinstance(node, bn.Observation):
+            self._add_observation(node)
+        elif isinstance(node, bn.Query):
+            self._add_query(node)
+        elif isinstance(node, bn.FactorNode):
+            self._add_factor(node)
+        elif isinstance(node, bn.DistributionNode):
+            self._add_distribution(node)
+        elif isinstance(node, bn.OperatorNode):
+            self._add_operator(node)
+        elif isinstance(node, bn.ConstantNode):
+            self._add_constant(node)
+
+    def _generate_cpp(self) -> None:
+        fix_problems(self.bmg).raise_errors()
+        for node in self.bmg._traverse_from_roots():
+            self._generate_node(node)
+        self.code = "\n".join(self._code)
+
+
+def to_bmg_cpp(bmg: BMGraphBuilder) -> GeneratedGraphCPP:
+    gg = GeneratedGraphCPP(bmg)
+    gg._generate_cpp()
+    return gg

--- a/src/beanmachine/ppl/compiler/tests/bm_graph_builder_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bm_graph_builder_test.py
@@ -32,6 +32,7 @@ from beanmachine.ppl.compiler.bmg_nodes import (
     SetOfTensors,
     ToRealNode,
 )
+from beanmachine.ppl.compiler.gen_bmg_cpp import to_bmg_cpp
 from beanmachine.ppl.compiler.gen_bmg_graph import to_bmg_graph
 from beanmachine.ppl.compiler.gen_bmg_python import to_bmg_python
 from beanmachine.ppl.compiler.gen_dot import to_dot
@@ -140,7 +141,7 @@ q0 = g.query(n7)
 """
         self.assertEqual(observed.strip(), expected.strip())
 
-        observed = bmg.to_cpp()
+        observed = to_bmg_cpp(bmg).code
 
         expected = """
 graph::Graph g;
@@ -152,18 +153,18 @@ uint n1 = g.add_distribution(
 uint n2 = g.add_operator(
   graph::OperatorType::SAMPLE, std::vector<uint>({n1}));
 g.observe([n2], true);
-uint n4 = g.add_constant(2);
-uint n5 = g.add_operator(
+uint n3 = g.add_constant(2.0);
+uint n4 = g.add_operator(
   graph::OperatorType::TO_REAL, std::vector<uint>({n2}));
+uint n5 = g.add_operator(
+  graph::OperatorType::NEGATE, std::vector<uint>({n4}));
 uint n6 = g.add_operator(
-  graph::OperatorType::NEGATE, std::vector<uint>({n5}));
+  graph::OperatorType::ADD, std::vector<uint>({n3, n5}));
 uint n7 = g.add_operator(
-  graph::OperatorType::ADD, std::vector<uint>({n4, n6}));
-uint n8 = g.add_operator(
-  graph::OperatorType::MULTIPLY, std::vector<uint>({n4, n7}));
-g.query(n8);
+  graph::OperatorType::MULTIPLY, std::vector<uint>({n3, n6}));
+uint q0 = g.query(n7);
 """
-        self.assertEqual(observed.strip(), expected.strip())
+        self.assertEqual(expected.strip(), observed.strip())
 
     def test_graph_builder_2(self) -> None:
         bmg = BMGraphBuilder()

--- a/src/beanmachine/ppl/compiler/tests/bmg_factor_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_factor_test.py
@@ -2,6 +2,7 @@
 import unittest
 
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
+from beanmachine.ppl.compiler.gen_bmg_cpp import to_bmg_cpp
 from beanmachine.ppl.compiler.gen_bmg_graph import to_bmg_graph
 from beanmachine.ppl.compiler.gen_bmg_python import to_bmg_python
 from beanmachine.ppl.compiler.gen_dot import to_dot
@@ -84,7 +85,7 @@ g.observe(n3, 7.0)
 """
         self.assertEqual(expected.strip(), observed.strip())
 
-        observed = bmg.to_cpp()
+        observed = to_bmg_cpp(bmg).code
 
         expected = """
 graph::Graph g;
@@ -99,7 +100,7 @@ uint n3 = g.add_operator(
 uint n4 = g.add_constant_probability(0.4);
 uint n5 = g.add_operator(
   graph::OperatorType::MULTIPLY, std::vector<uint>({n3, n3}));
-n6 = g.add_factor(
+uint n6 = g.add_factor(
   graph::FactorType::EXP_PRODUCT,
   std::vector<uint>({n3, n4, n5}));
 g.observe([n3], 7.0);

--- a/src/beanmachine/ppl/compiler/tests/clara_tensor_cgm_no_update_test.py
+++ b/src/beanmachine/ppl/compiler/tests/clara_tensor_cgm_no_update_test.py
@@ -209,7 +209,7 @@ uint n1 = g.add_distribution(
     graph::AtomicType::PROBABILITY,
     2,
     1
-  )
+  ),
   std::vector<uint>({n0}));
 uint n2 = g.add_operator(
   graph::OperatorType::SAMPLE, std::vector<uint>({n1}));
@@ -227,7 +227,7 @@ uint n8 = g.add_operator(
 uint n9 = g.add_operator(
   graph::OperatorType::LOG, std::vector<uint>({n8}));
 uint n10 = g.add_constant_neg_real(-0.010050326585769653);
-n11 = g.add_operator(
+uint n11 = g.add_operator(
   graph::OperatorType::ADD,
   std::vector<uint>({n7, n9, n10}));
 uint n12 = g.add_constant(1);
@@ -240,12 +240,11 @@ uint n15 = g.add_operator(
 uint n16 = g.add_operator(
   graph::OperatorType::LOG, std::vector<uint>({n15}));
 uint n17 = g.add_constant_neg_real(-4.605170249938965);
-n18 = g.add_operator(
+uint n18 = g.add_operator(
   graph::OperatorType::ADD,
   std::vector<uint>({n14, n16, n17}));
-n19 = g.add_operator(
-  graph::OperatorType::LOGSUMEXP,
-  std::vector<uint>({n11, n18}));
+uint n19 = g.add_operator(
+  graph::OperatorType::LOGSUMEXP, std::vector<uint>({n11, n18}));
 uint n20 = g.add_operator(
   graph::OperatorType::EXP, std::vector<uint>({n19}));
 uint n21 = g.add_operator(
@@ -257,9 +256,9 @@ uint n22 = g.add_distribution(
 uint n23 = g.add_operator(
   graph::OperatorType::SAMPLE, std::vector<uint>({n22}));
 g.observe([n23], true);
-g.query(n11);
-g.query(n2);
-g.query(n3);
+uint q0 = g.query(n11);
+uint q1 = g.query(n2);
+uint q2 = g.query(n3);
 """
         self.assertEqual(expected.strip(), observed.strip())
 

--- a/src/beanmachine/ppl/compiler/tests/coin_flip_test.py
+++ b/src/beanmachine/ppl/compiler/tests/coin_flip_test.py
@@ -109,16 +109,16 @@ uint n3 = g.add_distribution(
 uint n4 = g.add_operator(
   graph::OperatorType::SAMPLE, std::vector<uint>({n3}));
 g.observe([n4], false);
+uint n5 = g.add_operator(
+  graph::OperatorType::SAMPLE, std::vector<uint>({n3}));
+g.observe([n5], false);
 uint n6 = g.add_operator(
   graph::OperatorType::SAMPLE, std::vector<uint>({n3}));
-g.observe([n6], false);
-uint n8 = g.add_operator(
+g.observe([n6], true);
+uint n7 = g.add_operator(
   graph::OperatorType::SAMPLE, std::vector<uint>({n3}));
-g.observe([n8], true);
-uint n10 = g.add_operator(
-  graph::OperatorType::SAMPLE, std::vector<uint>({n3}));
-g.observe([n10], false);
-g.query(n2);"""
+g.observe([n7], false);
+uint q0 = g.query(n2);"""
         self.assertEqual(expected.strip(), observed.strip())
 
         observed = BMGInference().to_python(queries, observations)

--- a/src/beanmachine/ppl/compiler/tests/dirichlet_test.py
+++ b/src/beanmachine/ppl/compiler/tests/dirichlet_test.py
@@ -16,6 +16,7 @@ from beanmachine.graph import (
     VariableType,
 )
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
+from beanmachine.ppl.compiler.gen_bmg_cpp import to_bmg_cpp
 from beanmachine.ppl.compiler.gen_bmg_graph import to_bmg_graph
 from beanmachine.ppl.compiler.gen_bmg_python import to_bmg_python
 from beanmachine.ppl.compiler.gen_dot import to_dot
@@ -214,16 +215,14 @@ graph::Graph g;
 Eigen::MatrixXd m0(1, 1)
 m0 << 1.0;
 uint n0 = g.add_constant_pos_matrix(m0);
-
-Eigen::MatrixXd m2(2, 1)
-m2 << 1.0, 1.5;
+Eigen::MatrixXd m1(2, 1)
+m1 << 1.0, 1.5;
+uint n1 = g.add_constant_pos_matrix(m1);
+Eigen::MatrixXd m2(2, 2)
+m2 << 1.0, 1.5, 2.0, 2.5;
 uint n2 = g.add_constant_pos_matrix(m2);
-
-Eigen::MatrixXd m4(2, 2)
-m4 << 1.0, 1.5, 2.0, 2.5;
-uint n4 = g.add_constant_pos_matrix(m4);
         """
-        observed = bmg.to_cpp()
+        observed = to_bmg_cpp(bmg).code
         self.assertEqual(expected.strip(), observed.strip())
 
         # Notice that constant matrices are always expressed as a
@@ -531,14 +530,14 @@ uint n1 = g.add_distribution(
     graph::AtomicType::PROBABILITY,
     2,
     1
-  )
+  ),
   std::vector<uint>({n0}));
 uint n2 = g.add_operator(
   graph::OperatorType::SAMPLE, std::vector<uint>({n1}));
-Eigen::MatrixXd m3(2, 1)
-m3 << 0.5, 0.5;
-g.observe([n2], m3);
-g.query(n2);"""
+Eigen::MatrixXd o0(2, 1)
+o0 << 0.5, 0.5;
+g.observe([n2], o0);
+uint q0 = g.query(n2);"""
         self.assertEqual(expected.strip(), observed.strip())
 
     def test_dirichlet_observation_errors(self) -> None:

--- a/src/beanmachine/ppl/compiler/tests/log1mexp_test.py
+++ b/src/beanmachine/ppl/compiler/tests/log1mexp_test.py
@@ -259,30 +259,31 @@ uint n4 = g.add_distribution(
 uint n5 = g.add_operator(
   graph::OperatorType::SAMPLE, std::vector<uint>({n4}));
 g.observe([n5], false);
+uint n6 = g.add_operator(
+  graph::OperatorType::SAMPLE, std::vector<uint>({n4}));
+g.observe([n6], false);
 uint n7 = g.add_operator(
   graph::OperatorType::SAMPLE, std::vector<uint>({n4}));
-g.observe([n7], false);
+g.observe([n7], true);
+uint n8 = g.add_operator(
+  graph::OperatorType::SAMPLE, std::vector<uint>({n4}));
+g.observe([n8], false);
 uint n9 = g.add_operator(
-  graph::OperatorType::SAMPLE, std::vector<uint>({n4}));
-g.observe([n9], true);
-uint n11 = g.add_operator(
-  graph::OperatorType::SAMPLE, std::vector<uint>({n4}));
-g.observe([n11], false);
-uint n13 = g.add_operator(
   graph::OperatorType::TO_POS_REAL, std::vector<uint>({n3}));
-uint n14 = g.add_operator(
-  graph::OperatorType::NEGATE, std::vector<uint>({n13}));
-uint n15 = g.add_operator(
-  graph::OperatorType::LOG1MEXP, std::vector<uint>({n14}));
-uint n16 = g.add_operator(
-  graph::OperatorType::NEGATE, std::vector<uint>({n15}));
-uint n17 = g.add_distribution(
+uint n10 = g.add_operator(
+  graph::OperatorType::NEGATE, std::vector<uint>({n9}));
+uint n11 = g.add_operator(
+  graph::OperatorType::LOG1MEXP, std::vector<uint>({n10}));
+uint n12 = g.add_operator(
+  graph::OperatorType::NEGATE, std::vector<uint>({n11}));
+uint n13 = g.add_distribution(
   graph::DistributionType::BETA,
   graph::AtomicType::PROBABILITY,
-  std::vector<uint>({n0, n16}));
-uint n18 = g.add_operator(
-  graph::OperatorType::SAMPLE, std::vector<uint>({n17}));
-g.query(n18);"""
+  std::vector<uint>({n0, n12}));
+uint n14 = g.add_operator(
+  graph::OperatorType::SAMPLE, std::vector<uint>({n13}));
+uint q0 = g.query(n14);
+"""
         self.assertEqual(expected.strip(), observed.strip())
 
         observed = BMGInference().to_python(queries, observations)

--- a/src/beanmachine/ppl/inference/bmg_inference.py
+++ b/src/beanmachine/ppl/inference/bmg_inference.py
@@ -11,6 +11,7 @@ import beanmachine.ppl.compiler.profiler as prof
 import torch
 from beanmachine.graph import InferenceType
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
+from beanmachine.ppl.compiler.gen_bmg_cpp import to_bmg_cpp
 from beanmachine.ppl.compiler.gen_bmg_graph import to_bmg_graph
 from beanmachine.ppl.compiler.gen_bmg_python import to_bmg_python
 from beanmachine.ppl.compiler.gen_dot import to_dot
@@ -215,7 +216,8 @@ class BMGInference:
     ) -> str:
         """Produce a string containing a C++ program fragment which
         produces the graph deduced from the model."""
-        return self._accumulate_graph(queries, observations).to_cpp()
+        bmg = self._accumulate_graph(queries, observations)
+        return to_bmg_cpp(bmg).code
 
     def to_python(
         self,


### PR DESCRIPTION
Summary:
In previous diffs I moved responsibility for generating DOT visualization, graph objects and Python code to their own modules; in this diff I finish off this refactoring by moving responsibility for generating C++ code into its own module. Previously this code was split up amongst BMGInference, BMGraphBuilder and some dozens of node classes, none of which should own this concern.

The same improvements mentioned in the previous diff also apply here -- this refactoring also fixes a number of small bugs and warts.

Reviewed By: wtaha

Differential Revision: D27441356

