### PR TITLE
Implement runtime support for models with inversion operators

### DIFF
--- a/src/beanmachine/ppl/compiler/bm_graph_builder.py
+++ b/src/beanmachine/ppl/compiler/bm_graph_builder.py
@@ -589,6 +589,12 @@ class BMGraphBuilder:
         return node
 
     @memoize
+    def add_invert(self, operand: BMGNode) -> BMGNode:
+        node = bn.InvertNode(operand)
+        self.add_node(node)
+        return node
+
+    @memoize
     def add_complement(self, operand: BMGNode) -> BMGNode:
         if isinstance(operand, ConstantNode):
             return self.add_constant(1 - operand.value)

--- a/src/beanmachine/ppl/compiler/bm_to_bmg.py
+++ b/src/beanmachine/ppl/compiler/bm_to_bmg.py
@@ -167,7 +167,6 @@ _handle_index = PatternRule(
 )
 
 
-# TODO: UNARY: ~ (invert) operator
 # TODO: BINARY: // (integer division), % (modulus), <<, >>, |, ^, &, @ (matrix mult)
 # "and" and "or" are already eliminated by the single assignment rewriter.
 # TODO: COMPARISON: is, is not, in, not in
@@ -178,6 +177,7 @@ _math_to_bmg: Rule = _top_down(
             [
                 _handle_dot,
                 _handle_call,
+                _handle_unary(ast.Invert, "handle_invert"),
                 _handle_unary(ast.Not, "handle_not"),
                 _handle_unary(ast.UAdd, "handle_uadd"),
                 _handle_unary(ast.USub, "handle_negate"),

--- a/src/beanmachine/ppl/compiler/graph_labels.py
+++ b/src/beanmachine/ppl/compiler/graph_labels.py
@@ -59,6 +59,7 @@ _node_labels = {
     bn.IfThenElseNode: "if",
     bn.IndexNode: "index",
     bn.IndexNodeDeprecated: "index",
+    bn.InvertNode: "Invert",
     bn.LessThanEqualNode: "<=",
     bn.LessThanNode: "<",
     bn.Log1mexpNode: "Log1mexp",

--- a/src/beanmachine/ppl/compiler/runtime.py
+++ b/src/beanmachine/ppl/compiler/runtime.py
@@ -590,6 +590,11 @@ class BMGRuntime:
             right = self._bmg.add_constant(right)
         return self._bmg.add_index(left, right)
 
+    def handle_invert(self, input: Any) -> Any:
+        if not isinstance(input, BMGNode):
+            return ~input
+        return self._bmg.add_invert(input)
+
     def handle_negate(self, input: Any) -> Any:
         if not isinstance(input, BMGNode):
             return -input


### PR DESCRIPTION
Summary:
BMG does not support the bit inversion operator `~` but it is a bad user experience to have the compiler crash during graph accumulation with a type error should you use it.

We now accumulate an `InvertNode` into the graph, and then give an error when checking whether the graph has an equivalent BMG graph.

I'm going to be adding a lot of these unsupported nodes and I do not want to implement size and support computations for each. I want to eventually refactor the nodes so that the size and support computations are isolated to their own module rather than spread out across the nodes, as we did for type checking.

Therefore I've made size and support no longer abstract methods; the base implementation throws an exception.  We will revisit this code when we get conditional stochastic control flows working.

Reviewed By: wtaha

Differential Revision: D28424267

