### PR TITLE
Completely eliminate graph type feature from compiler

### DIFF
--- a/src/beanmachine/ppl/compiler/fix_requirements.py
+++ b/src/beanmachine/ppl/compiler/fix_requirements.py
@@ -53,9 +53,9 @@ class RequirementsFixer:
     def _node_meets_requirement(self, node: bn.BMGNode, r: bt.Requirement) -> bool:
         if isinstance(r, bt.AlwaysMatrix):
             return node.is_matrix and self._type_meets_requirement(
-                self._typer.graph_type(node), r.bound
+                self._typer[node], r.bound
             )
-        return self._type_meets_requirement(self._typer.graph_type(node), r)
+        return self._type_meets_requirement(self._typer[node], r)
 
     def _meet_constant_requirement(
         self,
@@ -121,7 +121,7 @@ class RequirementsFixer:
         # We have been given a node which does not meet a requirement,
         # but it can be converted to a node which does meet the requirement
         # that has the same semantics. Start by confirming those preconditions.
-        assert self._typer.graph_type(node) != requirement
+        assert self._typer[node] != requirement
         assert bt.supremum(self._typer[node], requirement) == requirement
 
         # TODO: We no longer support Tensor as a type in BMG.  We must

--- a/src/beanmachine/ppl/compiler/gen_dot.py
+++ b/src/beanmachine/ppl/compiler/gen_dot.py
@@ -13,8 +13,7 @@ from beanmachine.ppl.utils.dotbuilder import DotBuilder
 
 def to_dot(
     bmg: BMGraphBuilder,
-    graph_types: bool = False,
-    inf_types: bool = False,
+    inf_types: bool = False,  # TODO: Rename this to node_types
     edge_requirements: bool = False,
     after_transform: bool = False,
     label_edges: bool = True,
@@ -54,10 +53,8 @@ def to_dot(
     for node, index in nodes.items():
         n = to_id(index)
         node_label = get_node_label(node)
-        if graph_types:
-            node_label += ":" + lt.graph_type(node).short_name
         if inf_types:
-            node_label += ">=" + lt[node].short_name
+            node_label += ":" + lt[node].short_name
         db.with_node(n, node_label)
         for (i, edge_name, req) in zip(
             node.inputs, get_edge_labels(node), reqs.requirements(node)

--- a/src/beanmachine/ppl/compiler/lattice_typer.py
+++ b/src/beanmachine/ppl/compiler/lattice_typer.py
@@ -277,9 +277,3 @@ class LatticeTyper(TyperBase[bt.BMGLatticeType]):
     def is_prob_or_bool(self, node: bn.BMGNode) -> bool:
         t = self[node]
         return t != bt.Untypable and bt.supremum(t, bt.Probability) == bt.Probability
-
-    # TODO: In previous versions of the typer we distinguished between the graph
-    # type and lattice type of a constant, but we no longer need this; delete this
-    # feature.
-    def graph_type(self, node: bn.BMGNode) -> bt.BMGLatticeType:
-        return self[node]

--- a/src/beanmachine/ppl/compiler/tests/bmg_types_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_types_test.py
@@ -144,23 +144,22 @@ class BMGTypesTest(unittest.TestCase):
 
         observed = to_dot(
             bmg,
-            graph_types=True,
             inf_types=True,
             edge_requirements=True,
         )
         expected = """
 digraph "graph" {
-  N00[label="0.5:P>=P"];
-  N01[label="2.0:N>=N"];
-  N02[label="Beta:P>=P"];
-  N03[label="Sample:P>=P"];
-  N04[label="*:P>=P"];
-  N05[label="1.0:OH>=OH"];
-  N06[label="Normal:R>=R"];
-  N07[label="Sample:R>=R"];
-  N08[label="Bernoulli:B>=B"];
-  N09[label="Sample:B>=B"];
-  N10[label="Query:P>=P"];
+  N00[label="0.5:P"];
+  N01[label="2.0:N"];
+  N02[label="Beta:P"];
+  N03[label="Sample:P"];
+  N04[label="*:P"];
+  N05[label="1.0:OH"];
+  N06[label="Normal:R"];
+  N07[label="Sample:R"];
+  N08[label="Bernoulli:B"];
+  N09[label="Sample:B"];
+  N10[label="Query:P"];
   N00 -> N04[label="left:P"];
   N01 -> N02[label="alpha:R+"];
   N01 -> N02[label="beta:R+"];

--- a/src/beanmachine/ppl/compiler/tests/dirichlet_test.py
+++ b/src/beanmachine/ppl/compiler/tests/dirichlet_test.py
@@ -188,19 +188,18 @@ class DirichletTest(unittest.TestCase):
         bmg.add_query(c3)
         expected = """
 digraph "graph" {
-  N0[label="1.0:R+>=R+"];
-  N1[label="Query:R+>=R+"];
-  N2[label="[1.0,1.5]:MR+[1,2]>=MR+[1,2]"];
-  N3[label="Query:MR+[1,2]>=MR+[1,2]"];
-  N4[label="[[1.0,1.5],\\\\n[2.0,2.5]]:MR+[2,2]>=MR+[2,2]"];
-  N5[label="Query:MR+[2,2]>=MR+[2,2]"];
+  N0[label="1.0:R+"];
+  N1[label="Query:R+"];
+  N2[label="[1.0,1.5]:MR+[1,2]"];
+  N3[label="Query:MR+[1,2]"];
+  N4[label="[[1.0,1.5],\\\\n[2.0,2.5]]:MR+[2,2]"];
+  N5[label="Query:MR+[2,2]"];
   N0 -> N1;
   N2 -> N3;
   N4 -> N5;
 }"""
         observed = to_dot(
             bmg,
-            graph_types=True,
             inf_types=True,
             label_edges=False,
             after_transform=True,
@@ -257,7 +256,6 @@ Node 2 type 1 parents [ ] children [ ] matrix<positive real>   1   2
         bmg = BMGRuntime().accumulate_graph(queries, {})
         observed = to_dot(
             bmg,
-            graph_types=True,
             inf_types=True,
             edge_requirements=True,
             after_transform=False,
@@ -265,38 +263,38 @@ Node 2 type 1 parents [ ] children [ ] matrix<positive real>   1   2
         )
         expected = """
 digraph "graph" {
-  N00[label="[]:T>=T"];
-  N01[label="Dirichlet:S[1,1]>=S[1,1]"];
-  N02[label="Sample:S[1,1]>=S[1,1]"];
-  N03[label="Query:S[1,1]>=S[1,1]"];
-  N04[label="[1.0]:OH>=OH"];
-  N05[label="Dirichlet:S[1,1]>=S[1,1]"];
-  N06[label="Sample:S[1,1]>=S[1,1]"];
-  N07[label="Query:S[1,1]>=S[1,1]"];
-  N08[label="[[1.5]]:R+>=R+"];
-  N09[label="Dirichlet:S[1,1]>=S[1,1]"];
-  N10[label="Sample:S[1,1]>=S[1,1]"];
-  N11[label="Query:S[1,1]>=S[1,1]"];
-  N12[label="[[[2.0]]]:N>=N"];
-  N13[label="Dirichlet:S[1,1]>=S[1,1]"];
-  N14[label="Sample:S[1,1]>=S[1,1]"];
-  N15[label="Query:S[1,1]>=S[1,1]"];
-  N16[label="[2.5,3.0]:MR+[1,2]>=MR+[1,2]"];
-  N17[label="Dirichlet:S[1,2]>=S[1,2]"];
-  N18[label="Sample:S[1,2]>=S[1,2]"];
-  N19[label="Query:S[1,2]>=S[1,2]"];
-  N20[label="[[3.5,4.0]]:MR+[1,2]>=MR+[1,2]"];
-  N21[label="Dirichlet:S[1,2]>=S[1,2]"];
-  N22[label="Sample:S[1,2]>=S[1,2]"];
-  N23[label="Query:S[1,2]>=S[1,2]"];
-  N24[label="[[[4.5,5.0]]]:T>=T"];
-  N25[label="Dirichlet:S[1,2]>=S[1,2]"];
-  N26[label="Sample:S[1,2]>=S[1,2]"];
-  N27[label="Query:S[1,2]>=S[1,2]"];
-  N28[label="[[5.5,6.0,6.5],\\\\n[7.0,7.5,8.0]]:MR+[2,3]>=MR+[2,3]"];
-  N29[label="Dirichlet:S[1,3]>=S[1,3]"];
-  N30[label="Sample:S[1,3]>=S[1,3]"];
-  N31[label="Query:S[1,3]>=S[1,3]"];
+  N00[label="[]:T"];
+  N01[label="Dirichlet:S[1,1]"];
+  N02[label="Sample:S[1,1]"];
+  N03[label="Query:S[1,1]"];
+  N04[label="[1.0]:OH"];
+  N05[label="Dirichlet:S[1,1]"];
+  N06[label="Sample:S[1,1]"];
+  N07[label="Query:S[1,1]"];
+  N08[label="[[1.5]]:R+"];
+  N09[label="Dirichlet:S[1,1]"];
+  N10[label="Sample:S[1,1]"];
+  N11[label="Query:S[1,1]"];
+  N12[label="[[[2.0]]]:N"];
+  N13[label="Dirichlet:S[1,1]"];
+  N14[label="Sample:S[1,1]"];
+  N15[label="Query:S[1,1]"];
+  N16[label="[2.5,3.0]:MR+[1,2]"];
+  N17[label="Dirichlet:S[1,2]"];
+  N18[label="Sample:S[1,2]"];
+  N19[label="Query:S[1,2]"];
+  N20[label="[[3.5,4.0]]:MR+[1,2]"];
+  N21[label="Dirichlet:S[1,2]"];
+  N22[label="Sample:S[1,2]"];
+  N23[label="Query:S[1,2]"];
+  N24[label="[[[4.5,5.0]]]:T"];
+  N25[label="Dirichlet:S[1,2]"];
+  N26[label="Sample:S[1,2]"];
+  N27[label="Query:S[1,2]"];
+  N28[label="[[5.5,6.0,6.5],\\\\n[7.0,7.5,8.0]]:MR+[2,3]"];
+  N29[label="Dirichlet:S[1,3]"];
+  N30[label="Sample:S[1,3]"];
+  N31[label="Query:S[1,3]"];
   N00 -> N01[label="R+"];
   N01 -> N02[label="S[1,1]"];
   N02 -> N03[label=any];
@@ -372,7 +370,6 @@ digraph "graph" {
         bmg = BMGRuntime().accumulate_graph(queries, observations)
         observed = to_dot(
             bmg,
-            graph_types=True,
             inf_types=True,
             edge_requirements=True,
             after_transform=True,
@@ -381,11 +378,11 @@ digraph "graph" {
 
         expected = """
 digraph "graph" {
-  N0[label="[2.5,3.0]:MR+[1,2]>=MR+[1,2]"];
-  N1[label="Dirichlet:S[1,2]>=S[1,2]"];
-  N2[label="Sample:S[1,2]>=S[1,2]"];
-  N3[label="Observation tensor([0.5000, 0.5000]):S[1,2]>=S[1,2]"];
-  N4[label="Query:S[1,2]>=S[1,2]"];
+  N0[label="[2.5,3.0]:MR+[1,2]"];
+  N1[label="Dirichlet:S[1,2]"];
+  N2[label="Sample:S[1,2]"];
+  N3[label="Observation tensor([0.5000, 0.5000]):S[1,2]"];
+  N4[label="Query:S[1,2]"];
   N0 -> N1[label="MR+[1,2]"];
   N1 -> N2[label="S[1,2]"];
   N2 -> N3[label=any];
@@ -403,7 +400,6 @@ digraph "graph" {
         bmg = BMGRuntime().accumulate_graph(queries, {})
         observed = to_dot(
             bmg,
-            graph_types=True,
             inf_types=True,
             edge_requirements=True,
             after_transform=True,
@@ -415,10 +411,10 @@ digraph "graph" {
 
         expected = """
 digraph "graph" {
-  N0[label="[1.0]:R+>=R+"];
-  N1[label="Dirichlet:S[1,1]>=S[1,1]"];
-  N2[label="Sample:S[1,1]>=S[1,1]"];
-  N3[label="Query:S[1,1]>=S[1,1]"];
+  N0[label="[1.0]:R+"];
+  N1[label="Dirichlet:S[1,1]"];
+  N2[label="Sample:S[1,1]"];
+  N3[label="Query:S[1,1]"];
   N0 -> N1[label="R+"];
   N1 -> N2[label="S[1,1]"];
   N2 -> N3[label=any];

--- a/src/beanmachine/ppl/compiler/tests/fix_problems_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_problems_test.py
@@ -38,8 +38,7 @@ class FixProblemsTest(unittest.TestCase):
 
         observed = to_dot(
             bmg,
-            graph_types=True,
-            inf_types=False,
+            inf_types=True,
             edge_requirements=True,
         )
         expected = """
@@ -73,8 +72,7 @@ digraph "graph" {
         fix_problems(bmg)
         observed = to_dot(
             bmg,
-            graph_types=True,
-            inf_types=False,
+            inf_types=True,
             edge_requirements=True,
         )
         expected = """
@@ -149,8 +147,7 @@ digraph "graph" {
 
         observed = to_dot(
             bmg,
-            graph_types=True,
-            inf_types=False,
+            inf_types=True,
             edge_requirements=True,
         )
         expected = """
@@ -181,8 +178,7 @@ digraph "graph" {
         fix_problems(bmg)
         observed = to_dot(
             bmg,
-            graph_types=True,
-            inf_types=False,
+            inf_types=True,
             edge_requirements=True,
         )
         expected = """
@@ -295,22 +291,21 @@ The sigma of a Normal is required to be a positive real but is a negative real.
 
         observed = to_dot(
             bmg,
-            graph_types=True,
             inf_types=True,
             edge_requirements=True,
         )
 
         expected = """
 digraph "graph" {
-  N0[label="0.5:P>=P"];
-  N1[label="Bernoulli:B>=B"];
-  N2[label="Sample:B>=B"];
-  N3[label="2:N>=N"];
-  N4[label="Binomial:N>=N"];
-  N5[label="Sample:N>=N"];
-  N6[label="*:R+>=R+"];
-  N7[label="Binomial:N>=N"];
-  N8[label="Sample:N>=N"];
+  N0[label="0.5:P"];
+  N1[label="Bernoulli:B"];
+  N2[label="Sample:B"];
+  N3[label="2:N"];
+  N4[label="Binomial:N"];
+  N5[label="Sample:N"];
+  N6[label="*:R+"];
+  N7[label="Binomial:N"];
+  N8[label="Sample:N"];
   N0 -> N1[label="probability:P"];
   N0 -> N4[label="probability:P"];
   N0 -> N7[label="probability:P"];
@@ -332,25 +327,24 @@ digraph "graph" {
 
         observed = to_dot(
             bmg,
-            graph_types=True,
             inf_types=True,
             edge_requirements=True,
         )
 
         expected = """
 digraph "graph" {
-  N00[label="0.5:P>=P"];
-  N01[label="Bernoulli:B>=B"];
-  N02[label="Sample:B>=B"];
-  N03[label="2:N>=N"];
-  N04[label="Binomial:N>=N"];
-  N05[label="Sample:N>=N"];
-  N06[label="*:R+>=R+"];
-  N07[label="0:N>=N"];
-  N08[label="if:N>=N"];
-  N09[label="Binomial:N>=N"];
-  N10[label="Sample:N>=N"];
-  N11[label="0.0:Z>=Z"];
+  N00[label="0.5:P"];
+  N01[label="Bernoulli:B"];
+  N02[label="Sample:B"];
+  N03[label="2:N"];
+  N04[label="Binomial:N"];
+  N05[label="Sample:N"];
+  N06[label="*:R+"];
+  N07[label="0:N"];
+  N08[label="if:N"];
+  N09[label="Binomial:N"];
+  N10[label="Sample:N"];
+  N11[label="0.0:Z"];
   N00 -> N01[label="probability:P"];
   N00 -> N04[label="probability:P"];
   N00 -> N09[label="probability:P"];
@@ -399,28 +393,27 @@ digraph "graph" {
 
         observed = to_dot(
             bmg,
-            graph_types=True,
             inf_types=True,
             edge_requirements=True,
         )
 
         expected = """
 digraph "graph" {
-  N00[label="1.0:OH>=OH"];
-  N01[label="1.0:R+>=R+"];
-  N02[label="HalfCauchy:R+>=R+"];
-  N03[label="Sample:R+>=R+"];
-  N04[label="Sample:R+>=R+"];
-  N05[label="/:U>=U"];
-  N06[label="Sample:R+>=R+"];
-  N07[label="-1.0:R>=R"];
-  N08[label="**:R+>=R+"];
-  N09[label="*:R+>=R+"];
-  N10[label="**:R+>=R+"];
-  N11[label="Log:R>=R"];
-  N12[label="Normal:R>=R"];
-  N13[label="Sample:R>=R"];
-  N14[label="-1.0:R->=R-"];
+  N00[label="1.0:OH"];
+  N01[label="1.0:R+"];
+  N02[label="HalfCauchy:R+"];
+  N03[label="Sample:R+"];
+  N04[label="Sample:R+"];
+  N05[label="/:U"];
+  N06[label="Sample:R+"];
+  N07[label="-1.0:R"];
+  N08[label="**:R+"];
+  N09[label="*:R+"];
+  N10[label="**:R+"];
+  N11[label="Log:R"];
+  N12[label="Normal:R"];
+  N13[label="Sample:R"];
+  N14[label="-1.0:R-"];
   N01 -> N02[label="scale:R+"];
   N01 -> N12[label="sigma:R+"];
   N02 -> N03[label="operand:R+"];
@@ -463,20 +456,19 @@ digraph "graph" {
 
         observed = to_dot(
             bmg,
-            graph_types=True,
             inf_types=True,
             edge_requirements=True,
         )
 
         expected = """
 digraph "graph" {
-  N0[label="1.0:OH>=OH"];
-  N1[label="HalfCauchy:R+>=R+"];
-  N2[label="Sample:R+>=R+"];
-  N3[label="2.5:R+>=R+"];
-  N4[label="/:U>=U"];
-  N5[label="Normal:U>=U"];
-  N6[label="Sample:U>=U"];
+  N0[label="1.0:OH"];
+  N1[label="HalfCauchy:R+"];
+  N2[label="Sample:R+"];
+  N3[label="2.5:R+"];
+  N4[label="/:U"];
+  N5[label="Normal:U"];
+  N6[label="Sample:U"];
   N0 -> N1[label="scale:R+"];
   N0 -> N5[label="sigma:any"];
   N1 -> N2[label="operand:R+"];
@@ -495,24 +487,23 @@ digraph "graph" {
 
         observed = to_dot(
             bmg,
-            graph_types=True,
             inf_types=True,
             edge_requirements=True,
         )
         expected = """
 digraph "graph" {
-  N00[label="1.0:OH>=OH"];
-  N01[label="1.0:R+>=R+"];
-  N02[label="HalfCauchy:R+>=R+"];
-  N03[label="Sample:R+>=R+"];
-  N04[label="2.5:R+>=R+"];
-  N05[label="/:U>=U"];
-  N06[label="0.4:R+>=R+"];
-  N07[label="*:R+>=R+"];
-  N08[label="ToReal:R>=R"];
-  N09[label="Normal:R>=R"];
-  N10[label="Sample:R>=R"];
-  N11[label="0.4:P>=P"];
+  N00[label="1.0:OH"];
+  N01[label="1.0:R+"];
+  N02[label="HalfCauchy:R+"];
+  N03[label="Sample:R+"];
+  N04[label="2.5:R+"];
+  N05[label="/:U"];
+  N06[label="0.4:R+"];
+  N07[label="*:R+"];
+  N08[label="ToReal:R"];
+  N09[label="Normal:R"];
+  N10[label="Sample:R"];
+  N11[label="0.4:P"];
   N01 -> N02[label="scale:R+"];
   N01 -> N09[label="sigma:R+"];
   N02 -> N03[label="operand:R+"];
@@ -586,18 +577,17 @@ The unsupported node is the operand of a Sample.
 
         observed = to_dot(
             bmg,
-            graph_types=True,
             inf_types=True,
             edge_requirements=True,
         )
 
         expected = """
 digraph "graph" {
-  N0[label="1.0:OH>=OH"];
-  N1[label="HalfCauchy:R+>=R+"];
-  N2[label="Sample:R+>=R+"];
-  N3[label="Chi2:U>=U"];
-  N4[label="Sample:U>=U"];
+  N0[label="1.0:OH"];
+  N1[label="HalfCauchy:R+"];
+  N2[label="Sample:R+"];
+  N3[label="Chi2:U"];
+  N4[label="Sample:U"];
   N0 -> N1[label="scale:R+"];
   N1 -> N2[label="operand:R+"];
   N2 -> N3[label="df:any"];
@@ -613,22 +603,21 @@ digraph "graph" {
 
         observed = to_dot(
             bmg,
-            graph_types=True,
             inf_types=True,
             edge_requirements=True,
         )
 
         expected = """
 digraph "graph" {
-  N0[label="1.0:OH>=OH"];
-  N1[label="1.0:R+>=R+"];
-  N2[label="HalfCauchy:R+>=R+"];
-  N3[label="Sample:R+>=R+"];
-  N4[label="Chi2:U>=U"];
-  N5[label="0.5:R+>=R+"];
-  N6[label="*:R+>=R+"];
-  N7[label="Gamma:R+>=R+"];
-  N8[label="Sample:R+>=R+"];
+  N0[label="1.0:OH"];
+  N1[label="1.0:R+"];
+  N2[label="HalfCauchy:R+"];
+  N3[label="Sample:R+"];
+  N4[label="Chi2:U"];
+  N5[label="0.5:R+"];
+  N6[label="*:R+"];
+  N7[label="Gamma:R+"];
+  N8[label="Sample:R+"];
   N1 -> N2[label="scale:R+"];
   N2 -> N3[label="operand:R+"];
   N3 -> N4[label="df:any"];
@@ -671,22 +660,21 @@ digraph "graph" {
 
         observed = to_dot(
             bmg,
-            graph_types=True,
             inf_types=True,
             edge_requirements=True,
         )
 
         expected = """
 digraph "graph" {
-  N0[label="2:N>=N"];
-  N1[label="0.5:P>=P"];
-  N2[label="Binomial:N>=N"];
-  N3[label="Sample:N>=N"];
-  N4[label="Bernoulli:B>=B"];
-  N5[label="Sample:B>=B"];
-  N6[label="**:R+>=R+"];
-  N7[label="Binomial:N>=N"];
-  N8[label="Sample:N>=N"];
+  N0[label="2:N"];
+  N1[label="0.5:P"];
+  N2[label="Binomial:N"];
+  N3[label="Sample:N"];
+  N4[label="Bernoulli:B"];
+  N5[label="Sample:B"];
+  N6[label="**:R+"];
+  N7[label="Binomial:N"];
+  N8[label="Sample:N"];
   N0 -> N2[label="count:N"];
   N1 -> N2[label="probability:P"];
   N1 -> N4[label="probability:P"];
@@ -708,25 +696,24 @@ digraph "graph" {
 
         observed = to_dot(
             bmg,
-            graph_types=True,
             inf_types=True,
             edge_requirements=True,
         )
 
         expected = """
 digraph "graph" {
-  N00[label="2:N>=N"];
-  N01[label="0.5:P>=P"];
-  N02[label="Binomial:N>=N"];
-  N03[label="Sample:N>=N"];
-  N04[label="Bernoulli:B>=B"];
-  N05[label="Sample:B>=B"];
-  N06[label="**:R+>=R+"];
-  N07[label="1:N>=N"];
-  N08[label="if:N>=N"];
-  N09[label="Binomial:N>=N"];
-  N10[label="Sample:N>=N"];
-  N11[label="1.0:OH>=OH"];
+  N00[label="2:N"];
+  N01[label="0.5:P"];
+  N02[label="Binomial:N"];
+  N03[label="Sample:N"];
+  N04[label="Bernoulli:B"];
+  N05[label="Sample:B"];
+  N06[label="**:R+"];
+  N07[label="1:N"];
+  N08[label="if:N"];
+  N09[label="Binomial:N"];
+  N10[label="Sample:N"];
+  N11[label="1.0:OH"];
   N00 -> N02[label="count:N"];
   N01 -> N02[label="probability:P"];
   N01 -> N04[label="probability:P"];
@@ -774,21 +761,20 @@ digraph "graph" {
 
         observed = to_dot(
             bmg,
-            graph_types=True,
             inf_types=True,
             edge_requirements=True,
         )
 
         expected = """
 digraph "graph" {
-  N0[label="1.0:OH>=OH"];
-  N1[label="2.0:N>=N"];
-  N2[label="Beta:P>=P"];
-  N3[label="Sample:P>=P"];
-  N4[label="-:R->=R-"];
-  N5[label="+:R>=R"];
-  N6[label="Bernoulli:B>=B"];
-  N7[label="Sample:B>=B"];
+  N0[label="1.0:OH"];
+  N1[label="2.0:N"];
+  N2[label="Beta:P"];
+  N3[label="Sample:P"];
+  N4[label="-:R-"];
+  N5[label="+:R"];
+  N6[label="Bernoulli:B"];
+  N7[label="Sample:B"];
   N0 -> N5[label="left:R"];
   N1 -> N2[label="alpha:R+"];
   N1 -> N2[label="beta:R+"];
@@ -808,23 +794,22 @@ digraph "graph" {
 
         observed = to_dot(
             bmg,
-            graph_types=True,
             inf_types=True,
             edge_requirements=True,
         )
 
         expected = """
 digraph "graph" {
-  N0[label="2.0:N>=N"];
-  N1[label="1.0:OH>=OH"];
-  N2[label="2.0:R+>=R+"];
-  N3[label="Beta:P>=P"];
-  N4[label="Sample:P>=P"];
-  N5[label="-:R->=R-"];
-  N6[label="+:R>=R"];
-  N7[label="complement:P>=P"];
-  N8[label="Bernoulli:B>=B"];
-  N9[label="Sample:B>=B"];
+  N0[label="2.0:N"];
+  N1[label="1.0:OH"];
+  N2[label="2.0:R+"];
+  N3[label="Beta:P"];
+  N4[label="Sample:P"];
+  N5[label="-:R-"];
+  N6[label="+:R"];
+  N7[label="complement:P"];
+  N8[label="Bernoulli:B"];
+  N9[label="Sample:B"];
   N1 -> N6[label="left:R"];
   N2 -> N3[label="alpha:R+"];
   N2 -> N3[label="beta:R+"];
@@ -864,20 +849,19 @@ digraph "graph" {
 
         observed = to_dot(
             bmg,
-            graph_types=True,
             inf_types=True,
             edge_requirements=True,
         )
 
         expected = """
 digraph "graph" {
-  N0[label="2.0:N>=N"];
-  N1[label="Beta:P>=P"];
-  N2[label="Sample:P>=P"];
-  N3[label="Log:R->=R-"];
-  N4[label="-:R+>=R+"];
-  N5[label="Beta:P>=P"];
-  N6[label="Sample:P>=P"];
+  N0[label="2.0:N"];
+  N1[label="Beta:P"];
+  N2[label="Sample:P"];
+  N3[label="Log:R-"];
+  N4[label="-:R+"];
+  N5[label="Beta:P"];
+  N6[label="Sample:P"];
   N0 -> N1[label="alpha:R+"];
   N0 -> N1[label="beta:R+"];
   N0 -> N5[label="beta:R+"];
@@ -895,21 +879,20 @@ digraph "graph" {
 
         observed = to_dot(
             bmg,
-            graph_types=True,
             inf_types=True,
             edge_requirements=True,
         )
 
         expected = """
 digraph "graph" {
-  N0[label="2.0:N>=N"];
-  N1[label="2.0:R+>=R+"];
-  N2[label="Beta:P>=P"];
-  N3[label="Sample:P>=P"];
-  N4[label="Log:R->=R-"];
-  N5[label="-:R+>=R+"];
-  N6[label="Beta:P>=P"];
-  N7[label="Sample:P>=P"];
+  N0[label="2.0:N"];
+  N1[label="2.0:R+"];
+  N2[label="Beta:P"];
+  N3[label="Sample:P"];
+  N4[label="Log:R-"];
+  N5[label="-:R+"];
+  N6[label="Beta:P"];
+  N7[label="Sample:P"];
   N1 -> N2[label="alpha:R+"];
   N1 -> N2[label="beta:R+"];
   N1 -> N6[label="beta:R+"];
@@ -993,7 +976,6 @@ A Binomial distribution is observed to have value 5.25 but only produces samples
         self.assertEqual(str(error_report).strip(), "")
         observed = to_dot(
             bmg,
-            graph_types=True,
             inf_types=True,
             edge_requirements=True,
         )
@@ -1001,23 +983,23 @@ A Binomial distribution is observed to have value 5.25 but only produces samples
         # The observations have been converted to the correct types:
         expected = """
 digraph "graph" {
-  N00[label="0.0:Z>=Z"];
-  N01[label="1.0:OH>=OH"];
-  N02[label="2.0:N>=N"];
-  N03[label="0.5:P>=P"];
-  N04[label="0.5:P>=P"];
-  N05[label="Bernoulli:B>=B"];
-  N06[label="Sample:B>=B"];
-  N07[label="Observation False:B>=B"];
-  N08[label="2:N>=N"];
-  N09[label="Binomial:N>=N"];
-  N10[label="Sample:N>=N"];
-  N11[label="Observation 5:N>=N"];
-  N12[label="0.0:R>=R"];
-  N13[label="1.0:R+>=R+"];
-  N14[label="Normal:R>=R"];
-  N15[label="Sample:R>=R"];
-  N16[label="Observation 1.0:R>=R"];
+  N00[label="0.0:Z"];
+  N01[label="1.0:OH"];
+  N02[label="2.0:N"];
+  N03[label="0.5:P"];
+  N04[label="0.5:P"];
+  N05[label="Bernoulli:B"];
+  N06[label="Sample:B"];
+  N07[label="Observation False:B"];
+  N08[label="2:N"];
+  N09[label="Binomial:N"];
+  N10[label="Sample:N"];
+  N11[label="Observation 5:N"];
+  N12[label="0.0:R"];
+  N13[label="1.0:R+"];
+  N14[label="Normal:R"];
+  N15[label="Sample:R"];
+  N16[label="Observation 1.0:R"];
   N04 -> N05[label="probability:P"];
   N04 -> N09[label="probability:P"];
   N05 -> N06[label="operand:B"];
@@ -1055,8 +1037,7 @@ digraph "graph" {
         self.assertEqual(str(error_report).strip(), "")
         observed = to_dot(
             bmg,
-            graph_types=True,
-            inf_types=False,
+            inf_types=True,
             edge_requirements=True,
         )
 

--- a/src/beanmachine/ppl/inference/bmg_inference.py
+++ b/src/beanmachine/ppl/inference/bmg_inference.py
@@ -210,13 +210,11 @@ class BMGInference:
     ) -> str:
         """Produce a string containing a program in the GraphViz DOT language
         representing the graph deduced from the model."""
-        graph_types = False
         inf_types = False
         edge_requirements = False
         bmg = self._accumulate_graph(queries, observations)._bmg
         return to_dot(
             bmg,
-            graph_types,
             inf_types,
             edge_requirements,
             after_transform,


### PR DESCRIPTION
Summary: This finishes off the work of reforming the overall typing system of the compiler. As noted in the previous diff, we used to keep track of "graph type" and "inf type" separately due to an oddity in the way we constructed constant nodes. Now that this oddity has been eliminated, we can unify these two related ideas and eliminate one of them.

Reviewed By: wtaha

Differential Revision: D27926797

