### PR TITLE
Multiple random seed runs introduced to single_site_random_walk_conjugate_test_nightly.py

### DIFF
--- a/src/beanmachine/ppl/inference/tests/single_site_random_walk_conjugate_test_nightly.py
+++ b/src/beanmachine/ppl/inference/tests/single_site_random_walk_conjugate_test_nightly.py
@@ -8,24 +8,35 @@ from beanmachine.ppl.testlib.abstract_conjugate import AbstractConjugateTests
 class SingleSiteRandomWalkConjugateTest(unittest.TestCase, AbstractConjugateTests):
     def setUp(self):
         self.mh = bm.SingleSiteRandomWalk(step_size=1.0)
+        self.seeds = {123456789, 975318642, 918273645, 564738291}
 
     def test_beta_binomial_conjugate_run(self):
         mh = bm.SingleSiteRandomWalk(step_size=0.3)
-        self.beta_binomial_conjugate_run(mh, num_samples=5000)
+        for seed in self.seeds:
+            self.beta_binomial_conjugate_run(mh, num_samples=5000, random_seed=seed)
 
     def test_gamma_gamma_conjugate_run(self):
-        self.gamma_gamma_conjugate_run(self.mh, num_samples=10000)
+        for seed in self.seeds:
+            self.gamma_gamma_conjugate_run(self.mh, num_samples=10000, random_seed=seed)
 
     def test_gamma_normal_conjugate_run(self):
-        self.gamma_normal_conjugate_run(self.mh, num_samples=10000)
+        for seed in self.seeds:
+            self.gamma_normal_conjugate_run(
+                self.mh, num_samples=10000, random_seed=seed
+            )
 
     def test_normal_normal_conjugate_run(self):
         mh = bm.SingleSiteRandomWalk(step_size=1.5)
-        self.normal_normal_conjugate_run(mh, num_samples=1000)
+        for seed in self.seeds:
+            self.normal_normal_conjugate_run(mh, num_samples=1000, random_seed=seed)
 
     def test_distant_normal_normal_conjugate_run(self):
         mh = bm.SingleSiteRandomWalk(step_size=3.0)
-        self.normal_normal_conjugate_run(mh, num_samples=10000)
+        for seed in self.seeds:
+            self.normal_normal_conjugate_run(mh, num_samples=10000, random_seed=seed)
 
     def test_dirichlet_categorical_conjugate_run(self):
-        self.dirichlet_categorical_conjugate_run(self.mh, num_samples=10000)
+        for seed in self.seeds:
+            self.dirichlet_categorical_conjugate_run(
+                self.mh, num_samples=10000, random_seed=seed
+            )


### PR DESCRIPTION
Summary: To help defend against potential flakiness and differences in the behavior of the random number generators across platform, this diff is adding multiple random seed runs to the test file mentioned above.

Differential Revision: D28516365

