### PR TITLE
Fixes IAF shape error for beta binomial conjugate nightly

### DIFF
--- a/src/beanmachine/ppl/experimental/neutra/tests/iaf_conjugate_test_nightly.py
+++ b/src/beanmachine/ppl/experimental/neutra/tests/iaf_conjugate_test_nightly.py
@@ -23,8 +23,8 @@ class SingleSiteIAFConjugateTest(unittest.TestCase, AbstractConjugateTests):
     def test_beta_binomial_conjugate_run(self):
         training_sample_size = 1
         length = 2
-        in_layer = 1
-        out_layer = 1
+        in_layer = 2
+        out_layer = 4
         hidden_layer = 30
         n_block = 4
         seed_num = 11


### PR DESCRIPTION
Summary: Enabling this test used to cause a tensor shape error, after this diff the error is now an ESS error

Differential Revision: D28522546

