### PR TITLE
Automatically insert required matrix conversions

### DIFF
--- a/src/beanmachine/ppl/compiler/bmg_types.py
+++ b/src/beanmachine/ppl/compiler/bmg_types.py
@@ -527,6 +527,10 @@ def supremum(*ts: BMGLatticeType) -> BMGLatticeType:
     return result
 
 
+def is_convertible_to(source: BMGLatticeType, target: BMGLatticeType) -> bool:
+    return _supremum(source, target) == target
+
+
 simplex_precision = 1e-10
 
 


### PR DESCRIPTION
Summary:
I have rewritten the code which inserts TO_REAL and TO_POS_REAL nodes to (1) be more clear and understandable, and (2) to support TO_REAL_MATRIX and TO_POS_REAL_MATRIX.

I also am taking a suggestion made in code review earlier on this diff stack to create a helper method for the operation `sup(x, y) == y` that more clearly describes what we're doing here; we are asking the question "is x convertible to y"?

Reviewed By: wtaha

Differential Revision: D28169899

