### PR TITLE
Start eliminating graph_type altogether from compiler

### DIFF
--- a/src/beanmachine/ppl/compiler/bmg_nodes.py
+++ b/src/beanmachine/ppl/compiler/bmg_nodes.py
@@ -187,6 +187,21 @@ class ConstantNode(BMGNode, metaclass=ABCMeta):
         return 1.0
 
 
+class UntypedConstantNode(ConstantNode):
+    def __init__(self, value: Any) -> None:
+        self.value = value
+        ConstantNode.__init__(self)
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+    @property
+    def size(self) -> torch.Size:
+        if isinstance(self.value, torch.Tensor):
+            return self.value.size()
+        return torch.Size([])
+
+
 class BooleanNode(ConstantNode):
     """A Boolean constant"""
 

--- a/src/beanmachine/ppl/compiler/fix_requirements.py
+++ b/src/beanmachine/ppl/compiler/fix_requirements.py
@@ -65,7 +65,9 @@ class RequirementsFixer:
         edge: str,
     ) -> bn.BMGNode:
         # If the constant node already meets the requirement, we're done.
-        if self._node_meets_requirement(node, requirement):
+        if not isinstance(
+            node, bn.UntypedConstantNode
+        ) and self._node_meets_requirement(node, requirement):
             return node
 
         # It does not meet the requirement. Is there a semantically equivalent node

--- a/src/beanmachine/ppl/compiler/fix_unsupported.py
+++ b/src/beanmachine/ppl/compiler/fix_unsupported.py
@@ -78,7 +78,8 @@ class UnsupportedNodeFixer(ProblemFixerBase):
         return None
 
     def _needs_fixing(self, n: bn.BMGNode) -> bool:
-        return not is_supported_by_bmg(n)
+        # Untyped constant nodes will be replaced in the requirements checking pass.
+        return not isinstance(n, bn.UntypedConstantNode) and not is_supported_by_bmg(n)
 
     def _get_error(self, n: bn.BMGNode, index: int) -> Optional[BMGError]:
         # TODO: The edge labels used to visualize the graph in DOT

--- a/src/beanmachine/ppl/compiler/graph_labels.py
+++ b/src/beanmachine/ppl/compiler/graph_labels.py
@@ -6,10 +6,6 @@ import beanmachine.ppl.compiler.bmg_nodes as bn
 from torch import Tensor
 
 
-def _val(node: bn.ConstantNode) -> str:
-    return str(node.value)
-
-
 def _tensor_to_label(t: Tensor) -> str:
     length = len(t.shape)
     if length == 0:
@@ -20,6 +16,12 @@ def _tensor_to_label(t: Tensor) -> str:
 
 def _tensor_val(node: bn.ConstantTensorNode) -> str:
     return _tensor_to_label(node.value)
