### PR TITLE
Fix row/column mismatch in type system

### DIFF
--- a/src/beanmachine/ppl/compiler/bmg_nodes.py
+++ b/src/beanmachine/ppl/compiler/bmg_nodes.py
@@ -682,6 +682,7 @@ class DirichletNode(DistributionNode):
     def concentration(self) -> BMGNode:
         return self.inputs[0]
 
+    # TODO: Rename this required_rows or required_length
     @property
     def _required_columns(self) -> int:
         # The "max" is needed to handle the degenerate case of

--- a/src/beanmachine/ppl/compiler/lattice_typer.py
+++ b/src/beanmachine/ppl/compiler/lattice_typer.py
@@ -147,7 +147,7 @@ class LatticeTyper(TyperBase[bt.BMGLatticeType]):
         return self[node.operator]
 
     def _type_dirichlet(self, node: bn.DirichletNode) -> bt.BMGLatticeType:
-        return bt.SimplexMatrix(1, node._required_columns)
+        return bt.SimplexMatrix(node._required_columns, 1)
 
     def _type_addition(self, node: bn.BMGNode) -> bt.BMGLatticeType:
         op_type = bt.supremum(*[self[i] for i in node.inputs])

--- a/src/beanmachine/ppl/compiler/tests/bmg_types_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_types_test.py
@@ -97,10 +97,15 @@ class BMGTypesTest(unittest.TestCase):
         self.assertEqual(NegativeReal, type_of_value(-1.5))
         self.assertEqual(NegativeReal, type_of_value(tensor(-1.5)))
         self.assertEqual(NegativeReal, type_of_value(tensor([[-1.5]])))
+
         # 1-d tensor is matrix
-        self.assertEqual(ZeroMatrix(1, 2), type_of_value(tensor([0, 0])))
-        self.assertEqual(BooleanMatrix(1, 3), type_of_value(tensor([0, 1, 1])))
-        self.assertEqual(BooleanMatrix(1, 2), type_of_value(tensor([1, 1])))
+        # Tensors are row-major in torch but column-major in BMG. We give
+        # the BMG type of the tensor as though it were column-major.
+        # This is treated as if it were [[0],[0]], a 2-column 1-row tensor
+        # because that's what we're going to emit into BMG.
+        self.assertEqual(ZeroMatrix(2, 1), type_of_value(tensor([0, 0])))
+        self.assertEqual(BooleanMatrix(3, 1), type_of_value(tensor([0, 1, 1])))
+        self.assertEqual(BooleanMatrix(2, 1), type_of_value(tensor([1, 1])))
         # 2-d tensor is matrix
         self.assertEqual(OneHotMatrix(2, 2), type_of_value(tensor([[1, 0], [1, 0]])))
         self.assertEqual(BooleanMatrix(2, 2), type_of_value(tensor([[1, 1], [1, 0]])))

