### PR TITLE
Start adding support for COLUMN_INDEX in compiler

### DIFF
--- a/src/beanmachine/graph/operator/linalgop.cpp
+++ b/src/beanmachine/graph/operator/linalgop.cpp
@@ -126,8 +126,8 @@ ColumnIndex::ColumnIndex(const std::vector<graph::Node*>& in_nodes)
     throw std::invalid_argument(
         "the second parent of COLUMN_INDEX must be NATURAL number");
   }
-  value = graph::NodeValue(graph::ValueType(
-      graph::VariableType::BROADCAST_MATRIX, type0.atomic_type, type0.rows, 1));
+  value = graph::NodeValue(
+      graph::ValueType(type0.variable_type, type0.atomic_type, type0.rows, 1));
 }
 
 void ColumnIndex::eval(std::mt19937& /* gen */) {

--- a/src/beanmachine/graph/pybindings.cpp
+++ b/src/beanmachine/graph/pybindings.cpp
@@ -61,7 +61,8 @@ PYBIND11_MODULE(graph, module) {
       .value("INDEX", OperatorType::INDEX)
       .value("BROADCAST_ADD", OperatorType::BROADCAST_ADD)
       .value("TO_MATRIX", OperatorType::TO_MATRIX)
-      .value("LOGSUMEXP_VECTOR", OperatorType::LOGSUMEXP_VECTOR);
+      .value("LOGSUMEXP_VECTOR", OperatorType::LOGSUMEXP_VECTOR)
+      .value("COLUMN_INDEX", OperatorType::COLUMN_INDEX);
 
   py::enum_<DistributionType>(module, "DistributionType")
       .value("TABULAR", DistributionType::TABULAR)

--- a/src/beanmachine/graph/to_dot.cpp
+++ b/src/beanmachine/graph/to_dot.cpp
@@ -163,6 +163,8 @@ class DOT {
         return "Index";
       case OperatorType::TO_MATRIX:
         return "ToMatrix";
+      case OperatorType::COLUMN_INDEX:
+        return "ColumnIndex";
       default:
         return "Operator";
     }

--- a/src/beanmachine/ppl/compiler/bm_graph_builder.py
+++ b/src/beanmachine/ppl/compiler/bm_graph_builder.py
@@ -576,6 +576,15 @@ class BMGraphBuilder:
         return node
 
     @memoize
+    def add_column_index(self, left: bn.BMGNode, right: bn.BMGNode) -> bn.BMGNode:
+        # TODO: Better error handling when this is illegal.
+        if isinstance(left, bn.ConstantNode) and isinstance(right, bn.ConstantNode):
+            return self.add_constant(left.value[right.value])
+        node = bn.ColumnIndexNode(left, right)
+        self.add_node(node)
+        return node
+
+    @memoize
     def add_negate(self, operand: BMGNode) -> BMGNode:
         # TODO: We could optimize -(-x) to x here.
         if isinstance(operand, ConstantNode):

--- a/src/beanmachine/ppl/compiler/bmg_node_types.py
+++ b/src/beanmachine/ppl/compiler/bmg_node_types.py
@@ -56,6 +56,7 @@ def dist_type(node: bn.DistributionNode) -> Tuple[dt, Any]:
 
 _operator_types = {
     bn.AdditionNode: OperatorType.ADD,
+    bn.ColumnIndexNode: OperatorType.COLUMN_INDEX,
     bn.ComplementNode: OperatorType.COMPLEMENT,
     bn.ExpM1Node: OperatorType.EXPM1,
     bn.ExpNode: OperatorType.EXP,

--- a/src/beanmachine/ppl/compiler/bmg_nodes.py
+++ b/src/beanmachine/ppl/compiler/bmg_nodes.py
@@ -1376,6 +1376,21 @@ class IndexNode(BinaryOperatorNode):
         raise NotImplementedError("support of index operator not implemented")
 
 
+class ColumnIndexNode(BinaryOperatorNode):
+    def __init__(self, left: BMGNode, right: BMGNode):
+        BinaryOperatorNode.__init__(self, left, right)
+
+    @property
+    def size(self) -> torch.Size:
+        raise NotImplementedError("size of column index operator not implemented")
+
+    def __str__(self) -> str:
+        return "ColumnIndex"
+
+    def support(self) -> Iterable[Any]:
+        raise NotImplementedError("support of column index operator not implemented")
+
+
 class MatrixMultiplicationNode(BinaryOperatorNode):
     """This represents a matrix multiplication."""
 

--- a/src/beanmachine/ppl/compiler/graph_labels.py
+++ b/src/beanmachine/ppl/compiler/graph_labels.py
@@ -36,6 +36,7 @@ _node_labels = {
     if n.is_logits
     else "Categorical",
     bn.Chi2Node: "Chi2",
+    bn.ColumnIndexNode: "ColumnIndex",
     bn.ComplementNode: "complement",
     bn.ConstantBooleanMatrixNode: _tensor_val,
     bn.ConstantNaturalMatrixNode: _tensor_val,
@@ -121,6 +122,7 @@ _edge_labels = {
     bn.BooleanNode: _none,
     bn.CategoricalNode: _probability,
     bn.Chi2Node: ["df"],
+    bn.ColumnIndexNode: _left_right,
     bn.ComplementNode: _operand,
     bn.ConstantBooleanMatrixNode: _none,
     bn.ConstantNaturalMatrixNode: _none,

--- a/src/beanmachine/ppl/compiler/lattice_typer.py
+++ b/src/beanmachine/ppl/compiler/lattice_typer.py
@@ -125,6 +125,7 @@ class LatticeTyper(TyperBase[bt.BMGLatticeType]):
             bn.DirichletNode: self._type_dirichlet,
             # Operators
             bn.AdditionNode: self._type_addition,
+            bn.ColumnIndexNode: self._type_column_index,
             bn.ComplementNode: self._type_complement,
             bn.ExpM1Node: self._type_expm1,
             bn.ExpNode: self._type_exp,
@@ -155,6 +156,16 @@ class LatticeTyper(TyperBase[bt.BMGLatticeType]):
         if bt.supremum(op_type, bt.PositiveReal) == bt.PositiveReal:
             return bt.PositiveReal
         return bt.Real
+
+    def _type_column_index(self, node: bn.ColumnIndexNode) -> bt.BMGLatticeType:
+        # A stochastic index into a one-hot or all-zero constant matrix
+        # is treated as a column of bools.
+        lt = self[node.left]
+        assert isinstance(lt, bt.BMGMatrixType)
+        result = lt
+        if isinstance(lt, bt.ZeroMatrix) or isinstance(lt, bt.OneHotMatrix):
+            result = bt.Boolean
+        return result.with_dimensions(lt.rows, 1)
 
     def _type_complement(self, node: bn.ComplementNode) -> bt.BMGLatticeType:
         if bt.supremum(self[node.operand], bt.Boolean) == bt.Boolean:

--- a/src/beanmachine/ppl/compiler/tests/column_index_test.py
+++ b/src/beanmachine/ppl/compiler/tests/column_index_test.py
@@ -1,0 +1,200 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import unittest
+
+from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
+from beanmachine.ppl.compiler.gen_bmg_cpp import to_bmg_cpp
+from beanmachine.ppl.compiler.gen_bmg_graph import to_bmg_graph
+from beanmachine.ppl.compiler.gen_bmg_python import to_bmg_python
+from beanmachine.ppl.compiler.gen_dot import to_dot
+
+
+class ColumnIndexTest(unittest.TestCase):
+    def test_column_index_1(self) -> None:
+
+        self.maxDiff = None
+        bmg = BMGraphBuilder()
+        t = bmg.add_natural(2)
+        o = bmg.add_natural(1)
+        z = bmg.add_natural(0)
+        n = bmg.add_normal(z, o)
+        ns = bmg.add_sample(n)
+        e = bmg.add_exp(ns)
+        h = bmg.add_probability(0.5)
+        b = bmg.add_bernoulli(h)
+        bs = bmg.add_sample(b)
+        m = bmg.add_to_matrix(t, t, e, ns, ns, ns)
+        ci = bmg.add_column_index(m, bs)
+        lsev = bmg.add_logsumexp_vector(ci)
+        bmg.add_query(lsev)
+
+        observed = to_dot(
+            bmg,
+            inf_types=True,
+            edge_requirements=True,
+            after_transform=True,
+            label_edges=True,
+        )
+        expected = """
+digraph "graph" {
+  N00[label="0.0:R"];
+  N01[label="1.0:R+"];
+  N02[label="Normal:R"];
+  N03[label="Sample:R"];
+  N04[label="0.5:P"];
+  N05[label="Bernoulli:B"];
+  N06[label="Sample:B"];
+  N07[label="2:N"];
+  N08[label="Exp:R+"];
+  N09[label="ToReal:R"];
+  N10[label="ToMatrix:MR[2,2]"];
+  N11[label="1:N"];
+  N12[label="0:N"];
+  N13[label="if:N"];
+  N14[label="ColumnIndex:MR[2,1]"];
+  N15[label="LogSumExp:R"];
+  N16[label="Query:R"];
+  N00 -> N02[label="mu:R"];
+  N01 -> N02[label="sigma:R+"];
+  N02 -> N03[label="operand:R"];
+  N03 -> N08[label="operand:R"];
+  N03 -> N10[label="1:R"];
+  N03 -> N10[label="2:R"];
+  N03 -> N10[label="3:R"];
+  N04 -> N05[label="probability:P"];
+  N05 -> N06[label="operand:B"];
+  N06 -> N13[label="condition:B"];
+  N07 -> N10[label="columns:N"];
+  N07 -> N10[label="rows:N"];
+  N08 -> N09[label="operand:<=R"];
+  N09 -> N10[label="0:R"];
+  N10 -> N14[label="left:MR[2,2]"];
+  N11 -> N13[label="consequence:N"];
+  N12 -> N13[label="alternative:N"];
+  N13 -> N14[label="right:N"];
+  N14 -> N15[label="operand:MR[2,1]"];
+  N15 -> N16[label="operator:any"];
+}
+"""
+        self.assertEqual(expected.strip(), observed.strip())
+
+        observed = to_bmg_cpp(bmg).code
+        expected = """
+graph::Graph g;
+uint n0 = g.add_constant(0.0);
+uint n1 = g.add_constant_pos_real(1.0);
+uint n2 = g.add_distribution(
+  graph::DistributionType::NORMAL,
+  graph::AtomicType::REAL,
+  std::vector<uint>({n0, n1}));
+uint n3 = g.add_operator(
+  graph::OperatorType::SAMPLE, std::vector<uint>({n2}));
+uint n4 = g.add_constant_probability(0.5);
+uint n5 = g.add_distribution(
+  graph::DistributionType::BERNOULLI,
+  graph::AtomicType::BOOLEAN,
+  std::vector<uint>({n4}));
+uint n6 = g.add_operator(
+  graph::OperatorType::SAMPLE, std::vector<uint>({n5}));
+uint n7 = g.add_constant(2);
+uint n8 = g.add_operator(
+  graph::OperatorType::EXP, std::vector<uint>({n3}));
+uint n9 = g.add_operator(
+  graph::OperatorType::TO_REAL, std::vector<uint>({n8}));
+uint n10 = g.add_operator(
+  graph::OperatorType::TO_MATRIX,
+  std::vector<uint>({n7, n7, n9, n3, n3, n3}));
+uint n11 = g.add_constant(1);
+uint n12 = g.add_constant(0);
+uint n13 = g.add_operator(
+  graph::OperatorType::IF_THEN_ELSE,
+  std::vector<uint>({n6, n11, n12}));
+uint n14 = g.add_operator(
+  graph::OperatorType::COLUMN_INDEX, std::vector<uint>({n10, n13}));
+uint n15 = g.add_operator(
+  graph::OperatorType::LOGSUMEXP_VECTOR, std::vector<uint>({n14}));
+uint q0 = g.query(n15);
+        """
+        self.assertEqual(expected.strip(), observed.strip())
+
+        observed = to_bmg_python(bmg).code
+        expected = """
+from beanmachine import graph
+from torch import tensor
+g = graph.Graph()
+n0 = g.add_constant(0.0)
+n1 = g.add_constant_pos_real(1.0)
+n2 = g.add_distribution(
+  graph.DistributionType.NORMAL,
+  graph.AtomicType.REAL,
+  [n0, n1],
+)
+n3 = g.add_operator(graph.OperatorType.SAMPLE, [n2])
+n4 = g.add_constant_probability(0.5)
+n5 = g.add_distribution(
+  graph.DistributionType.BERNOULLI,
+  graph.AtomicType.BOOLEAN,
+  [n4],
+)
+n6 = g.add_operator(graph.OperatorType.SAMPLE, [n5])
+n7 = g.add_constant(2)
+n8 = g.add_operator(graph.OperatorType.EXP, [n3])
+n9 = g.add_operator(graph.OperatorType.TO_REAL, [n8])
+n10 = g.add_operator(
+  graph.OperatorType.TO_MATRIX,
+  [n7, n7, n9, n3, n3, n3],
+)
+n11 = g.add_constant(1)
+n12 = g.add_constant(0)
+n13 = g.add_operator(
+  graph.OperatorType.IF_THEN_ELSE,
+  [n6, n11, n12],
+)
+n14 = g.add_operator(graph.OperatorType.COLUMN_INDEX, [n10, n13])
+n15 = g.add_operator(graph.OperatorType.LOGSUMEXP_VECTOR, [n14])
+q0 = g.query(n15)
+        """
+        self.assertEqual(expected.strip(), observed.strip())
+
+        observed = to_bmg_graph(bmg).graph.to_dot()
+        expected = """
+digraph "graph" {
+  N0[label="0"];
+  N1[label="1"];
+  N2[label="Normal"];
+  N3[label="~"];
+  N4[label="0.5"];
+  N5[label="Bernoulli"];
+  N6[label="~"];
+  N7[label="2"];
+  N8[label="exp"];
+  N9[label="ToReal"];
+  N10[label="ToMatrix"];
+  N11[label="1"];
+  N12[label="0"];
+  N13[label="IfThenElse"];
+  N14[label="ColumnIndex"];
+  N15[label="LogSumExp"];
+  N0 -> N2;
+  N1 -> N2;
+  N2 -> N3;
+  N3 -> N8;
+  N3 -> N10;
+  N3 -> N10;
+  N3 -> N10;
+  N4 -> N5;
+  N5 -> N6;
+  N6 -> N13;
+  N7 -> N10;
+  N7 -> N10;
+  N8 -> N9;
+  N9 -> N10;
+  N10 -> N14;
+  N11 -> N13;
+  N12 -> N13;
+  N13 -> N14;
+  N14 -> N15;
+  Q0[label="Query"];
+  N15 -> Q0;
+}
+        """
+        self.assertEqual(expected.strip(), observed.strip())


### PR DESCRIPTION
Summary:
Lily has recently added a COLUMN_INDEX operator to BMG which takes as its input a 2d matrix and an integer, and produces a column matrix.

We will eventually need to support generating this from the compiler; the first step is adding a node type and getting its type analysis correct.  Here we demonstrate that we can construct a 2x2 matrix with the TO_MATRIX operator, and then randomly choose one of its columns based on a coin flip to get a 2x1 column vector, which can then be passed to the LOGSUMEXP_VECTOR operator added in the previous diff.

{F611018262}

Reviewed By: wtaha

Differential Revision: D27870459

