### PR TITLE
Selectively disable optimizations when generating BMG

### DIFF
--- a/src/beanmachine/ppl/compiler/fix_multiary_ops.py
+++ b/src/beanmachine/ppl/compiler/fix_multiary_ops.py
@@ -119,8 +119,6 @@ class MultiaryOperatorFixer(ProblemFixerBase):
             )
         )
 
-        return self._fixable_index(n) or self._fixable_sample(n)
-
     def _get_replacement(self, n: bn.BMGNode) -> Optional[bn.BMGNode]:
         # We require that this algorithm be non-recursive because the
         # path through the graph could be longer than the Python

--- a/src/beanmachine/ppl/compiler/fix_problems.py
+++ b/src/beanmachine/ppl/compiler/fix_problems.py
@@ -1,6 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
-from typing import List, Type
+from typing import List, Set, Type
 
 import beanmachine.ppl.compiler.profiler as prof
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
@@ -38,11 +38,18 @@ _standard_fixer_types: List[Type] = [
     ObservationsFixer,
 ]
 
+default_skip_optimizations: Set[str] = set()
 
-def fix_problems(bmg: BMGraphBuilder) -> ErrorReport:
+
+def fix_problems(
+    bmg: BMGraphBuilder, skip_optimizations: Set[str] = default_skip_optimizations
+) -> ErrorReport:
     bmg._begin(prof.fix_problems)
     typer = LatticeTyper()
-    fixer_types: List[Type] = _standard_fixer_types
+    fixer_types: List[Type] = []
+    for fixer_type in _standard_fixer_types:
+        if fixer_type.__name__ not in skip_optimizations:
+            fixer_types.append(fixer_type)
     errors = ErrorReport()
     if bmg._fix_observe_true:
         # Note: must NOT be +=, which would mutate _standard_fixer_types.

--- a/src/beanmachine/ppl/compiler/gen_dot.py
+++ b/src/beanmachine/ppl/compiler/gen_dot.py
@@ -2,10 +2,14 @@
 """
 Visualize the contents of a builder in the DOT graph language.
 """
+from typing import Set
 
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
 from beanmachine.ppl.compiler.bmg_requirements import EdgeRequirements
-from beanmachine.ppl.compiler.fix_problems import fix_problems
+from beanmachine.ppl.compiler.fix_problems import (
+    default_skip_optimizations,
+    fix_problems,
+)
 from beanmachine.ppl.compiler.graph_labels import get_edge_labels, get_node_label
 from beanmachine.ppl.compiler.lattice_typer import LatticeTyper
 from beanmachine.ppl.utils.dotbuilder import DotBuilder
