### PR TITLE
Extract edge requirements to own module

### DIFF
--- a/src/beanmachine/ppl/compiler/bmg_requirements.py
+++ b/src/beanmachine/ppl/compiler/bmg_requirements.py
@@ -1,0 +1,309 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+# In lattice_typer.py we assign a type to every node in a graph.
+# If the node or any ancestor node is unsupported in BMG then the node
+# is said to be "untypable"; otherwise, it computes (and caches) the smallest
+# possible lattice type for that node.
+#
+# We can similarly put "requirements" on edges. The rules are as follows:
+#
+# * Every node in a graph has n >= 0 inputs.  For every node we can compute
+#   a list of n requirements, one corresponding to each edge.
+#
+# * If a node is untypable then every edge requirement is "Any" -- that is,
+#   there is no requirement placed on the edge. The node cannot be represented
+#   in BMG, so there is no reason to report a requirement violation on any of
+#   its edges.
+#
+# * Requirements of input edges of typable nodes are computed for each node.
+#   Since this computation is cheap and requires no traversal of the graph
+#   once the lattice type is known, we do not attempt to cache this information.
+#
+
+from typing import Callable, Dict, List
+
+import beanmachine.ppl.compiler.bmg_nodes as bn
+import beanmachine.ppl.compiler.bmg_types as bt
+from beanmachine.ppl.compiler.lattice_typer import LatticeTyper
+
+
+# These are the nodes which always have the same requirements no matter
+# what their inputs are.
+
+_known_requirements: Dict[type, List[bt.Requirement]] = {
+    bn.Observation: [bt.AnyRequirement()],
+    bn.Query: [bt.AnyRequirement()],
+    # Distributions
+    bn.BernoulliLogitNode: [bt.Real],
+    bn.BernoulliNode: [bt.Probability],
+    bn.BetaNode: [bt.PositiveReal, bt.PositiveReal],
+    bn.BinomialNode: [bt.Natural, bt.Probability],
+    bn.GammaNode: [bt.PositiveReal, bt.PositiveReal],
+    bn.HalfCauchyNode: [bt.PositiveReal],
+    bn.NormalNode: [bt.Real, bt.PositiveReal],
+    bn.StudentTNode: [bt.PositiveReal, bt.Real, bt.PositiveReal],
+    # Operators
+    bn.LogisticNode: [bt.Real],
+    bn.Log1mexpNode: [bt.NegativeReal],
+    bn.PhiNode: [bt.Real],
+    bn.ToRealNode: [bt.upper_bound(bt.Real)],
+    bn.ToPositiveRealNode: [bt.upper_bound(bt.PositiveReal)],
+    bn.ToProbabilityNode: [bt.upper_bound(bt.Real)],
+}
+
+
+def _requirements_valid(node: bn.BMGNode, reqs: List[bt.Requirement]):
+    return len(reqs) == len(node.inputs) and not any(
+        r in bt._invalid_requirement_types for r in reqs
+    )
+
+
+class EdgeRequirements:
+
+    _dispatch: Dict[type, Callable]
+
+    typer: LatticeTyper
+
+    def __init__(self, typer: LatticeTyper) -> None:
+        self.typer = typer
+        self._dispatch = {
+            bn.ExpProductFactorNode: self._requirements_expproduct,
+            bn.DirichletNode: self._requirements_dirichlet,
+            # Operators
+            bn.AdditionNode: self._requirements_addition,
+            bn.ComplementNode: self._same_as_output,
+            bn.ExpM1Node: self._same_as_output,
+            bn.ExpNode: self._requirements_exp_neg,
+            bn.IfThenElseNode: self._requirements_if,
+            bn.IndexNode: self._requirements_index,
+            bn.LogNode: self._requirements_log,
+            bn.LogSumExpNode: self._requirements_logsumexp,
+            bn.MultiAdditionNode: self._requirements_addition,
+            bn.MultiplicationNode: self._requirements_multiplication,
+            bn.NegateNode: self._requirements_exp_neg,
+            bn.PowerNode: self._requirements_power,
+            bn.SampleNode: self._same_as_output,
+        }
+
+    def _requirements_expproduct(
+        self, node: bn.ExpProductFactorNode
+    ) -> List[bt.Requirement]:
+        # Each input to an exp-power is required to be a
+        # real, negative real, positive real or probability.
+        return [
+            self.typer[i]
+            if self.typer[i]
+            in {bt.Real, bt.NegativeReal, bt.PositiveReal, bt.Probability}
+            else bt.Real
+            for i in node.inputs
+        ]
+
+    def _requirements_dirichlet(self, node: bn.DirichletNode) -> List[bt.Requirement]:
+        # BMG's Dirichlet node requires that the input be exactly one
+        # vector of positive reals, and the length of the vector is
+        # the number of elements in the simplex we produce. We can
+        # express that restriction as a positive real matrix with
+        # row count equal to 1 and column count equal to the final
+        # dimension of the size.
+        #
+        # A degenerate case here is Dirichlet(tensor([1.0])); we would
+        # normally generate the input as a positive real constant, but
+        # we require that it be a positive real constant 1x1 *matrix*,
+        # which is a different node. The "always matrix" requirement
+        # forces the problem fixer to ensure that the input node is
+        # always considered by BMG to be a matrix.
+        #
+        # TODO: BMG requires it to be a *broadcast* matrix; what happens
+        # if we feed one Dirichlet into another?  That would be a simplex,
+        # not a broadcast matrix. Do some research here; do we actually
+        # need the semantics of "always a broadcast matrix" ?
+        return [
+            bt.always_matrix(bt.PositiveReal.with_dimensions(1, node._required_columns))
+        ]
+
+    def _requirements_addition(self, node: bn.BMGNode) -> List[bt.Requirement]:
+        it = self.typer[node]
+        assert it in {bt.Real, bt.NegativeReal, bt.PositiveReal}
+        return [it] * len(node.inputs)  # pyre-ignore
+
+    def _requirements_exp_neg(self, node: bn.UnaryOperatorNode) -> List[bt.Requirement]:
+        # Same logic for both exp and negate operators
+        ot = self.typer[node.operand]
+        if bt.supremum(ot, bt.NegativeReal) == bt.NegativeReal:
+            return [bt.NegativeReal]
+        if bt.supremum(ot, bt.PositiveReal) == bt.PositiveReal:
+            return [bt.PositiveReal]
+        return [bt.Real]
+
+    def _same_as_output(self, node: bn.BMGNode) -> List[bt.Requirement]:
+        # Input type must be same as output type
+        return [self.typer[node]]
+
+    def _requirements_if(self, node: bn.IfThenElseNode) -> List[bt.Requirement]:
+        # The condition has to be Boolean; the consequence and alternative need
+        # to be the same.
+        it = self.typer[node]
+        return [bt.Boolean, it, it]
+
+    def _requirements_index(self, node: bn.IndexNode) -> List[bt.Requirement]:
+        # The index operator introduces an interesting wrinkle into the
+        # "requirements" computation. Until now we have always had the property
+        # that queries and observations are "sinks" of the graph, and the transitive
+        # closure of the inputs to the sinks can have their requirements checked in
+        # order going from the nodes farthest from the sinks down to the sinks.
+        # That is, each node can meet its input requirements *before* its output
+        # nodes meet their requirements. We now have a case where doing so creates
+        # potential inefficiencies.
+        #
+        # B is the constant vector [0, 1, 1]
+        # N is any node of type natural.
+        # I is an index
+        # F is Bernoulli.
+        #
+        #   B N
+        #   | |
+        #    I
+        #    |
+        #    F
+        #
+        # The requirement on edge I->F is Probability
+        # The requirement on edge N->I is Natural.
+        # What is the requirement on the B->I edge?
+        #
+        # If we say that it is Boolean[1, 3], its inf type, then the graph we end up
+        # generating is
+        #
+        # b = const_bool_matrix([0, 1, 1])  # bool matrix
+        # n = whatever                      # natural
+        # i = index(b, i)                   # bool
+        # z = const_prob(0)                 # prob
+        # o = const_prob(1)                 # prob
+        # c = if_then_else(i, o, z)         # prob
+        # f = Bernoulli(c)                  # bool
+        #
+        # But it would be arguably better to produce
+        #
+        # b = const_prob_matrix([0, 1, 1])  # prob matrix
+        # n = whatever                      # natural
+        # i = index(b, i)                   # prob
+        # f = Bernoulli(i)                  # bool
+        #
+        # TODO: We might consider an optimization pass which does so.
+        #
+        # However there is an even worse situation. Suppose we have
+        # this unlikely-but-legal graph:
+        #
+        # Z is [0, 0, 0]
+        # N is any natural
+        # I is an index
+        # C requires a Boolean input
+        # L requires a NegativeReal input
+        #
+        #    Z   N
+        #     | |
+        #      I
+        #     | |
+        #    C   L
+        #
+        # The inf type of Z is Zero[1, 3].
+        # The I->C edge requirement is Boolean
+        # The I->L edge requirement is NegativeReal
+        #
+        # Now what requirement do we impose on the Z->I edge? We have our choice
+        # of "matrix of negative reals" or "matrix of bools", and whichever we
+        # pick will disappoint someone.
+        #
+        # Fortunately for us, this situation is unlikely; a model writer who
+        # contrives a situation where they are making a stochastic choice where
+        # all choices are all zero AND that zero needs to be used as both
+        # false and a negative number is not writing realistic models.
+        #
+        # What we will do in this unlikely situation is decide that the intended
+        # output type is Boolean and therefore the vector is a vector of bools.
+        #
+        # -----
+        #
+        # We require:
+        # * the vector must be one row
+        # * the vector must be a matrix, not a single value
+        # * the vector must be either a simplex, or a matrix where the element
+        #   type is the output type of the indexing operation
+        # * the index must be a natural
+        #
+
+        lt = self.typer[node.left]
+
+        # If we have a tensor that has more than two dimensions, who can
+        # say what the column count should be?
+
+        # TODO: We need a better error message for that scenario.
+        # It will be common for people to use tensors that are too high
+        # dimension for BMG to handle and we should say that clearly.
+
+        required_columns = lt.columns if isinstance(lt, bt.BMGMatrixType) else 1
+        required_rows = 1
+
+        if isinstance(lt, bt.SimplexMatrix):
+            vector_req = lt.with_dimensions(required_rows, required_columns)
+        else:
+            it = self.typer[node]
+            assert isinstance(it, bt.BMGMatrixType)
+            vector_req = it.with_dimensions(required_rows, required_columns)
+
+        return [bt.always_matrix(vector_req), bt.Natural]
+
+    def _requirements_log(self, node: bn.LogNode) -> List[bt.Requirement]:
+        # Input must be probability or positive real; choose the smaller.
+        ot = bt.supremum(self.typer[node.operand], bt.Probability)
+        if ot == bt.Probability:
+            return [bt.Probability]
+        return [bt.PositiveReal]
+
+    def _requirements_logsumexp(self, node: bn.LogSumExpNode) -> List[bt.Requirement]:
+        s = bt.supremum(*[self.typer[i] for i in node.inputs])
+        if s not in {bt.Real, bt.NegativeReal, bt.PositiveReal}:
+            s = bt.Real
+        return [s] * len(node.inputs)  # pyre-ignore
+
+    def _requirements_multiplication(
+        self, node: bn.MultiplicationNode
+    ) -> List[bt.Requirement]:
+        it = self.typer[node]
+        assert it in {bt.Probability, bt.PositiveReal, bt.Real}
+        return [it, it]
+
+    def _requirements_power(self, node: bn.PowerNode) -> List[bt.Requirement]:
+        # BMG supports a power node that has these possible combinations of
+        # base and exponent type:
+        #
+        # P ** R+  --> P
+        # P ** R   --> R+
+        # R+ ** R+ --> R+
+        # R+ ** R  --> R+
+        # R ** R+  --> R
+        # R ** R   --> R
+        req_base = bt.supremum(self.typer[node.left], bt.Probability)
+        if req_base not in {bt.Probability, bt.PositiveReal, bt.Real}:
+            req_base = bt.Real
+        req_exp = bt.supremum(self.typer[node.right], bt.PositiveReal)
+        if req_exp not in {bt.PositiveReal, bt.Real}:
+            req_exp = bt.Real
+        return [req_base, req_exp]
+
+    def requirements(self, node: bn.BMGNode) -> List[bt.Requirement]:
+        input_count = len(node.inputs)
+        if input_count == 0:
+            result = []
+        elif self.typer[node] == bt.Untypable:
+            result = [bt.AnyRequirement()] * input_count
+        else:
+            t = type(node)
+            if t in _known_requirements:
+                result = _known_requirements[t]
+            elif t in self._dispatch:
+                result = self._dispatch[t](node)
+            else:
+                result = [bt.AnyRequirement()] * input_count
+
+        assert _requirements_valid(node, result)
+        return result

