### PR TITLE
Fix a bug in global NUT (introduced accidentally when updating previous diff)

### DIFF
--- a/src/beanmachine/ppl/experimental/global_inference/proposer/hmc_proposer.py
+++ b/src/beanmachine/ppl/experimental/global_inference/proposer/hmc_proposer.py
@@ -57,7 +57,10 @@ class HMCProposer(BaseProposer):
     def _initialize_momentums(self, world: SimpleWorld) -> RVDict:
         """Randomly draw momentum from MultivariateNormal(0, I). This momentum variable
         is denoted as p in [1] and r in [2]."""
-        return {node: torch.randn(world[node].shape) for node in world.latent_nodes}
+        return {
+            node: torch.randn(world.get_transformed(node).shape)
+            for node in world.latent_nodes
+        }
 
     def _kinetic_energy(self, momentums: RVDict) -> torch.Tensor:
         """Returns the kinetic energy KE = 1/2 * p^T @ p (equation 2.6 in [1])"""

--- a/src/beanmachine/ppl/experimental/global_inference/proposer/nuts_proposer.py
+++ b/src/beanmachine/ppl/experimental/global_inference/proposer/nuts_proposer.py
@@ -69,7 +69,9 @@ class NUTSProposer(HMCProposer):
         left_angle = 0.0
         right_angle = 0.0
         for node in left_state.world.latent_nodes:
-            diff = right_state.world[node] - left_state.world[node]
+            diff = right_state.world.get_transformed(
+                node
+            ) - left_state.world.get_transformed(node)
             left_angle += torch.sum(diff * left_state.momentums[node])
             right_angle += torch.sum(diff * right_state.momentums[node])
         return bool((left_angle <= 0) or (right_angle <= 0))


### PR DESCRIPTION
Summary:
In one of the update in the my diff (D28215033 (https://github.com/facebookincubator/beanmachine/commit/e988549b1846f7cb1045375ab2306fcce47fbf12)) I modified `SimpleWorld`'s API so that `__getitem__` returns a variable in the constrained space, but I forgot to update the API call on the inference side.

I tried benchmark with a logistic regression model but that didn't catch the issue because it does not require transform. :(

Differential Revision: D28645807

