### PR TITLE
Start turning on new lattice typer

### DIFF
--- a/src/beanmachine/ppl/compiler/gen_dot.py
+++ b/src/beanmachine/ppl/compiler/gen_dot.py
@@ -6,6 +6,7 @@ Visualize the contents of a builder in the DOT graph language.
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
 from beanmachine.ppl.compiler.fix_problems import fix_problems
 from beanmachine.ppl.compiler.graph_labels import get_edge_labels, get_node_label
+from beanmachine.ppl.compiler.lattice_typer import LatticeTyper
 from beanmachine.ppl.utils.dotbuilder import DotBuilder
 
 
@@ -20,6 +21,7 @@ def to_dot(
     """This dumps the entire accumulated graph state, including
     orphans, as a DOT graph description; nodes are enumerated in the order
     they were created."""
+    lt = LatticeTyper()
     db = DotBuilder()
 
     if after_transform:
@@ -53,7 +55,7 @@ def to_dot(
         if graph_types:
             node_label += ":" + node.graph_type.short_name
         if inf_types:
-            node_label += ">=" + node.inf_type.short_name
+            node_label += ">=" + lt[node].short_name
         db.with_node(n, node_label)
         for (i, edge_name, req) in zip(
             node.inputs, get_edge_labels(node), node.requirements

--- a/src/beanmachine/ppl/compiler/tests/fix_problems_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_problems_test.py
@@ -411,7 +411,7 @@ digraph "graph" {
   N02[label="HalfCauchy:R+>=R+"];
   N03[label="Sample:R+>=R+"];
   N04[label="Sample:R+>=R+"];
-  N05[label="/:R+>=R+"];
+  N05[label="/:R+>=U"];
   N06[label="Sample:R+>=R+"];
   N07[label="-1.0:R>=R-"];
   N08[label="**:R+>=R+"];
@@ -473,9 +473,9 @@ digraph "graph" {
   N1[label="HalfCauchy:R+>=R+"];
   N2[label="Sample:R+>=R+"];
   N3[label="2.5:R>=R+"];
-  N4[label="/:M>=R+"];
-  N5[label="Normal:R>=R"];
-  N6[label="Sample:R>=R"];
+  N4[label="/:M>=U"];
+  N5[label="Normal:R>=U"];
+  N6[label="Sample:R>=U"];
   N0 -> N1[label="scale:R+"];
   N0 -> N5[label="sigma:R+"];
   N1 -> N2[label="operand:R+"];
@@ -505,7 +505,7 @@ digraph "graph" {
   N02[label="HalfCauchy:R+>=R+"];
   N03[label="Sample:R+>=R+"];
   N04[label="2.5:R>=R+"];
-  N05[label="/:M>=R+"];
+  N05[label="/:M>=U"];
   N06[label="0.4:R+>=P"];
   N07[label="*:R+>=R+"];
   N08[label="ToReal:R>=R"];
@@ -595,8 +595,8 @@ digraph "graph" {
   N0[label="1.0:R>=OH"];
   N1[label="HalfCauchy:R+>=R+"];
   N2[label="Sample:R+>=R+"];
-  N3[label="Chi2:R+>=R+"];
-  N4[label="Sample:R+>=R+"];
+  N3[label="Chi2:R+>=U"];
+  N4[label="Sample:R+>=U"];
   N0 -> N1[label="scale:R+"];
   N1 -> N2[label="operand:R+"];
   N2 -> N3[label="df:R+"];
@@ -623,7 +623,7 @@ digraph "graph" {
   N1[label="1.0:R+>=OH"];
   N2[label="HalfCauchy:R+>=R+"];
   N3[label="Sample:R+>=R+"];
-  N4[label="Chi2:R+>=R+"];
+  N4[label="Chi2:R+>=U"];
   N5[label="0.5:R+>=P"];
   N6[label="*:R+>=R+"];
   N7[label="Gamma:R+>=R+"];


### PR DESCRIPTION
Summary:
In this diff I start to use the new lattice typer instead of calling `inf_type` on graph nodes. The only place we are using it is in the DOT visualizer used by the fix_problems tests.

In the DOT output the lattice type is the type after the `>=` in the node label.  Notice that in all cases the new lattice typer agrees with the old `inf_type` *except* when the node in question is not supported in BMG. In those cases we now correctly report that the node is "U" for "untypable".  We no longer make any attempt to assign types to nodes that are not even legal in BMG.

Reviewed By: wtaha

Differential Revision: D27527210

