### PR TITLE
Adds missing distant normal conjugate test to IAF nightly

### DIFF
--- a/src/beanmachine/ppl/experimental/neutra/tests/iaf_conjugate_test_nightly.py
+++ b/src/beanmachine/ppl/experimental/neutra/tests/iaf_conjugate_test_nightly.py
@@ -123,8 +123,34 @@ class SingleSiteIAFConjugateTest(unittest.TestCase, AbstractConjugateTests):
             num_adaptive_samples=100,
         )
 
+    @unittest.skip("Known to fail. Investigating in T77865889.")
     def test_distant_normal_normal_conjugate_run(self):
-        pass
+        training_sample_size = 10
+        length = 2
+        in_layer = 2
+        out_layer = 4
+        hidden_layer = 30
+        n_block = 4
+        seed_num = 11
+        network_architecture = MaskedAutoencoder(
+            in_layer, out_layer, nn.ELU(), hidden_layer, n_block, seed_num
+        )
+
+        optimizer_func = self.optimizer_func(1e-4, 1e-5)
+        iaf = IAFMCMCinference(
+            training_sample_size,
+            length,
+            in_layer,
+            network_architecture,
+            optimizer_func,
+            True,
+            [],
+        )
+        self.distant_normal_normal_conjugate_run(
+            iaf,
+            num_samples=200,
+            num_adaptive_samples=100,
+        )
 
     @unittest.skip("Known to fail. Investigating in T77865889.")
     def test_dirichlet_categorical_conjugate_run(self):


### PR DESCRIPTION
Summary: Enabling this test used to cause a tensor shape error, after this diff the error is now an ESS error

Differential Revision: D28522726