--- a/src/beanmachine/ppl/compiler/tests/dirichlet_test.py
+++ b/src/beanmachine/ppl/compiler/tests/dirichlet_test.py
@@ -190,8 +190,8 @@ class DirichletTest(unittest.TestCase):
 digraph "graph" {
   N0[label="1.0:R+"];
   N1[label="Query:R+"];
-  N2[label="[1.0,1.5]:MR+[1,2]"];
-  N3[label="Query:MR+[1,2]"];
+  N2[label="[1.0,1.5]:MR+[2,1]"];
+  N3[label="Query:MR+[2,1]"];
   N4[label="[[1.0,1.5],\\\\n[2.0,2.5]]:MR+[2,2]"];
   N5[label="Query:MR+[2,2]"];
   N0 -> N1;
@@ -279,22 +279,22 @@ digraph "graph" {
   N13[label="Dirichlet:S[1,1]"];
   N14[label="Sample:S[1,1]"];
   N15[label="Query:S[1,1]"];
-  N16[label="[2.5,3.0]:MR+[1,2]"];
-  N17[label="Dirichlet:S[1,2]"];
-  N18[label="Sample:S[1,2]"];
-  N19[label="Query:S[1,2]"];
-  N20[label="[[3.5,4.0]]:MR+[1,2]"];
-  N21[label="Dirichlet:S[1,2]"];
-  N22[label="Sample:S[1,2]"];
-  N23[label="Query:S[1,2]"];
+  N16[label="[2.5,3.0]:MR+[2,1]"];
+  N17[label="Dirichlet:S[2,1]"];
+  N18[label="Sample:S[2,1]"];
+  N19[label="Query:S[2,1]"];
+  N20[label="[[3.5,4.0]]:MR+[2,1]"];
+  N21[label="Dirichlet:S[2,1]"];
+  N22[label="Sample:S[2,1]"];
+  N23[label="Query:S[2,1]"];
   N24[label="[[[4.5,5.0]]]:T"];
-  N25[label="Dirichlet:S[1,2]"];
-  N26[label="Sample:S[1,2]"];
-  N27[label="Query:S[1,2]"];
-  N28[label="[[5.5,6.0,6.5],\\\\n[7.0,7.5,8.0]]:MR+[2,3]"];
-  N29[label="Dirichlet:S[1,3]"];
-  N30[label="Sample:S[1,3]"];
-  N31[label="Query:S[1,3]"];
+  N25[label="Dirichlet:S[2,1]"];
+  N26[label="Sample:S[2,1]"];
+  N27[label="Query:S[2,1]"];
+  N28[label="[[5.5,6.0,6.5],\\\\n[7.0,7.5,8.0]]:MR+[3,2]"];
+  N29[label="Dirichlet:S[3,1]"];
+  N30[label="Sample:S[3,1]"];
+  N31[label="Query:S[3,1]"];
   N00 -> N01[label="R+"];
   N01 -> N02[label="S[1,1]"];
   N02 -> N03[label=any];
@@ -307,17 +307,17 @@ digraph "graph" {
   N12 -> N13[label="R+"];
   N13 -> N14[label="S[1,1]"];
   N14 -> N15[label=any];
-  N16 -> N17[label="MR+[1,2]"];
-  N17 -> N18[label="S[1,2]"];
+  N16 -> N17[label="MR+[2,1]"];
+  N17 -> N18[label="S[2,1]"];
   N18 -> N19[label=any];
-  N20 -> N21[label="MR+[1,2]"];
-  N21 -> N22[label="S[1,2]"];
+  N20 -> N21[label="MR+[2,1]"];
+  N21 -> N22[label="S[2,1]"];
   N22 -> N23[label=any];
-  N24 -> N25[label="MR+[1,2]"];
-  N25 -> N26[label="S[1,2]"];
+  N24 -> N25[label="MR+[2,1]"];
+  N25 -> N26[label="S[2,1]"];
   N26 -> N27[label=any];
-  N28 -> N29[label="MR+[1,3]"];
-  N29 -> N30[label="S[1,3]"];
+  N28 -> N29[label="MR+[3,1]"];
+  N29 -> N30[label="S[3,1]"];
   N30 -> N31[label=any];
 }
         """
@@ -342,7 +342,7 @@ digraph "graph" {
 
         expected = (
             "The concentration of a Dirichlet is required to be"
-            + " a 1 x 2 positive real matrix but is a tensor."
+            + " a 2 x 1 positive real matrix but is a tensor."
         )
 
         with self.assertRaises(ValueError) as ex:
@@ -351,8 +351,8 @@ digraph "graph" {
 
         expected = (
             "The concentration of a Dirichlet is required to be"
-            + " a 1 x 3 positive real matrix but is"
-            + " a 2 x 3 positive real matrix."
+            + " a 3 x 1 positive real matrix but is"
+            + " a 3 x 2 positive real matrix."
         )
 
         with self.assertRaises(ValueError) as ex:
@@ -378,13 +378,13 @@ digraph "graph" {
 
         expected = """
 digraph "graph" {
-  N0[label="[2.5,3.0]:MR+[1,2]"];
-  N1[label="Dirichlet:S[1,2]"];
-  N2[label="Sample:S[1,2]"];
-  N3[label="Observation tensor([0.5000, 0.5000]):S[1,2]"];
-  N4[label="Query:S[1,2]"];
-  N0 -> N1[label="MR+[1,2]"];
-  N1 -> N2[label="S[1,2]"];
+  N0[label="[2.5,3.0]:MR+[2,1]"];
+  N1[label="Dirichlet:S[2,1]"];
+  N2[label="Sample:S[2,1]"];
+  N3[label="Observation tensor([0.5000, 0.5000]):S[2,1]"];
+  N4[label="Query:S[2,1]"];
+  N0 -> N1[label="MR+[2,1]"];
+  N1 -> N2[label="S[2,1]"];
   N2 -> N3[label=any];
   N2 -> N4[label=any];
 }
@@ -544,7 +544,7 @@ uint q0 = g.query(n2);"""
             BMGInference().infer(queries, observations, 1)
         expected = (
             "A Dirichlet distribution is observed to have value 2.0 "
-            + "but only produces samples of type 1 x 2 simplex matrix."
+            + "but only produces samples of type 2 x 1 simplex matrix."
         )
         self.assertEqual(expected, str(ex.exception))
 
@@ -555,7 +555,7 @@ uint q0 = g.query(n2);"""
         expected = (
             "A Dirichlet distribution is observed to have value "
             + "tensor([0.2500, 0.2500, 0.2500, 0.2500]) "
-            + "but only produces samples of type 1 x 2 simplex matrix."
+            + "but only produces samples of type 2 x 1 simplex matrix."
         )
         self.assertEqual(expected, str(ex.exception))
 
@@ -566,7 +566,7 @@ uint q0 = g.query(n2);"""
         expected = (
             "A Dirichlet distribution is observed to have value "
             + "tensor([0.2500, 0.2500]) "
-            + "but only produces samples of type 1 x 2 simplex matrix."
+            + "but only produces samples of type 2 x 1 simplex matrix."
         )
         self.assertEqual(expected, str(ex.exception))
 

--- a/src/beanmachine/ppl/compiler/tests/fix_problems_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_problems_test.py
@@ -251,7 +251,7 @@ digraph "graph" {
         observed = str(error_report)
         expected = """
 The count of a Binomial is required to be a natural but is a positive real.
-The probability of a Bernoulli is required to be a probability but is a 1 x 2 simplex matrix.
+The probability of a Bernoulli is required to be a probability but is a 2 x 1 simplex matrix.
 The probability of a Binomial is required to be a probability but is a positive real.
 The sigma of a Normal is required to be a positive real but is a negative real.
         """


### PR DESCRIPTION
Summary:
Torch, and therefore Bean Machine, uses tensors in row-major order; for instance, if we are setting the parameters of a Dirichlet distribution to 1, 2, 3 then we expect the tensor to be `[1, 2, 3]`.  One row, three columns.

Bean Machine Graph by contrast prefers column major order; the input to a Dirichlet must be `[[1], [2], [3]]`  One column, three rows.

The BMG type system has scalar types and 2-d matrix types. How then should we assosciate matrix types with nodes?  Should we use the type of the *storage at runtime* and say that this vector of dirichlet parameters is a 1x3 matrix because it is a 1x3 tensor?  Or should we use the type of the *storage in the emitted graph* and call it a 3x1 matrix?

We were originally doing the former, but this becomes quite confusing when we need to check for requirements such as "the input to a Dirichlet must have exactly one column".

I have modified everywhere in the type system (I hope!) that determines the type of a matrix value; it now states the row x column size of the matrix as it will be in the BMG type system. After all, that is what we are analyzing here: what will the types of these nodes be in that type system?

Graph accumulator nodes still have a size property that I need to refactor away; this gives the size of the node using the conventions of the Bean Machine runtime.  But the computation of this property is (1) recursive, which is bad, and (2) frequently wrong. I will likely do a refactoring later to move this computation into its own type analyzer.

A question we will need to answer when we design a proper error reporting system is whether to phrase the errors in the jargon of the BMG type system or the BM type system. Right now we use the BMG type system but we might want to revisit that decision.

Reviewed By: wtaha

Differential Revision: D28066184

