### PR TITLE
BMG now allows queries on constants

### DIFF
--- a/src/beanmachine/graph/graph.cpp
+++ b/src/beanmachine/graph/graph.cpp
@@ -507,13 +507,21 @@ uint Graph::add_node(std::unique_ptr<Node> node, std::vector<uint> parents) {
   return index;
 }
 
-Node* Graph::check_node(uint node_id, NodeType node_type) {
+void Graph::check_node_id(uint node_id) {
   if (node_id >= nodes.size()) {
     throw std::out_of_range(
         "node_id (" + std::to_string(node_id) + ") must be less than " +
         std::to_string(nodes.size()));
   }
-  Node* node = nodes[node_id].get();
+}
+
+Node* Graph::get_node(uint node_id) {
+  check_node_id(node_id);
+  return nodes[node_id].get();
+}
+
+Node* Graph::check_node(uint node_id, NodeType node_type) {
+  Node* node = get_node(node_id);
   if (node->node_type != node_type) {
     throw std::invalid_argument(
         "node_id " + std::to_string(node_id) + "expected type " +
@@ -758,7 +766,17 @@ void Graph::remove_observations() {
 }
 
 uint Graph::query(uint node_id) {
-  check_node(node_id, NodeType::OPERATOR);
+  Node* node = get_node(node_id);
+  NodeType t = node->node_type;
+  if (t != NodeType::CONSTANT and t != NodeType::OPERATOR) {
+    throw std::invalid_argument(
+        "Query of node_id " + std::to_string(node_id) +
+        " expected a node of type " +
+        std::to_string(static_cast<int>(NodeType::CONSTANT)) + " or " +
+        std::to_string(static_cast<int>(NodeType::OPERATOR)) + " but is " +
+        std::to_string(static_cast<int>(t)));
+  }
+
   if (queried.find(node_id) != queried.end()) {
     throw std::invalid_argument(
         "duplicate query for node_id " + std::to_string(node_id));

--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -693,6 +693,8 @@ struct Graph {
   */
   double full_log_prob();
   std::vector<std::vector<double>>& get_log_prob();
+  Node* get_node(uint node_id);
+  void check_node_id(uint node_id);
   Node* check_node(uint node_id, NodeType node_type);
   uint thread_index;
 

--- a/src/beanmachine/graph/tests/graph_test.py
+++ b/src/beanmachine/graph/tests/graph_test.py
@@ -241,6 +241,21 @@ class TestBayesNet(unittest.TestCase):
         g.query(GrassWet)
         g.infer(1)
 
+        p = g.add_constant_probability(0.8)
+        b = g.add_distribution(
+            graph.DistributionType.BERNOULLI, graph.AtomicType.BOOLEAN, [p]
+        )
+        # Querying a constant is weird but allowed
+        g.query(p)
+        # But querying a distribution directly rather than a sample is
+        # illegal:
+        with self.assertRaises(ValueError) as cm:
+            g.query(b)
+        self.assertEqual(
+            f"Query of node_id {b} expected a node of type 1 or 3 but is 2",
+            str(cm.exception),
+        )
+
     def test_to_dot(self):
         self.maxDiff = None
         g, Rain, Sprinkler, GrassWet = self._create_graph()


### PR DESCRIPTION
Summary:
Before this change, BMG would throw an exception if you asked it to query a constant value. Though it is somewhat odd to ask "what is the value of this constant when given these observations?" there are situations where it might arise. For instance:

* Our own internal testing non-inference aspects of BMG APIs.

* A compiler producing a BMG graph as its output might be compiling a model where the developer has replaced a stochastic computation with a constant temporarily for testing purposes. It is onerous on the compiler to ensure that a query is never a constant.

* A compiler might have an optimization which deduces that a particular quantity that appears to be stochastic is in fact a constant. (Multiply by zero, stochastic IF with same constant on both sides, sum of x and its complement, and so on.)  It might be useful for the compiler to warn the user that it is doing so, but it should be allowed to do so.

* And so on.

We now allow a query on an operator or a constant. We still do not allow a query on a distribution or a factor, as doing so is not meaningful.

Differential Revision: D28714333