--- a/src/beanmachine/ppl/compiler/bmg_types.py
+++ b/src/beanmachine/ppl/compiler/bmg_types.py
@@ -650,6 +650,8 @@ def is_one(v: Any) -> bool:
     return type_of_value(v) == One
 
 
+# TODO: Move this to bmg_requirements.py
+
 # We need to be able to express requirements on inputs;
 # for example the input to a Bernoulli must be *exactly* a
 # Probability, but the input to a ToPositiveReal must have
@@ -686,6 +688,9 @@ def is_one(v: Any) -> bool:
 # We also occasionally need to express that an input edge has no restriction
 # on it whatsoever; we'll use a singleton object for that.
 
+# We should never create a requirement of a "fake" type.
+
+_invalid_requirement_types = {Zero, One, Untypable}
 
 # TODO: Mark this as abstract
 class BaseRequirement:
@@ -707,6 +712,7 @@ class UpperBound(BaseRequirement):
     bound: BMGLatticeType
 
     def __init__(self, bound: BMGLatticeType) -> None:
+        assert bound not in _invalid_requirement_types
         self.bound = bound
         BaseRequirement.__init__(self, f"<={bound.short_name}", f"<={bound.long_name}")
 
@@ -715,6 +721,7 @@ class AlwaysMatrix(BaseRequirement):
     bound: BMGMatrixType
 
     def __init__(self, bound: BMGMatrixType) -> None:
