### PR TITLE
Move simple arithmetic optimizations to optimization pass

### DIFF
--- a/src/beanmachine/ppl/compiler/bm_graph_builder.py
+++ b/src/beanmachine/ppl/compiler/bm_graph_builder.py
@@ -479,14 +479,8 @@ class BMGraphBuilder:
 
     @memoize
     def add_addition(self, left: BMGNode, right: BMGNode) -> BMGNode:
-        if isinstance(left, ConstantNode):
-            if isinstance(right, ConstantNode):
-                return self.add_constant(left.value + right.value)
-            if left.inf_type == bt.Zero:
-                return right
-        if isinstance(right, ConstantNode):
-            if right.inf_type == bt.Zero:
-                return left
+        if isinstance(left, ConstantNode) and isinstance(right, ConstantNode):
+            return self.add_constant(left.value + right.value)
 
         node = bn.AdditionNode(left, right)
         self.add_node(node)
@@ -508,21 +502,8 @@ class BMGraphBuilder:
 
     @memoize
     def add_multiplication(self, left: BMGNode, right: BMGNode) -> BMGNode:
-        # TODO: Consider moving this to an optimization pass.
-        if isinstance(left, ConstantNode):
-            if isinstance(right, ConstantNode):
-                return self.add_constant(left.value * right.value)
-            t = left.inf_type
-            if t == bt.One:
-                return right
-            if t == bt.Zero:
-                return left
-        if isinstance(right, ConstantNode):
-            t = right.inf_type
-            if t == bt.One:
-                return left
-            if t == bt.Zero:
-                return right
+        if isinstance(left, ConstantNode) and isinstance(right, ConstantNode):
+            return self.add_constant(left.value * right.value)
         node = bn.MultiplicationNode(left, right)
         self.add_node(node)
         return node

--- a/src/beanmachine/ppl/compiler/fix_bool_arithmetic.py
+++ b/src/beanmachine/ppl/compiler/fix_bool_arithmetic.py
@@ -1,0 +1,79 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+from typing import Optional
+
+import beanmachine.ppl.compiler.bmg_nodes as bn
+import beanmachine.ppl.compiler.bmg_types as bt
+from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
+from beanmachine.ppl.compiler.fix_problem import ProblemFixerBase
+
+
+class BoolArithmeticFixer(ProblemFixerBase):
+    def __init__(self, bmg: BMGraphBuilder) -> None:
+        ProblemFixerBase.__init__(self, bmg)
+
+    def _needs_fixing(self, n: bn.BMGNode) -> bool:
+        # We can simplify 1*anything, 0*anything or bool*anything
+        # to anything, 0, or an if-then-else respectively.
+        if isinstance(n, bn.MultiplicationNode):
+            return (
+                bt.supremum(n.left.inf_type, bt.Boolean) == bt.Boolean
+                or bt.supremum(n.right.inf_type, bt.Boolean) == bt.Boolean
+            )
+        # We can simplify 0+anything.
+        if isinstance(n, bn.AdditionNode):
+            return n.left.inf_type == bt.Zero or n.right.inf_type == bt.Zero
+
+        # We can simplify anything**bool.
+        if isinstance(n, bn.PowerNode):
+            return bt.supremum(n.right.inf_type, bt.Boolean) == bt.Boolean
+
+        # TODO: We could support b ** n where b is bool and n is a natural
+        # constant. If n is the constant zero then the result is just
+        # the Boolean constant true; if n is a non-zero constant then
+        # b ** n is simply b.
+        #
+        # NOTE: We CANNOT support b ** n where b is bool and n is a
+        # non-constant natural and the result is bool. That would
+        # have the semantics of "if b then true else n == 0" but we do
+        # not have an equality operator on naturals in BMG.
+
+        return False
+
+    def _get_replacement(self, n: bn.BMGNode) -> Optional[bn.BMGNode]:
+        if isinstance(n, bn.MultiplicationNode):
+            return self._fix_multiplication(n)
+        if isinstance(n, bn.AdditionNode):
+            return self._fix_addition(n)
+        assert isinstance(n, bn.PowerNode)
+        return self._fix_power(n)
+
+    def _fix_multiplication(self, n: bn.MultiplicationNode) -> bn.BMGNode:
+        lt = n.left.inf_type
+        if lt == bt.Zero:
+            return n.left
+        if lt == bt.One:
+            return n.right
+        rt = n.right.inf_type
+        if rt == bt.Zero:
+            return n.right
+        if rt == bt.One:
+            return n.left
+        zero = self._bmg.add_constant(0.0)
+        if lt == bt.Boolean:
+            return self._bmg.add_if_then_else(n.left, n.right, zero)
+        assert rt == bt.Boolean
+        return self._bmg.add_if_then_else(n.right, n.left, zero)
+
+    def _fix_addition(self, n: bn.AdditionNode) -> bn.BMGNode:
+        lt = n.left.inf_type
+        if lt == bt.Zero:
+            return n.right
+        assert n.right.inf_type == bt.Zero
+        return n.left
+
+    def _fix_power(self, n: bn.PowerNode) -> bn.BMGNode:
+        # x ** b  -->   if b then x else 1
+        assert bt.supremum(n.right.inf_type, bt.Boolean) == bt.Boolean
+        one = self._bmg.add_constant(1.0)
+        return self._bmg.add_if_then_else(n.right, n.left, one)

