### PR TITLE
Start implementing categorical distribution in BMG

### DIFF
--- a/src/beanmachine/graph/distribution/bernoulli.cpp
+++ b/src/beanmachine/graph/distribution/bernoulli.cpp
@@ -59,12 +59,21 @@ void Bernoulli::log_prob_iid(
   log_probs = value._bmatrix.select(pos_val, log_probs);
 }
 
-// Note: Bernoulli log_prob is defined as  x log(p) + (1-x) log(1-p)
-// where x is the value and p is the probability parameter
-// grad w.r.t. x is  log(p) - log(1-p) ; grad2 = 0
-// grad w.r.t p is   (x/p) * p' - ((1-x)/(1-p)) * p'
-// grad2 w.r.t. p is -(x/p^2) * p'^2 + (x/p) * p'' - ((1-x)/(1-p)^2) * p'^2 -
-// ((1-x)/(1-p)) * p''
+// The likelihood L(x|p) where x is the outcome and p is the parameter of
+// the Bernoulli distribution is L(x|p) = p if x is 1, (1-p) if x is 0.
+// We need the gradient of log(L(x|p)); how do we get a gradient on
+// a discrete function?
+//
+// We find a continuous function that agrees with L(x|p) for x = 0 or 1
+// and then differentiate that.  We choose L(x|p) = p^x * (1-p)^(1-x),
+// so log(L(x|p)) = x * log(p) + (1-x) * log(1-p)
+//
+// grad1 wrt x = log(p) - log(1-p)
+// grad2 wrt x = 0
+// grad1 wrt p = (x/p) * p' - ((1-x)/(1-p)) * p'
+// grad2 wrt p = -(x/p^2) * p'^2 + (x/p) * p'' - ((1-x)/(1-p)^2) * p'^2 -
+//               ((1-x)/(1-p)) * p''
+//
 // First order chain rule: f(g(x))' = f'(g(x)) g'(x),
 // - In backward propagation, f'(g(x)) is given by adjunct, the above equation
 // computes g'(x). [g is the current function f is the final target]

--- a/src/beanmachine/graph/distribution/categorical.cpp
+++ b/src/beanmachine/graph/distribution/categorical.cpp
@@ -1,0 +1,123 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+#include <cmath>
+
+#include "beanmachine/graph/distribution/categorical.h"
+
+namespace beanmachine {
+namespace distribution {
+
+Categorical::Categorical(
+    graph::AtomicType sample_type,
+    const std::vector<graph::Node*>& in_nodes)
+    : Distribution(graph::DistributionType::CATEGORICAL, sample_type) {
+  if (sample_type != graph::AtomicType::NATURAL) {
+    throw std::invalid_argument("Categorical produces natural valued samples");
+  }
+  if (in_nodes.size() != 1) {
+    throw std::invalid_argument(
+        "Categorical distribution must have exactly one parent");
+  }
+  const auto& parent0 = in_nodes[0]->value;
+  if (parent0.type.variable_type != graph::VariableType::COL_SIMPLEX_MATRIX or
+      parent0.type.cols != 1) {
+    throw std::invalid_argument(
+        "Categorical parent must be a one-column simplex");
+  }
+}
+
+graph::natural_t Categorical::_natural_sampler(std::mt19937& gen) const {
+  const Eigen::MatrixXd& matrix = in_nodes[0]->value._matrix;
+  assert(matrix.cols() == 1);
+
+  // distrib(c0.begin(), c0.end()) fails on CircleCI saying that there are no
+  // such methods on a Block<>; we make this seemingly unnecessary copy to
+  // a vector to get around that.
+
+  const auto& c0 = matrix.col(0);
+  std::vector<double> v;
+  for (int i = 0; i < c0.size(); i += 1) {
+    v.push_back(c0(i));
+  }
+  std::discrete_distribution<> distrib(v.begin(), v.end());
+  return (graph::natural_t)distrib(gen);
+}
+
+double Categorical::log_prob(const graph::NodeValue& value) const {
+  assert(in_nodes.size() == 1);
+  assert(in_nodes[0] != 0);
+  const Eigen::MatrixXd& matrix = in_nodes[0]->value._matrix;
+  double prob = 0.0;
+  graph::natural_t r = (graph::natural_t)matrix.rows();
+  if (0 <= value._natural and value._natural < r) {
+    prob = matrix(value._natural, 0);
+  }
+  return std::log(prob);
+}
+
+void Categorical::log_prob_iid(
+    const graph::NodeValue& value,
+    Eigen::MatrixXd& log_probs) const {
+  assert(value.type.variable_type == graph::VariableType::BROADCAST_MATRIX);
+  log_probs = Eigen::MatrixXd(value._nmatrix.rows(), value._nmatrix.cols());
+  uint rows = value._nmatrix.rows();
+  uint cols = value._nmatrix.cols();
+  for (uint r = 0; r < rows; r += 1) {
+    for (uint c = 0; c < cols; c += 1) {
+      log_probs(r, c) = log_prob(graph::NodeValue(value._nmatrix(r, c)));
+    }
+  }
+}
+
+// The likelihood L(x|p_0, ... p_(k-1)) (where x is the outcome and the p's are
+// the k parameters of the categorical distribution) is p_0 if x is 0, p_1 if
+// x is 1, and so on.
+//
+// We need the gradient of log(L(x|p_0...)); how do we get a gradient on
+// a discrete function?
+//
+// TODO: Yeah, how?
+
+void Categorical::gradient_log_prob_value(
+    const graph::NodeValue& /* value */,
+    double& grad1,
+    double& grad2) const {
+  assert(value.type.variable_type == graph::VariableType::SCALAR);
+  grad1 += 0; // TODO
+  grad2 += 0; // TODO
+}
+
+void Categorical::gradient_log_prob_param(
+    const graph::NodeValue& value,
+    double& grad1,
+    double& grad2) const {
+  assert(value.type.variable_type == graph::VariableType::SCALAR);
+  grad1 += 0; // TODO
+  grad2 += 0; // TODO
+}
+
+void Categorical::backward_param(const graph::NodeValue& value, double adjunct)
+    const {
+  assert(value.type.variable_type == graph::VariableType::SCALAR);
+  if (in_nodes[0]->needs_gradient()) {
+    in_nodes[0]->back_grad1._double += 0; // TODO
+  }
+}
+
+void Categorical::backward_param_iid(const graph::NodeValue& value) const {
+  assert(value.type.variable_type == graph::VariableType::BROADCAST_MATRIX);
+  if (in_nodes[0]->needs_gradient()) {
+    in_nodes[0]->back_grad1._double += 0; // TODO
+  }
+}
+
+void Categorical::backward_param_iid(
+    const graph::NodeValue& value,
+    Eigen::MatrixXd& adjunct) const {
+  assert(value.type.variable_type == graph::VariableType::BROADCAST_MATRIX);
+  if (in_nodes[0]->needs_gradient()) {
+    in_nodes[0]->back_grad1._double += 0; // TODO
+  }
+}
+
+} // namespace distribution
+} // namespace beanmachine

