### PR TITLE
Arithmetic rewriters now use lattice typer

### DIFF
--- a/src/beanmachine/ppl/compiler/fix_bool_arithmetic.py
+++ b/src/beanmachine/ppl/compiler/fix_bool_arithmetic.py
@@ -3,7 +3,6 @@
 from typing import Optional
 
 import beanmachine.ppl.compiler.bmg_nodes as bn
-import beanmachine.ppl.compiler.bmg_types as bt
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
 from beanmachine.ppl.compiler.fix_problem import ProblemFixerBase
 from beanmachine.ppl.compiler.lattice_typer import LatticeTyper
@@ -14,12 +13,12 @@ class BoolArithmeticFixer(ProblemFixerBase):
         ProblemFixerBase.__init__(self, bmg, typer)
 
     def _needs_fixing(self, n: bn.BMGNode) -> bool:
+        assert isinstance(self._typer, LatticeTyper)
         # We can simplify 1*anything, 0*anything or bool*anything
         # to anything, 0, or an if-then-else respectively.
         if isinstance(n, bn.MultiplicationNode):
-            return (
-                bt.supremum(n.left.inf_type, bt.Boolean) == bt.Boolean
-                or bt.supremum(n.right.inf_type, bt.Boolean) == bt.Boolean
+            return self._typer.is_bool(n.left) or self._typer.is_bool(  # pyre-ignore
+                n.right
             )
         # We can simplify 0+anything.
         if isinstance(n, bn.AdditionNode):
@@ -27,7 +26,7 @@ class BoolArithmeticFixer(ProblemFixerBase):
 
         # We can simplify anything**bool.
         if isinstance(n, bn.PowerNode):
-            return bt.supremum(n.right.inf_type, bt.Boolean) == bt.Boolean
+            return self._typer.is_bool(n.right)
 
         # TODO: We could support b ** n where b is bool and n is a natural
         # constant. If n is the constant zero then the result is just
@@ -59,9 +58,9 @@ class BoolArithmeticFixer(ProblemFixerBase):
         if bn.is_one(n.right):
             return n.left
         zero = self._bmg.add_constant(0.0)
-        if n.left.inf_type == bt.Boolean:
+        if self._typer.is_bool(n.left):  # pyre-ignore
             return self._bmg.add_if_then_else(n.left, n.right, zero)
-        assert n.right.inf_type == bt.Boolean
+        assert self._typer.is_bool(n.right)
         return self._bmg.add_if_then_else(n.right, n.left, zero)
 
     def _fix_addition(self, n: bn.AdditionNode) -> bn.BMGNode:
@@ -72,6 +71,6 @@ class BoolArithmeticFixer(ProblemFixerBase):
 
     def _fix_power(self, n: bn.PowerNode) -> bn.BMGNode:
         # x ** b  -->   if b then x else 1
-        assert bt.supremum(n.right.inf_type, bt.Boolean) == bt.Boolean
+        assert self._typer.is_bool(n.right)  # pyre-ignore
         one = self._bmg.add_constant(1.0)
         return self._bmg.add_if_then_else(n.right, n.left, one)

--- a/src/beanmachine/ppl/compiler/fix_bool_comparisons.py
+++ b/src/beanmachine/ppl/compiler/fix_bool_comparisons.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 import beanmachine.ppl.compiler.bmg_nodes as bn
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
-from beanmachine.ppl.compiler.bmg_types import Boolean, supremum
+from beanmachine.ppl.compiler.bmg_types import Boolean
 from beanmachine.ppl.compiler.fix_problem import ProblemFixerBase
 from beanmachine.ppl.compiler.lattice_typer import LatticeTyper
 
@@ -19,7 +19,8 @@ class BoolComparisonFixer(ProblemFixerBase):
     def _needs_fixing(self, n: bn.BMGNode) -> bool:
         return (
             isinstance(n, bn.ComparisonNode)
-            and supremum(n.left.inf_type, n.right.inf_type, Boolean) == Boolean
+            and self._typer.is_bool(n.left)  # pyre-ignore
+            and self._typer.is_bool(n.right)
         )
 
     def _replace_bool_equals(self, node: bn.EqualNode) -> bn.BMGNode:

--- a/src/beanmachine/ppl/compiler/fix_requirements.py
+++ b/src/beanmachine/ppl/compiler/fix_requirements.py
@@ -8,6 +8,8 @@ or cannot be made to meet type requirements, an error report is
 returned."""
 
 
+# TODO: Refactor this so that it inherits from the base fixer.
+
 import beanmachine.ppl.compiler.bmg_nodes as bn
 import beanmachine.ppl.compiler.bmg_types as bt
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder

--- a/src/beanmachine/ppl/compiler/lattice_typer.py
+++ b/src/beanmachine/ppl/compiler/lattice_typer.py
@@ -242,3 +242,11 @@ class LatticeTyper(TyperBase[bt.BMGLatticeType]):
         else:
             result = bt.Untypable
         return result
+
+    def is_bool(self, node: bn.BMGNode) -> bool:
+        t = self[node]
+        return t != bt.Untypable and bt.supremum(t, bt.Boolean) == bt.Boolean
+
+    def is_prob_or_bool(self, node: bn.BMGNode) -> bool:
+        t = self[node]
+        return t != bt.Untypable and bt.supremum(t, bt.Probability) == bt.Probability


### PR DESCRIPTION
Summary:
The arithmetic rewriters now use the lattice typer to detect rewritable sums, products, powers and so on.

Since "is this usable as a bool? probability?" are common questions, I've added a helper method for those to the typer, thereby making the code read more clearly at the call site.

Reviewed By: wtaha

Differential Revision: D27779492

