### PR TITLE
Remove last uses of inf_type property from fixers

### DIFF
--- a/src/beanmachine/ppl/compiler/error_report.py
+++ b/src/beanmachine/ppl/compiler/error_report.py
@@ -26,14 +26,21 @@ class BMGError(ABC):
 
 class Violation(BMGError):
     node: BMGNode
+    node_type: BMGLatticeType
     requirement: Requirement
     consumer: BMGNode
     edge: str
 
     def __init__(
-        self, node: BMGNode, requirement: Requirement, consumer: BMGNode, edge: str
+        self,
+        node: BMGNode,
+        node_type: BMGLatticeType,
+        requirement: Requirement,
+        consumer: BMGNode,
+        edge: str,
     ) -> None:
         self.node = node
+        self.node_type = node_type
         self.requirement = requirement
         self.consumer = consumer
         self.edge = edge
@@ -47,21 +54,23 @@ class Violation(BMGError):
         msg = (
             f"The {self.edge} of a {get_node_label(self.consumer)} "
             + f"is required to be a {t.long_name} "
-            + f"but is a {self.node.inf_type.long_name}."
+            + f"but is a {self.node_type.long_name}."
         )
         return msg
 
 
 class ImpossibleObservation(BMGError):
     node: Observation
+    distribution_type: BMGLatticeType
 
-    def __init__(self, node: Observation) -> None:
+    def __init__(self, node: Observation, distribution_type: BMGLatticeType) -> None:
         self.node = node
+        self.distribution_type = distribution_type
 
     def __str__(self) -> str:
         v = self.node.value
         d = get_node_label(self.node.observed.operand)
-        t = self.node.inf_type.long_name
+        t = self.distribution_type.long_name
         msg = (
             f"A {d} distribution is observed to have value {v} "
             + f"but only produces samples of type {t}."

--- a/src/beanmachine/ppl/compiler/fix_requirements.py
+++ b/src/beanmachine/ppl/compiler/fix_requirements.py
@@ -95,7 +95,7 @@ class RequirementsFixer:
 
         # We cannot convert this node to any type that meets the requirement.
         # Add an error.
-        self.errors.add_error(Violation(node, requirement, consumer, edge))
+        self.errors.add_error(Violation(node, it, requirement, consumer, edge))
         return node
 
     def _meet_distribution_requirement(
@@ -225,7 +225,7 @@ class RequirementsFixer:
                 return result
 
             # We have no way to make the conversion we need, so add an error.
-            self.errors.add_error(Violation(node, requirement, consumer, edge))
+            self.errors.add_error(Violation(node, it, requirement, consumer, edge))
             return node
 
         # We definitely can meet the requirement; it just remains to figure

--- a/src/beanmachine/ppl/compiler/tests/error_report_test.py
+++ b/src/beanmachine/ppl/compiler/tests/error_report_test.py
@@ -3,7 +3,7 @@
 import unittest
 
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
-from beanmachine.ppl.compiler.bmg_types import Probability
+from beanmachine.ppl.compiler.bmg_types import NegativeReal, Probability
 from beanmachine.ppl.compiler.error_report import ErrorReport, Violation
 
 
@@ -13,7 +13,7 @@ class ErrorReportTest(unittest.TestCase):
         bmg = BMGraphBuilder()
         r = bmg.add_real(-2.5)
         b = bmg.add_bernoulli(r)
-        v = Violation(r, Probability, b, "probability")
+        v = Violation(r, NegativeReal, Probability, b, "probability")
         e = ErrorReport()
         e.add_error(v)
         expected = """


### PR DESCRIPTION
Summary:
There was a small handful of remaining places where we used the inf_type property; this has now been replaced throughout the codebase with use of the lattice typer object.

In an upcoming diff I will delete the code which computes the inf_type property.

Reviewed By: wtaha

Differential Revision: D27795766

