### PR TITLE
Diagonal mass matrices for global HMC & NUTS

### DIFF
--- a/src/beanmachine/ppl/experimental/global_inference/hmc_inference.py
+++ b/src/beanmachine/ppl/experimental/global_inference/hmc_inference.py
@@ -15,6 +15,7 @@ class GlobalHamiltonianMonteCarlo(BaseInference):
     trajectory_length: float
     initial_step_size: float = 1.0
     adapt_step_size: bool = True
+    adapt_mass_matrix: bool = True
 
     def get_proposer(self, world: SimpleWorld) -> HMCProposer:
         return HMCProposer(world, **dataclasses.asdict(self))
@@ -26,6 +27,7 @@ class GlobalNoUTurnSampler(BaseInference):
     max_delta_energy: float = 1000.0
     initial_step_size: float = 1.0
     adapt_step_size: bool = True
+    adapt_mass_matrix: bool = True
     multinomial_sampling: bool = True
 
     def get_proposer(self, world: SimpleWorld) -> NUTSProposer:

--- a/src/beanmachine/ppl/experimental/global_inference/proposer/tests/nuts_proposer_test.py
+++ b/src/beanmachine/ppl/experimental/global_inference/proposer/tests/nuts_proposer_test.py
@@ -37,12 +37,15 @@ def tree_node(nuts):
 
 @pytest.fixture
 def tree_args(tree_node, nuts):
-    initial_energy = nuts._hamiltonian(nuts.world, tree_node.momentums, nuts._pe)
+    initial_energy = nuts._hamiltonian(
+        nuts.world, tree_node.momentums, nuts._mass_inv, nuts._pe
+    )
     return _TreeArgs(
         log_slice=-initial_energy,
         direction=1,
         step_size=nuts.step_size,
         initial_energy=initial_energy,
+        mass_inv=nuts._mass_inv,
     )
 
 

--- a/src/beanmachine/ppl/experimental/global_inference/tests/inference_test.py
+++ b/src/beanmachine/ppl/experimental/global_inference/tests/inference_test.py
@@ -25,7 +25,7 @@ def test_inference():
     nuts = bm.GlobalNoUTurnSampler()
     queries = [model.foo()]
     observations = {model.bar(): torch.tensor(0.5)}
-    num_samples = 10
+    num_samples = 30
     num_chains = 2
     samples = nuts.infer(
         queries,


### PR DESCRIPTION
Summary:
This diff combines the result of D28890364 (https://github.com/facebookincubator/beanmachine/commit/193ddc08ebbe4ff0997834e43041c828bd2de5ab) and D28974815 (https://github.com/facebookincubator/beanmachine/commit/f960d03a23527c5b081494b801eb4df9b4cb61d5) to add the diagonal mass matrix adaptation mechanism to HMC and NUTS.

To make it easier to trace & compile the functions with NNC in the future, the dictionary of matrices are passed around as an argument.

The adaptation phase is split into a sequence of windows with monotonically increasing sizes. At the end of a window, the step size adapter and the mass matrix adapter is re-initialize.
- See how [Stan reset the step size adapter when mass matrix get updated](https://github.com/stan-dev/stan/blob/7b291dac8d7c9509bf11db540f5efde7a649d410/src/stan/mcmc/hmc/nuts/adapt_dense_e_nuts.hpp#L35-L39)
- [Pyro also reset step size at the end of a window](https://github.com/pyro-ppl/pyro/blob/6fa4d8b2810dff9b3bcc4b7e994029cdc818520f/pyro/infer/mcmc/adaptation.py#L175-L178)

Adapting dense mass matrix is a bit trickier as we'll have to concatenate the momentums from multiple sites and have to deal with (potentially) dynamic models, so I will leave this to a separate diff.

A side note: For many PPLs (Stan, Pyro), the default behavior is to adapt diagonal mass matrices, as per [Stan Reference Manual](https://mc-stan.org/docs/2_27/reference-manual/hmc-algorithm-parameters.html#dense-vs.-diagonal-metrics):
> Statistical models for which sampling is problematic are not typically dominated by linear correlations for which a dense metric can adjust. Rather, they are governed by more complex nonlinear correlations that are best tackled with better parameterizations or more advanced algorithms, such as Riemannian HMC.

So I would expect our HMC/NUTS implementation to perform reasonably well at this stage in comparison to the other PPLs even without dense mass matrix, if things have been implemented correctly :).

Differential Revision: D28862600