@@ -17,6 +21,7 @@ def to_dot(
     edge_requirements: bool = False,
     after_transform: bool = False,
     label_edges: bool = True,
+    skip_optimizations: Set[str] = default_skip_optimizations,
 ) -> str:
     """This dumps the entire accumulated graph state, including
     orphans, as a DOT graph description; nodes are enumerated in the order
@@ -36,7 +41,7 @@ def to_dot(
         #
         # * Add a whole_graph flag, default to true, which decides
         #   whether to graph the whole thing or not.
-        fix_problems(bmg).raise_errors()
+        fix_problems(bmg, skip_optimizations).raise_errors()
         node_list = bmg.all_ancestor_nodes()
     else:
         node_list = bmg.all_nodes()

--- a/src/beanmachine/ppl/compiler/tests/disable_optimizations_test.py
+++ b/src/beanmachine/ppl/compiler/tests/disable_optimizations_test.py
@@ -1,0 +1,160 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import unittest
+
+import beanmachine.ppl as bm
+import scipy
+from beanmachine.ppl.inference import BMGInference
+from torch.distributions import Normal
+
+
+@bm.random_variable
+def norm(x):
+    return Normal(0.0, 1.0)
+
+
+@bm.functional
+def sum_1():
+    return norm(0) + norm(1) + norm(2)
+
+
+@bm.functional
+def sum_2():
+    return norm(3) + norm(4) + norm(5)
+
+
+@bm.functional
+def sum_3():
+    return sum_1() + 5.0
+
+
+@bm.functional
+def sum_4():
+    return sum_1() + sum_2()
+
+
+class DisableOptimizationsTest(unittest.TestCase):
+    def test_multiary_ops_opt_to_dot(self) -> None:
+        self.maxDiff = None
+        observations = {}
+        queries = [sum_3(), sum_4()]
+
+        skip_optimizations = {"MultiaryOperatorFixer"}
+        observed = BMGInference().to_dot(
+            queries, observations, skip_optimizations=skip_optimizations
+        )
+
+        # Expected model when skipping multiary addition optimization
+
+        expected = """
+digraph "graph" {
+  N00[label=0.0];
+  N01[label=1.0];
+  N02[label=Normal];
+  N03[label=Sample];
+  N04[label=Sample];
+  N05[label=Sample];
+  N06[label="+"];
+  N07[label="+"];
+  N08[label=5.0];
+  N09[label="+"];
+  N10[label=Query];
+  N11[label=Sample];
+  N12[label=Sample];
+  N13[label=Sample];
+  N14[label="+"];
+  N15[label="+"];
+  N16[label="+"];
+  N17[label=Query];
+  N00 -> N02;
+  N01 -> N02;
+  N02 -> N03;
+  N02 -> N04;
+  N02 -> N05;
+  N02 -> N11;
+  N02 -> N12;
+  N02 -> N13;
+  N03 -> N06;
+  N04 -> N06;
+  N05 -> N07;
+  N06 -> N07;
+  N07 -> N09;
+  N07 -> N16;
+  N08 -> N09;
+  N09 -> N10;
+  N11 -> N14;
+  N12 -> N14;
+  N13 -> N15;
+  N14 -> N15;
+  N15 -> N16;
+  N16 -> N17;
+}
+"""
+        self.assertEqual(expected.strip(), observed.strip())
+
+        # Expected graph without skipping multiary addition optimization:
+
+        observed = BMGInference().to_dot(queries, observations)
+        expected = """
+digraph "graph" {
+  N00[label=0.0];
+  N01[label=1.0];
+  N02[label=Normal];
+  N03[label=Sample];
+  N04[label=Sample];
+  N05[label=Sample];
+  N06[label="+"];
+  N07[label=5.0];
+  N08[label="+"];
+  N09[label=Query];
+  N10[label=Sample];
+  N11[label=Sample];
+  N12[label=Sample];
+  N13[label="+"];
+  N14[label=Query];
+  N00 -> N02;
+  N01 -> N02;
+  N02 -> N03;
+  N02 -> N04;
+  N02 -> N05;
+  N02 -> N10;
+  N02 -> N11;
+  N02 -> N12;
+  N03 -> N06;
+  N04 -> N06;
+  N05 -> N06;
+  N06 -> N08;
+  N06 -> N13;
+  N07 -> N08;
+  N08 -> N09;
+  N10 -> N13;
+  N11 -> N13;
+  N12 -> N13;
+  N13 -> N14;
+}
+"""
+        self.assertEqual(expected.strip(), observed.strip())
+
+    def test_multiary_ops_opt_inference(self) -> None:
+        observations = {}
+        queries = [sum_3(), sum_4()]
+        num_samples = 1000
+
+        skip_optimizations = {"MultiaryOperatorFixer"}
+        posterior_wo_opt = BMGInference().infer(
+            queries, observations, num_samples, skip_optimizations=skip_optimizations
+        )
+        sum_3_samples_wo_opt = posterior_wo_opt[sum_3()][0]
+        sum_4_samples_wo_opt = posterior_wo_opt[sum_4()][0]
+
+        posterior_w_opt = BMGInference().infer(queries, observations, num_samples)
+
+        sum_3_samples_w_opt = posterior_w_opt[sum_3()][0]
+        sum_4_samples_w_opt = posterior_w_opt[sum_4()][0]
+
+        self.assertGreaterEqual(
+            scipy.stats.ks_2samp(sum_3_samples_wo_opt, sum_3_samples_w_opt).pvalue, 0.05
+        )
+
+        self.assertGreaterEqual(
+            scipy.stats.ks_2samp(sum_4_samples_wo_opt, sum_4_samples_w_opt).pvalue, 0.05
+        )


### PR DESCRIPTION
Summary:
While trying to benchmark performance of binary vs multiary addition, I came across the following:

In Beanstalk error-detection (currently 6) and optimizations (currently 1) together are called fixer types. There is a flag named  `after_transform` in `BMGInference().to_dot(...)` that either enables/disables all of these fixer types together. This flag was introduced for debugging purpose to answer one of the two scenarios. (1) what does the graph look like immediately after graph accumulation is done (after_transform = False)  and (2) what graph are we actually going to send to BMG (after_transform = True).

There was no flag to selectively just enable/disable optimizations. So I added code to skip optimizations that have been passed as skip.  We expose the optimization toggle as a set of strings (which are names of the optimization fixer type classes) that a user could input to the `inference` and `to_dot` method of `BMGInference`. We also maintain a `default_skip_optimizations` set (currently empty) to make sure by default we carry out all optimizations.

Alternatively, we could separate the `fixer_types` into two lists and separate them. However, performance reports require the ordering of these to be same. For now to make minimal changes and to prevent report generation tests from breaking, I have left the `fixer_types` as a single list.

I added two test cases to check the correctness of this change. First we check if the graphs without and with optimizations are as expected. Further, we check if the KS distance between samples from optimized and un-optimized models are from same distribution.

Graph when multiary addition optimization is toggled off

{F629466640}

Graph when multiary addition optimization is toggled on
{F629466723}

Reviewed By: ericlippert

Differential Revision: D29504284

