### PR TITLE
Include unit_interval supports in NewtonianSimplex

### DIFF
--- a/src/beanmachine/ppl/inference/compositional_infer.py
+++ b/src/beanmachine/ppl/inference/compositional_infer.py
@@ -91,6 +91,7 @@ class CompositionalInference(AbstractMHInference):
                 support,
                 (
                     dist.constraints.real,
+                    dist.constraints.unit_interval,
                     dist.constraints.simplex,
                     dist.constraints.greater_than,
                 ),

--- a/src/beanmachine/ppl/inference/proposer/single_site_newtonian_monte_carlo_proposer.py
+++ b/src/beanmachine/ppl/inference/proposer/single_site_newtonian_monte_carlo_proposer.py
@@ -97,16 +97,12 @@ class SingleSiteNewtonianMonteCarloProposer(SingleSiteAncestralProposer):
             ):
                 self.proposers_[node] = SingleSiteHalfSpaceNewtonianMonteCarloProposer()
 
-            elif (
-                is_constraint_eq(node_distribution_support, dist.constraints.simplex)
-                or isinstance(node_var.distribution, dist.Beta)
-                or (
-                    isinstance(node_distribution_support, dist.constraints.independent)
-                    and (
-                        node_distribution_support.base_constraint
-                        == dist.constraints.unit_interval
-                    )
-                )
+            elif is_constraint_eq(
+                node_distribution_support, dist.constraints.simplex
+            ) or (
+                is_constraint_eq(node_distribution_support, dist.constraints.interval)
+                and node_distribution_support.lower_bound == 0.0
+                and node_distribution_support.upper_bound == 1.0
             ):
                 self.proposers_[node] = SingleSiteSimplexNewtonianMonteCarloProposer()
             else:


### PR DESCRIPTION
Summary:
Currently calls from https://www.internalfb.com/intern/diffusion/FBS/browse/master/fbcode/ax/fb/utils/bma/bma.py?commit=d6aced6c768d4f089e83a2907c5b350f07fe8419&lines=840
results in Ancestral proposer fallback, when we should be using the Newtonian Simplex proposer.

Also see N456274

Differential Revision: D27626914

