### PR TITLE
Compiler now generates appropriate index operation

### DIFF
--- a/src/beanmachine/ppl/compiler/bm_graph_builder.py
+++ b/src/beanmachine/ppl/compiler/bm_graph_builder.py
@@ -560,26 +560,21 @@ class BMGraphBuilder:
 
     @memoize
     def add_index(self, left: bn.BMGNode, right: bn.BMGNode) -> bn.BMGNode:
-        # If we have a constant index into a stochastic or constant tensor
-        # then we can optimize this by simply fetching the value we need
-        # out of the tensor and returning it directly.
-
-        # TODO: Type check that the constant index is a positive integer.
-        if isinstance(right, bn.ConstantNode):
-            # TODO: Range check these
-            if isinstance(left, bn.ConstantTensorNode):
-                return self.add_constant(left.value[right.value])
-            if isinstance(left, bn.TensorNode):
-                return left.inputs[right.value]
+        # Folding optimizations are done in the fixer.
         node = bn.IndexNode(left, right)
         self.add_node(node)
         return node
 
     @memoize
+    def add_vector_index(self, left: bn.BMGNode, right: bn.BMGNode) -> bn.BMGNode:
+        # Folding optimizations are done in the fixer.
+        node = bn.VectorIndexNode(left, right)
+        self.add_node(node)
+        return node
+
+    @memoize
     def add_column_index(self, left: bn.BMGNode, right: bn.BMGNode) -> bn.BMGNode:
-        # TODO: Better error handling when this is illegal.
-        if isinstance(left, bn.ConstantNode) and isinstance(right, bn.ConstantNode):
-            return self.add_constant(left.value[right.value])
+        # Folding optimizations are done in the fixer.
         node = bn.ColumnIndexNode(left, right)
         self.add_node(node)
         return node

