### PR TITLE
Fix bug in tensor constructor handling

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/tensor_operations_test.py
+++ b/src/beanmachine/ppl/compiler/tests/tensor_operations_test.py
@@ -16,7 +16,7 @@ def norm(n):
 
 @bm.functional
 def make_a_tensor():
-    return tensor(norm(1), norm(1), norm(2), 1.25)
+    return tensor([norm(1), norm(1), norm(2), 1.25])
 
 
 @bm.functional


### PR DESCRIPTION
Summary:
The tensor constructor is allowed to take a single ordinary value, such as `tensor(123)`, in which case its size is `Size([])`, or it can take a list of values, or a list of lists of values, and so on.

There was a bug in how I was handling the tensor constructor where I always treated it as one level more nested than it should have been. That is, I allowed `tensor(1, 2, 3)` even though that should be illegal, because I treated it like `tensor([1, 2, 3])`.  Similarly I treated `tensor([1, 2, 3])` as `tensor([[1, 2, 3]])`, and so on.

This is now fixed; we now verify that the tensor constructor has exactly one argument, and compute the size correctly.

Reviewed By: wtaha

Differential Revision: D28334386

