### PR TITLE
Implement transformation that discover logsumexp pattern

### DIFF
--- a/src/beanmachine/ppl/compiler/fix_logsumexp.py
+++ b/src/beanmachine/ppl/compiler/fix_logsumexp.py
@@ -1,0 +1,46 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+from typing import Optional
+
+import beanmachine.ppl.compiler.bmg_nodes as bn
+from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
+from beanmachine.ppl.compiler.fix_problem import ProblemFixerBase
+from beanmachine.ppl.compiler.lattice_typer import LatticeTyper
+
+
+class LogSumExpFixer(ProblemFixerBase):
+    """This class takes a Bean Machine Graph builder and attempts to
+    rewrite log expressions of the form:
+
+    * log( exp(a) + exp(b) + exp(c) ...) -> logsumexp(a,b,c, ...)
+
+    Note that this transformation depends on MultiaryOperatorFixer.
+    """
+
+    def __init__(self, bmg: BMGraphBuilder, typer: LatticeTyper) -> None:
+        ProblemFixerBase.__init__(self, bmg, typer)
+
+    def _is_exp_input(self, n: bn.MultiAdditionNode) -> bool:
+        return all(isinstance(i, bn.ExpNode) for i in n.inputs)
+
+    def can_be_log_sum_exp(self, n: bn.LogNode) -> bool:
+        o = n.operand
+        return isinstance(o, bn.MultiAdditionNode) and self._is_exp_input(o)
+
+    def _needs_fixing(self, n: bn.BMGNode) -> bool:
+        # A log expression is fixable if operand is a MultiAdditionNode.
+        # Additionally, each input of this MultiAdditionNode is an ExpNode
+
+        return isinstance(n, bn.LogNode) and self.can_be_log_sum_exp(n)
+
+    def _get_replacement(self, n: bn.BMGNode) -> Optional[bn.BMGNode]:
+        assert isinstance(n, bn.LogNode)
+        assert self.can_be_log_sum_exp(n)
+
+        acc = []
+        for c in n.operand.inputs:
+            assert isinstance(c, bn.ExpNode)
+            acc.append(c.operand)
+
+        assert len(acc) == len(n.operand.inputs)
+        return self._bmg.add_logsumexp(*acc)

--- a/src/beanmachine/ppl/compiler/fix_problems.py
+++ b/src/beanmachine/ppl/compiler/fix_problems.py
@@ -8,6 +8,7 @@ from beanmachine.ppl.compiler.error_report import ErrorReport
 from beanmachine.ppl.compiler.fix_additions import AdditionFixer
 from beanmachine.ppl.compiler.fix_bool_arithmetic import BoolArithmeticFixer
 from beanmachine.ppl.compiler.fix_bool_comparisons import BoolComparisonFixer
