### PR TITLE
Remove pass which eliminates subtractions

### DIFF
--- a/src/beanmachine/ppl/compiler/bm_graph_builder.py
+++ b/src/beanmachine/ppl/compiler/bm_graph_builder.py
@@ -492,6 +492,14 @@ class BMGraphBuilder:
         self.add_node(node)
         return node
 
+    # No need to memoize this since the addition will be memoized.
+    def add_subtraction(self, left: BMGNode, right: BMGNode) -> BMGNode:
+        # TODO: We don't have a subtraction node; we render this as
+        # left + (-right), which we do have.  Should we have a subtraction
+        # node? We could do this transformation in a problem-fixing pass,
+        # like we do for division.
+        return self.add_addition(left, self.add_negate(right))
+
     @memoize
     def add_multi_addition(self, *inputs: BMGNode) -> bn.MultiAdditionNode:
         node = bn.MultiAdditionNode(list(inputs))
@@ -587,6 +595,7 @@ class BMGraphBuilder:
 
     @memoize
     def add_negate(self, operand: BMGNode) -> BMGNode:
+        # TODO: We could optimize -(-x) to x here.
         if isinstance(operand, ConstantNode):
             return self.add_constant(-operand.value)
         node = bn.NegateNode(operand)

--- a/src/beanmachine/ppl/compiler/runtime.py
+++ b/src/beanmachine/ppl/compiler/runtime.py
@@ -126,6 +126,7 @@ known_tensor_instance_functions = [
     "neg",
     "pow",
     "sigmoid",
+    "sub",
 ]
 
 
@@ -293,6 +294,7 @@ class BMGRuntime:
             torch.Tensor.neg: self.handle_negate,
             torch.Tensor.pow: self.handle_power,
             torch.Tensor.sigmoid: self.handle_logistic,
+            torch.Tensor.sub: self.handle_subtraction,
             # Tensor static functions
             torch.add: self.handle_addition,
             torch.div: self.handle_division,
@@ -307,6 +309,7 @@ class BMGRuntime:
             torch.neg: self.handle_negate,
             torch.pow: self.handle_power,
             torch.sigmoid: self.handle_logistic,
+            torch.sub: self.handle_subtraction,
             # Distribution constructors
             dist.Bernoulli: self.handle_bernoulli,
             dist.Beta: self.handle_beta,
@@ -542,6 +545,17 @@ class BMGRuntime:
         if isinstance(input, ConstantNode) and isinstance(other, ConstantNode):
             return input.value + other.value
         return self._bmg.add_addition(input, other)
+
+    def handle_subtraction(self, input: Any, other: Any) -> Any:
+        if (not isinstance(input, BMGNode)) and (not isinstance(other, BMGNode)):
+            return input - other
+        if not isinstance(input, BMGNode):
+            input = self._bmg.add_constant(input)
+        if not isinstance(other, BMGNode):
+            other = self._bmg.add_constant(other)
+        if isinstance(input, ConstantNode) and isinstance(other, ConstantNode):
+            return input.value - other.value
+        return self._bmg.add_subtraction(input, other)
 
     # TODO: Do we need to represent both integer and float division?
     def handle_division(self, input: Any, other: Any) -> Any:


### PR DESCRIPTION
Summary:
Bean Machine Graph has no subtraction operator; it represents `x-y` as `x+(-y)`.

When adding the instrumentation to a function that causes it to accumulate the graph when executed, we first did a *syntactic* transformation, so we would generate `z = x - y` as

    t = handle_negate(y)
    z = handle_add(x, t)

But this has an important problem: what if x and y are tensors, and instead we have `z = x.sub(y)` ?

We cannot use a syntactic trick to eliminate subtractions from the lifted code; we will need to handle a variety of different subtraction operations that could be in the model.

I've eliminated the syntactic rewrite, and we now generate `z = handle_subtraction(x, y)` as we should. The runtime then detects usage of `Tensor.sub` and invokes `handle_subtraction` for it too.

This change deletes the last user of the constant folding code, so I'll delete that in a later diff.

Reviewed By: wtaha

Differential Revision: D27486823

