### PR TITLE
Accumulate non-numeric constants into graph, reject them later

### DIFF
--- a/src/beanmachine/ppl/compiler/bmg_node_types.py
+++ b/src/beanmachine/ppl/compiler/bmg_node_types.py
@@ -82,6 +82,24 @@ _operator_types = {
     bn.VectorIndexNode: OperatorType.INDEX,
 }
 
+_constant_value_types = {
+    bn.BooleanNode,
+    bn.NaturalNode,
+    bn.NegativeRealNode,
+    bn.PositiveRealNode,
+    bn.ProbabilityNode,
+    bn.RealNode,
+}
+
+_constant_matrix_types = {
+    bn.ConstantBooleanMatrixNode,
+    bn.ConstantNaturalMatrixNode,
+    bn.ConstantNegativeRealMatrixNode,
+    bn.ConstantPositiveRealMatrixNode,
+    bn.ConstantProbabilityMatrixNode,
+    bn.ConstantRealMatrixNode,
+}
+
 
 def operator_type(node: bn.OperatorNode) -> OperatorType:
     return _operator_types[type(node)]
@@ -90,9 +108,10 @@ def operator_type(node: bn.OperatorNode) -> OperatorType:
 def is_supported_by_bmg(node: bn.BMGNode) -> bool:
     t = type(node)
     return (
-        isinstance(node, bn.ConstantNode)
-        or t is bn.Observation
+        t is bn.Observation
         or t is bn.Query
+        or t in _constant_matrix_types
+        or t in _constant_value_types
         or t in _operator_types
         or t in _dist_types
         or t in _factor_types

--- a/src/beanmachine/ppl/compiler/bmg_types.py
+++ b/src/beanmachine/ppl/compiler/bmg_types.py
@@ -655,7 +655,7 @@ def type_of_value(v: Any) -> BMGLatticeType:
                 return Probability
             return PositiveReal
         return NegativeReal
-    raise ValueError("Unexpected value passed to type_of_value")
+    return Untypable
 
 
 def is_zero(v: Any) -> bool:

--- a/src/beanmachine/ppl/compiler/fix_requirements.py
+++ b/src/beanmachine/ppl/compiler/fix_requirements.py
@@ -73,6 +73,9 @@ class RequirementsFixer:
         # does not meet an UB requirement then there is no equivalent constant
         # node of the correct type and we give an error.
         it = self._typer[node]
+        # NOTE: By this point we should have already rejected any graph that contains
+        # a reachable but untypable constant node.  See comment in fix_unsupported
+        # regarding UntypedConstantNode support.
         if self._type_meets_requirement(it, bt.upper_bound(requirement)):
             required_type = bt.requirement_to_type(requirement)
             if bt.must_be_matrix(requirement):

--- a/src/beanmachine/ppl/compiler/fix_unsupported.py
+++ b/src/beanmachine/ppl/compiler/fix_unsupported.py
@@ -153,6 +153,15 @@ class UnsupportedNodeFixer(ProblemFixerBase):
         # will be converted in the requirements checking pass. For now, just detect
         # constants that cannot possibly be supported because they are the wrong
         # dimensionality. We will fail to fix it in _get_replacement and report an error.
+
+        # TODO: We should make a rewriter that detects stochastic index
+        # into list.  We will need to detect if the list is (1) all
+        # numbers, in which case we can make a constant matrix out of it,
+        # (2) mix of numbers and stochastic elements, in which case we can
+        # make it into a TO_MATRIX node, or (3) wrong shape or contents,
+        # in which case we must give an error.  We will likely want to
+        # move this check for unsupported constant value to AFTER that rewrite.
+
         if isinstance(n, bn.ConstantNode):
             t = bt.type_of_value(n.value)
             return t == bt.Tensor or t == bt.Untypable

--- a/src/beanmachine/ppl/compiler/tests/bmg_arithmetic_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_arithmetic_test.py
@@ -130,6 +130,13 @@ def unsupported_rshift():
     return bino() >> bino()
 
 
+@bm.functional
+def unsupported_add():
+    # What happens if we use a stochastic quantity in an operation with
+    # a non-tensor, non-number?
+    return bino() + "foo"
+
+
 class BMGArithmeticTest(unittest.TestCase):
     def test_bmg_arithmetic_expm1(self) -> None:
         self.maxDiff = None
@@ -450,6 +457,18 @@ The unsupported node is the operator of a Query.
         expected = """
 The model uses a >> operation unsupported by Bean Machine Graph.
 The unsupported node is the operator of a Query.
+        """
+        observed = str(ex.exception)
+        self.assertEqual(expected.strip(), observed.strip())
+
+    def test_unsupported_operands(self) -> None:
+        self.maxDiff = None
+        with self.assertRaises(ValueError) as ex:
+            BMGInference().infer([unsupported_add()], {}, 1)
+        # TODO: This error message is terrible; fix it.
+        expected = """
+The model uses a foo operation unsupported by Bean Machine Graph.
+The unsupported node is the right of a +.
         """
         observed = str(ex.exception)
         self.assertEqual(expected.strip(), observed.strip())

--- a/src/beanmachine/ppl/compiler/tests/typer_base_test.py
+++ b/src/beanmachine/ppl/compiler/tests/typer_base_test.py
@@ -22,7 +22,9 @@ class SupportedTyper(TyperBase[bool]):
         TyperBase.__init__(self)
 
     def _compute_type_inputs_known(self, node: bn.BMGNode) -> bool:
-        return is_supported_by_bmg(node) and all(self[i] for i in node.inputs)
+        return (isinstance(node, bn.ConstantNode) or is_supported_by_bmg(node)) and all(
+            self[i] for i in node.inputs
+        )
 
 
 class TyperTest(unittest.TestCase):


### PR DESCRIPTION
Summary:
While executing the model, the runtime adds nodes to the graph accumulator every time an operation has at least one stochastic operand (that is, an operand that is already a graph node.)  What should we do if the operation also has a non-stochastic "constant" operand?

Previously, we checked to see if the value could be represented in BMG -- if the value was a bool, int, real, single-valued tensor, or tensor with dimensionality<=2> we'd accept it, and if not then we'd crash during graph accumulation.

This is problematic for a number of reasons.

* BMG might not be the only backend we want to support; crashing early just because we cannot represent a thing in BMG makes supporting other backends harder.

* We might not want to generate BMG at all; we might just want to do an analysis of the stochastic operations in the model for some other reason.

* There may be transformations we can do on unsupported constant values to obtain an equivalent graph that is supported in BMG, but we cannot do that if we've already crashed.

* The error reporting experience is poor for the user.

* The error reporting code should, when possible, be isolated to analysis passes which detect specific problems, repair them if possible, and give sensible, understandable error messages if the problem cannot be fixed.

I've updated the graph accumulation code to always put a constant value into an UntypedConstantNode when it is used as an operand to an operator with at least one stochastic operand, and not check whether it is a supported-by-BMG value until a later error detection and repair pass.

This led to a number of knock-on effects on type analysis, but the summary is: we previously took advantage of the invariant that every UntypedConstantNode could be converted to a node with a supported type in the BMG type system. That's no longer the case, so now UntypedConstantNodes can be judged to be Untypeable.

Reviewed By: wtaha

Differential Revision: D28692541

