### PR TITLE
Implement TO_REAL_MATRIX and TO_POS_REAL_MATRIX in BMG

### DIFF
--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -301,7 +301,9 @@ enum class OperatorType {
   INDEX,
   COLUMN_INDEX,
   TO_MATRIX,
-  BROADCAST_ADD
+  BROADCAST_ADD,
+  TO_REAL_MATRIX,
+  TO_POS_REAL_MATRIX,
 };
 
 enum class DistributionType {

--- a/src/beanmachine/graph/operator/gradient.cpp
+++ b/src/beanmachine/graph/operator/gradient.cpp
@@ -26,10 +26,22 @@ void ToReal::compute_gradients() {
   grad2 = in_nodes[0]->grad2;
 }
 
+void ToRealMatrix::compute_gradients() {
+  assert(in_nodes.size() == 1);
+  Grad1 = in_nodes[0]->Grad1;
+  Grad2 = in_nodes[0]->Grad2;
+}
+
 void ToPosReal::compute_gradients() {
   assert(in_nodes.size() == 1);
   grad1 = in_nodes[0]->grad1;
   grad2 = in_nodes[0]->grad2;
+}
+
+void ToPosRealMatrix::compute_gradients() {
+  assert(in_nodes.size() == 1);
+  Grad1 = in_nodes[0]->Grad1;
+  Grad2 = in_nodes[0]->Grad2;
 }
 
 void ToProbability::compute_gradients() {

--- a/src/beanmachine/graph/operator/register.cpp
+++ b/src/beanmachine/graph/operator/register.cpp
@@ -47,9 +47,17 @@ bool ToReal::is_registered = OperatorFactory::register_op(
     graph::OperatorType::TO_REAL,
     &(ToReal::new_op));
 
+bool ToRealMatrix::is_registered = OperatorFactory::register_op(
+    graph::OperatorType::TO_REAL_MATRIX,
+    &(ToRealMatrix::new_op));
+
 bool ToPosReal::is_registered = OperatorFactory::register_op(
     graph::OperatorType::TO_POS_REAL,
     &(ToPosReal::new_op));
+
+bool ToPosRealMatrix::is_registered = OperatorFactory::register_op(
+    graph::OperatorType::TO_POS_REAL_MATRIX,
+    &(ToPosRealMatrix::new_op));
 
 bool ToProbability::is_registered = OperatorFactory::register_op(
     graph::OperatorType::TO_PROBABILITY,

--- a/src/beanmachine/graph/operator/tests/operator_test.cpp
+++ b/src/beanmachine/graph/operator/tests/operator_test.cpp
@@ -931,6 +931,82 @@ TEST(testoperator, column_index) {
   EXPECT_EQ(xy_eval[0][0]._matrix(1), 3.0);
 }
 
+TEST(testoperator, to_real_matrix) {
+  Graph g;
+  // Requires exactly one input
+  EXPECT_THROW(
+      g.add_operator(OperatorType::TO_REAL_MATRIX, std::vector<uint>{}),
+      std::invalid_argument);
+  // requires matrix input
+  uint three = g.add_constant_pos_real(3.0);
+  EXPECT_THROW(
+      g.add_operator(OperatorType::TO_REAL_MATRIX, std::vector<uint>{three}),
+      std::invalid_argument);
+
+  // Let's get a matrix of probabilities
+
+  uint beta = g.add_distribution(
+      DistributionType::BETA,
+      AtomicType::PROBABILITY,
+      std::vector<uint>{three, three});
+  uint b1 = g.add_operator(OperatorType::SAMPLE, std::vector<uint>{beta});
+  uint b2 = g.add_operator(OperatorType::SAMPLE, std::vector<uint>{beta});
+  uint b3 = g.add_operator(OperatorType::SAMPLE, std::vector<uint>{beta});
+  uint b4 = g.add_operator(OperatorType::SAMPLE, std::vector<uint>{beta});
+  uint two = g.add_constant((natural_t)2);
+  uint tm = g.add_operator(
+      OperatorType::TO_MATRIX, std::vector<uint>{two, two, b1, b2, b3, b4});
+
+  // Requires exactly one input
+  EXPECT_THROW(
+      g.add_operator(OperatorType::TO_REAL_MATRIX, std::vector<uint>{tm, tm}),
+      std::invalid_argument);
+
+  g.add_operator(OperatorType::TO_REAL_MATRIX, std::vector<uint>{tm});
+}
+
+TEST(testoperator, to_pos_real_matrix) {
+  Graph g;
+  // Requires exactly one input
+  EXPECT_THROW(
+      g.add_operator(OperatorType::TO_POS_REAL_MATRIX, std::vector<uint>{}),
+      std::invalid_argument);
+  // requires matrix input
+  uint three = g.add_constant_pos_real(3.0);
+  EXPECT_THROW(
+      g.add_operator(
+          OperatorType::TO_POS_REAL_MATRIX, std::vector<uint>{three}),
+      std::invalid_argument);
+
+  // Let's get a matrix of probabilities
+  uint beta = g.add_distribution(
+      DistributionType::BETA,
+      AtomicType::PROBABILITY,
+      std::vector<uint>{three, three});
+  uint b1 = g.add_operator(OperatorType::SAMPLE, std::vector<uint>{beta});
+  uint b2 = g.add_operator(OperatorType::SAMPLE, std::vector<uint>{beta});
+  uint b3 = g.add_operator(OperatorType::SAMPLE, std::vector<uint>{beta});
+  uint b4 = g.add_operator(OperatorType::SAMPLE, std::vector<uint>{beta});
+  uint two = g.add_constant((natural_t)2);
+  uint tm = g.add_operator(
+      OperatorType::TO_MATRIX, std::vector<uint>{two, two, b1, b2, b3, b4});
+
+  // Requires exactly one input
+  EXPECT_THROW(
+      g.add_operator(
+          OperatorType::TO_POS_REAL_MATRIX, std::vector<uint>{tm, tm}),
+      std::invalid_argument);
+
+  uint tr = g.add_operator(OperatorType::TO_REAL_MATRIX, std::vector<uint>{tm});
+
+  // Input must not be real matrix
+  EXPECT_THROW(
+      g.add_operator(OperatorType::TO_POS_REAL_MATRIX, std::vector<uint>{tr}),
+      std::invalid_argument);
+
+  g.add_operator(OperatorType::TO_POS_REAL_MATRIX, std::vector<uint>{tm});
+}
+
 TEST(testoperator, to_matrix) {
   Graph g;
   uint nat_one = g.add_constant((natural_t)1);

--- a/src/beanmachine/graph/operator/unaryop.h
+++ b/src/beanmachine/graph/operator/unaryop.h
@@ -71,6 +71,23 @@ class ToReal : public UnaryOperator {
   static bool is_registered;
 };
 
+class ToRealMatrix : public UnaryOperator {
+ public:
+  explicit ToRealMatrix(const std::vector<graph::Node*>& in_nodes);
+  ~ToRealMatrix() override {}
+
+  void eval(std::mt19937& gen) override;
+  void compute_gradients() override;
+
+  static std::unique_ptr<Operator> new_op(
+      const std::vector<graph::Node*>& in_nodes) {
+    return std::make_unique<ToRealMatrix>(in_nodes);
+  }
+
+ private:
+  static bool is_registered;
+};
+
 class ToPosReal : public UnaryOperator {
  public:
   explicit ToPosReal(const std::vector<graph::Node*>& in_nodes);
@@ -82,6 +99,23 @@ class ToPosReal : public UnaryOperator {
   static std::unique_ptr<Operator> new_op(
       const std::vector<graph::Node*>& in_nodes) {
     return std::make_unique<ToPosReal>(in_nodes);
+  }
+
+ private:
+  static bool is_registered;
+};
+
+class ToPosRealMatrix : public UnaryOperator {
+ public:
+  explicit ToPosRealMatrix(const std::vector<graph::Node*>& in_nodes);
+  ~ToPosRealMatrix() override {}
+
+  void eval(std::mt19937& gen) override;
+  void compute_gradients() override;
+
+  static std::unique_ptr<Operator> new_op(
+      const std::vector<graph::Node*>& in_nodes) {
+    return std::make_unique<ToPosRealMatrix>(in_nodes);
   }
 
  private:

--- a/src/beanmachine/graph/pybindings.cpp
+++ b/src/beanmachine/graph/pybindings.cpp
@@ -62,7 +62,9 @@ PYBIND11_MODULE(graph, module) {
       .value("BROADCAST_ADD", OperatorType::BROADCAST_ADD)
       .value("TO_MATRIX", OperatorType::TO_MATRIX)
       .value("LOGSUMEXP_VECTOR", OperatorType::LOGSUMEXP_VECTOR)
-      .value("COLUMN_INDEX", OperatorType::COLUMN_INDEX);
+      .value("COLUMN_INDEX", OperatorType::COLUMN_INDEX)
+      .value("TO_REAL_MATRIX", OperatorType::TO_REAL_MATRIX)
+      .value("TO_POS_REAL_MATRIX", OperatorType::TO_POS_REAL_MATRIX);
 
   py::enum_<DistributionType>(module, "DistributionType")
       .value("TABULAR", DistributionType::TABULAR)

--- a/src/beanmachine/graph/to_dot.cpp
+++ b/src/beanmachine/graph/to_dot.cpp
@@ -122,8 +122,10 @@ class DOT {
       case OperatorType::IID_SAMPLE:
         return "~";
       case OperatorType::TO_REAL:
+      case OperatorType::TO_REAL_MATRIX:
         return "ToReal";
       case OperatorType::TO_POS_REAL:
+      case OperatorType::TO_POS_REAL_MATRIX:
         return "ToPosReal";
       case OperatorType::COMPLEMENT:
         return "Complement";


### PR DESCRIPTION
Summary:
In BMG we had no way to easily turn a matrix of, say, probabilities, into a matrix of reals should the type system require one.

I've added operators TO_REAL_MATRIX and TO_POS_REAL_MATRIX which take a matrix as an input and produce the equivalent real / pos real matrix respectively as the output.

There are two more we might need for rare cases: convert a matrix of bools to a matrix of naturals, and convert a matrix of bools to a matrix of probabilities. We haven't run into a situation where we need them yet.

I have not yet implemented the code in the compiler to take advantage of these new operators; that will happen in the next diffs.

Reviewed By: yucenli

Differential Revision: D28081087

