### PR TITLE
Rename add_constant python bindings to avoid unexpected conversions

### DIFF
--- a/src/beanmachine/graph/pybindings.cpp
+++ b/src/beanmachine/graph/pybindings.cpp
@@ -105,10 +105,28 @@ PYBIND11_MODULE(graph, module) {
       .def_readwrite("path_length", &InferConfig::path_length)
       .def_readwrite("step_size", &InferConfig::step_size);
 
+  // CONSIDER: Remove the overloaded add_constant APIs; the overloaded API's
+  // binding behaviour is a little confusing. For example,
+  // add_constant(tensor(2.5)) has the effect of calling add_constant(True).
   py::class_<Graph>(module, "Graph")
       .def(py::init())
       .def("to_string", &Graph::to_string, "string representation of the graph")
       .def("to_dot", &Graph::to_dot, "DOT representation of the graph")
+      .def(
+          "add_constant_bool",
+          (uint(Graph::*)(bool)) & Graph::add_constant,
+          "add a Node with a constant boolean value",
+          py::arg("value"))
+      .def(
+          "add_constant_real",
+          (uint(Graph::*)(double)) & Graph::add_constant,
+          "add a Node with a constant real value",
+          py::arg("value"))
+      .def(
+          "add_constant_natural",
+          (uint(Graph::*)(graph::natural_t)) & Graph::add_constant,
+          "add a Node with a constant natural (integers >= 0) value",
+          py::arg("value"))
       .def(
           "add_constant",
           (uint(Graph::*)(bool)) & Graph::add_constant,

--- a/src/beanmachine/graph/tests/graph_test.py
+++ b/src/beanmachine/graph/tests/graph_test.py
@@ -63,14 +63,14 @@ class TestBayesNet(unittest.TestCase):
         g.add_distribution(
             graph.DistributionType.TABULAR,
             graph.AtomicType.BOOLEAN,
-            [c2, g.add_constant(True)],
+            [c2, g.add_constant_bool(True)],
         )
 
         with self.assertRaises(ValueError) as cm:
             g.add_distribution(
                 graph.DistributionType.TABULAR,
                 graph.AtomicType.BOOLEAN,
-                [c2, g.add_constant(1)],
+                [c2, g.add_constant_natural(1)],
             )
         self.assertTrue("only supports boolean parents" in str(cm.exception))
 
@@ -117,7 +117,7 @@ class TestBayesNet(unittest.TestCase):
         )
 
         # negative test on type of parent
-        c3 = g.add_constant(1)
+        c3 = g.add_constant_natural(1)
         with self.assertRaises(ValueError) as cm:
             g.add_distribution(
                 graph.DistributionType.BERNOULLI, graph.AtomicType.BOOLEAN, [c3]
@@ -159,7 +159,7 @@ class TestBayesNet(unittest.TestCase):
             "Beta distribution must have exactly two parents" in str(cm.exception)
         )
         # negative test on type of parent
-        c3 = g.add_constant(True)
+        c3 = g.add_constant_bool(True)
         with self.assertRaises(ValueError) as cm:
             g.add_distribution(
                 graph.DistributionType.BETA, graph.AtomicType.PROBABILITY, [c3, c3]
@@ -186,7 +186,7 @@ class TestBayesNet(unittest.TestCase):
 
     def test_binomial(self):
         g = graph.Graph()
-        c1 = g.add_constant(10)
+        c1 = g.add_constant_natural(10)
         c2 = g.add_constant_probability(0.55)
         d1 = g.add_distribution(
             graph.DistributionType.BINOMIAL, graph.AtomicType.NATURAL, [c1, c2]

--- a/src/beanmachine/graph/tests/nmc_test.py
+++ b/src/beanmachine/graph/tests/nmc_test.py
@@ -34,7 +34,7 @@ class TestNMC(unittest.TestCase):
             (6.7, 5.6),  # overall std
         ]
         g = graph.Graph()
-        zero = g.add_constant(0.0)
+        zero = g.add_constant_real(0.0)
         thousand = g.add_constant_pos_real(1000.0)
         # overall_mean ~ Normal(0, 1000)
         overall_mean_dist = g.add_distribution(
@@ -95,11 +95,11 @@ class TestNMC(unittest.TestCase):
         SIGMA_X = 5.0
         SIGMA_Y = 2.0
         RHO = 0.7
-        x_sq_term = g.add_constant(-0.5 / (1 - RHO ** 2) / SIGMA_X ** 2)
+        x_sq_term = g.add_constant_real(-0.5 / (1 - RHO ** 2) / SIGMA_X ** 2)
         g.add_factor(graph.FactorType.EXP_PRODUCT, [x_sq, x_sq_term])
-        y_sq_term = g.add_constant(-0.5 / (1 - RHO ** 2) / SIGMA_Y ** 2)
+        y_sq_term = g.add_constant_real(-0.5 / (1 - RHO ** 2) / SIGMA_Y ** 2)
         g.add_factor(graph.FactorType.EXP_PRODUCT, [y_sq, y_sq_term])
-        x_y_term = g.add_constant(RHO / (1 - RHO ** 2) / SIGMA_X / SIGMA_Y)
+        x_y_term = g.add_constant_real(RHO / (1 - RHO ** 2) / SIGMA_X / SIGMA_Y)
         g.add_factor(graph.FactorType.EXP_PRODUCT, [x_y, x_y_term])
         g.query(x)
         g.query(x_sq)
@@ -131,7 +131,7 @@ class TestNMC(unittest.TestCase):
         P(Phi(x) | y = false) ~ Beta(1, 2)
         """
         g = graph.Graph()
-        zero = g.add_constant(0.0)
+        zero = g.add_constant_real(0.0)
         one = g.add_constant_pos_real(1.0)
         prior = g.add_distribution(
             graph.DistributionType.NORMAL, graph.AtomicType.REAL, [zero, one]
@@ -213,10 +213,10 @@ class TestNMC(unittest.TestCase):
         )
         f = [g.add_operator(graph.OperatorType.SAMPLE, [flat]) for _ in SCORES]
         for i in range(len(SCORES)):
-            tau_i_i = g.add_constant(-0.5 * tau[i, i])
+            tau_i_i = g.add_constant_real(-0.5 * tau[i, i])
             g.add_factor(graph.FactorType.EXP_PRODUCT, [tau_i_i, f[i], f[i]])
             for j in range(i + 1, len(SCORES)):
-                tau_i_j = g.add_constant(-1.0 * tau[i, j])
+                tau_i_j = g.add_constant_real(-1.0 * tau[i, j])
                 g.add_factor(graph.FactorType.EXP_PRODUCT, [tau_i_j, f[i], f[j]])
         # for each labeler l:
         #     spec_l ~ Beta(SPEC_ALPHA, SPEC_BETA)
@@ -310,8 +310,8 @@ class TestNMC(unittest.TestCase):
         )
         X_1 = g.add_operator(graph.OperatorType.SAMPLE, [bernoulli])
         X_2 = g.add_operator(graph.OperatorType.SAMPLE, [bernoulli])
-        plus_one = g.add_constant(1.0)
-        minus_one = g.add_constant(-1.0)
+        plus_one = g.add_constant_real(1.0)
+        minus_one = g.add_constant_real(-1.0)
         sigma_1 = g.add_operator(
             graph.OperatorType.IF_THEN_ELSE, [X_1, plus_one, minus_one]
         )
@@ -334,7 +334,7 @@ class TestNMC(unittest.TestCase):
             -((np.expand_dims(scores, 1) - scores) ** 2) / 2 / rho ** 2
         )
         tau = np.linalg.inv(covar)  # the precision matrix
-        neg_mu = bmg.add_constant(-mu)
+        neg_mu = bmg.add_constant_real(-mu)
         # f ~ GP
         flat = bmg.add_distribution(
             graph.DistributionType.FLAT, graph.AtomicType.REAL, []
@@ -347,12 +347,12 @@ class TestNMC(unittest.TestCase):
                 bmg.add_operator(graph.OperatorType.ADD, [fi, neg_mu]) for fi in f
             ]
         for i in range(len(scores)):
-            tau_i_i = bmg.add_constant(-0.5 * tau[i, i])
+            tau_i_i = bmg.add_constant_real(-0.5 * tau[i, i])
             bmg.add_factor(
                 graph.FactorType.EXP_PRODUCT, [tau_i_i, f_centered[i], f_centered[i]]
             )
             for j in range(i + 1, len(scores)):
-                tau_i_j = bmg.add_constant(-1.0 * tau[i, j])
+                tau_i_j = bmg.add_constant_real(-1.0 * tau[i, j])
                 bmg.add_factor(
                     graph.FactorType.EXP_PRODUCT,
                     [tau_i_j, f_centered[i], f_centered[j]],

--- a/src/beanmachine/graph/tests/operator_test.py
+++ b/src/beanmachine/graph/tests/operator_test.py
@@ -19,13 +19,13 @@ class TestOperators(unittest.TestCase):
         self.maxDiff = None
 
         g = bmg.Graph()
-        c1 = g.add_constant(2.5)
-        c2 = g.add_constant(-1.5)
+        c1 = g.add_constant_real(2.5)
+        c2 = g.add_constant_real(-1.5)
         c3 = g.add_constant_probability(0.5)
         c4 = g.add_constant_probability(0.6)
         c5 = g.add_constant_probability(0.7)
-        c6 = g.add_constant(23)  # NATURAL
-        c7 = g.add_constant(False)
+        c6 = g.add_constant_natural(23)
+        c7 = g.add_constant_bool(False)
         c8 = g.add_constant_neg_real(-1.25)
         c9 = g.add_constant_pos_real(1.25)
         # add const matrices, operators on matrix to be added
@@ -186,7 +186,7 @@ Node 33 type 3 parents [ 0 1 ] children [ ] real 0
 
     def test_arithmetic(self) -> None:
         g = bmg.Graph()
-        c1 = g.add_constant(3)  # natural
+        c1 = g.add_constant_natural(3)
         o0 = g.add_operator(bmg.OperatorType.TO_REAL, [c1])
         o1 = g.add_operator(bmg.OperatorType.NEGATE, [o0])
         o2 = g.add_operator(bmg.OperatorType.EXP, [o1])  # positive real
@@ -234,9 +234,9 @@ Node 33 type 3 parents [ 0 1 ] children [ ] real 0
         # constrains it to the range (0.0, 1.0)
 
         g = bmg.Graph()
-        c0 = g.add_constant(0.25)
-        c1 = g.add_constant(0.5)
-        c2 = g.add_constant(0.75)
+        c0 = g.add_constant_real(0.25)
+        c1 = g.add_constant_real(0.5)
+        c2 = g.add_constant_real(0.75)
         o0 = g.add_operator(bmg.OperatorType.ADD, [c0, c1])
         o1 = g.add_operator(bmg.OperatorType.TO_PROBABILITY, [o0])
         o2 = g.add_operator(bmg.OperatorType.ADD, [c1, c2])

--- a/src/beanmachine/ppl/compiler/gen_bmg_graph.py
+++ b/src/beanmachine/ppl/compiler/gen_bmg_graph.py
@@ -68,11 +68,11 @@ class GeneratedGraph:
         elif t is bn.ProbabilityNode:
             graph_id = self.graph.add_constant_probability(float(v))
         elif t is bn.BooleanNode:
-            graph_id = self.graph.add_constant(bool(v))
+            graph_id = self.graph.add_constant_bool(bool(v))
         elif t is bn.NaturalNode:
-            graph_id = self.graph.add_constant(int(v))
+            graph_id = self.graph.add_constant_natural(int(v))
         elif t is bn.RealNode:
-            graph_id = self.graph.add_constant(float(v))
+            graph_id = self.graph.add_constant_real(float(v))
         elif t is bn.ConstantPositiveRealMatrixNode:
             graph_id = self.graph.add_constant_pos_matrix(_reshape(v))
         elif t is bn.ConstantRealMatrixNode:
@@ -88,7 +88,7 @@ class GeneratedGraph:
         elif isinstance(v, torch.Tensor) and v.numel() != 1:
             graph_id = self.graph.add_constant_real_matrix(_reshape(v))
         else:
-            graph_id = self.graph.add_constant(float(v))
+            graph_id = self.graph.add_constant_real(float(v))
         self.node_to_graph_id[node] = graph_id
 
     def _generate_node(self, node: bn.BMGNode) -> None:

--- a/src/beanmachine/ppl/compiler/gen_bmg_python.py
+++ b/src/beanmachine/ppl/compiler/gen_bmg_python.py
@@ -118,11 +118,11 @@ class GeneratedGraphPython:
         elif t is bn.ProbabilityNode:
             f = f"add_constant_probability({str(float(v))})"
         elif t is bn.BooleanNode:
-            f = f"add_constant({str(bool(v))})"
+            f = f"add_constant_bool({str(bool(v))})"
         elif t is bn.NaturalNode:
-            f = f"add_constant({str(int(v))})"
+            f = f"add_constant_natural({str(int(v))})"
         elif t is bn.RealNode:
-            f = f"add_constant({str(float(v))})"
+            f = f"add_constant_real({str(float(v))})"
         elif t is bn.ConstantPositiveRealMatrixNode:
             f = f"add_constant_pos_matrix({_matrix_to_python(v)})"
         elif t is bn.ConstantRealMatrixNode:
@@ -138,7 +138,7 @@ class GeneratedGraphPython:
         elif isinstance(v, torch.Tensor) and v.numel() != 1:
             f = f"add_constant_real_matrix({_matrix_to_python(v)})"
         else:
-            f = f"add_constant({str(float(v))})"
+            f = f"add_constant_real({str(float(v))})"
         self._code.append(f"n{graph_id} = g.{f}")
 
     def _generate_node(self, node: bn.BMGNode) -> None:

--- a/src/beanmachine/ppl/compiler/tests/bm_graph_builder_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bm_graph_builder_test.py
@@ -131,7 +131,7 @@ n1 = g.add_distribution(
 )
 n2 = g.add_operator(graph.OperatorType.SAMPLE, [n1])
 g.observe(n2, True)
-n3 = g.add_constant(2.0)
+n3 = g.add_constant_real(2.0)
 n4 = g.add_operator(graph.OperatorType.TO_REAL, [n2])
 n5 = g.add_operator(graph.OperatorType.NEGATE, [n4])
 n6 = g.add_operator(graph.OperatorType.ADD, [n3, n5])

--- a/src/beanmachine/ppl/compiler/tests/bmg_factor_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_factor_test.py
@@ -67,7 +67,7 @@ Node 6 type 4 parents [ 3 4 5 ] children [ ] unknown
 from beanmachine import graph
 from torch import tensor
 g = graph.Graph()
-n0 = g.add_constant(3.0)
+n0 = g.add_constant_real(3.0)
 n1 = g.add_constant_pos_real(2.0)
 n2 = g.add_distribution(
   graph.DistributionType.NORMAL,

--- a/src/beanmachine/ppl/compiler/tests/bmg_query_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_query_test.py
@@ -126,7 +126,7 @@ uint q1 = g.query(n1);
 from beanmachine import graph
 from torch import tensor
 g = graph.Graph()
-n0 = g.add_constant(2.5)
+n0 = g.add_constant_real(2.5)
 q0 = g.query(n0)
 n1 = g.add_constant_real_matrix(tensor([[1.5],[-2.5]]))
 q1 = g.query(n1)

--- a/src/beanmachine/ppl/compiler/tests/clara_tensor_cgm_no_update_test.py
+++ b/src/beanmachine/ppl/compiler/tests/clara_tensor_cgm_no_update_test.py
@@ -281,7 +281,7 @@ n1 = g.add_distribution(
 n2 = g.add_operator(graph.OperatorType.SAMPLE, [n1])
 n3 = g.add_operator(graph.OperatorType.SAMPLE, [n1])
 n4 = g.add_operator(graph.OperatorType.SAMPLE, [n1])
-n5 = g.add_constant(0)
+n5 = g.add_constant_natural(0)
 n6 = g.add_operator(graph.OperatorType.INDEX, [n2, n5])
 n7 = g.add_operator(graph.OperatorType.LOG, [n6])
 n8 = g.add_operator(graph.OperatorType.INDEX, [n3, n5])
@@ -291,7 +291,7 @@ n11 = g.add_operator(
   graph.OperatorType.ADD,
   [n7, n9, n10],
 )
-n12 = g.add_constant(1)
+n12 = g.add_constant_natural(1)
 n13 = g.add_operator(graph.OperatorType.INDEX, [n2, n12])
 n14 = g.add_operator(graph.OperatorType.LOG, [n13])
 n15 = g.add_operator(graph.OperatorType.INDEX, [n4, n5])

--- a/src/beanmachine/ppl/compiler/tests/column_index_test.py
+++ b/src/beanmachine/ppl/compiler/tests/column_index_test.py
@@ -121,7 +121,7 @@ uint q0 = g.query(n15);
 from beanmachine import graph
 from torch import tensor
 g = graph.Graph()
-n0 = g.add_constant(0.0)
+n0 = g.add_constant_real(0.0)
 n1 = g.add_constant_pos_real(1.0)
 n2 = g.add_distribution(
   graph.DistributionType.NORMAL,
@@ -136,15 +136,15 @@ n5 = g.add_distribution(
   [n4],
 )
 n6 = g.add_operator(graph.OperatorType.SAMPLE, [n5])
-n7 = g.add_constant(2)
+n7 = g.add_constant_natural(2)
 n8 = g.add_operator(graph.OperatorType.EXP, [n3])
 n9 = g.add_operator(graph.OperatorType.TO_REAL, [n8])
 n10 = g.add_operator(
   graph.OperatorType.TO_MATRIX,
   [n7, n7, n9, n3, n3, n3],
 )
-n11 = g.add_constant(1)
-n12 = g.add_constant(0)
+n11 = g.add_constant_natural(1)
+n12 = g.add_constant_natural(0)
 n13 = g.add_operator(
   graph.OperatorType.IF_THEN_ELSE,
   [n6, n11, n12],

--- a/src/beanmachine/ppl/compiler/tests/lse_vector_test.py
+++ b/src/beanmachine/ppl/compiler/tests/lse_vector_test.py
@@ -78,7 +78,7 @@ digraph "graph" {
 from beanmachine import graph
 from torch import tensor
 g = graph.Graph()
-n0 = g.add_constant(0.0)
+n0 = g.add_constant_real(0.0)
 n1 = g.add_constant_pos_real(1.0)
 n2 = g.add_distribution(
   graph.DistributionType.NORMAL,

--- a/src/beanmachine/ppl/compiler/tests/to_matrix_test.py
+++ b/src/beanmachine/ppl/compiler/tests/to_matrix_test.py
@@ -107,7 +107,7 @@ uint q0 = g.query(n8);
 from beanmachine import graph
 from torch import tensor
 g = graph.Graph()
-n0 = g.add_constant(0.0)
+n0 = g.add_constant_real(0.0)
 n1 = g.add_constant_pos_real(1.0)
 n2 = g.add_distribution(
   graph.DistributionType.NORMAL,
@@ -115,8 +115,8 @@ n2 = g.add_distribution(
   [n0, n1],
 )
 n3 = g.add_operator(graph.OperatorType.SAMPLE, [n2])
-n4 = g.add_constant(2)
-n5 = g.add_constant(1)
+n4 = g.add_constant_natural(2)
+n5 = g.add_constant_natural(1)
 n6 = g.add_operator(graph.OperatorType.EXP, [n3])
 n7 = g.add_operator(graph.OperatorType.TO_REAL, [n6])
 n8 = g.add_operator(
@@ -219,7 +219,7 @@ uint q0 = g.query(n8);
 from beanmachine import graph
 from torch import tensor
 g = graph.Graph()
-n0 = g.add_constant(0.0)
+n0 = g.add_constant_real(0.0)
 n1 = g.add_constant_pos_real(1.0)
 n2 = g.add_distribution(
   graph.DistributionType.NORMAL,
@@ -227,8 +227,8 @@ n2 = g.add_distribution(
   [n0, n1],
 )
 n3 = g.add_operator(graph.OperatorType.SAMPLE, [n2])
-n4 = g.add_constant(1)
-n5 = g.add_constant(2)
+n4 = g.add_constant_natural(1)
+n5 = g.add_constant_natural(2)
 n6 = g.add_operator(graph.OperatorType.EXP, [n3])
 n7 = g.add_operator(graph.OperatorType.TO_REAL, [n6])
 n8 = g.add_operator(

--- a/src/beanmachine/ppl/compiler/tests/tutorial_Neals_Funnel_test.py
+++ b/src/beanmachine/ppl/compiler/tests/tutorial_Neals_Funnel_test.py
@@ -266,7 +266,7 @@ uint q1 = g.query(n4);
 from beanmachine import graph
 from torch import tensor
 g = graph.Graph()
-n0 = g.add_constant(0.0)
+n0 = g.add_constant_real(0.0)
 n1 = g.add_constant_pos_real(10000.0)
 n2 = g.add_distribution(
   graph.DistributionType.NORMAL,
@@ -275,17 +275,17 @@ n2 = g.add_distribution(
 )
 n3 = g.add_operator(graph.OperatorType.SAMPLE, [n2])
 n4 = g.add_operator(graph.OperatorType.SAMPLE, [n2])
-n5 = g.add_constant(-0.9189385332046727)
-n6 = g.add_constant(0.3333333333333333)
+n5 = g.add_constant_real(-0.9189385332046727)
+n6 = g.add_constant_real(0.3333333333333333)
 n7 = g.add_operator(graph.OperatorType.MULTIPLY, [n3, n6])
 n8 = g.add_constant_pos_real(2.0)
 n9 = g.add_operator(graph.OperatorType.POW, [n7, n8])
-n10 = g.add_constant(0.5)
+n10 = g.add_constant_real(0.5)
 n11 = g.add_operator(graph.OperatorType.MULTIPLY, [n9, n10])
 n12 = g.add_operator(graph.OperatorType.NEGATE, [n11])
 n13 = g.add_operator(graph.OperatorType.MULTIPLY, [n3, n10])
 n14 = g.add_operator(graph.OperatorType.EXP, [n13])
-n15 = g.add_constant(-1.0)
+n15 = g.add_constant_real(-1.0)
 n16 = g.add_operator(graph.OperatorType.POW, [n14, n15])
 n17 = g.add_operator(graph.OperatorType.TO_REAL, [n16])
 n18 = g.add_operator(graph.OperatorType.MULTIPLY, [n4, n17])


### PR DESCRIPTION
Summary:
BMG has python bindings for graph methods; it overloads the method add_constant so that it presents a single method that, behind the scenes actually calls overloads that take bool, natural or real values.

This presents ample opportunities for confusion when you pass to add_constant an argument which is convertible to two or all of bool, natural and real; there is no requirement that the overload resolution algorithm choose the one you want, and in Python's very loosely typed world you can easily get the wrong behaviour.

I discovered this because I was accidentally calling `add_constant(tensor(2.5))` in a test, and the interop layer was unhelpfully deciding "a single valued tensor is convertible to bool: false if zero, true otherwise", and calling `add_constant(False)` instead of `add_constant(2.5)` as I expected.

I have added three new bindings each of which does exactly one thing: `add_constant_real`, `add_constant_natural` and `add_constant_bool`.

I have also modified the `to_python` and `to_graph` methods to use these new bindings.

I have not removed the existing overloaded `add_constant` yet because I have not yet removed all uses of them throughout the codebase.

Reviewed By: wtaha

Differential Revision: D28948416

