### PR TITLE
Move requirements-checking helper methods to call site

### DIFF
--- a/src/beanmachine/ppl/compiler/bmg_types.py
+++ b/src/beanmachine/ppl/compiler/bmg_types.py
@@ -752,25 +752,6 @@ def always_matrix(bound: BMGMatrixType) -> Requirement:
     return AlwaysMatrix(bound)
 
 
-def node_meets_requirement(node, r: Requirement) -> bool:
-    if isinstance(r, AlwaysMatrix):
-        return node.is_matrix and type_meets_requirement(node.graph_type, r.bound)
-    return type_meets_requirement(node.graph_type, r)
-
-
-def type_meets_requirement(t: BMGLatticeType, r: Requirement) -> bool:
-    assert t != Untypable
-    if isinstance(r, AnyRequirement):
-        return True
-    if t == Malformed:
-        return False
-    if isinstance(r, UpperBound):
-        return _supremum(t, r.bound) == r.bound
-    if isinstance(r, AlwaysMatrix):
-        return t == r.bound
-    return t == r
-
-
 def requirement_to_type(r: Requirement) -> BMGLatticeType:
     if isinstance(r, UpperBound):
         return r.bound

--- a/src/beanmachine/ppl/compiler/tests/bmg_types_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_types_test.py
@@ -25,9 +25,7 @@ from beanmachine.ppl.compiler.bmg_types import (
     ZeroMatrix,
     bottom,
     supremum,
-    type_meets_requirement,
     type_of_value,
-    upper_bound,
 )
 from beanmachine.ppl.compiler.gen_dot import to_dot
 from torch import tensor
@@ -128,14 +126,6 @@ class BMGTypesTest(unittest.TestCase):
         self.assertEqual(
             Tensor, type_of_value(tensor([[[0, 0], [0, 0]], [[0, 0], [0, 0]]]))
         )
-
-    def test_type_meets_requirement(self) -> None:
-        """test_type_meets_requirement"""
-        self.assertFalse(type_meets_requirement(Natural, Boolean))
-        self.assertTrue(type_meets_requirement(Natural, Natural))
-        self.assertTrue(type_meets_requirement(Boolean, upper_bound(Natural)))
-        self.assertTrue(type_meets_requirement(Natural, upper_bound(Natural)))
-        self.assertFalse(type_meets_requirement(PositiveReal, upper_bound(Natural)))
 
     def test_types_in_dot(self) -> None:
         """test_types_in_dot"""


### PR DESCRIPTION
Summary: Methods node_meets_requirement and type_meets_requirement had only one caller -- RequirementsFixer -- so they can safely be implementation details of RequirementsFixer.  This refactoring simply moves the methods to where they are used.

Reviewed By: wtaha

Differential Revision: D27781766

