### PR TITLE
Compiler now allows queries on constants when generating code or doing inference

### DIFF
--- a/src/beanmachine/ppl/compiler/gen_bmg_cpp.py
+++ b/src/beanmachine/ppl/compiler/gen_bmg_cpp.py
@@ -61,10 +61,6 @@ class GeneratedGraphCPP:
             self._code.append(f"g.observe([n{graph_id}], {_value_to_cpp(v)});")
 
     def _add_query(self, node: bn.Query) -> None:
-        # BMG does not allow a query on a constant, but it is possible
-        # to end up with one in the graph. Suppress those from codegen.
-        if isinstance(node.operator, bn.ConstantNode):
-            return
         query_id = len(self.query_to_query_id)
         self.query_to_query_id[node] = query_id
         graph_id = self.node_to_graph_id[node.operator]

--- a/src/beanmachine/ppl/compiler/gen_bmg_graph.py
+++ b/src/beanmachine/ppl/compiler/gen_bmg_graph.py
@@ -39,9 +39,8 @@ class GeneratedGraph:
         self.graph.observe(self.node_to_graph_id[node.observed], node.value)
 
     def _add_query(self, node: bn.Query) -> None:
-        if not isinstance(node.operator, bn.ConstantNode):
-            query_id = self.graph.query(self.node_to_graph_id[node.operator])
-            self.query_to_query_id[node] = query_id
+        query_id = self.graph.query(self.node_to_graph_id[node.operator])
+        self.query_to_query_id[node] = query_id
 
     def _inputs(self, node: bn.BMGNode) -> List[int]:
         return [self.node_to_graph_id[x] for x in node.inputs]
@@ -98,17 +97,13 @@ class GeneratedGraph:
         # TODO: We could consider traversing only nodes reachable from
         # observations or queries.
         #
-        # There are four cases to consider:
+        # There are three cases to consider:
         #
         # * Observations: there is no associated value returned by the graph
         #   when we add an observation, so there is nothing to track.
         #
-        # * Query of a constant: BMG does not support query on a constant.
-        #   We skip adding these; when it comes time to fill in the results
-        #   dictionary we will just make a vector of the constant value.
-        #
-        # * Query of an operator: The graph gives us the column index in the
-        #   list of samples it returns for this query. We track it in
+        # * Query of an operator (or constant): The graph gives us the column
+        #   index in the list of samples it returns for this query. We track it in
         #   query_to_query_id.
         #
         # * Any other node: the graph gives us the graph identifier of the new

--- a/src/beanmachine/ppl/compiler/gen_bmg_python.py
+++ b/src/beanmachine/ppl/compiler/gen_bmg_python.py
@@ -50,10 +50,6 @@ class GeneratedGraphPython:
         self._code.append(f"g.observe(n{graph_id}, {node.value})")
 
     def _add_query(self, node: bn.Query) -> None:
-        # BMG does not allow a query on a constant, but it is possible
-        # to end up with one in the graph. Suppress those from codegen.
-        if isinstance(node.operator, bn.ConstantNode):
-            return
         query_id = len(self.query_to_query_id)
         self.query_to_query_id[node] = query_id
         graph_id = self.node_to_graph_id[node.operator]

--- a/src/beanmachine/ppl/compiler/tests/dirichlet_test.py
+++ b/src/beanmachine/ppl/compiler/tests/dirichlet_test.py
@@ -215,12 +215,15 @@ graph::Graph g;
 Eigen::MatrixXd m0(1, 1)
 m0 << 1.0;
 uint n0 = g.add_constant_pos_matrix(m0);
+uint q0 = g.query(n0);
 Eigen::MatrixXd m1(2, 1)
 m1 << 1.0, 1.5;
 uint n1 = g.add_constant_pos_matrix(m1);
+uint q1 = g.query(n1);
 Eigen::MatrixXd m2(2, 2)
 m2 << 1.0, 1.5, 2.0, 2.5;
 uint n2 = g.add_constant_pos_matrix(m2);
+uint q2 = g.query(n2);
         """
         observed = to_bmg_cpp(bmg).code
         self.assertEqual(expected.strip(), observed.strip())
@@ -233,8 +236,12 @@ from beanmachine import graph
 from torch import tensor
 g = graph.Graph()
 n0 = g.add_constant_pos_matrix(tensor([[1.0]]))
+q0 = g.query(n0)
 n1 = g.add_constant_pos_matrix(tensor([[1.0],[1.5]]))
-n2 = g.add_constant_pos_matrix(tensor([[1.0,2.0],[1.5,2.5]]))"""
+q1 = g.query(n1)
+n2 = g.add_constant_pos_matrix(tensor([[1.0,2.0],[1.5,2.5]]))
+q2 = g.query(n2)
+"""
         observed = to_bmg_python(bmg).code
         self.assertEqual(expected.strip(), observed.strip())
 

--- a/src/beanmachine/ppl/inference/bmg_inference.py
+++ b/src/beanmachine/ppl/inference/bmg_inference.py
@@ -5,7 +5,6 @@ inferences on Bean Machine models."""
 
 from typing import Dict, List, Optional, Tuple
 
-import beanmachine.ppl.compiler.bmg_nodes as bn
 import beanmachine.ppl.compiler.performance_report as pr
 import beanmachine.ppl.compiler.profiler as prof
 import torch
@@ -124,12 +123,8 @@ class BMGInference:
 
         result: Dict[RVIdentifier, torch.Tensor] = {}
         for (rv, query) in rv_to_query.items():
-            if isinstance(query.operator, bn.ConstantNode):
-                # TODO: Test this with tensor and normal constants
-                result[rv] = torch.tensor([[query.operator.value] * num_samples])
-            else:
-                query_id = query_to_query_id[query]
-                result[rv] = samples[query_id]
+            query_id = query_to_query_id[query]
+            result[rv] = samples[query_id]
         mcsamples = MonteCarloSamples(result)
 
         self._finish(prof.build_mcsamples)


### PR DESCRIPTION
Summary:
Prior to recent changes, BMG did not support querying a constant. But querying a constant is (1) legal in Bean Machine, and (2) possibly useful in some scenarios, and (3) it is irritating to have to work around this restriction.  I have added the ability to do so in BMG in a prior diff.

This diff removes the code from the compiler which did an end run around this restriction. We no longer suppress queries on constants from code generation or graph generation.

Doing so has exposed an interesting bug in the code and graph generators, and the fix is likely to be somewhat complicated and might take a few diffs to complete. I am therefore going to leave the code in its current somewhat broken state; it's not hurting anyone for now.

The bug is that (1) querying a constant whose value is a single-valued tensor in the original model automatically converts that tensor to `True` or `False` depending on whether its single value is nonzero or zero, and (2) querying a multiple-valued tensor will crash.

I'll follow up on the bug fix in an upcoming diff stack.

Reviewed By: wtaha

Differential Revision: D28886660

