### PR TITLE
Error on operations involving unsupported constant inputs

### DIFF
--- a/src/beanmachine/ppl/compiler/fix_unsupported.py
+++ b/src/beanmachine/ppl/compiler/fix_unsupported.py
@@ -149,8 +149,15 @@ class UnsupportedNodeFixer(ProblemFixerBase):
         return None
 
     def _needs_fixing(self, n: bn.BMGNode) -> bool:
-        # Untyped constant nodes will be replaced in the requirements checking pass.
-        return not isinstance(n, bn.UntypedConstantNode) and not is_supported_by_bmg(n)
+        # Constants that can be converted to constant nodes of the appropriate type
+        # will be converted in the requirements checking pass. For now, just detect
+        # constants that cannot possibly be supported because they are the wrong
+        # dimensionality. We will fail to fix it in _get_replacement and report an error.
+        if isinstance(n, bn.ConstantNode):
+            t = bt.type_of_value(n.value)
+            return t == bt.Tensor or t == bt.Untypable
+        # It's not a constant. If the node is not supported then try to fix it.
+        return not is_supported_by_bmg(n)
 
     def _get_error(self, n: bn.BMGNode, index: int) -> Optional[BMGError]:
         # TODO: The edge labels used to visualize the graph in DOT

--- a/src/beanmachine/ppl/compiler/tests/bmg_types_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_types_test.py
@@ -130,6 +130,8 @@ class BMGTypesTest(unittest.TestCase):
         self.assertEqual(
             Tensor, type_of_value(tensor([[[0, 0], [0, 0]], [[0, 0], [0, 0]]]))
         )
+        # Empty tensor is Tensor
+        self.assertEqual(Tensor, type_of_value(tensor([])))
 
     def test_types_in_dot(self) -> None:
         """test_types_in_dot"""

--- a/src/beanmachine/ppl/compiler/tests/dirichlet_test.py
+++ b/src/beanmachine/ppl/compiler/tests/dirichlet_test.py
@@ -326,28 +326,13 @@ digraph "graph" {
     def test_dirichlet_errors(self) -> None:
         self.maxDiff = None
 
-        # These are the cases above where we cannot convert the
-        # given tensor to a one-row vector of positive reals.
+        # If the constant tensor given is not supported at all by BMG because of
+        # its dimensionality then that is the error we will report. If the tensor
+        # is supported by BMG but not valid for a Dirichlet then that's what we say.
 
-        # TODO: Error message could be more specific here than "a tensor".
-        # We could say what is wrong: its size.
-
-        expected = (
-            "The concentration of a Dirichlet is required to be"
-            + " a positive real but is a tensor."
-        )
-        with self.assertRaises(ValueError) as ex:
-            BMGInference().infer([d0()], {}, 1)
-        self.assertEqual(expected, str(ex.exception))
-
-        expected = (
-            "The concentration of a Dirichlet is required to be"
-            + " a 2 x 1 positive real matrix but is a tensor."
-        )
-
-        with self.assertRaises(ValueError) as ex:
-            BMGInference().infer([d2c()], {}, 1)
-        self.assertEqual(expected, str(ex.exception))
+        # TODO: Error message is misleading in that it says that the requirement
+        # is a 3x1 positive real matrix, when the real requirement is that it be
+        # ANY 1-d positive real matrix.
 
         expected = (
             "The concentration of a Dirichlet is required to be"


### PR DESCRIPTION
Summary:
If a constant value makes it into the accumulated graph then either it was queried, or it was used in a calculation with stochastic inputs. We should give an error if that constant value is a tensor that cannot be represented in BMG; BMG can only do 1-D and 2-D tensors.

We achieve this by adding a case to the unsupported operation error detection pass. The error message is re-used from the error used for invalid operations, and reads poorly as a result. I will update the error message in a later diff to make it more clear.

Reviewed By: wtaha

Differential Revision: D28840962

