### PR TITLE
Add support for TO_MATRIX operation in compiler

### DIFF
--- a/src/beanmachine/graph/pybindings.cpp
+++ b/src/beanmachine/graph/pybindings.cpp
@@ -59,7 +59,8 @@ PYBIND11_MODULE(graph, module) {
       .value("MATRIX_MULTIPLY", OperatorType::MATRIX_MULTIPLY)
       .value("TO_PROBABILITY", OperatorType::TO_PROBABILITY)
       .value("INDEX", OperatorType::INDEX)
-      .value("BROADCAST_ADD", OperatorType::BROADCAST_ADD);
+      .value("BROADCAST_ADD", OperatorType::BROADCAST_ADD)
+      .value("TO_MATRIX", OperatorType::TO_MATRIX);
 
   py::enum_<DistributionType>(module, "DistributionType")
       .value("TABULAR", DistributionType::TABULAR)

--- a/src/beanmachine/graph/to_dot.cpp
+++ b/src/beanmachine/graph/to_dot.cpp
@@ -159,6 +159,8 @@ class DOT {
         return "ToProb";
       case OperatorType::INDEX:
         return "Index";
+      case OperatorType::TO_MATRIX:
+        return "ToMatrix";
       default:
         return "Operator";
     }

--- a/src/beanmachine/ppl/compiler/bm_graph_builder.py
+++ b/src/beanmachine/ppl/compiler/bm_graph_builder.py
@@ -700,6 +700,14 @@ class BMGraphBuilder:
         return node
 
     @memoize
+    def add_to_matrix(
+        self, rows: bn.NaturalNode, columns: bn.NaturalNode, *data: BMGNode
+    ) -> bn.ToMatrixNode:
+        node = bn.ToMatrixNode(rows, columns, list(data))
+        self.add_node(node)
+        return node
+
+    @memoize
     def add_logsumexp(self, *inputs: BMGNode) -> bn.LogSumExpNode:
         node = bn.LogSumExpNode(list(inputs))
         self.add_node(node)

--- a/src/beanmachine/ppl/compiler/bmg_node_types.py
+++ b/src/beanmachine/ppl/compiler/bmg_node_types.py
@@ -71,6 +71,7 @@ _operator_types = {
     bn.PhiNode: OperatorType.PHI,
     bn.PowerNode: OperatorType.POW,
     bn.SampleNode: OperatorType.SAMPLE,
+    bn.ToMatrixNode: OperatorType.TO_MATRIX,
     bn.ToRealNode: OperatorType.TO_REAL,
     bn.ToPositiveRealNode: OperatorType.TO_POS_REAL,
     bn.ToProbabilityNode: OperatorType.TO_PROBABILITY,

--- a/src/beanmachine/ppl/compiler/bmg_nodes.py
+++ b/src/beanmachine/ppl/compiler/bmg_nodes.py
@@ -982,6 +982,35 @@ class LogSumExpNode(OperatorNode):
         raise ValueError("support of LogSumExp not yet implemented")
 
 
+class ToMatrixNode(OperatorNode):
+    """A 2-d tensor whose elements are graph nodes."""
+
+    def __init__(self, rows: NaturalNode, columns: NaturalNode, items: List[BMGNode]):
+        # The first two elements are the row and column counts; they must
+        # be constant naturals.
+        assert isinstance(items, list)
+        assert len(items) >= 1
+        rc: List[BMGNode] = [rows, columns]
+        BMGNode.__init__(self, rc + items)
+
+    def __str__(self) -> str:
+        return "ToMatrix"
+
+    @property
+    def size(self) -> torch.Size:
+        rows = self.inputs[0]
+        assert isinstance(rows, NaturalNode)
+        columns = self.inputs[1]
+        assert isinstance(columns, NaturalNode)
+        return torch.Size([rows.value, columns.value])
+
+    def support(self) -> Iterable[Any]:
+        raise NotImplementedError()
+
+    def support_size(self) -> float:
+        raise NotImplementedError()
+
+
 # ####
 # #### Ternary operators
 # ####

--- a/src/beanmachine/ppl/compiler/bmg_requirements.py
+++ b/src/beanmachine/ppl/compiler/bmg_requirements.py
@@ -83,6 +83,7 @@ class EdgeRequirements:
             bn.NegateNode: self._requirements_exp_neg,
             bn.PowerNode: self._requirements_power,
             bn.SampleNode: self._same_as_output,
+            bn.ToMatrixNode: self._requirements_to_matrix,
         }
 
     def _requirements_expproduct(
@@ -289,6 +290,14 @@ class EdgeRequirements:
         if req_exp not in {bt.PositiveReal, bt.Real}:
             req_exp = bt.Real
         return [req_base, req_exp]
+
+    def _requirements_to_matrix(self, node: bn.ToMatrixNode) -> List[bt.Requirement]:
+        node_type = self.typer[node]
+        assert isinstance(node_type, bt.BMGMatrixType)
+        item_type = node_type.with_dimensions(1, 1)
+        rc: List[bt.Requirement] = [bt.Natural, bt.Natural]
+        its: List[bt.Requirement] = [item_type]
+        return rc + its * (len(node.inputs) - 2)
 
     def requirements(self, node: bn.BMGNode) -> List[bt.Requirement]:
         input_count = len(node.inputs)

--- a/src/beanmachine/ppl/compiler/graph_labels.py
+++ b/src/beanmachine/ppl/compiler/graph_labels.py
@@ -84,6 +84,7 @@ _node_labels = {
     bn.SampleNode: "Sample",
     bn.StudentTNode: "StudentT",
     bn.TensorNode: "Tensor",
+    bn.ToMatrixNode: "ToMatrix",
     bn.ToPositiveRealNode: "ToPosReal",
     bn.ToProbabilityNode: "ToProb",
     bn.ToRealNode: "ToReal",
@@ -97,8 +98,16 @@ _operand = ["operand"]
 _probability = ["probability"]
 
 
+def _numbers(n: int) -> List[str]:
+    return [str(x) for x in range(n)]
+
+
 def _numbered(node: bn.BMGNode) -> List[str]:
-    return [str(x) for x in range(len(node.inputs))]
+    return _numbers(len(node.inputs))
+
+
+def _to_matrix(node: bn.BMGNode) -> List[str]:
+    return ["rows", "columns"] + _numbers(len(node.inputs) - 2)
 
 
 _edge_labels = {
@@ -159,6 +168,7 @@ _edge_labels = {
     bn.SampleNode: _operand,
     bn.StudentTNode: ["df", "loc", "scale"],
     bn.TensorNode: _numbered,
+    bn.ToMatrixNode: _to_matrix,
     bn.ToPositiveRealNode: _operand,
     bn.ToProbabilityNode: _operand,
     bn.ToRealNode: _operand,

--- a/src/beanmachine/ppl/compiler/tests/to_matrix_test.py
+++ b/src/beanmachine/ppl/compiler/tests/to_matrix_test.py
@@ -1,0 +1,132 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import unittest
+
+from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
+from beanmachine.ppl.compiler.gen_bmg_cpp import to_bmg_cpp
+from beanmachine.ppl.compiler.gen_bmg_graph import to_bmg_graph
+from beanmachine.ppl.compiler.gen_bmg_python import to_bmg_python
+from beanmachine.ppl.compiler.gen_dot import to_dot
+
+
+class ToMatrixTest(unittest.TestCase):
+    def test_to_matrix_1(self) -> None:
+
+        self.maxDiff = None
+        bmg = BMGraphBuilder()
+        t = bmg.add_natural(2)
+        o = bmg.add_natural(1)
+        z = bmg.add_natural(0)
+        n = bmg.add_normal(z, o)
+        ns = bmg.add_sample(n)
+        e = bmg.add_exp(ns)
+        m = bmg.add_to_matrix(o, t, e, ns)
+        bmg.add_query(m)
+
+        observed = to_dot(
+            bmg,
+            inf_types=True,
+            edge_requirements=True,
+            after_transform=True,
+            label_edges=True,
+        )
+        expected = """
+digraph "graph" {
+  N0[label="0.0:R"];
+  N1[label="1.0:R+"];
+  N2[label="Normal:R"];
+  N3[label="Sample:R"];
+  N4[label="1:N"];
+  N5[label="2:N"];
+  N6[label="Exp:R+"];
+  N7[label="ToReal:R"];
+  N8[label="ToMatrix:MR[1,2]"];
+  N9[label="Query:MR[1,2]"];
+  N0 -> N2[label="mu:R"];
+  N1 -> N2[label="sigma:R+"];
+  N2 -> N3[label="operand:R"];
+  N3 -> N6[label="operand:R"];
+  N3 -> N8[label="1:R"];
+  N4 -> N8[label="rows:N"];
+  N5 -> N8[label="columns:N"];
+  N6 -> N7[label="operand:<=R"];
+  N7 -> N8[label="0:R"];
+  N8 -> N9[label="operator:any"];
+}
+"""
+        self.assertEqual(expected.strip(), observed.strip())
+
+        observed = to_bmg_cpp(bmg).code
+        expected = """
+graph::Graph g;
+uint n0 = g.add_constant(0.0);
+uint n1 = g.add_constant_pos_real(1.0);
+uint n2 = g.add_distribution(
+  graph::DistributionType::NORMAL,
+  graph::AtomicType::REAL,
+  std::vector<uint>({n0, n1}));
+uint n3 = g.add_operator(
+  graph::OperatorType::SAMPLE, std::vector<uint>({n2}));
+uint n4 = g.add_constant(1);
+uint n5 = g.add_constant(2);
+uint n6 = g.add_operator(
+  graph::OperatorType::EXP, std::vector<uint>({n3}));
+uint n7 = g.add_operator(
+  graph::OperatorType::TO_REAL, std::vector<uint>({n6}));
+uint n8 = g.add_operator(
+  graph::OperatorType::TO_MATRIX,
+  std::vector<uint>({n4, n5, n7, n3}));
+uint q0 = g.query(n8);
+        """
+        self.assertEqual(expected.strip(), observed.strip())
+
+        observed = to_bmg_python(bmg).code
+        expected = """
+from beanmachine import graph
+from torch import tensor
+g = graph.Graph()
+n0 = g.add_constant(0.0)
+n1 = g.add_constant_pos_real(1.0)
+n2 = g.add_distribution(
+  graph.DistributionType.NORMAL,
+  graph.AtomicType.REAL,
+  [n0, n1],
+)
+n3 = g.add_operator(graph.OperatorType.SAMPLE, [n2])
+n4 = g.add_constant(1)
+n5 = g.add_constant(2)
+n6 = g.add_operator(graph.OperatorType.EXP, [n3])
+n7 = g.add_operator(graph.OperatorType.TO_REAL, [n6])
+n8 = g.add_operator(
+  graph.OperatorType.TO_MATRIX,
+  [n4, n5, n7, n3],
+)
+q0 = g.query(n8)
+        """
+        self.assertEqual(expected.strip(), observed.strip())
+
+        observed = to_bmg_graph(bmg).graph.to_dot()
+        expected = """
+digraph "graph" {
+  N0[label="0"];
+  N1[label="1"];
+  N2[label="Normal"];
+  N3[label="~"];
+  N4[label="1"];
+  N5[label="2"];
+  N6[label="exp"];
+  N7[label="ToReal"];
+  N8[label="ToMatrix"];
+  N0 -> N2;
+  N1 -> N2;
+  N2 -> N3;
+  N3 -> N6;
+  N3 -> N8;
+  N4 -> N8;
+  N5 -> N8;
+  N6 -> N7;
+  N7 -> N8;
+  Q0[label="Query"];
+  N8 -> Q0;
+}
+        """
+        self.assertEqual(expected.strip(), observed.strip())


### PR DESCRIPTION
Summary:
Lily recently added a TO_MATRIX operator in BMG which takes some number of graph nodes and forms a matrix from them. We will need to generate this operator in the compiler so I've added support for it.

So far all we have demonstrated is that we can add such a node to the graph builder and then:

* Label the node and edges correctly on a DOT output
* Compute the type of the node and the requirements on its input edges
* Generate correct C++ and Python code to make the corresponding BMG graph
* Generate the corresponding BMG graph object without error, and convert it to DOT as well.

We already accumulate TensorNode objects which appear to be exactly the same thing, but they are not quite. For example, since BMG is column major but pytorch is row-major, we will need to take the transpose when we generate the TO_MATRIX node from a tensor node.

I have not yet added support for Lily's indexing operation on multidimensional tensor, nor for the tensorized version of logsumexp; all that will come in future diffs.

Reviewed By: wtaha

Differential Revision: D27829449

