### PR TITLE
Integrate typers into problem fixers

### DIFF
--- a/src/beanmachine/ppl/compiler/fix_additions.py
+++ b/src/beanmachine/ppl/compiler/fix_additions.py
@@ -6,6 +6,7 @@ import beanmachine.ppl.compiler.bmg_nodes as bn
 import beanmachine.ppl.compiler.bmg_types as bt
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
 from beanmachine.ppl.compiler.fix_problem import ProblemFixerBase
+from beanmachine.ppl.compiler.lattice_typer import LatticeTyper
 
 
 class AdditionFixer(ProblemFixerBase):
@@ -15,8 +16,8 @@ class AdditionFixer(ProblemFixerBase):
     * add(1, negate(prob)) or add(negate(prob), 1) -> complement(prob)
     * add(1, negate(bool)) or add(negate(bool), 1) -> complement(bool)"""
 
-    def __init__(self, bmg: BMGraphBuilder) -> None:
-        ProblemFixerBase.__init__(self, bmg)
+    def __init__(self, bmg: BMGraphBuilder, typer: LatticeTyper) -> None:
+        ProblemFixerBase.__init__(self, bmg, typer)
 
     def _can_be_complement(self, n: bn.AdditionNode) -> bool:
         if bn.is_one(n.left):

--- a/src/beanmachine/ppl/compiler/fix_bool_arithmetic.py
+++ b/src/beanmachine/ppl/compiler/fix_bool_arithmetic.py
@@ -6,11 +6,12 @@ import beanmachine.ppl.compiler.bmg_nodes as bn
 import beanmachine.ppl.compiler.bmg_types as bt
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
 from beanmachine.ppl.compiler.fix_problem import ProblemFixerBase
+from beanmachine.ppl.compiler.lattice_typer import LatticeTyper
 
 
 class BoolArithmeticFixer(ProblemFixerBase):
-    def __init__(self, bmg: BMGraphBuilder) -> None:
-        ProblemFixerBase.__init__(self, bmg)
+    def __init__(self, bmg: BMGraphBuilder, typer: LatticeTyper) -> None:
+        ProblemFixerBase.__init__(self, bmg, typer)
 
     def _needs_fixing(self, n: bn.BMGNode) -> bool:
         # We can simplify 1*anything, 0*anything or bool*anything

--- a/src/beanmachine/ppl/compiler/fix_bool_comparisons.py
+++ b/src/beanmachine/ppl/compiler/fix_bool_comparisons.py
@@ -6,14 +6,15 @@ import beanmachine.ppl.compiler.bmg_nodes as bn
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
 from beanmachine.ppl.compiler.bmg_types import Boolean, supremum
 from beanmachine.ppl.compiler.fix_problem import ProblemFixerBase
+from beanmachine.ppl.compiler.lattice_typer import LatticeTyper
 
 
 class BoolComparisonFixer(ProblemFixerBase):
     """This class takes a Bean Machine Graph builder and replaces all comparison
     operators whose operands are bool with semantically equivalent IF nodes."""
 
-    def __init__(self, bmg: BMGraphBuilder) -> None:
-        ProblemFixerBase.__init__(self, bmg)
+    def __init__(self, bmg: BMGraphBuilder, typer: LatticeTyper) -> None:
+        ProblemFixerBase.__init__(self, bmg, typer)
 
     def _needs_fixing(self, n: bn.BMGNode) -> bool:
         return (

--- a/src/beanmachine/ppl/compiler/fix_multiary_ops.py
+++ b/src/beanmachine/ppl/compiler/fix_multiary_ops.py
@@ -5,6 +5,7 @@ from typing import Optional
 import beanmachine.ppl.compiler.bmg_nodes as bn
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
 from beanmachine.ppl.compiler.fix_problem import ProblemFixerBase
+from beanmachine.ppl.compiler.typer_base import TyperBase
 
 
 class MultiaryOperatorFixer(ProblemFixerBase):
@@ -15,8 +16,8 @@ class MultiaryOperatorFixer(ProblemFixerBase):
 
     # TODO: Do the same for multiplication.
 
-    def __init__(self, bmg: BMGraphBuilder) -> None:
-        ProblemFixerBase.__init__(self, bmg)
+    def __init__(self, bmg: BMGraphBuilder, typer: TyperBase) -> None:
+        ProblemFixerBase.__init__(self, bmg, typer)
 
     def _single_output_is_addition(self, n: bn.BMGNode) -> bool:
         if len(n.outputs.items) != 1:

--- a/src/beanmachine/ppl/compiler/fix_observations.py
+++ b/src/beanmachine/ppl/compiler/fix_observations.py
@@ -11,6 +11,7 @@ from beanmachine.ppl.compiler.bmg_types import (
     type_of_value,
 )
 from beanmachine.ppl.compiler.error_report import ErrorReport, ImpossibleObservation
+from beanmachine.ppl.compiler.typer_base import TyperBase
 
 
 class ObservationsFixer:
@@ -21,10 +22,16 @@ class ObservationsFixer:
 
     errors: ErrorReport
     bmg: BMGraphBuilder
+    _typer: TyperBase
 
-    def __init__(self, bmg: BMGraphBuilder) -> None:
+    def __init__(self, bmg: BMGraphBuilder, typer: TyperBase) -> None:
+        # The typer is not actually needed but the caller assumes that
+        # all problem fixers need a typer to either get types or propagate
+        # updates. This fixer does neither, since it only works on leaf nodes
+        # and types of values.
         self.errors = ErrorReport()
         self.bmg = bmg
+        self._typer = typer
 
     def fix_problems(self) -> None:
         for o in self.bmg.all_observations():

--- a/src/beanmachine/ppl/compiler/fix_observe_true.py
+++ b/src/beanmachine/ppl/compiler/fix_observe_true.py
@@ -14,6 +14,7 @@ from beanmachine.ppl.compiler.bmg_nodes import (
 )
 from beanmachine.ppl.compiler.bmg_types import Boolean
 from beanmachine.ppl.compiler.error_report import ErrorReport
+from beanmachine.ppl.compiler.typer_base import TyperBase
 
 
 def _is_conversion(n: BMGNode) -> bool:
@@ -51,10 +52,17 @@ class ObserveTrueFixer:
     #         --> EXP_PRODUCT
 
     bmg: BMGraphBuilder
-    errors = ErrorReport()
+    errors: ErrorReport
+    _typer: TyperBase
 
-    def __init__(self, bmg: BMGraphBuilder) -> None:
+    def __init__(self, bmg: BMGraphBuilder, typer: TyperBase) -> None:
+        # The typer is not actually needed but the caller assumes that
+        # all problem fixers need a typer to either get types or propagate
+        # updates. This fixer does neither, since it only works on leaf nodes
+        # and types of values.
         self.bmg = bmg
+        self.errors = ErrorReport()
+        self._typer = typer
 
     def _fix_observation(self, o: Observation) -> None:
         if o.graph_type != Boolean or not o.value:

--- a/src/beanmachine/ppl/compiler/fix_problems.py
+++ b/src/beanmachine/ppl/compiler/fix_problems.py
@@ -14,6 +14,7 @@ from beanmachine.ppl.compiler.fix_observe_true import ObserveTrueFixer
 from beanmachine.ppl.compiler.fix_requirements import RequirementsFixer
 from beanmachine.ppl.compiler.fix_tensor_ops import TensorOpsFixer
 from beanmachine.ppl.compiler.fix_unsupported import UnsupportedNodeFixer
+from beanmachine.ppl.compiler.lattice_typer import LatticeTyper
 
 
 # Some notes on ordering:
@@ -42,6 +43,7 @@ _standard_fixer_types: List[Type] = [
 
 def fix_problems(bmg: BMGraphBuilder, fix_observe_true: bool = False) -> ErrorReport:
     bmg._begin(prof.fix_problems)
+    typer = LatticeTyper()
     fixer_types: List[Type] = _standard_fixer_types
     errors = ErrorReport()
     if fix_observe_true:
@@ -49,7 +51,7 @@ def fix_problems(bmg: BMGraphBuilder, fix_observe_true: bool = False) -> ErrorRe
         fixer_types = fixer_types + [ObserveTrueFixer]
     for fixer_type in fixer_types:
         bmg._begin(fixer_type.__name__)
-        fixer = fixer_type(bmg)
+        fixer = fixer_type(bmg, typer)
         fixer.fix_problems()
         bmg._finish(fixer_type.__name__)
         errors = fixer.errors

--- a/src/beanmachine/ppl/compiler/fix_tensor_ops.py
+++ b/src/beanmachine/ppl/compiler/fix_tensor_ops.py
@@ -5,6 +5,7 @@ from typing import Optional
 import beanmachine.ppl.compiler.bmg_nodes as bn
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
 from beanmachine.ppl.compiler.fix_problem import ProblemFixerBase
+from beanmachine.ppl.compiler.typer_base import TyperBase
 
 
 class TensorOpsFixer(ProblemFixerBase):
@@ -31,8 +32,8 @@ class TensorOpsFixer(ProblemFixerBase):
     # Making this sort of change will require us to iterate on these changes until
     # we reach a fixpoint.
 
-    def __init__(self, bmg: BMGraphBuilder) -> None:
-        ProblemFixerBase.__init__(self, bmg)
+    def __init__(self, bmg: BMGraphBuilder, typer: TyperBase) -> None:
+        ProblemFixerBase.__init__(self, bmg, typer)
 
     def _needs_fixing(self, n: bn.BMGNode) -> bool:
         return (

--- a/src/beanmachine/ppl/compiler/fix_unsupported.py
+++ b/src/beanmachine/ppl/compiler/fix_unsupported.py
@@ -9,6 +9,7 @@ from beanmachine.ppl.compiler.bmg_types import PositiveReal
 from beanmachine.ppl.compiler.error_report import BMGError, UnsupportedNode
 from beanmachine.ppl.compiler.fix_problem import ProblemFixerBase
 from beanmachine.ppl.compiler.graph_labels import get_edge_label
+from beanmachine.ppl.compiler.typer_base import TyperBase
 
 
 class UnsupportedNodeFixer(ProblemFixerBase):
@@ -16,8 +17,8 @@ class UnsupportedNodeFixer(ProblemFixerBase):
     fix all uses of unsupported operators by replacing them with semantically
     equivalent nodes that are supported by BMG."""
 
