### PR TITLE
Fix test case with invalid observation

### DIFF
--- a/src/beanmachine/graph/distribution/tests/bernoulli_noisy_or_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/bernoulli_noisy_or_test.cpp
@@ -22,7 +22,7 @@ TEST(testdistrib, backward_bernoulli_noisy_or) {
       g.add_operator(OperatorType::IID_SAMPLE, std::vector<uint>{dist, two});
   g.observe(y, 2.0);
   g.observe(x1, true);
-  Eigen::MatrixXb x2_obs(1, 2);
+  Eigen::MatrixXb x2_obs(2, 1);
   x2_obs << false, true;
   g.observe(x2, x2_obs);
 


### PR DESCRIPTION
Summary:
We have a test case which creates a (2, 1) matrix of samples, and then observed it with a (1, 2) matrix of bools; this causes internal type system invariants to be violated.

I've fixed the test case but obviously a larger issue remains: a test case using a public API caused an invariant to be violated! In a well-designed and well-implemented API that should be impossible; what is happening here is we are assuming that the caller is doing the right thing BEFORE we check whether they got it wrong, and by the time we do the check, the mistake is now recorded into the type system and the check succeeds.

I've left a lengthy comment explaining what went wrong here; I will fix it in a later diff.

Reviewed By: wtaha

Differential Revision: D29044358

