### PR TITLE
Implement TO_NEG_REAL BMG graph node

### DIFF
--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -304,6 +304,7 @@ enum class OperatorType {
   BROADCAST_ADD,
   TO_REAL_MATRIX,
   TO_POS_REAL_MATRIX,
+  TO_NEG_REAL,
 };
 
 enum class DistributionType {

--- a/src/beanmachine/graph/operator/gradient.cpp
+++ b/src/beanmachine/graph/operator/gradient.cpp
@@ -50,6 +50,12 @@ void ToProbability::compute_gradients() {
   grad2 = in_nodes[0]->grad2;
 }
 
+void ToNegReal::compute_gradients() {
+  assert(in_nodes.size() == 1);
+  grad1 = in_nodes[0]->grad1;
+  grad2 = in_nodes[0]->grad2;
+}
+
 void Negate::compute_gradients() {
   assert(in_nodes.size() == 1);
   grad1 = -1 * in_nodes[0]->grad1;

--- a/src/beanmachine/graph/operator/register.cpp
+++ b/src/beanmachine/graph/operator/register.cpp
@@ -63,6 +63,10 @@ bool ToProbability::is_registered = OperatorFactory::register_op(
     graph::OperatorType::TO_PROBABILITY,
     &(ToProbability::new_op));
 
+bool ToNegReal::is_registered = OperatorFactory::register_op(
+    graph::OperatorType::TO_NEG_REAL,
+    &(ToNegReal::new_op));
+
 bool Negate::is_registered = OperatorFactory::register_op(
     graph::OperatorType::NEGATE,
     &(Negate::new_op));

--- a/src/beanmachine/graph/operator/unaryop.cpp
+++ b/src/beanmachine/graph/operator/unaryop.cpp
@@ -251,6 +251,32 @@ void ToProbability::eval(std::mt19937& /* gen */) {
   }
 }
 
+ToNegReal::ToNegReal(const std::vector<graph::Node*>& in_nodes)
+    : UnaryOperator(graph::OperatorType::TO_NEG_REAL, in_nodes) {
+  graph::ValueType type0 = in_nodes[0]->value.type;
+  if (type0 != graph::AtomicType::NEG_REAL and
+      type0 != graph::AtomicType::REAL) {
+    throw std::invalid_argument(
+        "operator TO_NEG_REAL requires a real or neg_real parent");
+  }
+  value = graph::NodeValue(graph::AtomicType::NEG_REAL);
+}
+
+void ToNegReal::eval(std::mt19937& /* gen */) {
+  assert(in_nodes.size() == 1);
+  const graph::NodeValue& parent = in_nodes[0]->value;
+  if (parent.type != graph::AtomicType::NEG_REAL and
+      parent.type != graph::AtomicType::REAL) {
+    throw std::runtime_error(
+        "invalid parent type " + parent.type.to_string() +
+        " for TO_NEG_REAL operator at node_id " + std::to_string(index));
+  }
+  // note: we have to cast it to an NodeValue object rather than directly
+  // assigning to ensure that the usual boundary checks for negative reals
+  // are made
+  value = graph::NodeValue(graph::AtomicType::NEG_REAL, parent._double);
+}
+
 Negate::Negate(const std::vector<graph::Node*>& in_nodes)
     : UnaryOperator(graph::OperatorType::NEGATE, in_nodes) {
   graph::ValueType type0 = in_nodes[0]->value.type;

--- a/src/beanmachine/graph/operator/unaryop.h
+++ b/src/beanmachine/graph/operator/unaryop.h
@@ -139,6 +139,23 @@ class ToProbability : public UnaryOperator {
   static bool is_registered;
 };
 
+class ToNegReal : public UnaryOperator {
+ public:
+  explicit ToNegReal(const std::vector<graph::Node*>& in_nodes);
+  ~ToNegReal() override {}
+
+  void eval(std::mt19937& gen) override;
+  void compute_gradients() override;
+
+  static std::unique_ptr<Operator> new_op(
+      const std::vector<graph::Node*>& in_nodes) {
+    return std::make_unique<ToNegReal>(in_nodes);
+  }
+
+ private:
+  static bool is_registered;
+};
+
 class Negate : public UnaryOperator {
  public:
   explicit Negate(const std::vector<graph::Node*>& in_nodes);

--- a/src/beanmachine/graph/pybindings.cpp
+++ b/src/beanmachine/graph/pybindings.cpp
@@ -64,7 +64,8 @@ PYBIND11_MODULE(graph, module) {
       .value("LOGSUMEXP_VECTOR", OperatorType::LOGSUMEXP_VECTOR)
       .value("COLUMN_INDEX", OperatorType::COLUMN_INDEX)
       .value("TO_REAL_MATRIX", OperatorType::TO_REAL_MATRIX)
-      .value("TO_POS_REAL_MATRIX", OperatorType::TO_POS_REAL_MATRIX);
+      .value("TO_POS_REAL_MATRIX", OperatorType::TO_POS_REAL_MATRIX)
+      .value("TO_NEG_REAL", OperatorType::TO_NEG_REAL);
 
   py::enum_<DistributionType>(module, "DistributionType")
       .value("TABULAR", DistributionType::TABULAR)

--- a/src/beanmachine/graph/to_dot.cpp
+++ b/src/beanmachine/graph/to_dot.cpp
@@ -161,6 +161,8 @@ class DOT {
         return "MatrixMultiply";
       case OperatorType::TO_PROBABILITY:
         return "ToProb";
+      case OperatorType::TO_NEG_REAL:
+        return "ToNegReal";
       case OperatorType::INDEX:
         return "Index";
       case OperatorType::TO_MATRIX:


### PR DESCRIPTION
Summary:
In BMG we have a TO_PROBABILITY node for cases when we have a real or positive real quantity, we know from some rule of algebra that it is actually a probability, but we cannot prove it in the type system.  We insert it as needed in graphs when compiling models.

Log probabilities are negative reals, and it is also necessary in some situations to say "we have a real number but we know algebraically that it is actually negative". This diff implements a node which acts like TO_PROBABILITY but for negative reals.

In an upcoming diff I will modify the compiler to generate this node when necessary to convert a real to a negative real.

Reviewed By: yucenli

Differential Revision: D28759914

