### PR TITLE
Factor graph performance testing flag was not read correctly

### DIFF
--- a/src/beanmachine/ppl/compiler/fix_problems.py
+++ b/src/beanmachine/ppl/compiler/fix_problems.py
@@ -39,12 +39,12 @@ _standard_fixer_types: List[Type] = [
 ]
 
 
-def fix_problems(bmg: BMGraphBuilder, fix_observe_true: bool = False) -> ErrorReport:
+def fix_problems(bmg: BMGraphBuilder) -> ErrorReport:
     bmg._begin(prof.fix_problems)
     typer = LatticeTyper()
     fixer_types: List[Type] = _standard_fixer_types
     errors = ErrorReport()
-    if fix_observe_true:
+    if bmg._fix_observe_true:
         # Note: must NOT be +=, which would mutate _standard_fixer_types.
         fixer_types = fixer_types + [ObserveTrueFixer]
     for fixer_type in fixer_types:

--- a/src/beanmachine/ppl/compiler/gen_dot.py
+++ b/src/beanmachine/ppl/compiler/gen_dot.py
@@ -36,7 +36,7 @@ def to_dot(
         #
         # * Add a whole_graph flag, default to true, which decides
         #   whether to graph the whole thing or not.
-        fix_problems(bmg, bmg._fix_observe_true).raise_errors()
+        fix_problems(bmg).raise_errors()
         node_list = bmg.all_ancestor_nodes()
     else:
         node_list = bmg.all_nodes()


### PR DESCRIPTION
Summary:
We have an undocumented flag for doing performance testing of factor graphs. My intention was to have the problem fixer detect this flag on the graph builder and turn on generation of factors, but I failed to complete the necessary refactoring.

The consequence of the error, unfortunately, was that the factor graphs were ONLY generated when `to_dot` was called, which is of course what I use to test the flag.  Factors were not generated on calling `to_python`, `to_cpp`, or `infer`.

Reviewed By: wtaha, kshah1997

Differential Revision: D28727102