+
+
+def _val(node: bn.ConstantNode) -> str:
+    if isinstance(node.value, Tensor):
+        return _tensor_to_label(node.value)
+    return str(node.value)
 
 
 _node_labels = {
@@ -86,6 +88,7 @@ _node_labels = {
     bn.ToProbabilityNode: "ToProb",
     bn.ToRealNode: "ToReal",
     bn.UniformNode: "Uniform",
+    bn.UntypedConstantNode: _val,
 }
 
 _none = []

--- a/src/beanmachine/ppl/compiler/tests/bmg_types_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_types_test.py
@@ -150,12 +150,12 @@ class BMGTypesTest(unittest.TestCase):
         )
         expected = """
 digraph "graph" {
-  N00[label="0.5:T>=P"];
-  N01[label="2.0:T>=N"];
+  N00[label="0.5:P>=P"];
+  N01[label="2.0:N>=N"];
   N02[label="Beta:P>=P"];
   N03[label="Sample:P>=P"];
   N04[label="*:P>=P"];
-  N05[label="1.0:T>=OH"];
+  N05[label="1.0:OH>=OH"];
   N06[label="Normal:R>=R"];
   N07[label="Sample:R>=R"];
   N08[label="Bernoulli:B>=B"];

--- a/src/beanmachine/ppl/compiler/tests/dirichlet_test.py
+++ b/src/beanmachine/ppl/compiler/tests/dirichlet_test.py
@@ -188,8 +188,8 @@ class DirichletTest(unittest.TestCase):
         bmg.add_query(c3)
         expected = """
 digraph "graph" {
-  N0[label="1.0:R+>=OH"];
-  N1[label="Query:R+>=OH"];
+  N0[label="1.0:R+>=R+"];
+  N1[label="Query:R+>=R+"];
   N2[label="[1.0,1.5]:MR+[1,2]>=MR+[1,2]"];
   N3[label="Query:MR+[1,2]>=MR+[1,2]"];
   N4[label="[[1.0,1.5],\\\\n[2.0,2.5]]:MR+[2,2]>=MR+[2,2]"];
@@ -269,23 +269,23 @@ digraph "graph" {
   N01[label="Dirichlet:S[1,1]>=S[1,1]"];
   N02[label="Sample:S[1,1]>=S[1,1]"];
   N03[label="Query:S[1,1]>=S[1,1]"];
-  N04[label="[1.0]:T>=OH"];
+  N04[label="[1.0]:OH>=OH"];
   N05[label="Dirichlet:S[1,1]>=S[1,1]"];
   N06[label="Sample:S[1,1]>=S[1,1]"];
   N07[label="Query:S[1,1]>=S[1,1]"];
-  N08[label="[[1.5]]:T>=R+"];
+  N08[label="[[1.5]]:R+>=R+"];
   N09[label="Dirichlet:S[1,1]>=S[1,1]"];
   N10[label="Sample:S[1,1]>=S[1,1]"];
   N11[label="Query:S[1,1]>=S[1,1]"];
-  N12[label="[[[2.0]]]:T>=N"];
+  N12[label="[[[2.0]]]:N>=N"];
   N13[label="Dirichlet:S[1,1]>=S[1,1]"];
   N14[label="Sample:S[1,1]>=S[1,1]"];
   N15[label="Query:S[1,1]>=S[1,1]"];
-  N16[label="[2.5,3.0]:T>=MR+[1,2]"];
+  N16[label="[2.5,3.0]:MR+[1,2]>=MR+[1,2]"];
   N17[label="Dirichlet:S[1,2]>=S[1,2]"];
   N18[label="Sample:S[1,2]>=S[1,2]"];
   N19[label="Query:S[1,2]>=S[1,2]"];
-  N20[label="[[3.5,4.0]]:T>=MR+[1,2]"];
+  N20[label="[[3.5,4.0]]:MR+[1,2]>=MR+[1,2]"];
   N21[label="Dirichlet:S[1,2]>=S[1,2]"];
   N22[label="Sample:S[1,2]>=S[1,2]"];
   N23[label="Query:S[1,2]>=S[1,2]"];
@@ -293,7 +293,7 @@ digraph "graph" {
   N25[label="Dirichlet:S[1,2]>=S[1,2]"];
   N26[label="Sample:S[1,2]>=S[1,2]"];
   N27[label="Query:S[1,2]>=S[1,2]"];
-  N28[label="[[5.5,6.0,6.5],\\\\n[7.0,7.5,8.0]]:T>=MR+[2,3]"];
+  N28[label="[[5.5,6.0,6.5],\\\\n[7.0,7.5,8.0]]:MR+[2,3]>=MR+[2,3]"];
   N29[label="Dirichlet:S[1,3]>=S[1,3]"];
   N30[label="Sample:S[1,3]>=S[1,3]"];
   N31[label="Query:S[1,3]>=S[1,3]"];
@@ -415,7 +415,7 @@ digraph "graph" {
 
         expected = """
 digraph "graph" {
-  N0[label="[1.0]:R+>=OH"];
+  N0[label="[1.0]:R+>=R+"];
   N1[label="Dirichlet:S[1,1]>=S[1,1]"];
   N2[label="Sample:S[1,1]>=S[1,1]"];
   N3[label="Query:S[1,1]>=S[1,1]"];

--- a/src/beanmachine/ppl/compiler/tests/fix_problems_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_problems_test.py
@@ -44,12 +44,12 @@ class FixProblemsTest(unittest.TestCase):
         )
         expected = """
 digraph "graph" {
-  N00[label="0.5:T"];
-  N01[label="2.0:T"];
+  N00[label="0.5:P"];
+  N01[label="2.0:N"];
   N02[label="Beta:P"];
   N03[label="Sample:P"];
   N04[label="*:P"];
-  N05[label="1.0:T"];
+  N05[label="1.0:OH"];
   N06[label="Normal:R"];
   N07[label="Sample:R"];
   N08[label="Bernoulli:B"];
@@ -79,9 +79,9 @@ digraph "graph" {
         )
         expected = """
 digraph "graph" {
-  N00[label="1.0:T"];
-  N01[label="2.0:T"];
-  N02[label="0.5:T"];
+  N00[label="1.0:OH"];
+  N01[label="2.0:N"];
+  N02[label="0.5:P"];
   N03[label="0.5:P"];
   N04[label="2.0:R+"];
   N05[label="Beta:P"];
@@ -155,10 +155,10 @@ digraph "graph" {
         )
         expected = """
 digraph "graph" {
-  N0[label="0.5:T"];
+  N0[label="0.5:P"];
   N1[label="Bernoulli:B"];
   N2[label="Sample:B"];
-  N3[label="1.0:T"];
+  N3[label="1.0:OH"];
   N4[label="+:R+"];
   N5[label="Normal:R"];
   N6[label="Sample:R"];
@@ -187,8 +187,8 @@ digraph "graph" {
         )
         expected = """
 digraph "graph" {
-  N00[label="1.0:T"];
-  N01[label="0.5:T"];
+  N00[label="1.0:OH"];
+  N01[label="0.5:P"];
   N02[label="0.5:P"];
   N03[label="Bernoulli:B"];
   N04[label="Sample:B"];
@@ -214,8 +214,8 @@ digraph "graph" {
   N07 -> N08[label="right:R+"];
   N08 -> N09[label="sigma:R+"];
   N09 -> N10[label="operand:R"];
-  N11 -> N13[label="consequence:B"];
-  N12 -> N13[label="alternative:B"];
+  N11 -> N13[label="consequence:N"];
+  N12 -> N13[label="alternative:N"];
   N13 -> N14[label="count:N"];
   N14 -> N15[label="operand:N"];
 }"""
@@ -346,11 +346,11 @@ digraph "graph" {
   N04[label="Binomial:N>=N"];
   N05[label="Sample:N>=N"];
   N06[label="*:R+>=R+"];
-  N07[label="0:N>=Z"];
+  N07[label="0:N>=N"];
   N08[label="if:N>=N"];
   N09[label="Binomial:N>=N"];
   N10[label="Sample:N>=N"];
-  N11[label="0.0:R>=Z"];
+  N11[label="0.0:Z>=Z"];
   N00 -> N01[label="probability:P"];
   N00 -> N04[label="probability:P"];
   N00 -> N09[label="probability:P"];
@@ -406,20 +406,21 @@ digraph "graph" {
 
         expected = """
 digraph "graph" {
-  N00[label="1.0:R>=OH"];
-  N01[label="1.0:R+>=OH"];
+  N00[label="1.0:OH>=OH"];
+  N01[label="1.0:R+>=R+"];
   N02[label="HalfCauchy:R+>=R+"];
   N03[label="Sample:R+>=R+"];
   N04[label="Sample:R+>=R+"];
   N05[label="/:U>=U"];
   N06[label="Sample:R+>=R+"];
-  N07[label="-1.0:R>=R-"];
+  N07[label="-1.0:R>=R"];
   N08[label="**:R+>=R+"];
   N09[label="*:R+>=R+"];
   N10[label="**:R+>=R+"];
   N11[label="Log:R>=R"];
   N12[label="Normal:R>=R"];
   N13[label="Sample:R>=R"];
+  N14[label="-1.0:R->=R-"];
   N01 -> N02[label="scale:R+"];
   N01 -> N12[label="sigma:R+"];
   N02 -> N03[label="operand:R+"];
@@ -469,10 +470,10 @@ digraph "graph" {
 
         expected = """
 digraph "graph" {
-  N0[label="1.0:R>=OH"];
+  N0[label="1.0:OH>=OH"];
   N1[label="HalfCauchy:R+>=R+"];
   N2[label="Sample:R+>=R+"];
-  N3[label="2.5:R>=R+"];
+  N3[label="2.5:R+>=R+"];
   N4[label="/:U>=U"];
   N5[label="Normal:U>=U"];
   N6[label="Sample:U>=U"];
@@ -500,18 +501,18 @@ digraph "graph" {
         )
         expected = """
 digraph "graph" {
-  N00[label="1.0:R>=OH"];
-  N01[label="1.0:R+>=OH"];
+  N00[label="1.0:OH>=OH"];
+  N01[label="1.0:R+>=R+"];
   N02[label="HalfCauchy:R+>=R+"];
   N03[label="Sample:R+>=R+"];
-  N04[label="2.5:R>=R+"];
+  N04[label="2.5:R+>=R+"];
   N05[label="/:U>=U"];
-  N06[label="0.4:R+>=P"];
+  N06[label="0.4:R+>=R+"];
   N07[label="*:R+>=R+"];
   N08[label="ToReal:R>=R"];
   N09[label="Normal:R>=R"];
   N10[label="Sample:R>=R"];
-  N11[label="0.4:R>=P"];
+  N11[label="0.4:P>=P"];
   N01 -> N02[label="scale:R+"];
   N01 -> N09[label="sigma:R+"];
   N02 -> N03[label="operand:R+"];
@@ -592,7 +593,7 @@ The unsupported node is the operand of a Sample.
 
         expected = """
 digraph "graph" {
-  N0[label="1.0:R>=OH"];
+  N0[label="1.0:OH>=OH"];
   N1[label="HalfCauchy:R+>=R+"];
   N2[label="Sample:R+>=R+"];
   N3[label="Chi2:U>=U"];
@@ -619,12 +620,12 @@ digraph "graph" {
 
         expected = """
 digraph "graph" {
-  N0[label="1.0:R>=OH"];
-  N1[label="1.0:R+>=OH"];
+  N0[label="1.0:OH>=OH"];
+  N1[label="1.0:R+>=R+"];
   N2[label="HalfCauchy:R+>=R+"];
   N3[label="Sample:R+>=R+"];
   N4[label="Chi2:U>=U"];
-  N5[label="0.5:R+>=P"];
+  N5[label="0.5:R+>=R+"];
   N6[label="*:R+>=R+"];
   N7[label="Gamma:R+>=R+"];
   N8[label="Sample:R+>=R+"];
@@ -721,11 +722,11 @@ digraph "graph" {
   N04[label="Bernoulli:B>=B"];
   N05[label="Sample:B>=B"];
   N06[label="**:R+>=R+"];
-  N07[label="1:N>=OH"];
+  N07[label="1:N>=N"];
   N08[label="if:N>=N"];
   N09[label="Binomial:N>=N"];
   N10[label="Sample:N>=N"];
-  N11[label="1.0:R>=OH"];
+  N11[label="1.0:OH>=OH"];
   N00 -> N02[label="count:N"];
   N01 -> N02[label="probability:P"];
   N01 -> N04[label="probability:P"];
@@ -780,8 +781,8 @@ digraph "graph" {
 
         expected = """
 digraph "graph" {
-  N0[label="1.0:R>=OH"];
-  N1[label="2.0:R>=N"];
+  N0[label="1.0:OH>=OH"];
+  N1[label="2.0:N>=N"];
   N2[label="Beta:P>=P"];
   N3[label="Sample:P>=P"];
   N4[label="-:R->=R-"];
@@ -814,9 +815,9 @@ digraph "graph" {
 
         expected = """
 digraph "graph" {
-  N0[label="2.0:R>=N"];
-  N1[label="1.0:R>=OH"];
-  N2[label="2.0:R+>=N"];
+  N0[label="2.0:N>=N"];
+  N1[label="1.0:OH>=OH"];
+  N2[label="2.0:R+>=R+"];
   N3[label="Beta:P>=P"];
   N4[label="Sample:P>=P"];
   N5[label="-:R->=R-"];
@@ -870,7 +871,7 @@ digraph "graph" {
 
         expected = """
 digraph "graph" {
-  N0[label="2.0:R>=N"];
+  N0[label="2.0:N>=N"];
   N1[label="Beta:P>=P"];
   N2[label="Sample:P>=P"];
   N3[label="Log:R->=R-"];
@@ -901,8 +902,8 @@ digraph "graph" {
 
         expected = """
 digraph "graph" {
-  N0[label="2.0:R>=N"];
-  N1[label="2.0:R+>=N"];
+  N0[label="2.0:N>=N"];
+  N1[label="2.0:R+>=R+"];
   N2[label="Beta:P>=P"];
   N3[label="Sample:P>=P"];
   N4[label="Log:R->=R-"];
@@ -1000,34 +1001,36 @@ A Binomial distribution is observed to have value 5.25 but only produces samples
         # The observations have been converted to the correct types:
         expected = """
 digraph "graph" {
-  N00[label="1.0:R>=OH"];
-  N01[label="2.0:R>=N"];
-  N02[label="0.5:R>=P"];
+  N00[label="0.0:Z>=Z"];
+  N01[label="1.0:OH>=OH"];
+  N02[label="2.0:N>=N"];
   N03[label="0.5:P>=P"];
-  N04[label="Bernoulli:B>=B"];
-  N05[label="Sample:B>=B"];
-  N06[label="Observation False:B>=B"];
-  N07[label="2:N>=N"];
-  N08[label="Binomial:N>=N"];
-  N09[label="Sample:N>=N"];
-  N10[label="Observation 5:N>=N"];
-  N11[label="0.0:R>=Z"];
-  N12[label="1.0:R+>=OH"];
-  N13[label="Normal:R>=R"];
-  N14[label="Sample:R>=R"];
-  N15[label="Observation 1.0:R>=R"];
-  N03 -> N04[label="probability:P"];
-  N03 -> N08[label="probability:P"];
-  N04 -> N05[label="operand:B"];
-  N05 -> N06[label="operand:any"];
-  N07 -> N08[label="count:N"];
-  N08 -> N09[label="operand:N"];
-  N09 -> N10[label="operand:any"];
-  N11 -> N13[label="mu:R"];
-  N12 -> N13[label="sigma:R+"];
-  N13 -> N14[label="operand:R"];
-  N14 -> N15[label="operand:any"];
-}"""
+  N04[label="0.5:P>=P"];
+  N05[label="Bernoulli:B>=B"];
+  N06[label="Sample:B>=B"];
+  N07[label="Observation False:B>=B"];
+  N08[label="2:N>=N"];
+  N09[label="Binomial:N>=N"];
+  N10[label="Sample:N>=N"];
+  N11[label="Observation 5:N>=N"];
+  N12[label="0.0:R>=R"];
+  N13[label="1.0:R+>=R+"];
+  N14[label="Normal:R>=R"];
+  N15[label="Sample:R>=R"];
+  N16[label="Observation 1.0:R>=R"];
+  N04 -> N05[label="probability:P"];
+  N04 -> N09[label="probability:P"];
+  N05 -> N06[label="operand:B"];
+  N06 -> N07[label="operand:any"];
+  N08 -> N09[label="count:N"];
+  N09 -> N10[label="operand:N"];
+  N10 -> N11[label="operand:any"];
+  N12 -> N14[label="mu:R"];
+  N13 -> N14[label="sigma:R+"];
+  N14 -> N15[label="operand:R"];
+  N15 -> N16[label="operand:any"];
+}
+"""
         self.assertEqual(expected.strip(), observed.strip())
 
     def test_fix_problems_14(self) -> None:

--- a/src/beanmachine/ppl/compiler/tests/gen_builder_test.py
+++ b/src/beanmachine/ppl/compiler/tests/gen_builder_test.py
@@ -30,8 +30,8 @@ from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
 from torch import tensor
 
 bmg = BMGraphBuilder()
-n0 = bmg.add_node(bn.ConstantTensorNode(tensor(0.)))
-n1 = bmg.add_node(bn.ConstantTensorNode(tensor(1.)))
+n0 = bmg.add_node(bn.UntypedConstantNode(tensor(0.)))
+n1 = bmg.add_node(bn.UntypedConstantNode(tensor(1.)))
 n2 = bmg.add_node(bn.NormalNode(n0, n1))
 n3 = bmg.add_node(bn.SampleNode(n2))
 n4 = bmg.add_node(bn.SampleNode(n2))


### PR DESCRIPTION
Summary:
In this diff and the next I will eliminate the graph_type feature from the compiler entirely, and simplify how constant nodes are created and managed.

Let's start by describing the existing design and its shortcomings.

In a Python model, almost all relevant non-stochastic values are float-valued single-valued tensors. There is no particular type system imposed upon them.

In Bean Machine Graph by contrast, there are many different nodes that represent constant values: we have distinct nodes for bool, natural, negative real, positive real and real values, and similarly for two-dimensional fixed-size matrices of those types.

Moreover, the actual values used in a Python model are different; a Bernoulli coin flip in a Python model for example will produce a tensor(1.0) value for "heads", but in BMG that thing is the Boolean "true".

This presents a problem to be solved when transforming a Python model to BMG; when we encounter a constant value that is a parameter to a stochastic computation, how do we know what kind of node to generate?

The original strategy was as follows:

* Transform the Python program into a form that, when executed, calls back graph accumulation methods on every operation.

* Suppose for example we have an addition of 1.5 to a draw from a half Cauchy. We create nodes for the distribution, for the sample, for the addition, and for the constant 1.5. We generate a real-valued node for the constant.

* When it comes time to check the type of each node, we note that the addition is adding a positive real sample from a half Cauchy to a real constant 1.5, but that constant value is compatible with the positive real type. We replace the real constant with a positive real constant.

This means that for every constant node we need to effectively keep track of two things: what is the type of the *node*, from BMG's perspective, and what is the type of the *value*, so that we know what kinds of constant nodes we could convert this value to if so required.  I referred to the former as the "graph type" and the latter as the "inf type", and we had two mechanisms for computing each when we needed them.

This is needlessly complicated; what is the source of the complication? **That a real-valued constant node can be treated as having a smaller type sometimes, depending on its value**.

But there is another problem here too. As much as possible I wish to keep the *type semantics of BMG* separate from *decisions made by the graph accumulator at accumulation time*.  The BMG type system should be relevant when *deciding how to convert an accumulated graph into a BMG graph*, and not relevant when simply executing a model and recording what it does.

I therefore have removed creation of "typed" BMG nodes completely from the graph accumulation step.  When the model is executing and we are accumulating nodes, we always accumulate UntypedConstantNode nodes.  We regularize the value to bool, int, float or tensor, we deduplicate based on both value and type, but we do NOT attempt to assign a BMG node type to the untyped constant node.

When we assign types to each node during the problem fixing phase we associate the "inf type" -- the type associated with the *value* -- to untyped constant nodes. When we compute an edge requirement on an edge where an input is an untyped constant, we can compare the requirement to the type of the value; if the requirement can be met then we can generate a typed node containing that value.

In this system there is no difference between the "graph type" and "inf type" of any node, so for now I have assigned them to be equal. You can see this reflected in the DOT test output which shows both graph and inf types:

* Graph and inf types are now always identical
* Type of an "untyped" const node is the type of its value
* Type of a "typed" const node is the type of the node

You can also see by looking at the graph output:

* We are now "orphaning" all the untyped constant nodes. Every untyped constant node which outputs to a supported graph node is replaced with the equivalent typed node, leaving the untyped constant as the ancestor of no sample, query or observation.

In the next diff I will delete the graph_type feature and redo every test case which displays this now-redundant information.

Reviewed By: wtaha

Differential Revision: D27921722

