### PR TITLE
Reword and reorganize some error messages for sample node construction

### DIFF
--- a/src/beanmachine/graph/operator/multiaryop.cpp
+++ b/src/beanmachine/graph/operator/multiaryop.cpp
@@ -167,7 +167,7 @@ ToMatrix::ToMatrix(const std::vector<graph::Node*>& in_nodes)
   if (in_nodes[0]->value.type != graph::AtomicType::NATURAL or
       in_nodes[1]->value.type != graph::AtomicType::NATURAL) {
     throw std::invalid_argument(
-        "operator TO_MATRIX requires the first and second arguments to be NATURAL"
+        "operator TO_MATRIX requires the first and second parents to be NATURAL"
         "representing the number of rows and the number of columns respectively");
   } else if (
       in_nodes[0]->node_type != graph::NodeType::CONSTANT or

--- a/src/beanmachine/graph/operator/tests/operator_test.cpp
+++ b/src/beanmachine/graph/operator/tests/operator_test.cpp
@@ -666,13 +666,40 @@ TEST(testoperator, iid_sample) {
   bern_dist.in_nodes.push_back(&prob_node);
   auto int_value = NodeValue(AtomicType::NATURAL, (natural_t)2);
   auto int_node = ConstNode(int_value);
-  // negative tests on the number and types of parents
+  auto one = ConstNode(NodeValue(AtomicType::NATURAL, (natural_t)1));
+
+  // Negative test: There must be two or three parents.
   EXPECT_THROW(oper::IIdSample(std::vector<Node*>{}), std::invalid_argument);
+  EXPECT_THROW(
+      oper::IIdSample(std::vector<Node*>{&bern_dist}), std::invalid_argument);
+  EXPECT_THROW(
+      oper::IIdSample(
+          std::vector<Node*>{&bern_dist, &int_node, &int_node, &int_node}),
+      std::invalid_argument);
+  // Negative test: The first parent must be a distribution.
+  EXPECT_THROW(
+      oper::IIdSample(std::vector<Node*>{&int_node, &int_node, &int_node}),
+      std::invalid_argument);
+  // Negative test: The second parent must be a constant natural.
   EXPECT_THROW(
       oper::IIdSample(std::vector<Node*>{&bern_dist, &bern_dist}),
       std::invalid_argument);
   EXPECT_THROW(
       oper::IIdSample(std::vector<Node*>{&int_node, &prob_node}),
+      std::invalid_argument);
+  // Negative test: The third parent must be a constant natural.
+  EXPECT_THROW(
+      oper::IIdSample(std::vector<Node*>{&bern_dist, &int_node, &bern_dist}),
+      std::invalid_argument);
+  EXPECT_THROW(
+      oper::IIdSample(std::vector<Node*>{&int_node, &int_node, &prob_node}),
+      std::invalid_argument);
+  // Negative test: The product of the constant parents must be two or greater.
+  EXPECT_THROW(
+      oper::IIdSample(std::vector<Node*>{&bern_dist, &one}),
+      std::invalid_argument);
+  EXPECT_THROW(
+      oper::IIdSample(std::vector<Node*>{&bern_dist, &one, &one}),
       std::invalid_argument);
 
   // test initialization


### PR DESCRIPTION
Summary:
The error messages in the BMG node constructors are inconsistently worded; I've been gradually making them more consistent.  In this diff:

* a `ToMatrix` error message described the wrong values as "arguments"; all the other error messages describe them as "parents".
* many `Sample` and `IidSample` errors said things like `~ operator requires...` but the other operator error messages say the identifier of the operator and are phrased `operator OPERATOR_NAME requires...`.
* we should standardize on describing operators with words `first` and `second` and `third`, not abbrvs like `1st`, `2nd` and `3rd`
* we should try to say precisely what the problem is; elsewhere in the code when we require a node to be both natural and a constant then we have separate error messages for "not a natural" and "not a constant". This is a small point but it costs nothing to be consistent.
* we had an error message recommending that the user try instead to use `IID_SAMPLE_COL`, a node type which does not exist. Error messages should not refer to non-existing workarounds. Once we implement that operator, if we ever do, *then* make recommendations that it be used.
* generally speaking I try to avoid `or` operators in error condition tests. If an error can happen because of this or that, then we probably could use two errors.

Reviewed By: wtaha

Differential Revision: D29049772

