### PR TITLE
Refactor performance gathering code

### DIFF
--- a/src/beanmachine/ppl/compiler/bm_graph_builder.py
+++ b/src/beanmachine/ppl/compiler/bm_graph_builder.py
@@ -306,10 +306,10 @@ class BMGraphBuilder:
 
     _fix_observe_true: bool = False
 
-    pd: prof.ProfilerData
+    _pd: Optional[prof.ProfilerData]
 
     def __init__(self) -> None:
-        self.pd = prof.ProfilerData()
+        self._pd = None
         self.rv_map = {}
         self.lifted_map = {}
         self.in_flight = set()
@@ -363,6 +363,16 @@ class BMGraphBuilder:
             log1mexp: self.handle_log1mexp,
             math_log1mexp: self.handle_log1mexp,
         }
+
+    def _begin(self, s: str) -> None:
+        pd = self._pd
+        if pd is not None:
+            pd.begin(s)
+
+    def _finish(self, s: str) -> None:
+        pd = self._pd
+        if pd is not None:
+            pd.finish(s)
 
     # ####
     # #### Node creation and accumulation
@@ -1946,7 +1956,7 @@ class BMGraphBuilder:
         observations: Dict[RVIdentifier, Any],
     ) -> None:
         _verify_queries_and_observations(queries, observations, True)
-        self.pd.begin(prof.accumulate)
+        self._begin(prof.accumulate)
         for rv, val in observations.items():
             node = self._rv_to_node(rv)
             assert isinstance(node, bn.SampleNode)
@@ -1955,4 +1965,4 @@ class BMGraphBuilder:
             node = self._rv_to_node(qrv)
             q = self.add_query(node)
             self._rv_to_query[qrv] = q
-        self.pd.finish(prof.accumulate)
+        self._finish(prof.accumulate)

--- a/src/beanmachine/ppl/compiler/fix_problems.py
+++ b/src/beanmachine/ppl/compiler/fix_problems.py
@@ -39,19 +39,19 @@ _standard_fixer_types: List[Type] = [
 
 
 def fix_problems(bmg: BMGraphBuilder, fix_observe_true: bool = False) -> ErrorReport:
-    bmg.pd.begin(prof.fix_problems)
+    bmg._begin(prof.fix_problems)
     fixer_types: List[Type] = _standard_fixer_types
     errors = ErrorReport()
     if fix_observe_true:
         # Note: must NOT be +=, which would mutate _standard_fixer_types.
         fixer_types = fixer_types + [ObserveTrueFixer]
     for fixer_type in fixer_types:
-        bmg.pd.begin(fixer_type.__name__)
+        bmg._begin(fixer_type.__name__)
         fixer = fixer_type(bmg)
         fixer.fix_problems()
-        bmg.pd.finish(fixer_type.__name__)
+        bmg._finish(fixer_type.__name__)
         errors = fixer.errors
         if errors.any():
             break
-    bmg.pd.finish(prof.fix_problems)
+    bmg._finish(prof.fix_problems)
     return errors

--- a/src/beanmachine/ppl/compiler/gen_bmg_graph.py
+++ b/src/beanmachine/ppl/compiler/gen_bmg_graph.py
@@ -130,10 +130,10 @@ class GeneratedGraph:
 
     def _generate_graph(self) -> None:
         fix_problems(self.bmg).raise_errors()
-        self.bmg.pd.begin(prof.build_bmg_graph)
+        self.bmg._begin(prof.build_bmg_graph)
         for node in self.bmg._traverse_from_roots():
             self._generate_node(node)
-        self.bmg.pd.finish(prof.build_bmg_graph)
+        self.bmg._finish(prof.build_bmg_graph)
 
 
 def to_bmg_graph(bmg: BMGraphBuilder) -> GeneratedGraph:


### PR DESCRIPTION
Summary:
In this diff, just a small refactoring of the performance gathering code:

* We were doing this strange dance where BMGInference created a BMGraphBuilder and then used its profiler data object. BMGInference is the thing that is kicking off the process of collecting profiler data, so it should be the thing which creates and owns that object.

Also, collecting profiler data should be off by default; it is now.

Reviewed By: wtaha

Differential Revision: D27447933

