### PR TITLE
move InferConfig to inference

### DIFF
--- a/src/beanmachine/graph/gibbs.cpp
+++ b/src/beanmachine/graph/gibbs.cpp
@@ -11,7 +11,10 @@
 namespace beanmachine {
 namespace graph {
 
-void Graph::gibbs(uint num_samples, std::mt19937& gen) {
+void Graph::gibbs(
+    uint num_samples,
+    std::mt19937& gen,
+    InferConfig infer_config) {
   std::set<uint> supp = compute_support();
   // eval each node so that we have a starting value and verify that these
   // values are all scalar

--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -769,12 +769,17 @@ struct Graph {
   std::vector<Node*> convert_parent_ids(const std::vector<uint>& parents) const;
   std::vector<uint> get_parent_ids(
       const std::vector<Node*>& parent_nodes) const;
-  void _infer(uint num_samples, InferenceType algorithm, uint seed);
+  void _infer(
+      uint num_samples,
+      InferenceType algorithm,
+      uint seed,
+      InferConfig infer_config);
   void _infer_parallel(
       uint num_samples,
       InferenceType algorithm,
       uint seed,
-      uint n_chains);
+      uint n_chains,
+      InferConfig infer_config);
   std::vector<std::unique_ptr<Node>> nodes; // all nodes in topological order
   std::set<uint> observed; // set of observed nodes
   // we store redundant information in queries and queried. The latter is a
@@ -791,16 +796,15 @@ struct Graph {
   std::vector<std::vector<double>> variational_params;
   std::vector<double> elbo_vals;
   void collect_sample();
-  void rejection(uint num_samples, std::mt19937& gen);
-  void gibbs(uint num_samples, std::mt19937& gen);
+  void rejection(uint num_samples, std::mt19937& gen, InferConfig infer_config);
+  void gibbs(uint num_samples, std::mt19937& gen, InferConfig infer_config);
   class NMC;
-  void nmc(uint num_samples, std::mt19937& gen);
+  void nmc(uint num_samples, std::mt19937& gen, InferConfig infer_config);
   void cavi(
       uint num_iters,
       uint steps_per_iter,
       std::mt19937& gen,
       uint elbo_samples);
-  InferConfig infer_config;
   /*
   Evaluate the full log probability over the support of the graph.
   :param ordered_supp: node pointers in the support in topological order.

--- a/src/beanmachine/graph/nmc.cpp
+++ b/src/beanmachine/graph/nmc.cpp
@@ -62,10 +62,10 @@ class Graph::NMC {
  public:
   NMC(Graph* g, std::mt19937& gen) : g(g), gen(gen) {}
 
-  void infer(uint num_samples) {
+  void infer(uint num_samples, InferConfig infer_config) {
     g->pd_begin(ProfilerEvent::NMC_INFER);
     initialize();
-    collect_samples(num_samples);
+    collect_samples(num_samples, infer_config);
     g->pd_finish(ProfilerEvent::NMC_INFER);
   }
 
@@ -187,18 +187,18 @@ class Graph::NMC {
     }
   }
 
-  void collect_samples(uint num_samples) {
+  void collect_samples(uint num_samples, InferConfig infer_config) {
     g->pd_begin(ProfilerEvent::NMC_INFER_COLLECT_SAMPLES);
     for (uint snum = 0; snum < num_samples; snum++) {
       generate_sample();
-      collect_sample();
+      collect_sample(infer_config);
     }
     g->pd_finish(ProfilerEvent::NMC_INFER_COLLECT_SAMPLES);
   }
 
-  void collect_sample() {
+  void collect_sample(InferConfig infer_config) {
     g->pd_begin(ProfilerEvent::NMC_INFER_COLLECT_SAMPLE);
-    if (g->infer_config.keep_log_prob) {
+    if (infer_config.keep_log_prob) {
       g->collect_log_prob(g->_full_log_prob(supp));
     }
     g->collect_sample();
@@ -620,8 +620,8 @@ class Graph::NMC {
   }
 };
 
-void Graph::nmc(uint num_samples, std::mt19937& gen) {
-  Graph::NMC(this, gen).infer(num_samples);
+void Graph::nmc(uint num_samples, std::mt19937& gen, InferConfig infer_config) {
+  Graph::NMC(this, gen).infer(num_samples, infer_config);
 }
 
 } // namespace graph

--- a/src/beanmachine/graph/rejection.cpp
+++ b/src/beanmachine/graph/rejection.cpp
@@ -4,7 +4,10 @@
 namespace beanmachine {
 namespace graph {
 
-void Graph::rejection(uint num_samples, std::mt19937& gen) {
+void Graph::rejection(
+    uint num_samples,
+    std::mt19937& gen,
+    InferConfig infer_config) {
   std::vector<Node*> ordered_supp;
   if (infer_config.keep_log_prob) {
     std::set<uint> supp = compute_support();


### PR DESCRIPTION
Summary: detach InferConfig from Graph and pass it directly to Inference methods to prepare for warmup samples

Reviewed By: rodrigodesalvobraz, SepehrAkhavan

Differential Revision: D29231242