--- a/src/beanmachine/ppl/compiler/fix_problems.py
+++ b/src/beanmachine/ppl/compiler/fix_problems.py
@@ -6,6 +6,7 @@ import beanmachine.ppl.compiler.profiler as prof
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
 from beanmachine.ppl.compiler.error_report import ErrorReport
 from beanmachine.ppl.compiler.fix_additions import AdditionFixer
+from beanmachine.ppl.compiler.fix_bool_arithmetic import BoolArithmeticFixer
 from beanmachine.ppl.compiler.fix_bool_comparisons import BoolComparisonFixer
 from beanmachine.ppl.compiler.fix_multiary_ops import MultiaryOperatorFixer
 from beanmachine.ppl.compiler.fix_observations import ObservationsFixer
@@ -29,6 +30,7 @@ from beanmachine.ppl.compiler.fix_unsupported import UnsupportedNodeFixer
 
 _standard_fixer_types: List[Type] = [
     TensorOpsFixer,
+    BoolArithmeticFixer,
     AdditionFixer,
     BoolComparisonFixer,
     UnsupportedNodeFixer,

--- a/src/beanmachine/ppl/compiler/tests/binary_nodes_test.py
+++ b/src/beanmachine/ppl/compiler/tests/binary_nodes_test.py
@@ -60,18 +60,14 @@ class BMGNodesTest(unittest.TestCase):
         # we could meet the requirements of the BMG type system by inserting code
         # that converted the bool to a probability."
 
-        # In fact, a bool multiplied by any type can be converted to an "if-then-else"
-        # that chooses between the other operand and a zero of that type, so they
-        # are all possible.
-
-        # Boolean x Boolean -> Boolean
+        # Boolean x Boolean -> Probability
         # Boolean x Probability -> Probability
-        # Boolean x Natural -> Natural
+        # Boolean x Natural -> PositiveReal
         # Boolean x PositiveReal -> PositiveReal
         # Boolean x Real -> Real
-        self.assertEqual(MultiplicationNode(bern, bern).inf_type, Boolean)
+        self.assertEqual(MultiplicationNode(bern, bern).inf_type, Probability)
         self.assertEqual(MultiplicationNode(bern, beta).inf_type, Probability)
-        self.assertEqual(MultiplicationNode(bern, bino).inf_type, Natural)
+        self.assertEqual(MultiplicationNode(bern, bino).inf_type, PositiveReal)
         self.assertEqual(MultiplicationNode(bern, half).inf_type, PositiveReal)
         self.assertEqual(MultiplicationNode(bern, norm).inf_type, Real)
 
@@ -86,12 +82,12 @@ class BMGNodesTest(unittest.TestCase):
         self.assertEqual(MultiplicationNode(beta, half).inf_type, PositiveReal)
         self.assertEqual(MultiplicationNode(beta, norm).inf_type, Real)
 
-        # Natural x Boolean -> Natural
+        # Natural x Boolean -> PositiveReal
         # Natural x Probability -> PositiveReal
         # Natural x Natural -> PositiveReal
         # Natural x PositiveReal -> PositiveReal
         # Natural x Real -> Real
-        self.assertEqual(MultiplicationNode(bino, bern).inf_type, Natural)
+        self.assertEqual(MultiplicationNode(bino, bern).inf_type, PositiveReal)
         self.assertEqual(MultiplicationNode(bino, beta).inf_type, PositiveReal)
         self.assertEqual(MultiplicationNode(bino, bino).inf_type, PositiveReal)
         self.assertEqual(MultiplicationNode(bino, half).inf_type, PositiveReal)
@@ -120,18 +116,6 @@ class BMGNodesTest(unittest.TestCase):
         self.assertEqual(MultiplicationNode(norm, norm).inf_type, Real)
 
         # Addition
-
-        # Special case: 1 + (-P) -> P
-        # Special case: 1 + (-B) -> B
-        # Special case: (-P) + 1 -> P
-        # Special case: (-B) + 1 -> B
-        nb = NegateNode(bern)
-        np = NegateNode(beta)
-        one = RealNode(1.0)
-        self.assertEqual(AdditionNode(np, one).inf_type, Probability)
-        self.assertEqual(AdditionNode(nb, one).inf_type, Boolean)
-        self.assertEqual(AdditionNode(one, np).inf_type, Probability)
-        self.assertEqual(AdditionNode(one, nb).inf_type, Boolean)
 
         # Boolean + Boolean -> PositiveReal
         # Boolean + Probability -> PositiveReal
@@ -212,13 +196,15 @@ class BMGNodesTest(unittest.TestCase):
         self.assertEqual(AdditionNode(norm, norm).inf_type, Real)
 
         # Power
-        # * The inf type is equal to the base inf type with a few exceptions:
-        # * If the base is P or B and the exponent is R, the output is R+.
-        # * If the base is B the output is P.
-        # * If the base is N the output is R+.
+        # P ** R+  --> P
+        # P ** R   --> R+
+        # R+ ** R+ --> R+
+        # R+ ** R  --> R+
+        # R ** R+  --> R
+        # R ** R   --> R
 
-        # Base is B
-        self.assertEqual(PowerNode(bern, bern).inf_type, Boolean)
+        # Base is B; treated as P
+        self.assertEqual(PowerNode(bern, bern).inf_type, Probability)
         self.assertEqual(PowerNode(bern, beta).inf_type, Probability)
         self.assertEqual(PowerNode(bern, bino).inf_type, Probability)
         self.assertEqual(PowerNode(bern, half).inf_type, Probability)
@@ -231,8 +217,8 @@ class BMGNodesTest(unittest.TestCase):
         self.assertEqual(PowerNode(beta, half).inf_type, Probability)
         self.assertEqual(PowerNode(beta, norm).inf_type, PositiveReal)
 
-        # Base is N
-        self.assertEqual(PowerNode(bino, bern).inf_type, Natural)
+        # Base is N; treated as R+
+        self.assertEqual(PowerNode(bino, bern).inf_type, PositiveReal)
         self.assertEqual(PowerNode(bino, beta).inf_type, PositiveReal)
         self.assertEqual(PowerNode(bino, bino).inf_type, PositiveReal)
         self.assertEqual(PowerNode(bino, half).inf_type, PositiveReal)

--- a/src/beanmachine/ppl/compiler/tests/fix_problems_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_problems_test.py
@@ -308,7 +308,7 @@ digraph "graph" {
   N3[label="2:N>=N"];
   N4[label="Binomial:N>=N"];
   N5[label="Sample:N>=N"];
-  N6[label="*:M>=N"];
+  N6[label="*:M>=R+"];
   N7[label="Binomial:N>=N"];
   N8[label="Sample:N>=N"];
   N0 -> N1[label="probability:P"];
@@ -345,11 +345,12 @@ digraph "graph" {
   N03[label="2:N>=N"];
   N04[label="Binomial:N>=N"];
   N05[label="Sample:N>=N"];
-  N06[label="*:M>=N"];
+  N06[label="*:M>=R+"];
   N07[label="0:N>=Z"];
   N08[label="if:N>=N"];
   N09[label="Binomial:N>=N"];
   N10[label="Sample:N>=N"];
+  N11[label="0.0:R>=Z"];
   N00 -> N01[label="probability:P"];
   N00 -> N04[label="probability:P"];
   N00 -> N09[label="probability:P"];
@@ -682,7 +683,7 @@ digraph "graph" {
   N3[label="Sample:N>=N"];
   N4[label="Bernoulli:B>=B"];
   N5[label="Sample:B>=B"];
-  N6[label="**:M>=N"];
+  N6[label="**:M>=R+"];
   N7[label="Binomial:N>=N"];
   N8[label="Sample:N>=N"];
   N0 -> N2[label="count:N"];
@@ -718,11 +719,12 @@ digraph "graph" {
   N03[label="Sample:N>=N"];
   N04[label="Bernoulli:B>=B"];
   N05[label="Sample:B>=B"];
-  N06[label="**:M>=N"];
+  N06[label="**:M>=R+"];
   N07[label="1:N>=OH"];
   N08[label="if:N>=N"];
   N09[label="Binomial:N>=N"];
   N10[label="Sample:N>=N"];
+  N11[label="1.0:R>=OH"];
   N00 -> N02[label="count:N"];
   N01 -> N02[label="probability:P"];
   N01 -> N04[label="probability:P"];
@@ -782,7 +784,7 @@ digraph "graph" {
   N2[label="Beta:P>=P"];
   N3[label="Sample:P>=P"];
   N4[label="-:M>=R-"];
-  N5[label="+:M>=P"];
+  N5[label="+:M>=R"];
   N6[label="Bernoulli:B>=B"];
   N7[label="Sample:B>=B"];
   N0 -> N5[label="left:OH"];
@@ -817,7 +819,7 @@ digraph "graph" {
   N3[label="Beta:P>=P"];
   N4[label="Sample:P>=P"];
   N5[label="-:M>=R-"];
-  N6[label="+:M>=P"];
+  N6[label="+:M>=R"];
   N7[label="complement:P>=P"];
   N8[label="Bernoulli:B>=B"];
   N9[label="Sample:B>=B"];

--- a/src/beanmachine/ppl/compiler/tests/graph_accumulation_test.py
+++ b/src/beanmachine/ppl/compiler/tests/graph_accumulation_test.py
@@ -303,17 +303,32 @@ def beta_eliminate_identities():
 
 
 expected_bmg_7 = """
-Node 0 type 1 parents [ ] children [ 1 ] positive real 1
-Node 1 type 2 parents [ 0 ] children [ 2 3 4 ] unknown
-Node 2 type 3 parents [ 1 ] children [ ] positive real 1e-10
-Node 3 type 3 parents [ 1 ] children [ 7 ] positive real 1e-10
-Node 4 type 3 parents [ 1 ] children [ 6 ] positive real 1e-10
-Node 5 type 1 parents [ ] children [ 6 ] positive real 2
-Node 6 type 3 parents [ 5 4 ] children [ 7 ] positive real 1e-10
-Node 7 type 3 parents [ 3 6 ] children [ 9 ] positive real 1e-10
-Node 8 type 1 parents [ ] children [ 9 ] positive real 4
-Node 9 type 2 parents [ 7 8 ] children [ 10 ] unknown
-Node 10 type 3 parents [ 9 ] children [ ] probability 1e-10
+digraph "graph" {
+  N0[label="1"];
+  N1[label="HalfCauchy"];
+  N2[label="~"];
+  N3[label="~"];
+  N4[label="~"];
+  N5[label="2"];
+  N6[label="*"];
+  N7[label="+"];
+  N8[label="4"];
+  N9[label="Beta"];
+  N10[label="~"];
+  N0 -> N1;
+  N1 -> N2;
+  N1 -> N3;
+  N1 -> N4;
+  N3 -> N7;
+  N4 -> N6;
+  N5 -> N6;
+  N6 -> N7;
+  N7 -> N9;
+  N8 -> N9;
+  N9 -> N10;
+  Q0[label="Query"];
+  N10 -> Q0;
+}
 """
 
 
@@ -383,7 +398,9 @@ class GraphAccumulationTests(unittest.TestCase):
 
     def test_accumulate_eliminate_identities(self) -> None:
         self.maxDiff = None
+        # TODO: We end up with an extraneous zero addend in the
+        # sum; eliminate that.
         queries = [beta_eliminate_identities()]
         bmg = BMGRuntime().accumulate_graph(queries, {})
-        observed = to_bmg_graph(bmg).graph.to_string()
-        self.assertEqual(tidy(observed), tidy(expected_bmg_7))
+        observed = to_bmg_graph(bmg).graph.to_dot()
+        self.assertEqual(expected_bmg_7.strip(), observed.strip())

--- a/src/beanmachine/ppl/compiler/tests/perf_report_test.py
+++ b/src/beanmachine/ppl/compiler/tests/perf_report_test.py
@@ -78,6 +78,7 @@ profiler_report: accumulate:(1) -- ms
 infer:(1) -- ms
   fix_problems:(1) -- ms
     TensorOpsFixer:(1) -- ms
+    BoolArithmeticFixer:(--) -- ms
     AdditionFixer:(1) -- ms
     BoolComparisonFixer:(1) -- ms
     UnsupportedNodeFixer:(1) -- ms


### PR DESCRIPTION
Summary:
There are a number of problems with how we compute the inf type of addition, multiplication and power nodes that I have addressed in this diff.

First let me say what the goal is. The basic idea of the inf type computation is to answer the question "what is the smallest lattice type could this node be, based on its inputs?"  We need to know that so that (1) we can insert type conversion nodes as necessary to meet the type rules of BMG, and (2) we need to produce errors for the cases where we cannot.

The problems I've fixed here are:

* Some of this code was written when we supported arithmetic operations on tensors in BMG. BMG no longer has an unbounded tensor type, so this logic was wrong.

* The inf type computation should never say that *the smallest type a node can be* is a type that it cannot possibly be! But there were cases where that could happen.

* The inf type computation attempted in several cases to answer the question "if we replaced this graph node with a different node that computed the same value, what is the smallest type THAT thing could be?"  Attempting to do so is, first off, pointless; we don't need to know what type a *different* node could be, we need to know what type *this* node could be. And second, attempting to do so requires the type computation to know what optimization passes might do in the future!

The more sensible approach is to say that for the addition, multiplication and power operators:

* If the inputs' types meet the requirements of the node in BMG, then the inf type is computed based on those types, and is the smallest possible output type.

* If the inputs' types do NOT meet those requirements then just return the largest legal type. For instance, if we have a sum of a real value and a simplex matrix, we CANNOT meet the requirements of an addition, but we must not lie and say "this sum is a tensor".  We say "this sum is a real", put a requirement on the edges that they both be reals, and then when the simplex cannot be converted to a real, we report an error.

This practice of nodes always reporting a legal type as their inf types will help prevent cascading error reports in requirements checking; if an addition node cannot be legal then we want to report that ONCE; we don't want that to then trigger a report that the consumer of the sum ALSO has a type error on the output edge.

To fix these problems:

* All arithmetic optimizations on sum, product and power nodes (other than constant folding) are moved out of node construction and requirements checking; they are moved into an arithmetic optimization class.

* Computing the inf types of these nodes no longer lies; it always reports a type that the node actually could be.

Reviewed By: wtaha

Differential Revision: D27571429

