### PR TITLE
Fix cut-n-pasted error in AST construction

### DIFF
--- a/src/beanmachine/ppl/compiler/single_assignment.py
+++ b/src/beanmachine/ppl/compiler/single_assignment.py
@@ -832,7 +832,7 @@ class SingleAssignment:
                     value=ast.Subscript(
                         value=source_term.value.value,
                         slice=ast.Slice(
-                            lower=ast.Name(id=new_name, ctx=ast.Load()),
+                            lower=new_name,
                             upper=source_term.value.slice.upper,
                             step=source_term.value.slice.step,
                         ),
@@ -863,7 +863,7 @@ class SingleAssignment:
                         value=source_term.value.value,
                         slice=ast.Slice(
                             lower=source_term.value.slice.lower,
-                            upper=ast.Name(id=new_name, ctx=ast.Load()),
+                            upper=new_name,
                             step=source_term.value.slice.step,
                         ),
                         ctx=ast.Store(),
@@ -896,7 +896,7 @@ class SingleAssignment:
                         slice=ast.Slice(
                             lower=source_term.value.slice.lower,
                             upper=source_term.value.slice.upper,
-                            step=ast.Name(id=new_name, ctx=ast.Load()),
+                            step=new_name,
                         ),
                         ctx=ast.Store(),
                     ),
@@ -2013,7 +2013,7 @@ class SingleAssignment:
                 lambda source_term, new_name: ast.Assign(
                     targets=[
                         ast.Attribute(
-                            value=ast.Name(id=new_name, ctx=ast.Load()),
+                            value=new_name,
                             attr=source_term.targets[0].attr,
                             ctx=ast.Store(),
                         )
@@ -2034,7 +2034,7 @@ class SingleAssignment:
                 lambda source_term, new_name: ast.Assign(
                     targets=[
                         ast.Subscript(
-                            value=ast.Name(id=new_name, ctx=ast.Load()),
+                            value=new_name,
                             slice=source_term.targets[0].slice,
                             ctx=ast.Store(),
                         )
@@ -2060,7 +2060,7 @@ class SingleAssignment:
                         ast.Subscript(
                             value=source_term.targets[0].value,
                             slice=ast.Index(
-                                value=ast.Name(id=new_name, ctx=ast.Load()),
+                                value=new_name,
                                 ctx=ast.Load(),
                             ),
                             ctx=ast.Store(),
@@ -2091,7 +2091,7 @@ class SingleAssignment:
                         ast.Subscript(
                             value=source_term.targets[0].value,
                             slice=ast.Slice(
-                                lower=ast.Name(id=new_name, ctx=ast.Load()),
+                                lower=new_name,
                                 upper=source_term.targets[0].slice.upper,
                                 step=source_term.targets[0].slice.step,
                             ),
@@ -2127,7 +2127,7 @@ class SingleAssignment:
                             value=source_term.targets[0].value,
                             slice=ast.Slice(
                                 lower=source_term.targets[0].slice.lower,
-                                upper=ast.Name(id=new_name, ctx=ast.Load()),
+                                upper=new_name,
                                 step=source_term.targets[0].slice.step,
                             ),
                             ctx=ast.Store(),
@@ -2165,7 +2165,7 @@ class SingleAssignment:
                             slice=ast.Slice(
                                 lower=source_term.targets[0].slice.lower,
                                 upper=source_term.targets[0].slice.upper,
-                                step=ast.Name(id=new_name, ctx=ast.Load()),
+                                step=new_name,
                             ),
                             ctx=ast.Store(),
                         )


### PR DESCRIPTION
Summary:
There is a small mistake that has been cut-n-pasted into a number of places in the AST rewriter.

The issue is that `new_name` is not a string, it is a `Name` object, but it is being used in a context in which a string is expected. That is, we are constructing

    whatever=Name(id=new_name, ctx=Load())`

but `new_name` is *already* a `Name` object. It should just be `whatever=new_name`.

Why was this bug undetected by the single assignment rewriter test cases?  Because those test cases use the output of `astor.to_source` to check for correctness, but `astor` does not check that the AST is *sensible*.  It just converts the `id` to a string, and if the `id` is incorrectly another `Name` object, it converts that to a string in turn.

But when you pass a malformed AST to `compile`, that raises an error saying that `id` is required to be a string.  For example, if you attempt to compile a random variable method with a line such as

    a[b][c] = d

then when it attempts to rewrite as

    x = a[b]
    x[c] = d

the `x` in the second line is `Name(id=Name(id="x"))` instead of `Name(id="x")`, and compilation of the single assignment form then crashes.

Reviewed By: wtaha

Differential Revision: D28545987

