### PR TITLE
Fix observe error detection

### DIFF
--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -774,6 +774,8 @@ struct Graph {
   std::string performance_report();
 
  private:
+  Node* check_observed_node(uint node_id, bool is_scalar);
+  void add_observe(Node* node, NodeValue val);
   Node* get_node(uint node_id);
   void check_node_id(uint node_id);
 

--- a/src/beanmachine/graph/tests/graph_test.py
+++ b/src/beanmachine/graph/tests/graph_test.py
@@ -312,7 +312,9 @@ digraph "graph" {
         o2 = g.add_operator(graph.OperatorType.SAMPLE, [d1])
         with self.assertRaises(ValueError) as cm:
             g.observe(o1, True)
-        self.assertTrue("only sample nodes may be observed" in str(cm.exception))
+        self.assertTrue(
+            "only SAMPLE and IID_SAMPLE nodes may be observed" in str(cm.exception)
+        )
         g.observe(o2, True)  # ok to observe this node
         with self.assertRaises(ValueError) as cm:
             g.observe(o2, False)


### PR DESCRIPTION
Summary:
The observe() APIs in BMG did not correctly validate their arguments; rather, they assumed, for instance, that when given an observation of a 2x3 matrix of doubles, that the observed quantity was in fact a 2x3 matrix of some type with storage type double, and then violated a bunch of type system invariants along the way.

We now check early on that an observation matches the sample being observed.

We do not yet do range checks; that is, an observation of a probability must be a double, but we do not check that it is between 0 and 1.  I might add that in a later diff.

Reviewed By: yucenli

Differential Revision: D29073748