-    def __init__(self, bmg: BMGraphBuilder) -> None:
-        ProblemFixerBase.__init__(self, bmg)
+    def __init__(self, bmg: BMGraphBuilder, typer: TyperBase) -> None:
+        ProblemFixerBase.__init__(self, bmg, typer)
 
     def _replace_division(self, node: bn.DivisionNode) -> Optional[bn.BMGNode]:
         # BMG has no division node. We replace division by a constant with


### PR DESCRIPTION
Summary:
Since I will be removing the ability for nodes to type themselves, the problem fixers will need to be able to obtain the type of a node using a typer.

In a perfect world, each fixer would create the typer it needs, use it to fix the problem, and discard it. However, that introduces a potential performance problem: typing a node can be O(n) in the size of the graph because the type is a function of the types of all the ancestor nodes.

We therefore cache the computed type information in the typer, but that then introduces a second problem: the typer must be informed of when a node is updated, so that if a node type changes, that change is propagated to its descendants.

What we do then is: we create a single typer at the start of the problem fixing pass and give it to each of the fixers. A fixer is required to update the typer when it makes a change to the graph.

This scheme introduces some possibilities for bugs -- a fixer might forget to make an update, which causes a wrong type to be deduced later, for instance.  To mitigate this possibility I've put the updating logic in the fixer base class so that we have only one place where we need to get it right.

The requirements fixer does not inherit from that base class yet -- I mean to refactor it later.  In the meanwhile I have ensured that it does update the typer appropriately.

None of the fixers *use* the typer yet. This diff just gets the underlying plumbing working.  In the next diffs I will change the problem fixers over to use the typers rather than calling inf_type on the nodes.

Reviewed By: wtaha

Differential Revision: D27757065

