### PR TITLE
Eliminate all callers of graph_type property

### DIFF
--- a/src/beanmachine/ppl/compiler/fix_observe_true.py
+++ b/src/beanmachine/ppl/compiler/fix_observe_true.py
@@ -12,7 +12,7 @@ from beanmachine.ppl.compiler.bmg_nodes import (
     ToRealNode,
     UnaryOperatorNode,
 )
-from beanmachine.ppl.compiler.bmg_types import Boolean
+from beanmachine.ppl.compiler.bmg_types import is_one
 from beanmachine.ppl.compiler.error_report import ErrorReport
 from beanmachine.ppl.compiler.typer_base import TyperBase
 
@@ -65,7 +65,7 @@ class ObserveTrueFixer:
         self._typer = typer
 
     def _fix_observation(self, o: Observation) -> None:
-        if o.graph_type != Boolean or not o.value:
+        if not is_one(o.value):
             return
         sample = o.observed
         if not isinstance(sample, SampleNode):

--- a/src/beanmachine/ppl/compiler/fix_requirements.py
+++ b/src/beanmachine/ppl/compiler/fix_requirements.py
@@ -55,9 +55,9 @@ class RequirementsFixer:
     def _node_meets_requirement(self, node: bn.BMGNode, r: bt.Requirement) -> bool:
         if isinstance(r, bt.AlwaysMatrix):
             return node.is_matrix and self._type_meets_requirement(
-                node.graph_type, r.bound
+                self._typer.graph_type(node), r.bound
             )
