### PR TITLE
BROADCAST_ADD

### DIFF
--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -301,6 +301,7 @@ enum class OperatorType {
   INDEX,
   COLUMN_INDEX,
   TO_MATRIX,
+  BROADCAST_ADD
 };
 
 enum class DistributionType {

--- a/src/beanmachine/graph/operator/backward.cpp
+++ b/src/beanmachine/graph/operator/backward.cpp
@@ -221,5 +221,15 @@ void ToMatrix::backward() {
   }
 }
 
+void BroadcastAdd::backward() {
+  assert(in_nodes.size() == 2);
+  if (in_nodes[0]->needs_gradient()) {
+    in_nodes[0]->back_grad1._double += back_grad1._matrix.sum();
+  }
+  if (in_nodes[1]->needs_gradient()) {
+    in_nodes[1]->back_grad1._matrix += back_grad1._matrix;
+  }
+}
+
 } // namespace oper
 } // namespace beanmachine

--- a/src/beanmachine/graph/operator/gradient.cpp
+++ b/src/beanmachine/graph/operator/gradient.cpp
@@ -290,5 +290,22 @@ void ToMatrix::compute_gradients() {
   }
 }
 
+void BroadcastAdd::compute_gradients() {
+  assert(in_nodes.size() == 2);
+  auto rows = in_nodes[1]->value.type.rows;
+  auto cols = in_nodes[1]->value.type.cols;
+  Grad1.setConstant(rows, cols, in_nodes[0]->grad1);
+  Grad2.setConstant(rows, cols, in_nodes[0]->grad2);
+
+  // in_nodes[1] can be a constant matrix that does not have Grad1/Grad2
+  // initialized
+  if (in_nodes[1]->Grad1.size() != 0) {
+    Grad1 += in_nodes[1]->Grad1;
+  }
+  if (in_nodes[1]->Grad2.size() != 0) {
+    Grad2 += in_nodes[1]->Grad2;
+  }
+}
+
 } // namespace oper
 } // namespace beanmachine

--- a/src/beanmachine/graph/operator/linalgop.h
+++ b/src/beanmachine/graph/operator/linalgop.h
@@ -63,5 +63,23 @@ class ColumnIndex : public Operator {
   static bool is_registered;
 };
 
+class BroadcastAdd : public Operator {
+ public:
+  explicit BroadcastAdd(const std::vector<graph::Node*>& in_nodes);
+  ~BroadcastAdd() override {}
+
+  void eval(std::mt19937& gen) override;
+  void backward() override;
+  void compute_gradients() override;
+
+  static std::unique_ptr<Operator> new_op(
+      const std::vector<graph::Node*>& in_nodes) {
+    return std::make_unique<BroadcastAdd>(in_nodes);
+  }
+
+ private:
+  static bool is_registered;
+};
+
 } // namespace oper
 } // namespace beanmachine

--- a/src/beanmachine/graph/operator/register.cpp
+++ b/src/beanmachine/graph/operator/register.cpp
@@ -92,6 +92,10 @@ bool MatrixMultiply::is_registered = OperatorFactory::register_op(
     graph::OperatorType::MATRIX_MULTIPLY,
     &(MatrixMultiply::new_op));
 
+bool BroadcastAdd::is_registered = OperatorFactory::register_op(
+    graph::OperatorType::BROADCAST_ADD,
+    &(BroadcastAdd::new_op));
+
 // matrix index
 bool Index::is_registered =
     OperatorFactory::register_op(graph::OperatorType::INDEX, &(Index::new_op));

--- a/src/beanmachine/graph/pybindings.cpp
+++ b/src/beanmachine/graph/pybindings.cpp
@@ -58,7 +58,8 @@ PYBIND11_MODULE(graph, module) {
       .value("POW", OperatorType::POW)
       .value("MATRIX_MULTIPLY", OperatorType::MATRIX_MULTIPLY)
       .value("TO_PROBABILITY", OperatorType::TO_PROBABILITY)
-      .value("INDEX", OperatorType::INDEX);
+      .value("INDEX", OperatorType::INDEX)
+      .value("BROADCAST_ADD", OperatorType::BROADCAST_ADD);
 
   py::enum_<DistributionType>(module, "DistributionType")
       .value("TABULAR", DistributionType::TABULAR)


### PR DESCRIPTION
Summary:
This diff adds a `BROADCAST_ADD` operator, which takes a real scalar value (`in_nodes[0]`) and a real M x N matrix (`in_nodes[1]`) and outputs a M x N real matrix.

This is my first diff in BMG so feel free to correct me if I made any mistakes :).

Reviewed By: yucenli

Differential Revision: D27695149

