### PR TITLE
Bump beanmachine's flowtorch dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ setup(
         "botorch>=0.3.3",
         "xarray>=0.16.0",
         "arviz>=0.11.0",
-        "flowtorch>=0.0.dev2",
+        "flowtorch>=0.1",
     ],
     packages=find_packages("src/"),
     package_dir={"": "src"},


### PR DESCRIPTION
Summary: Bumps flowtorch dependency to 0.2 to pick up changes in D29563904 (https://github.com/facebookresearch/beanmachine/commit/43345c07c6737f67d05f762624c7ca3e733ab349) to fix CircleCI signal

Differential Revision: D29664385

