### PR TITLE
Eliminate some unnecessary type analysis

### DIFF
--- a/src/beanmachine/ppl/compiler/bmg_nodes.py
+++ b/src/beanmachine/ppl/compiler/bmg_nodes.py
@@ -37,11 +37,6 @@ from torch.distributions import Normal
 from torch.distributions.utils import broadcast_all
 
 
-# TODO: Extract inf type, graph type and requirements computations to own module
-# TODO: Add assertions which ensure that type requirements are never "fake" types
-# like Zero or OneHot.  Also assert that a requirement is never Malformed.
-
-
 def prod(x):
     """Compute the product of a sequence of values of arbitrary length"""
     return functools.reduce(operator.mul, x, 1)

--- a/src/beanmachine/ppl/compiler/fix_additions.py
+++ b/src/beanmachine/ppl/compiler/fix_additions.py
@@ -4,7 +4,6 @@ from typing import Optional
 
 import beanmachine.ppl.compiler.bmg_nodes as bn
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
-from beanmachine.ppl.compiler.bmg_types import One
 from beanmachine.ppl.compiler.fix_problem import ProblemFixerBase
 
 
@@ -19,6 +18,7 @@ class AdditionFixer(ProblemFixerBase):
         ProblemFixerBase.__init__(self, bmg)
 
     def _needs_fixing(self, n: bn.BMGNode) -> bool:
+        # TODO: Move can_be_complement to this module
         return isinstance(n, bn.AdditionNode) and n.can_be_complement
 
     def _get_replacement(self, n: bn.BMGNode) -> Optional[bn.BMGNode]:
@@ -26,10 +26,10 @@ class AdditionFixer(ProblemFixerBase):
         assert n.can_be_complement
         # We have 1+(-x) or (-x)+1 where x is either P or B, and require
         # a P or B. Complement(x) is of the same type as x if x is P or B.
-        if n.left.inf_type == One:
+        if bn.is_one(n.left):
             other = n.right
         else:
-            assert n.right.inf_type == One
+            assert bn.is_one(n.right)
             other = n.left
         assert isinstance(other, bn.NegateNode)
         return self._bmg.add_complement(other.operand)

--- a/src/beanmachine/ppl/compiler/fix_bool_arithmetic.py
+++ b/src/beanmachine/ppl/compiler/fix_bool_arithmetic.py
@@ -22,7 +22,7 @@ class BoolArithmeticFixer(ProblemFixerBase):
             )
         # We can simplify 0+anything.
         if isinstance(n, bn.AdditionNode):
-            return n.left.inf_type == bt.Zero or n.right.inf_type == bt.Zero
+            return bn.is_zero(n.left) or bn.is_zero(n.right)
 
         # We can simplify anything**bool.
         if isinstance(n, bn.PowerNode):
@@ -49,27 +49,24 @@ class BoolArithmeticFixer(ProblemFixerBase):
         return self._fix_power(n)
 
     def _fix_multiplication(self, n: bn.MultiplicationNode) -> bn.BMGNode:
-        lt = n.left.inf_type
-        if lt == bt.Zero:
+        if bn.is_zero(n.left):
             return n.left
-        if lt == bt.One:
+        if bn.is_one(n.left):
             return n.right
-        rt = n.right.inf_type
-        if rt == bt.Zero:
+        if bn.is_zero(n.right):
             return n.right
-        if rt == bt.One:
+        if bn.is_one(n.right):
             return n.left
         zero = self._bmg.add_constant(0.0)
-        if lt == bt.Boolean:
+        if n.left.inf_type == bt.Boolean:
             return self._bmg.add_if_then_else(n.left, n.right, zero)
-        assert rt == bt.Boolean
+        assert n.right.inf_type == bt.Boolean
         return self._bmg.add_if_then_else(n.right, n.left, zero)
 
     def _fix_addition(self, n: bn.AdditionNode) -> bn.BMGNode:
-        lt = n.left.inf_type
-        if lt == bt.Zero:
+        if bn.is_zero(n.left):
             return n.right
-        assert n.right.inf_type == bt.Zero
+        assert bn.is_zero(n.right)
         return n.left
 
     def _fix_power(self, n: bn.PowerNode) -> bn.BMGNode:

--- a/src/beanmachine/ppl/compiler/fix_bool_comparisons.py
+++ b/src/beanmachine/ppl/compiler/fix_bool_comparisons.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 import beanmachine.ppl.compiler.bmg_nodes as bn
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
-from beanmachine.ppl.compiler.bmg_types import Boolean, One, Zero, supremum
+from beanmachine.ppl.compiler.bmg_types import Boolean, supremum
 from beanmachine.ppl.compiler.fix_problem import ProblemFixerBase
 
 
@@ -27,13 +27,13 @@ class BoolComparisonFixer(ProblemFixerBase):
         # 0 == y        -->  not y
         # x == 0        -->  not x
         # x == y        -->  if x then y else not y
-        if node.left.inf_type == One:
+        if bn.is_one(node.left):
             return node.right
