### PR TITLE
Template to test original and conjugate prior-based transformed model

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/beta_binomial_basic_test.py
+++ b/src/beanmachine/ppl/compiler/tests/beta_binomial_basic_test.py
@@ -1,0 +1,109 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+"""Compare original and conjugate prior transformed model"""
+
+import random
+import unittest
+
+import beanmachine.ppl as bm
+import scipy
+import torch
+from beanmachine.ppl.inference.bmg_inference import BMGInference
+from torch import tensor
+from torch.distributions import Bernoulli, Beta
+
+
+class HeadsRateModel(object):
+    """Original, untransformed model"""
+
+    @bm.random_variable
+    def theta(self):
+        return Beta(2.0, 2.0)
+
+    @bm.random_variable
+    def y(self, i):
+        return Bernoulli(self.theta())
+
+    def run(self):
+        queries = [self.theta()]
+        observations = {
+            self.y(0): tensor(0.0),
+            self.y(1): tensor(0.0),
+            self.y(2): tensor(1.0),
+            self.y(3): tensor(0.0),
+        }
+        num_samples = 1000
+        bmg = BMGInference()
+        posterior = bmg.infer(queries, observations, num_samples)
+        theta_samples = posterior[self.theta()][0]
+        return theta_samples
+
+
+class HeadsRateModelTransformed(object):
+    """Conjugate Prior Transformed model"""
+
+    @bm.random_variable
+    def theta(self):
+        return Beta(2.0, 2.0)
+
+    @bm.random_variable
+    def y(self, i):
+        return Bernoulli(self.theta())
+
+    @bm.random_variable
+    def theta_transformed(self):
+        # Analytical posterior Beta(alpha + sum y_i, beta + n - sum y_i)
+        return Beta(2.0 + 1.0, 2.0 + (4.0 - 1.0))
+
+    def run(self):
+        # queries = [self.theta()]
+        queries_transformed = [self.theta_transformed()]
+        # observations = {
+        #     self.y(0): tensor(0.0),
+        #     self.y(1): tensor(0.0),
+        #     self.y(2): tensor(1.0),
+        #     self.y(3): tensor(0.0),
+        # }
+        observations_transformed = {}
+        num_samples = 1000
+        bmg = BMGInference()
+        # posterior = bmg.infer(queries, observations, num_samples)
+        posterior_transformed = bmg.infer(
+            queries_transformed, observations_transformed, num_samples
+        )
+        # theta_samples = posterior[self.theta](0)
+        theta_samples_transformed = posterior_transformed[self.theta_transformed()][0]
+        return theta_samples_transformed
+
+
+class HeadsRateModelTest(unittest.TestCase):
+    def test_beta_binomial_conjugate(self) -> None:
+        """
+        KS test to check if HeadsRateModel().run() and HeadsRateModelTransformed().run()
+        is within a certain bound.
+        We initialize the seed to ensure the test is deterministic.
+        """
+        seed = 0
+        torch.manual_seed(seed)
+        random.seed(seed)
+
+        heads_rate_model_samples = HeadsRateModel().run()
+        heads_rate_model_transformed_samples = HeadsRateModelTransformed().run()
+
+        self.assertEqual(
+            type(heads_rate_model_samples),
+            type(heads_rate_model_transformed_samples),
+            "Sample type of original and transformed model should be the same.",
+        )
+
+        self.assertEqual(
+            len(heads_rate_model_samples),
+            len(heads_rate_model_transformed_samples),
+            "Sample size of original and transformed model should be the same.",
+        )
+
+        self.assertGreaterEqual(
+            scipy.stats.ks_2samp(
+                heads_rate_model_samples, heads_rate_model_transformed_samples
+            ).pvalue,
+            0.05,
+        )


### PR DESCRIPTION
Summary:
This is the first diff for my internship project. The plan is to implement conjugate prior-based transformations. This diff adds tests to check that original and transformed models have equivalent output. Note, here I chose a specific case of transformation, namely beta-binomial.

Given a model like `HeadsRate`, with Bernoulli likelihood and Beta prior, we want Beanstalk compiler to identify that it is an instance of conjugate prior and produce a transformed model that looks like `HeadsRateTransformed`.

First, the transformation would identify that the queried parameter `theta()` has a Beta-Binomial conjugate relationship. It  analytically computes the posterior parameters (specifically for our example it would be `Beta(alpha + sum y_i, beta + n - sum y_i)`) , based on the prior parameters and observations. Now it inserts a new random variable function, `theta_transformed()` . Now we query this transformed function and further, the observations are set to be empty. We modify calls to inference with the updated queries and observations. The idea is that the resulting model samples directly from the transformed analytical posterior.

Currently this test checks (using KS) if these two models produce samples from the same distribution. Once we have implemented the transformation, we could additionally check that the graphs produced from `HeadsRate` and `HeadsRateTransformed` are syntactically same.

Reviewed By: ericlippert, horizon-blue

Differential Revision: D29430975

