### PR TITLE
Fix code and graph generation for tensor constants

### DIFF
--- a/src/beanmachine/ppl/compiler/gen_bmg_graph.py
+++ b/src/beanmachine/ppl/compiler/gen_bmg_graph.py
@@ -85,8 +85,10 @@ class GeneratedGraph:
             graph_id = self.graph.add_constant_natural_matrix(_reshape(v))
         elif t is bn.ConstantBooleanMatrixNode:
             graph_id = self.graph.add_constant_bool_matrix(_reshape(v))
+        elif isinstance(v, torch.Tensor) and v.numel() != 1:
+            graph_id = self.graph.add_constant_real_matrix(_reshape(v))
         else:
-            graph_id = self.graph.add_constant(v)
+            graph_id = self.graph.add_constant(float(v))
         self.node_to_graph_id[node] = graph_id
 
     def _generate_node(self, node: bn.BMGNode) -> None:

--- a/src/beanmachine/ppl/compiler/gen_bmg_python.py
+++ b/src/beanmachine/ppl/compiler/gen_bmg_python.py
@@ -123,8 +123,6 @@ class GeneratedGraphPython:
             f = f"add_constant({str(int(v))})"
         elif t is bn.RealNode:
             f = f"add_constant({str(float(v))})"
-        elif t is bn.ConstantTensorNode:
-            f = f"add_constant(tensor({_tensor_to_python(v)}))"
         elif t is bn.ConstantPositiveRealMatrixNode:
             f = f"add_constant_pos_matrix({_matrix_to_python(v)})"
         elif t is bn.ConstantRealMatrixNode:
@@ -137,8 +135,10 @@ class GeneratedGraphPython:
             f = f"add_constant_natural_matrix({_matrix_to_python(v)})"
         elif t is bn.ConstantBooleanMatrixNode:
             f = f"add_constant_bool_matrix({_matrix_to_python(v)})"
+        elif isinstance(v, torch.Tensor) and v.numel() != 1:
+            f = f"add_constant_real_matrix({_matrix_to_python(v)})"
         else:
-            f = "UNKNOWN"
+            f = f"add_constant({str(float(v))})"
         self._code.append(f"n{graph_id} = g.{f}")
 
     def _generate_node(self, node: bn.BMGNode) -> None:


### PR DESCRIPTION
Summary:
When we generate a BMG graph from a model, or generate the Python code to do so, we were doing it wrong for a certain set of tensor values; the bug was mostly unobservable until recently, when I added ability to query directly on a constant value.

We no longer crash when generating a query on a multi-value tensor, and no longer automatically convert the tensor to bool when querying a single-value tensor.

The C++ code generation still looks wrong but we can fix that in a later diff.

There is still the lingering problem that `add_constant(tensor(2.5))` does not do what you think it does in Python because the python bindings turn that into `add_constant(True)`.  I'll fix that in an upcoming diff.

Reviewed By: wtaha

Differential Revision: D28911908