-        if node.right.inf_type == One:
+        if bn.is_one(node.right):
             return node.left
-        if node.left.inf_type == Zero:
+        if bn.is_zero(node.left):
             return self._bmg.add_complement(node.right)
-        if node.right.inf_type == Zero:
+        if bn.is_zero(node.right):
             return self._bmg.add_complement(node.left)
         alt = self._bmg.add_complement(node.right)
         return self._bmg.add_if_then_else(node.left, node.right, alt)
@@ -44,13 +44,13 @@ class BoolComparisonFixer(ProblemFixerBase):
         # 0 != y        -->  y
         # x != 0        -->  x
         # x != y        -->  if x then not y else y
-        if node.left.inf_type == One:
+        if bn.is_one(node.left):
             return self._bmg.add_complement(node.right)
-        if node.right.inf_type == One:
+        if bn.is_one(node.right):
             return self._bmg.add_complement(node.left)
-        if node.left.inf_type == Zero:
+        if bn.is_zero(node.left):
             return node.right
-        if node.right.inf_type == Zero:
+        if bn.is_zero(node.right):
             return node.left
         cons = self._bmg.add_complement(node.right)
         return self._bmg.add_if_then_else(node.left, cons, node.right)
@@ -61,13 +61,13 @@ class BoolComparisonFixer(ProblemFixerBase):
         # 0 >= y        -->  not y
         # x >= 0        -->  true
         # x >= y        -->  if x then true else not y
-        if node.left.inf_type == One:
+        if bn.is_one(node.left):
             return self._bmg.add_constant_of_type(True, Boolean)
-        if node.right.inf_type == One:
+        if bn.is_one(node.right):
             return node.left
-        if node.left.inf_type == Zero:
+        if bn.is_zero(node.left):
             return self._bmg.add_complement(node.right)
-        if node.right.inf_type == Zero:
+        if bn.is_zero(node.right):
             return self._bmg.add_constant_of_type(True, Boolean)
         cons = self._bmg.add_constant_of_type(True, Boolean)
         alt = self._bmg.add_complement(node.right)
@@ -79,13 +79,13 @@ class BoolComparisonFixer(ProblemFixerBase):
         # 0 > y        -->  false
         # x > 0        -->  x
         # x > y        -->  if x then not y else false
-        if node.left.inf_type == One:
+        if bn.is_one(node.left):
             return self._bmg.add_complement(node.right)
-        if node.right.inf_type == One:
+        if bn.is_one(node.right):
             return self._bmg.add_constant_of_type(False, Boolean)
-        if node.left.inf_type == Zero:
+        if bn.is_zero(node.left):
             return self._bmg.add_constant_of_type(False, Boolean)
-        if node.right.inf_type == Zero:
+        if bn.is_zero(node.right):
             return node.left
         cons = self._bmg.add_complement(node.right)
         alt = self._bmg.add_constant_of_type(False, Boolean)
@@ -97,13 +97,13 @@ class BoolComparisonFixer(ProblemFixerBase):
         # 0 <= y        -->  true
         # x <= 0        -->  not x
         # x <= y        -->  if x then y else true
-        if node.left.inf_type == One:
+        if bn.is_one(node.left):
             return node.right
-        if node.right.inf_type == One:
+        if bn.is_one(node.right):
             return self._bmg.add_constant_of_type(True, Boolean)
-        if node.left.inf_type == Zero:
+        if bn.is_zero(node.left):
             return self._bmg.add_constant_of_type(True, Boolean)
-        if node.right.inf_type == Zero:
+        if bn.is_zero(node.right):
             return self._bmg.add_complement(node.left)
         alt = self._bmg.add_constant_of_type(True, Boolean)
         return self._bmg.add_if_then_else(node.left, node.right, alt)
@@ -114,13 +114,13 @@ class BoolComparisonFixer(ProblemFixerBase):
         # 0 < y        -->  y
         # x < 0        -->  false
         # x < y        -->  if x then false else y
-        if node.left.inf_type == One:
+        if bn.is_one(node.left):
             return self._bmg.add_constant_of_type(False, Boolean)
-        if node.right.inf_type == One:
+        if bn.is_one(node.right):
             return self._bmg.add_complement(node.left)
-        if node.left.inf_type == Zero:
+        if bn.is_zero(node.left):
             return node.right
-        if node.right.inf_type == Zero:
+        if bn.is_zero(node.right):
             return self._bmg.add_constant_of_type(False, Boolean)
         cons = self._bmg.add_constant_of_type(False, Boolean)
         return self._bmg.add_if_then_else(node.left, cons, node.right)


### PR DESCRIPTION
Summary:
I want to eventually switch over all uses of inf_type property to use a lattice typer. We can start by eliminating a bunch of unnecessary inf_type calls. A lot of the time we check the type of a thing, we are actually asking "is this the constant zero?" or "is this the constant one?" and in those cases all we have to do is type the value; we don't need a node typer.

I've changed a bunch of the calls to inf_type with helper methods that check to see if we have a constant one or constant zero.

Reviewed By: wtaha

Differential Revision: D27756204

