### PR TITLE
Robust U-turn condition

### DIFF
--- a/src/beanmachine/ppl/experimental/global_inference/proposer/nuts_proposer.py
+++ b/src/beanmachine/ppl/experimental/global_inference/proposer/nuts_proposer.py
@@ -184,6 +184,28 @@ class NUTSProposer(HMCProposer):
             right_tree.right.momentums,
             sum_momentums,
         )
+        # More robust U-turn condition
+        # https://discourse.mc-stan.org/t/nuts-misses-u-turns-runs-in-circles-until-max-treedepth/9727
+        if not turned_or_diverged and right_tree.num_proposals > 1:
+            extended_sum_momentums = {
+                node: left_tree.sum_momentums[node] + right_tree.left.momentums[node]
+                for node in sum_momentums
+            }
+            turned_or_diverged = self._is_u_turning(
+                left_tree.left.momentums,
+                right_tree.left.momentums,
+                extended_sum_momentums,
+            )
+        if not turned_or_diverged and left_tree.num_proposals > 1:
+            extended_sum_momentums = {
+                node: right_tree.sum_momentums[node] + left_tree.right.momentums[node]
+                for node in sum_momentums
+            }
+            turned_or_diverged = self._is_u_turning(
+                left_tree.right.momentums,
+                right_tree.right.momentums,
+                extended_sum_momentums,
+            )
 
         return _Tree(
             left=left_tree.left,


### PR DESCRIPTION
Summary:
An issue with the U-turn condition was discovered and discussed in [this post in Stan forum](https://discourse.mc-stan.org/t/nuts-misses-u-turns-runs-in-circles-until-max-treedepth/9727)

TL;DR: we can make the U-turn condition more robust by introducing two additional checks across subtrees. This can help us avoid missing U-turns for approximately iid normal models.

{F619223264}

Since the tree combining code are almost identical in `_build_tree` and `propose`, I also take the chance to refactor them into a common function called `_combine_tree`. If you look closely you will notice that most part of `_combine_tree` are moved from existing code as-is. The only addition is the two additional call to `_is_u_turning`

Related PR that implements this change:
- Stan: https://github.com/stan-dev/stan/pull/2800
- PyMC3: https://github.com/pymc-devs/pymc3/pull/3605
- Turing.jl: https://github.com/TuringLang/AdvancedHMC.jl/pull/207
- DynamicHMC.jl: https://github.com/tpapp/DynamicHMC.jl/pull/145

Differential Revision: D28735950

