### PR TITLE
Bump PyTorch version in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,21 +2,6 @@ version: 2.1
 
 commands:
 
-  pip_install_deps:
-    description: "Install beanmachine dependencies via pip"
-    steps:
-      - run:
-          name: "Upgrade pip"
-          command: pip install --progress-bar off --upgrade pip
-      - run:
-          name: "Install numpy"
-          command: pip install --progress-bar off numpy
-      - run:
-          name: "Install pytorch"
-          command: >
-            pip install --progress-bar off --pre torch==1.8.0.dev20210205 -f
-            https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
-
   dev_install_beanmachine:
     description: "Install beanmachine[dev] in editable mode via pip"
     steps:
@@ -170,7 +155,6 @@ jobs:
       - image: circleci/python:3.7
     steps:
       - apt_get_install_deps
-      - pip_install_deps
       - checkout
       - dev_install_beanmachine
       - pip_install_pytest_patch
@@ -182,7 +166,6 @@ jobs:
       - image: circleci/python:3.7
     steps:
       - apt_get_install_deps
-      - pip_install_deps
       - checkout
       - user_install_beanmachine
       - pip_install_pytest_patch
@@ -196,7 +179,6 @@ jobs:
       - checkout
       - install_miniconda_macos
       - brew_install_deps
-      - pip_install_deps
       - conda_install_beanmachine
       - pip_install_pytest_patch
       - pip_list
@@ -218,7 +200,6 @@ jobs:
       - image: circleci/python:3.7
     steps:
       - apt_get_install_deps
-      - pip_install_deps
       - checkout
       - user_install_beanmachine
       - pip_install_pytest_patch

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ setup(
     long_description_content_type="text/markdown",
     python_requires=">={}.{}".format(REQUIRED_MAJOR, REQUIRED_MINOR),
     install_requires=[
-        "torch>=1.7.0",
+        "torch>=1.8.1",
         "numpy>=1.18.1",
         "pandas>=0.24.2",
         "plotly>=2.2.1",

--- a/src/beanmachine/ppl/utils/tensorops.py
+++ b/src/beanmachine/ppl/utils/tensorops.py
@@ -3,6 +3,7 @@ from typing import Tuple
 
 import torch
 import torch.autograd
+from torch._vmap_internals import _vmap as vmap
 
 
 def gradients(
@@ -27,7 +28,7 @@ def gradients(
     )[0].reshape(-1)
 
     # using identity matrix to reconstruct the full hessian from vector-Jacobian product
-    hessians = torch.vmap(
+    hessians = vmap(
         lambda vec: torch.autograd.grad(
             grad1,
             inputs,


### PR DESCRIPTION
Now that we don't rely on any of the experimental features, let's pin PyTorch version to 1.8.1 on GitHub so that we don't need to keep worrying about experimental release break our build.

(A note on the change in `tensorops.py`: as for torch 1.8.1, `torch.vmap` is still not available so I need to import it from `torch._vmap_internals`.)

Differential Revision: D27746321

