### PR TITLE
Make CI linting consistent by switching to usort

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ commands:
           command: pip install --progress-bar off --upgrade pip
       - run:
           name: "Install lint packages"
-          command: pip install --progress-bar off black==20.8b1 isort==4.3.21 flake8
+          command: pip install --progress-bar off black==20.8b1 usort flake8
 
   install_miniconda_macos:
     steps:
@@ -99,22 +99,20 @@ commands:
           name: "Lint with flake8"
           command: flake8
 
-  lint_isort:
-    description: "Lint with isort"
+  lint_usort:
+    description: "Lint with usort"
     steps:
       - run:
-          name: "Lint with isort"
+          name: "Lint with usort"
           command: >
-            isort --check-only --diff --line-width=88 --multi-line=3
-            --trailing-comma --force-grid-wrap=0 --section-default=THIRDPARTY
-            --lines-after-imports=2 --combine-as
+            usort check .
 
   lint_black:
     description: "Lint with black"
     steps:
       - run:
           name: "Lint with black"
-          command: black --check --diff --line-length=88 .
+          command: black --check .
 
   dev_unit_tests:
     description: "Run unit tests when installed in dev mode"
@@ -192,7 +190,7 @@ jobs:
       - pip_lint_install
       - pip_list
       - lint_flake8
-      - lint_isort
+      - lint_usort
       - lint_black
 
   nightly_test_py37_pip:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,3 +19,6 @@ filterwarnings = [
     # statsmodels's deprecation warning
     "default:the 'unbiased'' keyword is deprecated, use 'adjusted' instead.*:FutureWarning"
 ]
+
+[tool.usort]
+first_party_detection=false

--- a/setup.py
+++ b/setup.py
@@ -16,11 +16,11 @@ REQUIRED_MINOR = 6
 TEST_REQUIRES = ["pytest", "pytest-cov"]
 DEV_REQUIRES = TEST_REQUIRES + [
     "black==20.8b1",
-    "isort",
     "flake8",
     "flake8-bugbear",
     "sphinx",
     "sphinx-autodoc-typehints",
+    "usort",
 ]
 TUTORIALS_REQUIRES = ["jupyter", "matplotlib", "cma", "torchvision"]
 CPP_COMPILE_ARGS = ["-std=c++14", "-Werror"]

--- a/src/beanmachine/applications/hme/abstract_model.py
+++ b/src/beanmachine/applications/hme/abstract_model.py
@@ -13,7 +13,7 @@ import pandas as pd
 from .configs import InferConfig, ModelConfig
 
 
-import torch  # isort:skip # noqa: F401
+import torch  # usort: skip # noqa: F401
 
 
 logger = logging.getLogger("hme")


### PR DESCRIPTION
Summary:
Phabricator linting https://www.internalfb.com/intern/wiki/Linting/fbsource-linters/ uses pyfmt (https://fb.workplace.com/groups/pyfmt/), a combination of black and usort. However, CircleCI uses black and **isort** and has resulted in toil such as https://www.internalfb.com/intern/diff/D29397720 (https://github.com/facebookresearch/beanmachine/commit/d2d8200cee3b9c856c7ab2ed92ec40a47e3a77c3)/.

By switching the project's linter to usort, this moves us closer to having consistent CI checks between phabricator and circleci.

Reviewed By: ericlippert

Differential Revision: D29398738

