### PR TITLE
Fixing CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,23 +121,23 @@ commands:
           name: "Run unit tests"
           command: pytest --cov=. --cov-report term-missing
 
-  user_par_unit_tests:
-    description: "Run unit tests in parallel as an ordinary user"
+  user_unit_tests:
+    description: "Run unit tests as an ordinary user"
     steps:
       - run:
           name: "Install test dependencies"
-          command: pip install pytest pytest-xdist
+          command: pip install pytest
       - run:
-          name: "Run unit tests in parallel"
+          name: "Run unit tests"
           no_output_timeout: 1h
-          command: pytest -n 20 -vv
+          command: pytest -vv
 
   nightly_tests:
     description: "Run nightly tests as an ordinary user"
     steps:
       - run:
           name: "Install test dependencies"
-          command: pip install pytest pytest-xdist
+          command: pip install pytest
       - run:
           name: "Run nightly tests and report overall runtimes"
           no_output_timeout: 1h
@@ -159,7 +159,7 @@ jobs:
       - pip_list
       - dev_unit_tests
 
-  user_par_install_test_py37_pip:
+  user_install_test_py37_pip:
     docker:
       - image: circleci/python:3.7
     steps:
@@ -168,7 +168,7 @@ jobs:
       - user_install_beanmachine
       - pip_install_pytest_patch
       - pip_list
-      - user_par_unit_tests
+      - user_unit_tests
 
   macos_dev_install_test_py37_conda:
     macos:
@@ -188,6 +188,7 @@ jobs:
     steps:
       - checkout
       - pip_lint_install
+      - pip_install_pytest_patch
       - pip_list
       - lint_flake8
       - lint_usort
@@ -224,7 +225,7 @@ workflows:
       - dev_install_test_py37_pip:
           filters: *exclude_ghpages_fbconfig
 
-      - user_par_install_test_py37_pip:
+      - user_install_test_py37_pip:
           filters: *exclude_ghpages_fbconfig
 
       - macos_dev_install_test_py37_conda:

--- a/src/beanmachine/graph/distribution/half_normal.cpp
+++ b/src/beanmachine/graph/distribution/half_normal.cpp
@@ -57,17 +57,15 @@ double Half_Normal::_double_sampler(std::mt19937& gen) const {
 
 double Half_Normal::log_prob(const NodeValue& value) const {
   double s = in_nodes[0]->value._double;
-  double result, sum_x, sum_xsq;
+  double result, sum_xsq;
   int size;
 
   if (value.type.variable_type == graph::VariableType::SCALAR) {
     size = 1;
-    sum_x = value._double;
     sum_xsq = value._double * value._double;
   } else if (
       value.type.variable_type == graph::VariableType::BROADCAST_MATRIX) {
     size = value._matrix.size();
-    sum_x = value._matrix.sum();
     sum_xsq = value._matrix.squaredNorm();
   } else {
     throw std::runtime_error(
@@ -184,7 +182,6 @@ void Half_Normal::backward_param_iid(const graph::NodeValue& value) const {
   double s_sq = s * s;
 
   int size = value._matrix.size();
-  double sum_x = value._matrix.sum();
   /// The following should be deleted
   ///  if (in_nodes[0]->needs_gradient()) {
   ///    in_nodes[0]->back_grad1._double += sum_x / s_sq - size * m / s_sq;
@@ -202,7 +199,6 @@ void Half_Normal::backward_param_iid(
   double s = in_nodes[0]->value._double;
   double s_sq = s * s;
 
-  double sum_x = (value._matrix.array() * adjunct.array()).sum();
   double sum_adjunct = adjunct.sum();
   /// The following should be deleted
   /// if (in_nodes[0]->needs_gradient()) {

--- a/src/beanmachine/ppl/compiler/tests/bm_graph_builder_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bm_graph_builder_test.py
@@ -17,7 +17,6 @@ from beanmachine.ppl.compiler.bmg_nodes import (
     ExpNode,
     GreaterThanEqualNode,
     GreaterThanNode,
-    HalfNormalNode,
     LessThanEqualNode,
     LessThanNode,
     Log1mexpNode,


### PR DESCRIPTION
Summary:
Over the past weeks I have seen `user_par_unit_tests` keeps crashing while the other workflows seem to work fine. It's the only workflow that uses `pytest-xdist` so I suspect that might be problematic.



Differential Revision: D29470774