-        return self._type_meets_requirement(node.graph_type, r)
+        return self._type_meets_requirement(self._typer.graph_type(node), r)
 
     def _meet_constant_requirement(
         self,
@@ -121,7 +121,7 @@ class RequirementsFixer:
         # We have been given a node which does not meet a requirement,
         # but it can be converted to a node which does meet the requirement
         # that has the same semantics. Start by confirming those preconditions.
-        assert node.graph_type != requirement
+        assert self._typer.graph_type(node) != requirement
         assert bt.supremum(self._typer[node], requirement) == requirement
 
         # TODO: We no longer support Tensor as a type in BMG.  We must

--- a/src/beanmachine/ppl/compiler/gen_dot.py
+++ b/src/beanmachine/ppl/compiler/gen_dot.py
@@ -55,7 +55,7 @@ def to_dot(
         n = to_id(index)
         node_label = get_node_label(node)
         if graph_types:
-            node_label += ":" + node.graph_type.short_name
+            node_label += ":" + lt.graph_type(node).short_name
         if inf_types:
             node_label += ">=" + lt[node].short_name
         db.with_node(n, node_label)

--- a/src/beanmachine/ppl/compiler/tests/bmg_types_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_types_test.py
@@ -154,13 +154,13 @@ digraph "graph" {
   N01[label="2.0:T>=N"];
   N02[label="Beta:P>=P"];
   N03[label="Sample:P>=P"];
-  N04[label="*:M>=P"];
+  N04[label="*:P>=P"];
   N05[label="1.0:T>=OH"];
   N06[label="Normal:R>=R"];
   N07[label="Sample:R>=R"];
   N08[label="Bernoulli:B>=B"];
   N09[label="Sample:B>=B"];
-  N10[label="Query:M>=P"];
+  N10[label="Query:P>=P"];
   N00 -> N04[label="left:P"];
   N01 -> N02[label="alpha:R+"];
   N01 -> N02[label="beta:R+"];

--- a/src/beanmachine/ppl/compiler/tests/fix_problems_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_problems_test.py
@@ -48,13 +48,13 @@ digraph "graph" {
   N01[label="2.0:T"];
   N02[label="Beta:P"];
   N03[label="Sample:P"];
-  N04[label="*:M"];
+  N04[label="*:P"];
   N05[label="1.0:T"];
   N06[label="Normal:R"];
   N07[label="Sample:R"];
   N08[label="Bernoulli:B"];
   N09[label="Sample:B"];
-  N10[label="Query:M"];
+  N10[label="Query:P"];
   N00 -> N04[label="left:P"];
   N01 -> N02[label="alpha:R+"];
   N01 -> N02[label="beta:R+"];
@@ -159,7 +159,7 @@ digraph "graph" {
   N1[label="Bernoulli:B"];
   N2[label="Sample:B"];
   N3[label="1.0:T"];
-  N4[label="+:M"];
+  N4[label="+:R+"];
   N5[label="Normal:R"];
   N6[label="Sample:R"];
   N7[label="Binomial:N"];
@@ -308,7 +308,7 @@ digraph "graph" {
   N3[label="2:N>=N"];
   N4[label="Binomial:N>=N"];
   N5[label="Sample:N>=N"];
-  N6[label="*:M>=R+"];
+  N6[label="*:R+>=R+"];
   N7[label="Binomial:N>=N"];
   N8[label="Sample:N>=N"];
   N0 -> N1[label="probability:P"];
@@ -345,7 +345,7 @@ digraph "graph" {
   N03[label="2:N>=N"];
   N04[label="Binomial:N>=N"];
   N05[label="Sample:N>=N"];
-  N06[label="*:M>=R+"];
+  N06[label="*:R+>=R+"];
   N07[label="0:N>=Z"];
   N08[label="if:N>=N"];
   N09[label="Binomial:N>=N"];
@@ -411,7 +411,7 @@ digraph "graph" {
   N02[label="HalfCauchy:R+>=R+"];
   N03[label="Sample:R+>=R+"];
   N04[label="Sample:R+>=R+"];
-  N05[label="/:R+>=U"];
+  N05[label="/:U>=U"];
   N06[label="Sample:R+>=R+"];
   N07[label="-1.0:R>=R-"];
   N08[label="**:R+>=R+"];
@@ -473,9 +473,9 @@ digraph "graph" {
   N1[label="HalfCauchy:R+>=R+"];
   N2[label="Sample:R+>=R+"];
   N3[label="2.5:R>=R+"];
-  N4[label="/:M>=U"];
-  N5[label="Normal:R>=U"];
-  N6[label="Sample:R>=U"];
+  N4[label="/:U>=U"];
+  N5[label="Normal:U>=U"];
+  N6[label="Sample:U>=U"];
   N0 -> N1[label="scale:R+"];
   N0 -> N5[label="sigma:any"];
   N1 -> N2[label="operand:R+"];
@@ -505,7 +505,7 @@ digraph "graph" {
   N02[label="HalfCauchy:R+>=R+"];
   N03[label="Sample:R+>=R+"];
   N04[label="2.5:R>=R+"];
-  N05[label="/:M>=U"];
+  N05[label="/:U>=U"];
   N06[label="0.4:R+>=P"];
   N07[label="*:R+>=R+"];
   N08[label="ToReal:R>=R"];
@@ -595,8 +595,8 @@ digraph "graph" {
   N0[label="1.0:R>=OH"];
   N1[label="HalfCauchy:R+>=R+"];
   N2[label="Sample:R+>=R+"];
-  N3[label="Chi2:R+>=U"];
-  N4[label="Sample:R+>=U"];
+  N3[label="Chi2:U>=U"];
+  N4[label="Sample:U>=U"];
   N0 -> N1[label="scale:R+"];
   N1 -> N2[label="operand:R+"];
   N2 -> N3[label="df:any"];
@@ -623,7 +623,7 @@ digraph "graph" {
   N1[label="1.0:R+>=OH"];
   N2[label="HalfCauchy:R+>=R+"];
   N3[label="Sample:R+>=R+"];
-  N4[label="Chi2:R+>=U"];
+  N4[label="Chi2:U>=U"];
   N5[label="0.5:R+>=P"];
   N6[label="*:R+>=R+"];
   N7[label="Gamma:R+>=R+"];
@@ -683,7 +683,7 @@ digraph "graph" {
   N3[label="Sample:N>=N"];
   N4[label="Bernoulli:B>=B"];
   N5[label="Sample:B>=B"];
-  N6[label="**:M>=R+"];
+  N6[label="**:R+>=R+"];
   N7[label="Binomial:N>=N"];
   N8[label="Sample:N>=N"];
   N0 -> N2[label="count:N"];
@@ -720,7 +720,7 @@ digraph "graph" {
   N03[label="Sample:N>=N"];
   N04[label="Bernoulli:B>=B"];
   N05[label="Sample:B>=B"];
-  N06[label="**:M>=R+"];
+  N06[label="**:R+>=R+"];
   N07[label="1:N>=OH"];
   N08[label="if:N>=N"];
   N09[label="Binomial:N>=N"];
@@ -784,8 +784,8 @@ digraph "graph" {
   N1[label="2.0:R>=N"];
   N2[label="Beta:P>=P"];
   N3[label="Sample:P>=P"];
-  N4[label="-:M>=R-"];
-  N5[label="+:M>=R"];
+  N4[label="-:R->=R-"];
+  N5[label="+:R>=R"];
   N6[label="Bernoulli:B>=B"];
   N7[label="Sample:B>=B"];
   N0 -> N5[label="left:R"];
@@ -819,8 +819,8 @@ digraph "graph" {
   N2[label="2.0:R+>=N"];
   N3[label="Beta:P>=P"];
   N4[label="Sample:P>=P"];
-  N5[label="-:M>=R-"];
-  N6[label="+:M>=R"];
+  N5[label="-:R->=R-"];
+  N6[label="+:R>=R"];
   N7[label="complement:P>=P"];
   N8[label="Bernoulli:B>=B"];
   N9[label="Sample:B>=B"];


### PR DESCRIPTION
Summary:
The graph_type property on nodes is now called nowhere; I will remove it in an upcoming diff.

In a small number of cases we need to distinguish between the lattice type of a constant -- how small a type can this value fit into? -- and the type that BMG associates with an actual node. I've put the logic for those cases in a method `graph_type` of the lattice typer.

There are a couple of small changes in the value computed by `graph_type`:

* I've eliminated generation of the Malformed type annotation, which was used for situations such as an addition where the addends were not of the same type. We do not actually need to track this in the type system, and I will remove it in an upcomding diff as well.  Nodes which were previously marked as malformed are now considered to have their lattice type for display purposes.

* Nodes which are classified as untypable by the lattice typer are similarl classifed as untypable by `graph_type`.

Reviewed By: wtaha

Differential Revision: D27806244

