### PR TITLE
Fix linter error

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/n-schools_test.py
+++ b/src/beanmachine/ppl/compiler/tests/n-schools_test.py
@@ -15,6 +15,7 @@ from beanmachine.ppl.inference.bmg_inference import BMGInference
 from scipy.stats import norm
 from torch import tensor
 
+
 LOGGER = logging.getLogger(__name__)
 
 # Planned additions:


### PR DESCRIPTION
Summary: The python linter is complaining about a missing newline.

Reviewed By: kshah1997

Differential Revision: D29397720