+from beanmachine.ppl.compiler.fix_logsumexp import LogSumExpFixer
 from beanmachine.ppl.compiler.fix_multiary_ops import (
     MultiaryMultiplicationFixer,
     MultiaryOperatorFixer,
@@ -37,6 +38,7 @@ _standard_fixer_types: List[Type] = [
     BoolComparisonFixer,
     UnsupportedNodeFixer,
     MultiaryOperatorFixer,
+    LogSumExpFixer,
     MultiaryMultiplicationFixer,
     RequirementsFixer,
     ObservationsFixer,

--- a/src/beanmachine/ppl/compiler/tests/binary_vs_multiary_addition_perf_test.py
+++ b/src/beanmachine/ppl/compiler/tests/binary_vs_multiary_addition_perf_test.py
@@ -103,6 +103,7 @@ infer:(1) -- ms
     BoolComparisonFixer:(1) -- ms
     UnsupportedNodeFixer:(1) -- ms
     MultiaryOperatorFixer:(1) -- ms
+    LogSumExpFixer:(1) -- ms
     MultiaryMultiplicationFixer:(1) -- ms
     RequirementsFixer:(1) -- ms
     ObservationsFixer:(1) -- ms
@@ -162,6 +163,7 @@ infer:(1) -- ms
     AdditionFixer:(1) -- ms
     BoolComparisonFixer:(1) -- ms
     UnsupportedNodeFixer:(1) -- ms
+    LogSumExpFixer:(1) -- ms
     MultiaryMultiplicationFixer:(1) -- ms
     RequirementsFixer:(1) -- ms
     ObservationsFixer:(1) -- ms

--- a/src/beanmachine/ppl/compiler/tests/binary_vs_multiary_multiplication_perf_test.py
+++ b/src/beanmachine/ppl/compiler/tests/binary_vs_multiary_multiplication_perf_test.py
@@ -103,6 +103,7 @@ infer:(1) -- ms
     BoolComparisonFixer:(1) -- ms
     UnsupportedNodeFixer:(1) -- ms
     MultiaryOperatorFixer:(1) -- ms
+    LogSumExpFixer:(1) -- ms
     MultiaryMultiplicationFixer:(1) -- ms
     RequirementsFixer:(1) -- ms
     ObservationsFixer:(1) -- ms
@@ -164,6 +165,7 @@ infer:(1) -- ms
     BoolComparisonFixer:(1) -- ms
     UnsupportedNodeFixer:(1) -- ms
     MultiaryOperatorFixer:(1) -- ms
+    LogSumExpFixer:(1) -- ms
     RequirementsFixer:(1) -- ms
     ObservationsFixer:(1) -- ms
     unattributed: -- ms

--- a/src/beanmachine/ppl/compiler/tests/fix_logsumexp_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_logsumexp_test.py
@@ -1,0 +1,157 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import unittest
+
+import beanmachine.ppl as bm
+import torch
+from beanmachine.ppl.inference import BMGInference
+from torch import exp, log, logsumexp
+from torch.distributions import Normal
+
+
+@bm.random_variable
+def norm(x):
+    return Normal(0.0, 1.0)
+
+
+@bm.functional
+def log_1():
+    return log(exp(norm(0)) + exp(norm(1)) + exp(norm(2)))
+
+
+@bm.functional
+def logsumexp_1():
+    return logsumexp(torch.tensor([norm(0), norm(1), norm(2)]), 0)
+
+
+@bm.functional
+def log_2():
+    return log_1()
+
+
+@bm.functional
+def log_3():
+    return logsumexp_1()
+
+
+@bm.functional
+def exp_1():
+    return exp(norm(3)) + exp(norm(4))
+
+
+@bm.functional
+def log_4():
+    return log(exp(norm(0)) + exp(norm(1)) + exp(norm(2)) + exp_1())
+
+
+@bm.functional
+def log_5():
+    return log_4()
+
+
+@bm.functional
+def log_6():
+    return log_4() + exp_1()
+
+
+class FixLogSumExpTest(unittest.TestCase):
+    def test_fix_log_sum_exp_1(self) -> None:
+        observations = {}
+        queries_observed = [log_2()]
+
+        graph_observed = BMGInference().to_dot(queries_observed, observations)
+
+        queries_expected = [log_3()]
+
+        graph_expected = BMGInference().to_dot(queries_expected, observations)
+
+        self.assertEqual(graph_observed.strip(), graph_expected.strip())
+
+    def test_fix_log_sum_exp_2(self) -> None:
+        observations = {}
+        queries_observed = [log_5()]
+
+        graph_observed = BMGInference().to_dot(queries_observed, observations)
+
+        graph_expected = """
+digraph "graph" {
+  N0[label=0.0];
+  N1[label=1.0];
+  N2[label=Normal];
+  N3[label=Sample];
+  N4[label=Sample];
+  N5[label=Sample];
+  N6[label=Sample];
+  N7[label=Sample];
+  N8[label=LogSumExp];
+  N9[label=Query];
+  N0 -> N2;
+  N1 -> N2;
+  N2 -> N3;
+  N2 -> N4;
+  N2 -> N5;
+  N2 -> N6;
+  N2 -> N7;
+  N3 -> N8;
+  N4 -> N8;
+  N5 -> N8;
+  N6 -> N8;
+  N7 -> N8;
+  N8 -> N9;
+}
+"""
+        self.assertEqual(graph_observed.strip(), graph_expected.strip())
+
+    def test_fix_log_sum_exp_3(self) -> None:
+        observations = {}
+        queries_observed = [log_6()]
+
+        graph_observed = BMGInference().to_dot(queries_observed, observations)
+
+        graph_expected = """
+digraph "graph" {
+  N00[label=0.0];
+  N01[label=1.0];
+  N02[label=Normal];
+  N03[label=Sample];
+  N04[label=Sample];
+  N05[label=Sample];
+  N06[label=Sample];
+  N07[label=Sample];
+  N08[label=Exp];
+  N09[label=Exp];
+  N10[label=Exp];
+  N11[label=Exp];
+  N12[label=Exp];
+  N13[label="+"];
+  N14[label="+"];
+  N15[label=Log];
+  N16[label=ToReal];
+  N17[label="+"];
+  N18[label=Query];
+  N00 -> N02;
+  N01 -> N02;
+  N02 -> N03;
+  N02 -> N04;
+  N02 -> N05;
+  N02 -> N06;
+  N02 -> N07;
+  N03 -> N08;
+  N04 -> N09;
+  N05 -> N10;
+  N06 -> N11;
+  N07 -> N12;
+  N08 -> N14;
+  N09 -> N14;
+  N10 -> N14;
+  N11 -> N13;
+  N12 -> N13;
+  N13 -> N14;
+  N13 -> N16;
+  N14 -> N15;
+  N15 -> N17;
+  N16 -> N17;
+  N17 -> N18;
+}
+"""
+
+        self.assertEqual(graph_observed.strip(), graph_expected.strip())

--- a/src/beanmachine/ppl/compiler/tests/perf_report_test.py
+++ b/src/beanmachine/ppl/compiler/tests/perf_report_test.py
@@ -83,6 +83,7 @@ infer:(1) -- ms
     BoolComparisonFixer:(1) -- ms
     UnsupportedNodeFixer:(1) -- ms
     MultiaryOperatorFixer:(1) -- ms
+    LogSumExpFixer:(1) -- ms
     MultiaryMultiplicationFixer:(1) -- ms
     RequirementsFixer:(1) -- ms
     ObservationsFixer:(1) -- ms


### PR DESCRIPTION
Summary:
With PPL models it is quite common to expect the summation pattern `log( exp(a) + exp(b) + exp(c) ...)` , for example in logistic regression with more than 2 categories. This pattern can instead be replaced with a more stable `logsumexp(a,b,c, ...)` operation. In BMG this transformation leads to reduction in the number of nodes and edges, which could translate to inference speedup.

Design Choice:
There are two ways we could handle this transformation, we can make the transformations not depend on each other or we can make it ordered. Former would lead to duplicated transformation efforts. For example, in this case we would need to detect that there is a chain of summations which multiary addition already does for us. Therefore for this version, I decided to go with the latter, where we assume an order to the transformations i.e. to carry out `LogSumExpFixer` we need to do `MultiaryOperatorFixer` first.  However, we should make a todo somewhere that if a user selectively disables transformations, we need to alert them that it could effectively disable other transformations that depend on it.

Fixing Criteria:
As a simple case, a log expression is fixable if operand is a `MultiAdditionNode`. Additionally, each input of this `MultiAdditionNode` is an `ExpNode`.

Test:
The new test case shows a simple case of how the rewrite works. We start with the following model:

{F631027695}

After rewrite we get the following:

{F631027529}

Since we ensure `MultiaryOperatorFixer` is carried out before `LogSumExpFixer`, the following graph does not meet the fixing criteria, therefore it is not transformed to use `logsumexp`.

{F631028191}

Reviewed By: ericlippert

Differential Revision: D29640106