--- a/src/beanmachine/ppl/compiler/bmg_node_types.py
+++ b/src/beanmachine/ppl/compiler/bmg_node_types.py
@@ -61,7 +61,6 @@ _operator_types = {
     bn.ExpM1Node: OperatorType.EXPM1,
     bn.ExpNode: OperatorType.EXP,
     bn.IfThenElseNode: OperatorType.IF_THEN_ELSE,
-    bn.IndexNode: OperatorType.INDEX,
     bn.Log1mexpNode: OperatorType.LOG1MEXP,
     bn.LogNode: OperatorType.LOG,
     bn.LogisticNode: OperatorType.LOGISTIC,
@@ -79,6 +78,7 @@ _operator_types = {
     bn.ToPositiveRealMatrixNode: OperatorType.TO_POS_REAL_MATRIX,
     bn.ToPositiveRealNode: OperatorType.TO_POS_REAL,
     bn.ToProbabilityNode: OperatorType.TO_PROBABILITY,
+    bn.VectorIndexNode: OperatorType.INDEX,
 }
 
 

--- a/src/beanmachine/ppl/compiler/bmg_nodes.py
+++ b/src/beanmachine/ppl/compiler/bmg_nodes.py
@@ -1329,7 +1329,25 @@ class IndexNodeDeprecated(BinaryOperatorNode):
         raise NotImplementedError()
 
 
+# This represents an indexing operation in the original source code.
+# It will be replaced by a VectorIndexNode or ColumnIndexNode in the
+# problem fixing phase.
 class IndexNode(BinaryOperatorNode):
+    def __init__(self, left: BMGNode, right: BMGNode):
+        BinaryOperatorNode.__init__(self, left, right)
+
+    @property
+    def size(self) -> torch.Size:
+        raise NotImplementedError()
+
+    def __str__(self) -> str:
+        return str(self.left) + "[" + str(self.right) + "]"
+
+    def support(self) -> Iterable[Any]:
+        raise NotImplementedError("support of index operator not implemented")
+
+
+class VectorIndexNode(BinaryOperatorNode):
     """This represents a stochastic index into a vector. The left operand
     is the vector and the right operand is the index."""
 
@@ -1338,7 +1356,7 @@ class IndexNode(BinaryOperatorNode):
 
     @property
     def size(self) -> torch.Size:
-        return torch.Size([])
+        raise NotImplementedError()
 
     def __str__(self) -> str:
         return str(self.left) + "[" + str(self.right) + "]"

--- a/src/beanmachine/ppl/compiler/bmg_requirements.py
+++ b/src/beanmachine/ppl/compiler/bmg_requirements.py
@@ -76,7 +76,6 @@ class EdgeRequirements:
             bn.ExpM1Node: self._same_as_output,
             bn.ExpNode: self._requirements_exp_neg,
             bn.IfThenElseNode: self._requirements_if,
-            bn.IndexNode: self._requirements_index,
             bn.LogNode: self._requirements_log,
             bn.LogSumExpNode: self._requirements_logsumexp,
             bn.LogSumExpVectorNode: self._requirements_logsumexp_vector,
@@ -86,6 +85,7 @@ class EdgeRequirements:
             bn.PowerNode: self._requirements_power,
             bn.SampleNode: self._same_as_output,
             bn.ToMatrixNode: self._requirements_to_matrix,
+            bn.VectorIndexNode: self._requirements_index,
         }
 
     def _requirements_expproduct(
@@ -161,7 +161,7 @@ class EdgeRequirements:
         it = self.typer[node]
         return [bt.Boolean, it, it]
 
-    def _requirements_index(self, node: bn.IndexNode) -> List[bt.Requirement]:
+    def _requirements_index(self, node: bn.VectorIndexNode) -> List[bt.Requirement]:
         # The index operator introduces an interesting wrinkle into the
         # "requirements" computation. Until now we have always had the property
         # that queries and observations are "sinks" of the graph, and the transitive

--- a/src/beanmachine/ppl/compiler/fix_unsupported.py
+++ b/src/beanmachine/ppl/compiler/fix_unsupported.py
@@ -10,7 +10,7 @@ from beanmachine.ppl.compiler.bmg_types import PositiveReal
 from beanmachine.ppl.compiler.error_report import BMGError, UnsupportedNode
 from beanmachine.ppl.compiler.fix_problem import ProblemFixerBase
 from beanmachine.ppl.compiler.graph_labels import get_edge_label
-from beanmachine.ppl.compiler.typer_base import TyperBase
+from beanmachine.ppl.compiler.lattice_typer import LatticeTyper
 
 
 class UnsupportedNodeFixer(ProblemFixerBase):
@@ -18,7 +18,7 @@ class UnsupportedNodeFixer(ProblemFixerBase):
     fix all uses of unsupported operators by replacing them with semantically
     equivalent nodes that are supported by BMG."""
 
-    def __init__(self, bmg: BMGraphBuilder, typer: TyperBase) -> None:
+    def __init__(self, bmg: BMGraphBuilder, typer: LatticeTyper) -> None:
         ProblemFixerBase.__init__(self, bmg, typer)
 
     def _replace_division(self, node: bn.DivisionNode) -> Optional[bn.BMGNode]:
@@ -66,6 +66,30 @@ class UnsupportedNodeFixer(ProblemFixerBase):
         mult = self._bmg.add_multiplication(node.df, half)
         return self._bmg.add_gamma(mult, half)
 
+    def _replace_index(self, node: bn.IndexNode) -> Optional[bn.BMGNode]:
+        # * If we have an index into a one-column matrix, replace it with
+        #   a vector index.
+        # * If we have an index into a multi-column matrix, replace it with
+        #   a column index
+        # TODO: Consider if there are more optimizations we can make here
+        # if either operand is a constant.
+        typer = self._typer
+        assert isinstance(typer, LatticeTyper)
+        right = node.right
+        left = node.left
+        node_type = typer[left]
+        if isinstance(node_type, bt.BMGMatrixType):
+            if node_type.columns == 1:
+                if (
+                    isinstance(left, bn.ToMatrixNode)
+                    and isinstance(right, bn.ConstantNode)
+                    and typer.is_natural(right)
+                ):
+                    return left.inputs[right.value + 2]
+                return self._bmg.add_vector_index(left, right)
+            return self._bmg.add_column_index(left, right)
+        return None
+
     def _replace_tensor(self, node: bn.TensorNode) -> Optional[bn.BMGNode]:
         # Replace a 1-d or 2-d tensor with a TO_MATRIX node.
         size = node.size
@@ -88,6 +112,8 @@ class UnsupportedNodeFixer(ProblemFixerBase):
             return self._replace_chi2(n)
         if isinstance(n, bn.DivisionNode):
             return self._replace_division(n)
+        if isinstance(n, bn.IndexNode):
+            return self._replace_index(n)
         if isinstance(n, bn.TensorNode):
             return self._replace_tensor(n)
         if isinstance(n, bn.UniformNode):

--- a/src/beanmachine/ppl/compiler/graph_labels.py
+++ b/src/beanmachine/ppl/compiler/graph_labels.py
@@ -95,6 +95,7 @@ _node_labels = {
     bn.ToRealNode: "ToReal",
     bn.UniformNode: "Uniform",
     bn.UntypedConstantNode: _val,
+    bn.VectorIndexNode: "index",
 }
 
 _none = []
@@ -183,6 +184,7 @@ _edge_labels = {
     bn.ToRealMatrixNode: _operand,
     bn.ToRealNode: _operand,
     bn.UniformNode: ["low", "high"],
+    bn.VectorIndexNode: _left_right,
 }
 
 

--- a/src/beanmachine/ppl/compiler/lattice_typer.py
+++ b/src/beanmachine/ppl/compiler/lattice_typer.py
@@ -141,7 +141,6 @@ class LatticeTyper(TyperBase[bt.BMGLatticeType]):
             bn.ExpM1Node: self._type_expm1,
             bn.ExpNode: self._type_exp,
             bn.IfThenElseNode: self._type_if,
-            bn.IndexNode: self._type_index,
             bn.LogNode: self._type_log,
             bn.MultiAdditionNode: self._type_addition,
             bn.MultiplicationNode: self._type_multiplication,
@@ -151,6 +150,7 @@ class LatticeTyper(TyperBase[bt.BMGLatticeType]):
             bn.ToMatrixNode: self._type_to_matrix,
             bn.ToPositiveRealMatrixNode: self._type_to_pos_real_matrix,
             bn.ToRealMatrixNode: self._type_to_real_matrix,
+            bn.VectorIndexNode: self._type_index,
         }
 
     def _type_observation(self, node: bn.Observation) -> bt.BMGLatticeType:
@@ -213,7 +213,7 @@ class LatticeTyper(TyperBase[bt.BMGLatticeType]):
             result = bt.Boolean
         return result
 
-    def _type_index(self, node: bn.IndexNode) -> bt.BMGLatticeType:
+    def _type_index(self, node: bn.VectorIndexNode) -> bt.BMGLatticeType:
         # The lattice type of an index is derived from the lattice type of
         # the vector, but it's not as straightforward as just
         # shrinking the type down to a 1x1 matrix. The elements of
@@ -337,6 +337,10 @@ class LatticeTyper(TyperBase[bt.BMGLatticeType]):
     def is_bool(self, node: bn.BMGNode) -> bool:
         t = self[node]
         return t != bt.Untypable and bt.supremum(t, bt.Boolean) == bt.Boolean
+
+    def is_natural(self, node: bn.BMGNode) -> bool:
+        t = self[node]
+        return t != bt.Untypable and bt.supremum(t, bt.Natural) == bt.Natural
 
     def is_prob_or_bool(self, node: bn.BMGNode) -> bool:
         t = self[node]


### PR DESCRIPTION
Summary:
When a model contains an `[]` operator we now accumulate it into the graph as an `IndexNode` that is NOT supported by BMG.

In the problem fixing pass we determine if it is an index into a 1-column vector or a multi-column vector, and replace the  `IndexNode` with `VectorIndexNode` or `ColumnIndexNode` as appropriate.

Optimizations for scenarios where the index is a constant are moved into the fixer rather than the factory. Generally speaking I'd like to move these peephole optimizations out of the factories; the factories should not need to know the semantics of the operators.

Reviewed By: wtaha

Differential Revision: D28364431