--- a/src/beanmachine/graph/distribution/categorical.h
+++ b/src/beanmachine/graph/distribution/categorical.h
@@ -1,0 +1,50 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+#pragma once
+#include "beanmachine/graph/distribution/distribution.h"
+
+namespace beanmachine {
+namespace distribution {
+
+class Categorical : public Distribution {
+ public:
+  Categorical(
+      graph::AtomicType sample_type,
+      const std::vector<graph::Node*>& in_nodes);
+  ~Categorical() override {}
+  graph::natural_t _natural_sampler(std::mt19937& gen) const override;
+  double log_prob(const graph::NodeValue& value) const override;
+  void log_prob_iid(const graph::NodeValue& value, Eigen::MatrixXd& log_probs)
+      const override;
+  void gradient_log_prob_value(
+      const graph::NodeValue& value,
+      double& grad1,
+      double& grad2) const override;
+  void gradient_log_prob_param(
+      const graph::NodeValue& value,
+      double& grad1,
+      double& grad2) const override;
+
+  void backward_value(
+      const graph::NodeValue& /* value */,
+      graph::DoubleMatrix& /* back_grad */,
+      double /* adjunct */ = 1.0) const override {}
+  void backward_value_iid(
+      const graph::NodeValue& /* value */,
+      graph::DoubleMatrix& /* back_grad */) const override {}
+  void backward_value_iid(
+      const graph::NodeValue& /* value */,
+      graph::DoubleMatrix& /* back_grad */,
+      Eigen::MatrixXd& /* adjunct */) const override {}
+
+  void backward_param(const graph::NodeValue& value, double adjunct = 1.0)
+      const override;
+  void backward_param_iid(const graph::NodeValue& value) const override;
+  void backward_param_iid(
+      const graph::NodeValue& value,
+      Eigen::MatrixXd& adjunct) const override;
+
+  static double _grad1_log_prob_param(bool x, double p);
+};
+
+} // namespace distribution
+} // namespace beanmachine

--- a/src/beanmachine/graph/distribution/distribution.cpp
+++ b/src/beanmachine/graph/distribution/distribution.cpp
@@ -6,6 +6,7 @@
 #include "beanmachine/graph/distribution/beta.h"
 #include "beanmachine/graph/distribution/bimixture.h"
 #include "beanmachine/graph/distribution/binomial.h"
+#include "beanmachine/graph/distribution/categorical.h"
 #include "beanmachine/graph/distribution/dirichlet.h"
 #include "beanmachine/graph/distribution/flat.h"
 #include "beanmachine/graph/distribution/gamma.h"
