### PR TITLE
Refactor worlds

### DIFF
--- a/src/beanmachine/ppl/world/__init__.py
+++ b/src/beanmachine/ppl/world/__init__.py
@@ -1,4 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
+from beanmachine.ppl.world.base_world import get_world_context
 from beanmachine.ppl.world.diff import Diff
 from beanmachine.ppl.world.diff_stack import DiffStack
 from beanmachine.ppl.world.utils import BetaDimensionTransform, get_default_transforms
@@ -23,4 +24,5 @@ __all__ = [
     "TransformData",
     "TransformType",
     "BetaDimensionTransform",
+    "get_world_context",
 ]

--- a/src/beanmachine/ppl/world/base_world.py
+++ b/src/beanmachine/ppl/world/base_world.py
@@ -1,0 +1,54 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+from __future__ import annotations
+
+from abc import ABCMeta, abstractmethod
+from typing import TYPE_CHECKING
+
+import torch
+
+
+if TYPE_CHECKING:
+    from beanmachine.ppl.model.rv_identifier import RVIdentifier
+
+_WORLD_STACK = []
+
+
+def get_world_context():
+    return _WORLD_STACK[-1] if _WORLD_STACK else None
+
+
+class BaseWorld(metaclass=ABCMeta):
+    def __enter__(self):
+        """
+        This method, together with __exit__, allow us to use world as a context, e.g.
+        ```
+        with World():
+            # invoke random variables to update the graph
+        ```
+        By keeping a stack of context tokens, we can easily nest multiple worlds and
+        restore the outer context if needed, e.g.
+        ```
+        world1, world2 = World(), World()
+        with world1:
+            # do some graph update specific to world1
+            with world2:
+                # update world2
+            # back to updating world1
+        ```
+        """
+        _WORLD_STACK.append(self)
+        return self
+
+    def __exit__(self, *args):
+        _WORLD_STACK.pop()
+
+    def call(self, node: RVIdentifier):
+        """
+        A helper function that invokes the random variable and return its value
+        """
+        with self:
+            return node.wrapper(*node.arguments)
+
+    @abstractmethod
+    def update_graph(self, node: RVIdentifier) -> torch.Tensor:
+        raise NotImplementedError

--- a/src/beanmachine/ppl/world/tests/utils_test.py
+++ b/src/beanmachine/ppl/world/tests/utils_test.py
@@ -2,7 +2,7 @@
 import unittest
 
 import torch.distributions as dist
-from beanmachine.ppl.world.utils import get_default_transforms
+from beanmachine.ppl.world.utils import get_default_transforms, initialize_value
 
 
 class InferenceUtilsTest(unittest.TestCase):
@@ -18,3 +18,11 @@ class InferenceUtilsTest(unittest.TestCase):
         gamma = dist.Gamma(1, 1)
         transforms = get_default_transforms(gamma)
         self.assertTrue(transforms.bijective)
+
+    def test_initialize_value(self):
+        distribution = dist.Normal(0, 1)
+        value = initialize_value(distribution)
+        self.assertAlmostEqual(value.item(), 0, delta=1e-5)
+        first_sample = initialize_value(distribution, True)
+        second_sample = initialize_value(distribution, True)
+        self.assertNotEqual(first_sample.item(), second_sample.item())

--- a/src/beanmachine/ppl/world/tests/variable_test.py
+++ b/src/beanmachine/ppl/world/tests/variable_test.py
@@ -4,7 +4,7 @@ from collections import namedtuple
 
 import torch
 import torch.distributions as dist
-from beanmachine.ppl.world.utils import get_default_transforms
+from beanmachine.ppl.world.utils import get_default_transforms, initialize_value
 from beanmachine.ppl.world.variable import TransformData, TransformType, Variable
 from torch import tensor
 
@@ -53,23 +53,6 @@ class VariableTest(unittest.TestCase):
         self.assertEqual(var_copy.children, set({tmp(name="name")}))
         self.assertEqual(var_copy.parent is var.parent, False)
         self.assertEqual(var_copy.children is var.children, False)
-
-    def test_initialize(self):
-        distribution = dist.Normal(0, 1)
-        val = distribution.sample()
-        log_prob = distribution.log_prob(val)
-        var = Variable(
-            distribution=distribution,
-            value=val,
-            log_prob=log_prob,
-            transformed_value=None,
-            jacobian=tensor(0.0),
-        )
-        value = var.initialize_value(None)
-        self.assertAlmostEqual(value.item(), 0, delta=1e-5)
-        first_sample = var.initialize_value(None, True)
-        second_sample = var.initialize_value(None, True)
-        self.assertNotEqual(first_sample.item(), second_sample.item())
 
     def test_transform_gamma_log_prob(self):
         distribution = dist.Gamma(2, 2)
@@ -245,7 +228,7 @@ class VariableTest(unittest.TestCase):
             transformed_value=None,
             jacobian=None,
         )
-        value = var.initialize_value(None)
+        value = initialize_value(distribution)
         var.update_value(value)
         try:
             str(var)


### PR DESCRIPTION
Summary:
This diff does nothing special by its own other than splitting the current `World` class into a `BaseWorld` and a single-site specific `World`. A few utility functions are also refactor into `utils.py` so that they can be used by other "worlds".

The change in this diff enable us to do different things with the model by subclassing from the `BaseWorld`. When a `bm.random_variable` function is invoked, it will look up the world instance from the closest context and invoke the `update_graph()` method.

In this diff the `BaseWorld` class only holds the the context manager interface because I can't find a good way to utilize the other methods that are currently defined in single site `World` and adapt them to the global world (which will be introduce in the next diff in the stack, D28215033).

So in a way the purpose of this diff is just to open up an API that allow me to redirect the random variable decorator so I can start developing a relatively independent global inference framework without changing a ton of existing codebase.

Differential Revision: D28215010