+        assert bound not in _invalid_requirement_types
         self.bound = bound
         # We won't bother to make these have a special representation
         # when we display requirements on edges in DOT.

--- a/src/beanmachine/ppl/compiler/gen_dot.py
+++ b/src/beanmachine/ppl/compiler/gen_dot.py
@@ -4,6 +4,7 @@ Visualize the contents of a builder in the DOT graph language.
 """
 
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
+from beanmachine.ppl.compiler.bmg_requirements import EdgeRequirements
 from beanmachine.ppl.compiler.fix_problems import fix_problems
 from beanmachine.ppl.compiler.graph_labels import get_edge_labels, get_node_label
 from beanmachine.ppl.compiler.lattice_typer import LatticeTyper
@@ -22,6 +23,7 @@ def to_dot(
     orphans, as a DOT graph description; nodes are enumerated in the order
     they were created."""
     lt = LatticeTyper()
+    reqs = EdgeRequirements(lt)
     db = DotBuilder()
 
     if after_transform:
@@ -58,7 +60,7 @@ def to_dot(
             node_label += ">=" + lt[node].short_name
         db.with_node(n, node_label)
         for (i, edge_name, req) in zip(
-            node.inputs, get_edge_labels(node), node.requirements
+            node.inputs, get_edge_labels(node), reqs.requirements(node)
         ):
             if label_edges:
                 edge_label = edge_name

--- a/src/beanmachine/ppl/compiler/lattice_typer.py
+++ b/src/beanmachine/ppl/compiler/lattice_typer.py
@@ -154,6 +154,12 @@ class LatticeTyper(TyperBase[bt.BMGLatticeType]):
         return bt.Real
 
     def _type_if(self, node: bn.IfThenElseNode) -> bt.BMGLatticeType:
+        # TODO: This isn't quite right. Suppose we have a degenerate case
+        # such as IF(flip(), 0, 0).  We should conclude that the type
+        # of this node is BOOL, not ZERO.
+        # TODO: What about IF (flip(), 1, 1) -- is that BOOL or SIMPLEX?
+        # TODO: Consider adding a pass which optimizes away IF(X, Y, Y) to
+        # just plain Y.
         return bt.supremum(self[node.consequence], self[node.alternative])
 
     def _type_index(self, node: bn.IndexNode) -> bt.BMGLatticeType:

--- a/src/beanmachine/ppl/compiler/tests/fix_problems_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_problems_test.py
@@ -315,10 +315,10 @@ digraph "graph" {
   N0 -> N4[label="probability:P"];
   N0 -> N7[label="probability:P"];
   N1 -> N2[label="operand:B"];
-  N2 -> N6[label="left:B"];
+  N2 -> N6[label="left:R+"];
   N3 -> N4[label="count:N"];
   N4 -> N5[label="operand:N"];
-  N5 -> N6[label="right:N"];
+  N5 -> N6[label="right:R+"];
   N6 -> N7[label="count:N"];
   N7 -> N8[label="operand:N"];
 }
@@ -355,11 +355,11 @@ digraph "graph" {
   N00 -> N04[label="probability:P"];
   N00 -> N09[label="probability:P"];
   N01 -> N02[label="operand:B"];
-  N02 -> N06[label="left:B"];
+  N02 -> N06[label="left:R+"];
   N02 -> N08[label="condition:B"];
   N03 -> N04[label="count:N"];
   N04 -> N05[label="operand:N"];
-  N05 -> N06[label="right:N"];
+  N05 -> N06[label="right:R+"];
   N05 -> N08[label="consequence:N"];
   N07 -> N08[label="alternative:N"];
   N08 -> N09[label="count:N"];
@@ -425,9 +425,9 @@ digraph "graph" {
   N02 -> N03[label="operand:R+"];
   N02 -> N04[label="operand:R+"];
   N02 -> N06[label="operand:R+"];
-  N03 -> N05[label="left:R+"];
+  N03 -> N05[label="left:any"];
   N03 -> N09[label="left:R+"];
-  N04 -> N05[label="right:R+"];
+  N04 -> N05[label="right:any"];
   N04 -> N08[label="left:R+"];
   N06 -> N10[label="left:R+"];
   N07 -> N08[label="right:R"];
@@ -477,12 +477,12 @@ digraph "graph" {
   N5[label="Normal:R>=U"];
   N6[label="Sample:R>=U"];
   N0 -> N1[label="scale:R+"];
-  N0 -> N5[label="sigma:R+"];
+  N0 -> N5[label="sigma:any"];
   N1 -> N2[label="operand:R+"];
-  N2 -> N4[label="left:R+"];
-  N3 -> N4[label="right:R+"];
-  N4 -> N5[label="mu:R"];
-  N5 -> N6[label="operand:R"];
+  N2 -> N4[label="left:any"];
+  N3 -> N4[label="right:any"];
+  N4 -> N5[label="mu:any"];
+  N5 -> N6[label="operand:any"];
 }
 """
 
@@ -515,9 +515,9 @@ digraph "graph" {
   N01 -> N02[label="scale:R+"];
   N01 -> N09[label="sigma:R+"];
   N02 -> N03[label="operand:R+"];
-  N03 -> N05[label="left:R+"];
+  N03 -> N05[label="left:any"];
   N03 -> N07[label="left:R+"];
-  N04 -> N05[label="right:R+"];
+  N04 -> N05[label="right:any"];
   N06 -> N07[label="right:R+"];
   N07 -> N08[label="operand:<=R"];
   N08 -> N09[label="mu:R"];
@@ -599,8 +599,8 @@ digraph "graph" {
   N4[label="Sample:R+>=U"];
   N0 -> N1[label="scale:R+"];
   N1 -> N2[label="operand:R+"];
-  N2 -> N3[label="df:R+"];
-  N3 -> N4[label="operand:R+"];
+  N2 -> N3[label="df:any"];
+  N3 -> N4[label="operand:any"];
 }
 """
 
@@ -630,7 +630,7 @@ digraph "graph" {
   N8[label="Sample:R+>=R+"];
   N1 -> N2[label="scale:R+"];
   N2 -> N3[label="operand:R+"];
-  N3 -> N4[label="df:R+"];
+  N3 -> N4[label="df:any"];
   N3 -> N6[label="left:R+"];
   N5 -> N6[label="right:R+"];
   N5 -> N7[label="rate:R+"];
@@ -691,12 +691,13 @@ digraph "graph" {
   N1 -> N4[label="probability:P"];
   N1 -> N7[label="probability:P"];
   N2 -> N3[label="operand:N"];
-  N3 -> N6[label="left:N"];
+  N3 -> N6[label="left:R+"];
   N4 -> N5[label="operand:B"];
-  N5 -> N6[label="right:B"];
+  N5 -> N6[label="right:R+"];
   N6 -> N7[label="count:N"];
   N7 -> N8[label="operand:N"];
-}"""
+}
+"""
 
         self.assertEqual(expected.strip(), observed.strip())
 
@@ -730,10 +731,10 @@ digraph "graph" {
   N01 -> N04[label="probability:P"];
   N01 -> N09[label="probability:P"];
   N02 -> N03[label="operand:N"];
-  N03 -> N06[label="left:N"];
+  N03 -> N06[label="left:R+"];
   N03 -> N08[label="consequence:N"];
   N04 -> N05[label="operand:B"];
-  N05 -> N06[label="right:B"];
+  N05 -> N06[label="right:R+"];
   N05 -> N08[label="condition:B"];
   N07 -> N08[label="alternative:N"];
   N08 -> N09[label="count:N"];
@@ -787,12 +788,12 @@ digraph "graph" {
   N5[label="+:M>=R"];
   N6[label="Bernoulli:B>=B"];
   N7[label="Sample:B>=B"];
-  N0 -> N5[label="left:OH"];
+  N0 -> N5[label="left:R"];
   N1 -> N2[label="alpha:R+"];
   N1 -> N2[label="beta:R+"];
   N2 -> N3[label="operand:P"];
   N3 -> N4[label="operand:R+"];
-  N4 -> N5[label="right:R-"];
+  N4 -> N5[label="right:R"];
   N5 -> N6[label="probability:P"];
   N6 -> N7[label="operand:B"];
 }
@@ -823,13 +824,13 @@ digraph "graph" {
   N7[label="complement:P>=P"];
   N8[label="Bernoulli:B>=B"];
   N9[label="Sample:B>=B"];
-  N1 -> N6[label="left:OH"];
+  N1 -> N6[label="left:R"];
   N2 -> N3[label="alpha:R+"];
   N2 -> N3[label="beta:R+"];
   N3 -> N4[label="operand:P"];
   N4 -> N5[label="operand:R+"];
   N4 -> N7[label="operand:P"];
-  N5 -> N6[label="right:R-"];
+  N5 -> N6[label="right:R"];
   N7 -> N8[label="probability:P"];
   N8 -> N9[label="operand:B"];
 }"""


### PR DESCRIPTION
Summary:
I am continuing the effort to encapsulate concerns such as node and edge typing into their own modules, rather than spread out amongst all the node classes. This time I'm putting all the edge requirement computations into its own module.  Given a type assignment to each node in a graph, we then can compute requirements on each edge; if the requirements can be met through graph transformations

This is not just a code-reorganizing refactoring; the logic changes as follows:

* Previously we attempted to compute requirements even on input edges of nodes that are unsupported in BMG; we no longer attempt to make guesses about irrelevant requirements. An unsupported node in a graph will either be removed or will cause an error to be reported. If removed, its requirements are irrelevant.  If an error is reported then requirements are never checked at all. So either way it is pointless to write code that computes these requirements.  Unsupported nodes put an "any" requirement on all input edges.

* Same for descendants of unsupported nodes; we make no attempt to compute requirements for all edges that descend from unsupported nodes, for the same reason.

* Computation of requirements often needs to know the type of the node and its input nodes. We now compute that using LatticeTyper rather than calling inf_type on the node.

* Previously we attempted to compute requirements based on substitutions that we knew would be made in the graph in the future. For instance, a power node requires that the exponent input be positive real, or real. But if we knew that the exponent of the power node could be a boolean then we would reason "this power node could be rewritten as IF(exponent, base, 1)" and put a "boolean" requirement on the exponent.  This is silly. The IF node is *a different node*, so why would we say that the *power* requires a boolean here? the *IF* requires a boolean.  We do not make guesses about what transformations will be made in the future; rather, we say what requirements are needed by *the graph that is given* in order to make it compliant with the BMG type system. We don't *need* to know what the requirements are on some hypothetical future edge; we need to know what the requirements are of the *given* edge.

I have not yet updated the requirements checker to use this new logic; rather, I've updated the DOT visualizer to use it, to verify that the changes to the output are the expected ones.

Upcoming work:

In an upcoming diff I will update fix_requirements to use the new type analyzer and requirements computer to assign types and requirements to nodes and edges.

After that I will update (or delete) existing requirements tests, and then delete the requirement and inf_type computation code from the node classes.

I also want to move the requirements logic in bmg_types.py out of there and into bmg_requirements.py.

Finally, the graph_type computation may be unnecessary; it can probably be replaced by a final verification pass and all that code can be deleted.

Reviewed By: wtaha

Differential Revision: D27667711

