### PR TITLE
Refactor is_matrix operation into type checker

### DIFF
--- a/src/beanmachine/ppl/compiler/bmg_nodes.py
+++ b/src/beanmachine/ppl/compiler/bmg_nodes.py
@@ -90,13 +90,6 @@ class BMGNode(ABC):
         self.inputs = InputList(self, inputs)
         self.outputs = ItemCounter()
 
-    # TODO: This isn't a concern of this class hierarchy. Extract this to
-    # a helper class.
-    @property
-    def is_matrix(self) -> bool:
-        """Is this node classified as a matrix in BMG?"""
-        return False
-
     @property
     @abstractmethod
     def size(self) -> torch.Size:
@@ -328,19 +321,11 @@ class ConstantPositiveRealMatrixNode(ConstantTensorNode):
         assert len(value.size()) <= 2
         ConstantTensorNode.__init__(self, value)
 
-    @property
-    def is_matrix(self) -> bool:
-        return True
-
 
 class ConstantRealMatrixNode(ConstantTensorNode):
     def __init__(self, value: Tensor):
         assert len(value.size()) <= 2
         ConstantTensorNode.__init__(self, value)
-
-    @property
-    def is_matrix(self) -> bool:
-        return True
 
 
 class ConstantNegativeRealMatrixNode(ConstantTensorNode):
@@ -348,19 +333,11 @@ class ConstantNegativeRealMatrixNode(ConstantTensorNode):
         assert len(value.size()) <= 2
         ConstantTensorNode.__init__(self, value)
 
-    @property
-    def is_matrix(self) -> bool:
-        return True
-
 
 class ConstantProbabilityMatrixNode(ConstantTensorNode):
     def __init__(self, value: Tensor):
         assert len(value.size()) <= 2
         ConstantTensorNode.__init__(self, value)
-
-    @property
-    def is_matrix(self) -> bool:
-        return True
 
 
 class ConstantNaturalMatrixNode(ConstantTensorNode):
@@ -368,19 +345,11 @@ class ConstantNaturalMatrixNode(ConstantTensorNode):
         assert len(value.size()) <= 2
         ConstantTensorNode.__init__(self, value)
 
-    @property
-    def is_matrix(self) -> bool:
-        return True
-
 
 class ConstantBooleanMatrixNode(ConstantTensorNode):
     def __init__(self, value: Tensor):
         assert len(value.size()) <= 2
         ConstantTensorNode.__init__(self, value)
-
-    @property
-    def is_matrix(self) -> bool:
-        return True
 
 
 class TensorNode(BMGNode):
@@ -1021,10 +990,6 @@ class ToMatrixNode(OperatorNode):
 
     def support_size(self) -> float:
         raise NotImplementedError()
-
-    @property
-    def is_matrix(self) -> bool:
-        return True
 
 
 # ####

--- a/src/beanmachine/ppl/compiler/fix_requirements.py
+++ b/src/beanmachine/ppl/compiler/fix_requirements.py
@@ -52,7 +52,7 @@ class RequirementsFixer:
 
     def _node_meets_requirement(self, node: bn.BMGNode, r: bt.Requirement) -> bool:
         if isinstance(r, bt.AlwaysMatrix):
-            return node.is_matrix and self._type_meets_requirement(
+            return self._typer.is_matrix(node) and self._type_meets_requirement(
                 self._typer[node], r.bound
             )
         return self._type_meets_requirement(self._typer[node], r)


### PR DESCRIPTION
Summary:
We need to keep track of whether a particular node is typed as being an atomic value, say, real, or as a 1x1 matrix of reals.  (I am somewhat regretting my early decision to make the atomic types and the 1x1 matrix types represented by the same object; this is not how BMG does it, and it might be smart to make the two type systems more similar at the implementation choices level.  I'm not going to address that design problem here though.)

That fact was represented with a flag on the node, but it properly should be an API on the type analyzer. It now is.

Reviewed By: wtaha

Differential Revision: D28128342

