### PR TITLE
HMC mass matrix adaptation window

### DIFF
--- a/src/beanmachine/ppl/experimental/global_inference/proposer/base_proposer.py
+++ b/src/beanmachine/ppl/experimental/global_inference/proposer/base_proposer.py
@@ -9,6 +9,9 @@ class BaseProposer(metaclass=ABCMeta):
     def propose(self, world: Optional[SimpleWorld] = None) -> SimpleWorld:
         raise NotImplementedError
 
+    def init_adaptation(self, num_adaptive_samples: int) -> None:
+        ...
+
     def do_adaptation(self) -> None:
         ...
 

--- a/src/beanmachine/ppl/experimental/global_inference/proposer/hmc_proposer.py
+++ b/src/beanmachine/ppl/experimental/global_inference/proposer/hmc_proposer.py
@@ -7,6 +7,7 @@ from beanmachine.ppl.experimental.global_inference.proposer.base_proposer import
 )
 from beanmachine.ppl.experimental.global_inference.proposer.hmc_utils import (
     DualAverageAdapter,
+    WindowScheme,
 )
 from beanmachine.ppl.experimental.global_inference.simple_world import (
     RVDict,
@@ -44,6 +45,7 @@ class HMCProposer(BaseProposer):
         # initialize parameters
         self.trajectory_length = trajectory_length
         self.adapt_step_size = adapt_step_size
+        self._window_scheme: Optional[WindowScheme] = None
         if self.adapt_step_size:
             self.step_size = self._find_reasonable_step_size(
                 initial_step_size, self.world, self._pe, self._pe_grad
@@ -53,6 +55,9 @@ class HMCProposer(BaseProposer):
             self.step_size = initial_step_size
         # alpha will store the accept prob and will be used to adapt step size
         self._alpha = None
+
+    def init_adaptation(self, num_adaptive_samples: int) -> None:
+        self._window_scheme = WindowScheme(num_adaptive_samples)
 
     def _initialize_momentums(self, world: SimpleWorld) -> RVDict:
         """Randomly draw momentum from MultivariateNormal(0, I). This momentum variable

--- a/src/beanmachine/ppl/experimental/global_inference/proposer/tests/hmc_utils_test.py
+++ b/src/beanmachine/ppl/experimental/global_inference/proposer/tests/hmc_utils_test.py
@@ -1,6 +1,8 @@
+import pytest
 import torch
 from beanmachine.ppl.experimental.global_inference.proposer.hmc_utils import (
     DualAverageAdapter,
+    WindowScheme,
 )
 
 
@@ -9,3 +11,44 @@ def test_dual_average_adapter():
     epsilon1 = adapter.step(torch.tensor(1.0))
     epsilon2 = adapter.step(torch.tensor(0.0))
     assert epsilon2 < adapter.finalize() < epsilon1
+
+
+def test_small_window_scheme():
+    num_adaptive_samples = 10
+    scheme = WindowScheme(num_adaptive_samples)
+    for _ in range(num_adaptive_samples):
+        # no window should be created if num_adaptive_samples is too small
+        assert not scheme.is_in_window
+        scheme.step()
+
+
+def test_middle_window_scheme():
+    num_adaptive_samples = 125
+    scheme = WindowScheme(num_adaptive_samples)
+    num_windows = 0
+    for i in range(num_adaptive_samples):
+        if scheme.is_in_window:
+            # there should be a margin at the beginning and the end of a window
+            assert i > 0
+            if scheme.is_end_window:
+                num_windows += 1
+                assert i < num_adaptive_samples
+        scheme.step()
+    # there should only be a single window
+    assert num_windows == 1
+
+
+@pytest.mark.parametrize("num_adaptive_samples", [175, 300, 399, 543])
+def test_large_window_scheme(num_adaptive_samples):
+    scheme = WindowScheme(num_adaptive_samples)
+    window_sizes = []
+    for _ in range(num_adaptive_samples):
+        if scheme.is_end_window:
+            window_sizes.append(scheme._window_size)
+        scheme.step()
+    # size of windows should be monotonically increasing
+    sorted_window_sizes = sorted(window_sizes)
+    assert window_sizes == sorted_window_sizes
+    for win1, win2 in zip(window_sizes[:-1], window_sizes[1:-1]):
+        # except for last window, window size should keep doubling
+        assert win2 == win1 * 2

--- a/src/beanmachine/ppl/experimental/global_inference/sampler.py
+++ b/src/beanmachine/ppl/experimental/global_inference/sampler.py
@@ -15,6 +15,7 @@ class Sampler(Generator[SimpleWorld, Optional[SimpleWorld], None]):
         num_adaptive_samples: int = 0,
     ):
         self.proposer = proposer
+        self.proposer.init_adaptation(num_adaptive_samples)
         self._num_samples_remaining = (
             float("inf") if num_samples is None else num_samples
         )


### PR DESCRIPTION
Summary:
This diff adds the `WindowScheme` class, which can be used to generate a sequence of windows (with monotonically increasing sizes) for adapting mass matrix.

{F621591831}
(Image taken from [Stan Reference Manual](https://mc-stan.org/docs/2_27/reference-manual/hmc-algorithm-parameters.html#automatic-parameter-tuning))

I split this diff from the next one (diagonal mass matrix adaptation) to make the reviewing process easier, though diff adds nothing to the algorithms by itself. Feel free to take a look at D28862600 if you're interesting previewing how this class is going to be used :)

Related implementation in other PPLs:
- [Stan](https://github.com/stan-dev/stan/blob/7b291dac8d7c9509bf11db540f5efde7a649d410/src/stan/mcmc/windowed_adaptation.hpp)
- [Pyro](https://github.com/pyro-ppl/pyro/blob/6fa4d8b2810dff9b3bcc4b7e994029cdc818520f/pyro/infer/mcmc/adaptation.py#L63-L94)

Differential Revision: D28890364

