### PR TITLE
remove distant normal normal conj test

### DIFF
--- a/src/beanmachine/ppl/experimental/neutra/tests/iaf_conjugate_test_nightly.py
+++ b/src/beanmachine/ppl/experimental/neutra/tests/iaf_conjugate_test_nightly.py
@@ -123,9 +123,6 @@ class SingleSiteIAFConjugateTest(unittest.TestCase, AbstractConjugateTests):
             num_adaptive_samples=100,
         )
 
-    def test_distant_normal_normal_conjugate_run(self):
-        pass
-
     @unittest.skip("Known to fail. Investigating in T77865889.")
     def test_dirichlet_categorical_conjugate_run(self):
         training_sample_size = 10

--- a/src/beanmachine/ppl/inference/tests/compositional_infer_conjugate_test_nightly.py
+++ b/src/beanmachine/ppl/inference/tests/compositional_infer_conjugate_test_nightly.py
@@ -26,8 +26,5 @@ class CompositionalInferenceConjugateTest(unittest.TestCase, AbstractConjugateTe
     def test_normal_normal_conjugate_run(self):
         self.normal_normal_conjugate_run(self.mh)
 
-    def test_distant_normal_normal_conjugate_run(self):
-        self.distant_normal_normal_conjugate_run(self.mh, num_samples=1000)
-
     def test_dirichlet_categorical_conjugate_run(self):
         self.dirichlet_categorical_conjugate_run(self.mh)

--- a/src/beanmachine/ppl/inference/tests/single_site_ancestral_mh_conjugate_test_nightly.py
+++ b/src/beanmachine/ppl/inference/tests/single_site_ancestral_mh_conjugate_test_nightly.py
@@ -23,10 +23,5 @@ class SingleSiteAncestralMetropolisHastingsConjugateTest(
     def test_normal_normal_conjugate_run(self):
         self.normal_normal_conjugate_run(self.mh, num_samples=5000)
 
-    @unittest.skip("Expect to fail. N_eff is 5 @ 1K sample size.")
-    def test_distant_normal_normal_conjugate_run(self):
-        # We don't expect ancestral to be able to converge fast for this model.
-        self.distant_normal_normal_conjugate_run(self.mh, num_samples=1000)
-
     def test_dirichlet_categorical_conjugate_run(self):
         self.dirichlet_categorical_conjugate_run(self.mh, num_samples=10000)

--- a/src/beanmachine/ppl/inference/tests/single_site_hamiltonian_monte_carlo_adaptive_conjugate_test_nightly.py
+++ b/src/beanmachine/ppl/inference/tests/single_site_hamiltonian_monte_carlo_adaptive_conjugate_test_nightly.py
@@ -34,11 +34,6 @@ class SingleSiteAdaptiveHamiltonianMonteCarloConjugateTest(
         self.normal_normal_conjugate_run(hmc, num_samples=200, num_adaptive_samples=50)
 
     @unittest.skip("Known to fail. Investigating in T77865889.")
-    def test_distant_normal_normal_conjugate_run(self):
-        hmc = bm.SingleSiteHamiltonianMonteCarlo(1.0)
-        self.distant_normal_normal_conjugate_run(hmc, num_samples=1000)
-
-    @unittest.skip("Known to fail. Investigating in T77865889.")
     def test_dirichlet_categorical_conjugate_run(self):
         hmc = bm.SingleSiteHamiltonianMonteCarlo(0.1)
         self.dirichlet_categorical_conjugate_run(hmc, num_samples=1000)

--- a/src/beanmachine/ppl/inference/tests/single_site_hamiltonian_monte_carlo_conjugate_test_nightly.py
+++ b/src/beanmachine/ppl/inference/tests/single_site_hamiltonian_monte_carlo_conjugate_test_nightly.py
@@ -31,11 +31,6 @@ class SingleSiteHamiltonianMonteCarloConjugateTest(
         self.normal_normal_conjugate_run(hmc, num_samples=500)
 
     @unittest.skip("Known to fail. Investigating in T77865889.")
-    def test_distant_normal_normal_conjugate_run(self):
-        hmc = bm.SingleSiteHamiltonianMonteCarlo(1.0, 0.1)
-        self.distant_normal_normal_conjugate_run(hmc, num_samples=1000)
-
-    @unittest.skip("Known to fail. Investigating in T77865889.")
     def test_dirichlet_categorical_conjugate_run(self):
         hmc = bm.SingleSiteHamiltonianMonteCarlo(0.1, 0.01)
         self.dirichlet_categorical_conjugate_run(hmc, num_samples=10000)

--- a/src/beanmachine/ppl/inference/tests/single_site_newtonian_monte_carlo_conjugate_test_nightly.py
+++ b/src/beanmachine/ppl/inference/tests/single_site_newtonian_monte_carlo_conjugate_test_nightly.py
@@ -29,11 +29,6 @@ class SingleSiteNewtonianMonteCarloConjugateTest(
         nw = bm.SingleSiteNewtonianMonteCarlo()
         self.normal_normal_conjugate_run(nw, num_samples=500)
 
-    # Following had to be increased to 1600 to pass variance test
-    def test_distant_normal_normal_conjugate_run(self):
-        nw = bm.SingleSiteNewtonianMonteCarlo()
-        self.distant_normal_normal_conjugate_run(nw, num_samples=1600)
-
     def test_dirichlet_categorical_conjugate_run(self):
         nw = bm.SingleSiteNewtonianMonteCarlo()
         self.dirichlet_categorical_conjugate_run(nw, num_samples=2000)

--- a/src/beanmachine/ppl/inference/tests/single_site_no_u_turn_conjugate_test_nightly.py
+++ b/src/beanmachine/ppl/inference/tests/single_site_no_u_turn_conjugate_test_nightly.py
@@ -48,19 +48,6 @@ class SingleSiteNoUTurnConjugateTest(unittest.TestCase, AbstractConjugateTests):
             nuts, num_samples=600, num_adaptive_samples=300
         )
 
-    @unittest.skip("Known to fail. Investigating in T77865889.")
-    def test_distant_normal_normal_conjugate_run(self):
-        nuts = SingleSiteNoUTurnSampler(use_dense_mass_matrix=False)
-        self.distant_normal_normal_conjugate_run(
-            nuts, num_samples=200, num_adaptive_samples=100
-        )
-        # TODO: The following produces a poor n_eff = tensor([47.3868, 69.6567]),
-        # and then the resulting variance fails the variance test.
-        nuts = SingleSiteNoUTurnSampler()
-        self.distant_normal_normal_conjugate_run(
-            nuts, num_samples=1100, num_adaptive_samples=550
-        )
-
     def test_dirichlet_categorical_conjugate_run(self):
         nuts = SingleSiteNoUTurnSampler(use_dense_mass_matrix=False)
         self.dirichlet_categorical_conjugate_run(

--- a/src/beanmachine/ppl/inference/tests/single_site_random_walk_adaptive_conjugate_test_nightly.py
+++ b/src/beanmachine/ppl/inference/tests/single_site_random_walk_adaptive_conjugate_test_nightly.py
@@ -37,11 +37,6 @@ class SingleSiteAdaptiveRandomWalkConjugateTest(
             self.mh, num_samples=5000, num_adaptive_samples=5000
         )
 
-    def test_distant_normal_normal_conjugate_run(self):
-        self.normal_normal_conjugate_run(
-            self.mh, num_samples=500, num_adaptive_samples=500
-        )
-
     # Increased n to 1000 so that n_eff passes the 30 threshold (!)
     # TODO: Expected n_eff levels should be documented in tests
     def test_dirichlet_categorical_conjugate_run(self):

--- a/src/beanmachine/ppl/inference/tests/single_site_random_walk_conjugate_test_nightly.py
+++ b/src/beanmachine/ppl/inference/tests/single_site_random_walk_conjugate_test_nightly.py
@@ -25,9 +25,5 @@ class SingleSiteRandomWalkConjugateTest(unittest.TestCase, AbstractConjugateTest
         mh = bm.SingleSiteRandomWalk(step_size=1.5)
         self.normal_normal_conjugate_run(mh, num_samples=1000)
 
-    def test_distant_normal_normal_conjugate_run(self):
-        mh = bm.SingleSiteRandomWalk(step_size=3.0)
-        self.normal_normal_conjugate_run(mh, num_samples=10000)
-
     def test_dirichlet_categorical_conjugate_run(self):
         self.dirichlet_categorical_conjugate_run(self.mh, num_samples=10000)

--- a/src/beanmachine/ppl/inference/tests/single_site_uniform_mh_conjugate_test_nightly.py
+++ b/src/beanmachine/ppl/inference/tests/single_site_uniform_mh_conjugate_test_nightly.py
@@ -24,12 +24,5 @@ class SingleSiteUniformMetropolisHastingsConjugateTest(
     def test_normal_normal_conjugate_run(self):
         self.normal_normal_conjugate_run(self.mh, num_samples=5000)
 
-    # Ridiculous detla due to failing convergence
-    # The delta should be unnecessary after new testing is in place
-    @unittest.skip("Expect to fail. N_eff is 5 @ 1K sample size.")
-    def test_distant_normal_normal_conjugate_run(self):
-        # We don't expect uniform to be able to converge fast for this model.
-        self.distant_normal_normal_conjugate_run(self.mh, num_samples=1000)
-
     def test_dirichlet_categorical_conjugate_run(self):
         self.dirichlet_categorical_conjugate_run(self.mh, num_samples=5000)

--- a/src/beanmachine/ppl/testlib/abstract_conjugate.py
+++ b/src/beanmachine/ppl/testlib/abstract_conjugate.py
@@ -140,27 +140,6 @@ class AbstractConjugateTests(metaclass=ABCMeta):
         #  List[typing.Any], Dict[typing.Any, typing.Any]]`.
         return (expected_mean, expected_std, queries, observations)
 
-    def compute_distant_normal_normal_moments(self):
-        """
-        Computes mean and standard deviation of a small normal normal model
-        where the prior and posterior are far from each other.
-
-        :return: expected mean, expected standard deviation, conjugate model
-        queries and observations
-        """
-        mu = tensor([1.0, 1.0])
-        std = tensor([1.0, 1.0])
-        sigma = tensor([1.0, 1.0])
-        obs = tensor([100.0, 100.0])
-        model = NormalNormalModel(mu, std, sigma)
-        queries = [model.normal_p()]
-        observations = {model.normal(): obs}
-        expected_mean = (1 / (1 / sigma.pow(2.0) + 1 / std.pow(2.0))) * (
-            mu / std.pow(2.0) + obs / sigma.pow(2.0)
-        )
-        expected_std = (std.pow(-2.0) + sigma.pow(-2.0)).pow(-0.5)
-        return (expected_mean, expected_std, queries, observations)
-
     def compute_dirichlet_categorical_moments(self):
         """
         Computes mean and standard deviation of a small dirichlet categorical
@@ -434,33 +413,6 @@ class AbstractConjugateTests(metaclass=ABCMeta):
             num_adaptive_samples,
         )
 
-    def distant_normal_normal_conjugate_run(
-        self,
-        mh: AbstractMHInference,
-        num_chains: int = 1,
-        num_samples: int = 1000,
-        random_seed: Optional[int] = 17,
-        num_adaptive_samples: int = 0,
-    ):
-        """
-        Tests the inference run for a small normal normal model
-        where the prior and posterior are far from each other.
-
-        :param mh: inference algorithm
-        :param num_samples: number of samples
-        :param num_chains: number of chains
-        :param random_seed: seed for pytorch random number generator
-        """
-        moments = self.compute_distant_normal_normal_moments()
-        self._compare_run(
-            moments,
-            mh,
-            num_chains,
-            num_samples,
-            random_seed,
-            num_adaptive_samples,
-        )
-
     def dirichlet_categorical_conjugate_run(
         self,
         mh: AbstractMHInference,
@@ -516,15 +468,6 @@ class AbstractConjugateTests(metaclass=ABCMeta):
 
     @abstractmethod
     def test_normal_normal_conjugate_run(self):
-        """
-        To be implemented for all classes extending AbstractConjugateTests.
-        """
-        raise NotImplementedError(
-            "Conjugate test must implement test_normal_normal_conjugate_run."
-        )
-
-    @abstractmethod
-    def test_distant_normal_normal_conjugate_run(self):
         """
         To be implemented for all classes extending AbstractConjugateTests.
         """


### PR DESCRIPTION
Summary: Removes the distant normal normal test. Almost all of the inference algorithms fail this test, even external implementations that are verified to be correct. It's not a good test since it's a (very) misspecified model and there's no reason to expect that algorithms to pass a strict hypothesis test on such a model.

Differential Revision: D28528998

