### PR TITLE
remove dead code for NMC dirichlet

### DIFF
--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -768,16 +768,5 @@ struct Graph {
   }
 };
 
-/*
-A temporary solution to use NMC sampler on Dirichlet sample.
-*/
-void nmc_step_for_dirichlet(
-    Node* tgt_node,
-    const std::vector<uint>& det_nodes,
-    const std::vector<uint>& sto_nodes,
-    const std::vector<Node*>& node_ptrs,
-    std::vector<NodeValue>& old_values,
-    std::mt19937& gen);
-
 } // namespace graph
 } // namespace beanmachine


### PR DESCRIPTION
Summary: remove unused Dirichlet code from graph.h

Differential Revision: D27825386

