### PR TITLE
Produce TO_MATRIX BMG nodes when a tensor constructor is used in the model

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/tensor_operations_test.py
+++ b/src/beanmachine/ppl/compiler/tests/tensor_operations_test.py
@@ -122,13 +122,9 @@ digraph "graph" {
         with self.assertRaises(ValueError) as ex:
             BMGInference().infer([lse_bad_1()], {}, 1)
         # TODO: Do a better job here. Say why the operation is unsupported.
-        # TODO: The tensor op will be rewritten by a rewriter that is
-        # not yet implemented, so this error will go away.
         expected = """
 The model uses a LogSumExp operation unsupported by Bean Machine Graph.
 The unsupported node is the operator of a Query.
-The model uses a Tensor operation unsupported by Bean Machine Graph.
-The unsupported node is the operand of a LogSumExp.
         """
         self.assertEqual(expected.strip(), str(ex.exception).strip())
 


### PR DESCRIPTION
Summary: When we have a tensor construction in a model where some of the tensor elements are graph nodes we accumulate that into the graph as a `TensorNode` and then later convert it to a `TO_MATRIX` node if it can be realized as a 2-d matrix.

Reviewed By: wtaha

Differential Revision: D28295533

