### PR TITLE
Split graph builder into two classes

### DIFF
--- a/src/beanmachine/ppl/compiler/bm_to_bmg.py
+++ b/src/beanmachine/ppl/compiler/bm_to_bmg.py
@@ -8,7 +8,7 @@ import types
 from typing import Callable, List, Tuple
 
 import astor
-from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
+from beanmachine.ppl.compiler.bm_graph_builder import BMGRuntime
 from beanmachine.ppl.compiler.internal_error import LiftedCompilationError
 from beanmachine.ppl.utils.ast_patterns import (
     arguments,
@@ -334,7 +334,7 @@ def _bm_function_to_bmg_ast(f: Callable, helper_name: str) -> Tuple[ast.AST, str
     return helper, source
 
 
-def _bm_function_to_bmg_function(f: Callable, bmg: BMGraphBuilder) -> Callable:
+def _bm_function_to_bmg_function(f: Callable, bmg: BMGRuntime) -> Callable:
     # We only know how to compile certain kinds of code containers.
     # If we don't have one of those, just return the function unmodified
     # and hope for the best.

--- a/src/beanmachine/ppl/compiler/tests/dirichlet_test.py
+++ b/src/beanmachine/ppl/compiler/tests/dirichlet_test.py
@@ -15,7 +15,7 @@ from beanmachine.graph import (
     ValueType,
     VariableType,
 )
-from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
+from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder, BMGRuntime
 from beanmachine.ppl.compiler.gen_bmg_cpp import to_bmg_cpp
 from beanmachine.ppl.compiler.gen_bmg_graph import to_bmg_graph
 from beanmachine.ppl.compiler.gen_bmg_python import to_bmg_python
@@ -252,9 +252,8 @@ Node 2 type 1 parents [ ] children [ ] matrix<positive real>   1   2
 
     def test_dirichlet_type_analysis(self) -> None:
         self.maxDiff = None
-        bmg = BMGraphBuilder()
         queries = [d0(), d1b(), d1c(), d1d(), d2a(), d2b(), d2c(), d23()]
-        bmg.accumulate_graph(queries, {})
+        bmg = BMGRuntime().accumulate_graph(queries, {})
         observed = to_dot(
             bmg,
             graph_types=True,
@@ -367,10 +366,9 @@ digraph "graph" {
         # replace it with a positive real constant matrix node?
 
         self.maxDiff = None
-        bmg = BMGraphBuilder()
         queries = [d2a()]
         observations = {d2a(): tensor([0.5, 0.5])}
-        bmg.accumulate_graph(queries, observations)
+        bmg = BMGRuntime().accumulate_graph(queries, observations)
         observed = to_dot(
             bmg,
             graph_types=True,
@@ -400,9 +398,8 @@ digraph "graph" {
         # one value, and we need to make sure that we generate a matrix
         # constant rather than a regular positive real constant:
 
-        bmg = BMGraphBuilder()
         queries = [d1b()]
-        bmg.accumulate_graph(queries, {})
+        bmg = BMGRuntime().accumulate_graph(queries, {})
         observed = to_dot(
             bmg,
             graph_types=True,

--- a/src/beanmachine/ppl/compiler/tests/gen_builder_test.py
+++ b/src/beanmachine/ppl/compiler/tests/gen_builder_test.py
@@ -3,7 +3,7 @@
 import unittest
 
 import beanmachine.ppl as bm
-from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
+from beanmachine.ppl.compiler.bm_graph_builder import BMGRuntime
 from beanmachine.ppl.compiler.gen_builder import generate_builder
 from torch.distributions import Normal
 
@@ -21,8 +21,7 @@ def norm_sum():
 class GenerateBuilderTest(unittest.TestCase):
     def test_generate_builder_1(self) -> None:
         self.maxDiff = None
-        bmg = BMGraphBuilder()
-        bmg.accumulate_graph([norm_sum()], {})
+        bmg = BMGRuntime().accumulate_graph([norm_sum()], {})
         observed = generate_builder(bmg)
         expected = """
 import beanmachine.ppl.compiler.bmg_nodes as bn

--- a/src/beanmachine/ppl/compiler/tests/graph_accumulation_test.py
+++ b/src/beanmachine/ppl/compiler/tests/graph_accumulation_test.py
@@ -3,7 +3,7 @@
 import unittest
 
 import beanmachine.ppl as bm
-from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
+from beanmachine.ppl.compiler.bm_graph_builder import BMGRuntime
 from beanmachine.ppl.compiler.gen_bmg_graph import to_bmg_graph
 from torch import tensor
 from torch.distributions import (
@@ -336,62 +336,54 @@ class GraphAccumulationTests(unittest.TestCase):
             chi2(),
         ]
 
-        bmg = BMGraphBuilder()
-        bmg.accumulate_graph(queries, {})
+        bmg = BMGRuntime().accumulate_graph(queries, {})
         observed = to_bmg_graph(bmg).graph.to_string()
         self.assertEqual(tidy(observed), tidy(expected_bmg_1))
 
     def test_accumulate_bool_conversions(self) -> None:
         self.maxDiff = None
         queries = [normal_from_bools(), binomial_from_bools()]
-        bmg = BMGraphBuilder()
-        bmg.accumulate_graph(queries, {})
+        bmg = BMGRuntime().accumulate_graph(queries, {})
         observed = to_bmg_graph(bmg).graph.to_string()
         self.assertEqual(tidy(observed), tidy(expected_bmg_2))
 
     def test_accumulate_bool_nat_mult(self) -> None:
         self.maxDiff = None
         queries = [bool_times_natural()]
-        bmg = BMGraphBuilder()
-        bmg.accumulate_graph(queries, {})
+        bmg = BMGRuntime().accumulate_graph(queries, {})
         observed = to_bmg_graph(bmg).graph.to_string()
         self.assertEqual(tidy(observed), tidy(expected_bmg_3))
 
     def test_accumulate_math(self) -> None:
         self.maxDiff = None
         queries = [math1(), math2(), math3()]
-        bmg = BMGraphBuilder()
-        bmg.accumulate_graph(queries, {})
+        bmg = BMGRuntime().accumulate_graph(queries, {})
         observed = to_bmg_graph(bmg).graph.to_string()
         self.assertEqual(tidy(observed), tidy(expected_bmg_4))
 
         # Try with a different version of CDF syntax.
         queries = [math1(), math2(), math4()]
-        bmg = BMGraphBuilder()
-        bmg.accumulate_graph(queries, {})
+        bmg = BMGRuntime().accumulate_graph(queries, {})
         observed = to_bmg_graph(bmg).graph.to_string()
         self.assertEqual(tidy(observed), tidy(expected_bmg_4))
 
     def test_accumulate_complement(self) -> None:
         self.maxDiff = None
         queries = [flip_complement()]
-        bmg = BMGraphBuilder()
-        bmg.accumulate_graph(queries, {})
+        bmg = BMGRuntime().accumulate_graph(queries, {})
         observed = to_bmg_graph(bmg).graph.to_string()
         self.assertEqual(tidy(observed), tidy(expected_bmg_5))
 
     def test_accumulate_neg_log(self) -> None:
         self.maxDiff = None
         queries = [beta_neg_log()]
-        bmg = BMGraphBuilder()
-        bmg.accumulate_graph(queries, {})
+        bmg = BMGRuntime().accumulate_graph(queries, {})
         observed = to_bmg_graph(bmg).graph.to_string()
         self.assertEqual(tidy(observed), tidy(expected_bmg_6))
 
     def test_accumulate_eliminate_identities(self) -> None:
         self.maxDiff = None
         queries = [beta_eliminate_identities()]
-        bmg = BMGraphBuilder()
-        bmg.accumulate_graph(queries, {})
+        bmg = BMGRuntime().accumulate_graph(queries, {})
         observed = to_bmg_graph(bmg).graph.to_string()
         self.assertEqual(tidy(observed), tidy(expected_bmg_7))

--- a/src/beanmachine/ppl/compiler/tests/stochastic_control_flow_test.py
+++ b/src/beanmachine/ppl/compiler/tests/stochastic_control_flow_test.py
@@ -2,7 +2,7 @@
 import unittest
 
 import beanmachine.ppl as bm
-from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
+from beanmachine.ppl.compiler.bm_graph_builder import BMGRuntime
 from beanmachine.ppl.compiler.gen_dot import to_dot
 from torch import tensor
 from torch.distributions import Bernoulli, Beta, Normal
@@ -105,10 +105,9 @@ class StochasticControlFlowTest(unittest.TestCase):
     def test_stochastic_control_flow_1(self) -> None:
         self.maxDiff = None
 
-        bmg = BMGraphBuilder()
         queries = [any_index_you_want_as_long_as_it_is_zero()]
         observations = {}
-        bmg.accumulate_graph(queries, observations)
+        bmg = BMGRuntime().accumulate_graph(queries, observations)
 
         # Here we have what looks like a stochastic control flow but
         # in reality there is only one possibility. We should ensure
@@ -138,10 +137,9 @@ digraph "graph" {
     def test_stochastic_control_flow_2(self) -> None:
         self.maxDiff = None
 
-        bmg = BMGraphBuilder()
         queries = [choose_your_mean()]
         observations = {}
-        bmg.accumulate_graph(queries, observations)
+        bmg = BMGRuntime().accumulate_graph(queries, observations)
 
         # Note that we generate an if-then-else node here to express the
         # flip that chooses between two alternatives, and therefore can
@@ -191,10 +189,9 @@ digraph "graph" {
     def test_stochastic_control_flow_3(self) -> None:
         self.maxDiff = None
 
-        bmg = BMGraphBuilder()
         queries = [three_possibilities()]
         observations = {}
-        bmg.accumulate_graph(queries, observations)
+        bmg = BMGRuntime().accumulate_graph(queries, observations)
 
         # Now we have three possibilities, and we cannot yet represent
         # that in BMG.
@@ -248,7 +245,6 @@ digraph "graph" {
     def test_stochastic_control_flow_composition_broken(self) -> None:
         self.maxDiff = None
 
-        bmg = BMGraphBuilder()
         queries = [composition_is_broken()]
         observations = {}
 
@@ -258,15 +254,14 @@ digraph "graph" {
         # TODO: Fix it.
 
         with self.assertRaises(ValueError):
-            bmg.accumulate_graph(queries, observations)
+            BMGRuntime().accumulate_graph(queries, observations)
 
     def test_stochastic_control_flow_4(self) -> None:
         self.maxDiff = None
 
-        bmg = BMGraphBuilder()
         queries = [two_parameters()]
         observations = {}
-        bmg.accumulate_graph(queries, observations)
+        bmg = BMGRuntime().accumulate_graph(queries, observations)
 
         # Here we have four possibilities but since each is a Boolean choice
         # it turns out we can in fact represent it.

--- a/src/beanmachine/ppl/compiler/tests/tensor_operations_test.py
+++ b/src/beanmachine/ppl/compiler/tests/tensor_operations_test.py
@@ -2,7 +2,7 @@
 import unittest
 
 import beanmachine.ppl as bm
-from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
+from beanmachine.ppl.compiler.bm_graph_builder import BMGRuntime
 from beanmachine.ppl.compiler.gen_dot import to_dot
 from torch import logsumexp, tensor
 from torch.distributions import Normal
@@ -32,8 +32,7 @@ class TensorOperationsTest(unittest.TestCase):
     def test_tensor_operations_1(self) -> None:
         self.maxDiff = None
 
-        bmg = BMGraphBuilder()
-        bmg.accumulate_graph([lse1()], {})
+        bmg = BMGRuntime().accumulate_graph([lse1()], {})
         observed = to_dot(bmg)
         expected = """
 digraph "graph" {
@@ -62,8 +61,7 @@ digraph "graph" {
         # Do it again, but this time with the static method flavor of
         # logsumexp. We should get the same result.
 
-        bmg = BMGraphBuilder()
-        bmg.accumulate_graph([lse2()], {})
+        bmg = BMGRuntime().accumulate_graph([lse2()], {})
         observed = to_dot(bmg)
         self.assertEqual(observed.strip(), expected.strip())
 
@@ -92,7 +90,6 @@ digraph "graph" {
 }
 """
 
-        bmg = BMGraphBuilder()
-        bmg.accumulate_graph([lse1()], {})
+        bmg = BMGRuntime().accumulate_graph([lse1()], {})
         observed = to_dot(bmg, after_transform=True)
         self.assertEqual(observed.strip(), expected.strip())


### PR DESCRIPTION
Summary:
In the previous diff I noted that half the functions in the graph builder class are used only for building the graph, and half the functions are used as runtime hooks when the graph accumulator is running. These tasks are logically seperable into two classes, and so I have done so. BMGraphBuilder is now responsible only for creating a deduplicated graph. BMGRuntime is responsible for intercepting function calls, rewriting their source code, and intercepting the function calls in the rewritten code.

There is still some more minor refactoring to do here to make the interface clean and stop the various classes from looking at each other's internals, but this split is a large step towards making all this code more targetted at a specific concern.

In the next diff I'll move these into separate modules.

Reviewed By: wtaha

Differential Revision: D27481957

