### PR TITLE
Make adding a query to BMG idempotent.

### DIFF
--- a/src/beanmachine/graph/graph.cpp
+++ b/src/beanmachine/graph/graph.cpp
@@ -790,13 +790,16 @@ uint Graph::query(uint node_id) {
         std::to_string(static_cast<int>(NodeType::OPERATOR)) + " but is " +
         std::to_string(static_cast<int>(t)));
   }
-
-  if (queried.find(node_id) != queried.end()) {
-    throw std::invalid_argument(
-        "duplicate query for node_id " + std::to_string(node_id));
+  // Adding a query is idempotent; querying the same node twice returns
+  // the same query identifier both times.
+  //
+  // This is a linear search but the vector of queries is almost always
+  // very short.
+  auto it = std::find(queries.begin(), queries.end(), node_id);
+  if (it != queries.end()) {
+    return it - queries.begin();
   }
   queries.push_back(node_id);
-  queried.insert(node_id);
   return queries.size() - 1; // the index is 0-based
 }
 

--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -775,8 +775,7 @@ struct Graph {
   // we store redundant information in queries and queried. The latter is a
   // cache of the queried nodes while the former gives the order of nodes
   // queried
-  std::vector<uint> queries; // list of queried nodenums
-  std::set<uint> queried; // set of queried nodes
+  std::vector<uint> queries; // list of queried node ids
   std::vector<std::vector<NodeValue>> samples;
   std::vector<std::vector<std::vector<NodeValue>>> samples_allchains;
   std::vector<double> means;

--- a/src/beanmachine/graph/tests/graph_test.py
+++ b/src/beanmachine/graph/tests/graph_test.py
@@ -323,11 +323,10 @@ digraph "graph" {
     def test_inference(self):
         g, Rain, Sprinkler, GrassWet = self._create_graph()
         g.observe(GrassWet, True)
-        g.query(Rain)
+        qr = g.query(Rain)
         g.query(GrassWet)
-        with self.assertRaises(ValueError) as cm:
-            g.query(Rain)
-        self.assertTrue("duplicate query for node" in str(cm.exception))
+        # Querying the same node twice is idempotent.
+        self.assertEqual(g.query(Rain), qr)
         samples = g.infer(1)
         self.assertTrue(len(samples) == 1)
         # since we have observed grass wet is true the query should be true

--- a/src/beanmachine/ppl/compiler/tests/bmg_query_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_query_test.py
@@ -188,13 +188,7 @@ digraph "graph" {
 """
         self.assertEqual(expected.strip(), str(observed).strip())
 
-        # TODO: This crashes BMG with error "duplicate query for node_id 2".
-        # We need to figure out what to do here; an easy and powerful fix
-        # would be to make adding a query to a BMG node idempotent.
-        # An alternative solution would be to run a pass which merges the
-        # two query nodes into one that is associated with both RVIDs.
-        #
-        # samples = BMGInference().infer([flip3(), flip4()], {}, 10)
-        # f = samples[flip3()]
-        # f2 = samples[flip4()]
-        # self.assertEqual(str(f), str(f2))
+        samples = BMGInference().infer([flip3(), flip4()], {}, 10)
+        f3 = samples[flip3()]
+        f4 = samples[flip4()]
+        self.assertEqual(str(f3), str(f4))


### PR DESCRIPTION
Summary:
As noted in the previous diff, we need to somehow handle the situation where the compiler produces a graph with two queries on the same node; either BMG has to allow that, or the compiler needs to deduplicate the query nodes while continuing to track which queries are associated with which RVIDs.

There is no particular downside I'm aware of to making BMG allow multiple queries on the same node; the query ID is just the index into the sample vector returned by BMG, so asking for the same node to be queried twice can be implemented by returning the same index again.

Reviewed By: wtaha

Differential Revision: D28817397

