### PR TITLE
Runtime now supports unary add on graph nodes

### DIFF
--- a/src/beanmachine/ppl/compiler/bm_to_bmg.py
+++ b/src/beanmachine/ppl/compiler/bm_to_bmg.py
@@ -167,8 +167,6 @@ _handle_index = PatternRule(
 )
 
 
-# TODO: UNARY: Do we need to handle unary plus? In Python, unary plus
-# converts bool to int.
 # TODO: UNARY: ~ (invert) operator
 # TODO: BINARY: // (integer division), % (modulus), <<, >>, |, ^, &, @ (matrix mult)
 # "and" and "or" are already eliminated by the single assignment rewriter.
@@ -181,6 +179,7 @@ _math_to_bmg: Rule = _top_down(
                 _handle_dot,
                 _handle_call,
                 _handle_unary(ast.Not, "handle_not"),
+                _handle_unary(ast.UAdd, "handle_uadd"),
                 _handle_unary(ast.USub, "handle_negate"),
                 _handle_binary(ast.Add, "handle_addition"),
                 _handle_binary(ast.Sub, "handle_subtraction"),

--- a/src/beanmachine/ppl/compiler/runtime.py
+++ b/src/beanmachine/ppl/compiler/runtime.py
@@ -597,6 +597,14 @@ class BMGRuntime:
             return -input.value
         return self._bmg.add_negate(input)
 
+    def handle_uadd(self, input: Any) -> Any:
+        # Unary plus on a graph node is an identity.
+        if not isinstance(input, BMGNode):
+            return +input
+        return input
+
+    # TODO: Remove this. We should insert TO_REAL nodes when necessary
+    # to ensure compatibility with the BMG type system.
     def handle_to_real(self, operand: Any) -> Any:
         if not isinstance(operand, BMGNode):
             return float(operand)

--- a/src/beanmachine/ppl/compiler/tests/bmg_arithmetic_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_arithmetic_test.py
@@ -78,10 +78,11 @@ def neg_of_neg():
 @bm.functional
 def subtractions():
     # Show that we can handle a bunch of different ways to subtract things
-    n = norm()
-    b = beta()
-    h = hc()
-    return torch.sub(n.sub(b), b - h)
+    # Show that unary plus operations are discarded.
+    n = +norm()
+    b = +beta()
+    h = +hc()
+    return +torch.sub(+n.sub(+b), +b - h)
 
 
 class BMGArithmeticTest(unittest.TestCase):


### PR DESCRIPTION
Summary:
Use of a unary addition operator on a graph node during graph accumulation was producing an exception "TypeError: bad operand type for unary +: 'SampleNode'"

The rewriter now rewrites unary add nodes into `handle_uadd` calls. We ignore the unary add operator on graph nodes; we do not accumulate a useless identity operator into the graph.

Reviewed By: wtaha

Differential Revision: D28422551

