### PR TITLE
Set unconstrained value of simplex to broadcast matrix

### DIFF
--- a/src/beanmachine/graph/operator/stochasticop.cpp
+++ b/src/beanmachine/graph/operator/stochasticop.cpp
@@ -141,11 +141,16 @@ Sample::Sample(const std::vector<graph::Node*>& in_nodes)
   }
   const distribution::Distribution* dist =
       static_cast<distribution::Distribution*>(in_nodes[0]);
-  // the type of value of a SAMPLE node is obviously the sample type
-  // of the distribution parent
+  // The type of value of a SAMPLE node is obviously the sample type
+  // of the distribution parent.
   value = graph::NodeValue(dist->sample_type);
-  unconstrained_value = graph::NodeValue(graph::ValueType(
-      dist->sample_type.variable_type, graph::AtomicType::REAL, 1, 0));
+  // For the unconstrained value we want to avoid unnecessary early memory
+  // allocation; just set it to a real scalar or 1x0 array of reals.
+  auto vt = dist->sample_type.variable_type;
+  if (vt == graph::VariableType::COL_SIMPLEX_MATRIX)
+    vt = graph::VariableType::BROADCAST_MATRIX;
+  auto at = graph::AtomicType::REAL;
+  unconstrained_value = graph::NodeValue(graph::ValueType(vt, at, 1, 0));
 }
 
 IIdSample::IIdSample(const std::vector<graph::Node*>& in_nodes)


### PR DESCRIPTION
Summary:
To avoid allocating memory unnecessarily we set the unconstrained value of a sample node to either an atomic real or a 1x0 array of reals. Consider however the Dirichlet distribution, where the sample type is a simplex; a ValueType with variable type COL_SIMPLEX_MATRIX and atomic type REAL violates the invariants of ValueType.  (A simplex is required to have elements that are probabilities.)

We avoid the problem here by setting the unconstrained value to a broadcast matrix of reals in this scenario.

Differential Revision: D29599594