@@ -64,6 +65,9 @@ std::unique_ptr<Distribution> Distribution::new_distribution(
       }
       case graph::DistributionType::BIMIXTURE: {
         return std::make_unique<Bimixture>(atype, in_nodes);
+      }
+      case graph::DistributionType::CATEGORICAL: {
+        return std::make_unique<Categorical>(atype, in_nodes);
       }
       default: {
         throw std::invalid_argument(

--- a/src/beanmachine/graph/distribution/tests/categorical_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/categorical_test.cpp
@@ -1,0 +1,76 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+#include <gtest/gtest.h>
+
+#include "beanmachine/graph/distribution/categorical.h"
+#include "beanmachine/graph/graph.h"
+
+using namespace beanmachine;
+
+TEST(testdistrib, categorical) {
+  graph::Graph g;
+
+  // 50% chance of 0, 25% chance of 1, 12.5% chance of 3, 4.
+  Eigen::MatrixXd matrix(4, 1);
+  matrix << 0.5, 0.25, 0.125, 0.125;
+  // We only support single-column simplexes.
+  Eigen::MatrixXd matrix2(4, 2);
+  matrix2 << 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25;
+
+  uint c0 = g.add_constant(0.0);
+  uint c1 = g.add_constant_col_simplex_matrix(matrix);
+  uint c2 = g.add_constant_col_simplex_matrix(matrix2);
+
+  // Negative test: bad return type
+  EXPECT_THROW(
+      g.add_distribution(
+          graph::DistributionType::CATEGORICAL,
+          graph::AtomicType::BOOLEAN,
+          std::vector<uint>({c1})),
+      std::invalid_argument);
+
+  // Negative test: wrong argument counts:
+  EXPECT_THROW(
+      g.add_distribution(
+          graph::DistributionType::CATEGORICAL,
+          graph::AtomicType::NATURAL,
+          std::vector<uint>({})),
+      std::invalid_argument);
+
+  EXPECT_THROW(
+      g.add_distribution(
+          graph::DistributionType::CATEGORICAL,
+          graph::AtomicType::NATURAL,
+          std::vector<uint>({c1, c1})),
+      std::invalid_argument);
+
+  // Negative test: wrong argument type
+  EXPECT_THROW(
+      g.add_distribution(
+          graph::DistributionType::CATEGORICAL,
+          graph::AtomicType::NATURAL,
+          std::vector<uint>({c0})),
+      std::invalid_argument);
+
+  // Negative test: wrong simplex dimensionality
+  EXPECT_THROW(
+      g.add_distribution(
+          graph::DistributionType::CATEGORICAL,
+          graph::AtomicType::NATURAL,
+          std::vector<uint>({c2})),
+      std::invalid_argument);
+
+  // Positive test: construct a categorical correctly:
+  uint d1 = g.add_distribution(
+      graph::DistributionType::CATEGORICAL,
+      graph::AtomicType::NATURAL,
+      std::vector<uint>({c1}));
+
+  uint s1 = g.add_operator(graph::OperatorType::SAMPLE, std::vector<uint>{d1});
+
+  // There should be a 0.125 chance of observing a 3:
+  g.observe(s1, (graph::natural_t)3);
+  EXPECT_NEAR(g.full_log_prob(), log(0.125), 1e-3);
+
+  // TODO: test IID_SAMPLE
+  // TODO: test g.eval_and_grad
+}

--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -337,6 +337,7 @@ enum class DistributionType {
   BERNOULLI_LOGIT,
   GAMMA,
   BIMIXTURE,
+  CATEGORICAL,
 };
 
 enum class FactorType {

--- a/src/beanmachine/graph/pybindings.cpp
+++ b/src/beanmachine/graph/pybindings.cpp
@@ -81,7 +81,8 @@ PYBIND11_MODULE(graph, module) {
       .value("BERNOULLI_LOGIT", DistributionType::BERNOULLI_LOGIT)
       .value("GAMMA", DistributionType::GAMMA)
       .value("BIMIXTURE", DistributionType::BIMIXTURE)
-      .value("DIRICHLET", DistributionType::DIRICHLET);
+      .value("DIRICHLET", DistributionType::DIRICHLET)
+      .value("CATEGORICAL", DistributionType::CATEGORICAL);
 
   py::enum_<FactorType>(module, "FactorType")
       .value("EXP_PRODUCT", FactorType::EXP_PRODUCT);

--- a/src/beanmachine/graph/to_dot.cpp
+++ b/src/beanmachine/graph/to_dot.cpp
@@ -107,6 +107,8 @@ class DOT {
         return "Gamma";
       case DistributionType::BIMIXTURE:
         return "Bimixture";
+      case DistributionType::CATEGORICAL:
+        return "Categorical";
       default:
         return "distribution";
     }


### PR DESCRIPTION
Summary:
In this diff I am implementing the categorical distribution in BMG:

* argument checking verifies that there is one parent and it is a one-column simplex
* argument checking verifies that the return type is set to natural
* sampling is implemented using the discrete distribution
* log probability computation looks up the sampled value's likelihood in the parent simplex
* computation of the gradient is not yet implemented; the code is stubbed out to always return a flat slope.  We will implement the gradient and test it in an upcoming diff.

Differential Revision: D29015213

