### PR TITLE
Replace APIs that are deprecated in PyTorch 1.9 (to fix CI)

### DIFF
--- a/src/beanmachine/ppl/inference/proposer/newtonian_monte_carlo_utils.py
+++ b/src/beanmachine/ppl/inference/proposer/newtonian_monte_carlo_utils.py
@@ -104,7 +104,7 @@ def symmetric_inverse(
     later inversed as we'd like to compute negative hessian inverse eigenvalues.
     :returns: eigen value and eigen vector of the negative hessian inverse
     """
-    eig_vals, eig_vecs = torch.symeig(neg_hessian, eigenvectors=True)
+    eig_vals, eig_vecs = torch.linalg.eigh(neg_hessian)
     eig_vals[eig_vals <= 0] = max_zval
     inverse_eig_vals = eig_vals.reciprocal()
     return eig_vecs, inverse_eig_vals

--- a/src/beanmachine/ppl/inference/proposer/single_site_no_u_turn_sampler_proposer.py
+++ b/src/beanmachine/ppl/inference/proposer/single_site_no_u_turn_sampler_proposer.py
@@ -233,7 +233,7 @@ class SingleSiteNoUTurnSamplerProposer(SingleSiteAncestralProposer):
                 self.covariance
                 + torch.eye(len(self.covariance)) * self.covariance_diagonal_padding
             )
-            lower = torch.cholesky(self.covariance)
+            lower = torch.linalg.cholesky(self.covariance)
             identity_matrix = torch.eye(lower.size(-1), dtype=lower.dtype)
             self.l_inv = torch.triangular_solve(
                 identity_matrix, lower, upper=False

--- a/src/beanmachine/ppl/inference/proposer/tests/normal_eig_test.py
+++ b/src/beanmachine/ppl/inference/proposer/tests/normal_eig_test.py
@@ -10,7 +10,7 @@ from torch.distributions.multivariate_normal import MultivariateNormal
 class NormalEigTest(unittest.TestCase):
     def test_normal_eig(self) -> None:
         covar = torch.Tensor([[1, 0.1, 0], [0.1, 2, 0.5], [0, 0.5, 3]])
-        evals, evecs = torch.symeig(covar, eigenvectors=True)
+        evals, evecs = torch.linalg.eigh(covar)
         mean = torch.Tensor([1.0, 3.5, -1.2])
         # we want to test that both distributions are identical
         ref_dist = MultivariateNormal(mean, covar)

--- a/src/beanmachine/ppl/inference/proposer/tests/single_site_real_space_newtonian_monte_carlo_proposer_test.py
+++ b/src/beanmachine/ppl/inference/proposer/tests/single_site_real_space_newtonian_monte_carlo_proposer_test.py
@@ -80,7 +80,7 @@ class SingleSiteRealSpaceNewtonianMonteCarloProposerTest(unittest.TestCase):
         )[0]
         mean, scale_tril = parse_arguments(prop_dist.arguments)
         expected_mean = tensor([1.5, 1.5])
-        expected_scale_tril = torch.cholesky(
+        expected_scale_tril = torch.linalg.cholesky(
             tensor([[0.5000, 0.4000], [0.4000, 0.5000]])
         )
         self.assertTrue(torch.isclose(mean, expected_mean).all())
@@ -113,7 +113,7 @@ class SingleSiteRealSpaceNewtonianMonteCarloProposerTest(unittest.TestCase):
         mean, scale_tril = parse_arguments(prop_dist.arguments)
 
         expected_mean = tensor([1.0, 1.0])
-        expected_scale_tril = torch.cholesky(tensor([[1.0, 0.8], [0.8, 1]]))
+        expected_scale_tril = torch.linalg.cholesky(tensor([[1.0, 0.8], [0.8, 1]]))
         self.assertTrue(torch.isclose(mean, expected_mean).all())
         self.assertTrue(torch.isclose(scale_tril, expected_scale_tril).all())
 
@@ -254,7 +254,7 @@ class SingleSiteRealSpaceNewtonianMonteCarloProposerTest(unittest.TestCase):
         ).unsqueeze(0)
 
         expected_covar = expected_second_gradient.unsqueeze(0).inverse() * -1
-        expected_scale_tril = torch.cholesky(expected_covar)
+        expected_scale_tril = torch.linalg.cholesky(expected_covar)
         self.assertAlmostEqual(
             expected_scale_tril.item(), scale_tril.item(), delta=0.001
         )
@@ -309,7 +309,7 @@ class SingleSiteRealSpaceNewtonianMonteCarloProposerTest(unittest.TestCase):
         expected_second_gradient = (
             proposal_value.grad - expected_first_gradient
         ).unsqueeze(0)
-        expected_scale_tril = torch.cholesky(
+        expected_scale_tril = torch.linalg.cholesky(
             (expected_second_gradient.unsqueeze(0)).inverse() * -1
         )
         self.assertAlmostEqual(


### PR DESCRIPTION
Summary:
PyTorch 1.9 was officially [released yesterday](https://pytorch.org/blog/pytorch-1.9-released/) and our CI [promptly fails](https://app.circleci.com/pipelines/github/facebookincubator/beanmachine/3044/workflows/0edbdf12-fe2c-4089-b8fa-e371db4a4ce6/jobs/8199) because a few torch functions that we are using have been marked as deprecated.

So this diff simply replace the old API with a new one based on the error message:
- replace `torch.cholesky` with `torch.linalg.cholesky`
- replace `torch.symeig(*, eigenvectors=True)` with `torch.linalg.eignh`

Differential Revision: D29172232

