### PR TITLE
Rename MultiaryOperatorFixer to MultiaryAdditionFixer

### DIFF
--- a/src/beanmachine/ppl/compiler/fix_logsumexp.py
+++ b/src/beanmachine/ppl/compiler/fix_logsumexp.py
@@ -14,7 +14,7 @@ class LogSumExpFixer(ProblemFixerBase):
 
     * log( exp(a) + exp(b) + exp(c) ...) -> logsumexp(a,b,c, ...)
 
-    Note that this transformation depends on MultiaryOperatorFixer.
+    Note that this transformation depends on MultiaryAdditionFixer.
     """
 
     def __init__(self, bmg: BMGraphBuilder, typer: LatticeTyper) -> None:

--- a/src/beanmachine/ppl/compiler/fix_multiary_ops.py
+++ b/src/beanmachine/ppl/compiler/fix_multiary_ops.py
@@ -8,7 +8,7 @@ from beanmachine.ppl.compiler.fix_problem import ProblemFixerBase
 from beanmachine.ppl.compiler.typer_base import TyperBase
 
 
-class MultiaryOperatorFixer(ProblemFixerBase):
+class MultiaryAdditionFixer(ProblemFixerBase):
     """This fixer transforms graphs with long chains of binary addition nodes
     into multiary additions. This greatly decreases both the number of nodes
     and the number of edges in the graph, which can lead to performance wins

--- a/src/beanmachine/ppl/compiler/fix_problems.py
+++ b/src/beanmachine/ppl/compiler/fix_problems.py
@@ -10,8 +10,8 @@ from beanmachine.ppl.compiler.fix_bool_arithmetic import BoolArithmeticFixer
 from beanmachine.ppl.compiler.fix_bool_comparisons import BoolComparisonFixer
 from beanmachine.ppl.compiler.fix_logsumexp import LogSumExpFixer
 from beanmachine.ppl.compiler.fix_multiary_ops import (
+    MultiaryAdditionFixer,
     MultiaryMultiplicationFixer,
-    MultiaryOperatorFixer,
 )
 from beanmachine.ppl.compiler.fix_observations import ObservationsFixer
 from beanmachine.ppl.compiler.fix_observe_true import ObserveTrueFixer
@@ -37,7 +37,7 @@ _standard_fixer_types: List[Type] = [
     AdditionFixer,
     BoolComparisonFixer,
     UnsupportedNodeFixer,
-    MultiaryOperatorFixer,
+    MultiaryAdditionFixer,
     LogSumExpFixer,
     MultiaryMultiplicationFixer,
     RequirementsFixer,

--- a/src/beanmachine/ppl/compiler/tests/binary_vs_multiary_addition_perf_test.py
+++ b/src/beanmachine/ppl/compiler/tests/binary_vs_multiary_addition_perf_test.py
@@ -102,7 +102,7 @@ infer:(1) -- ms
     AdditionFixer:(1) -- ms
     BoolComparisonFixer:(1) -- ms
     UnsupportedNodeFixer:(1) -- ms
-    MultiaryOperatorFixer:(1) -- ms
+    MultiaryAdditionFixer:(1) -- ms
     LogSumExpFixer:(1) -- ms
     MultiaryMultiplicationFixer:(1) -- ms
     RequirementsFixer:(1) -- ms
@@ -121,7 +121,7 @@ infer:(1) -- ms
             tidy(expected_report_w_optimization).strip(),
         )
 
-        skip_optimizations = {"MultiaryOperatorFixer"}
+        skip_optimizations = {"MultiaryAdditionFixer"}
         report_wo_optimization = get_report(skip_optimizations)
 
         observed_report_wo_optimization = str(report_wo_optimization)

--- a/src/beanmachine/ppl/compiler/tests/binary_vs_multiary_multiplication_perf_test.py
+++ b/src/beanmachine/ppl/compiler/tests/binary_vs_multiary_multiplication_perf_test.py
@@ -102,7 +102,7 @@ infer:(1) -- ms
     AdditionFixer:(1) -- ms
     BoolComparisonFixer:(1) -- ms
     UnsupportedNodeFixer:(1) -- ms
-    MultiaryOperatorFixer:(1) -- ms
+    MultiaryAdditionFixer:(1) -- ms
     LogSumExpFixer:(1) -- ms
     MultiaryMultiplicationFixer:(1) -- ms
     RequirementsFixer:(1) -- ms
@@ -164,7 +164,7 @@ infer:(1) -- ms
     AdditionFixer:(1) -- ms
     BoolComparisonFixer:(1) -- ms
     UnsupportedNodeFixer:(1) -- ms
-    MultiaryOperatorFixer:(1) -- ms
+    MultiaryAdditionFixer:(1) -- ms
     LogSumExpFixer:(1) -- ms
     RequirementsFixer:(1) -- ms
     ObservationsFixer:(1) -- ms

--- a/src/beanmachine/ppl/compiler/tests/disable_transformations_test.py
+++ b/src/beanmachine/ppl/compiler/tests/disable_transformations_test.py
@@ -32,13 +32,13 @@ def sum_4():
     return sum_1() + sum_2()
 
 
-class DisableOptimizationsTest(unittest.TestCase):
+class DisableTransformationsTest(unittest.TestCase):
     def test_multiary_ops_opt_to_dot(self) -> None:
         self.maxDiff = None
         observations = {}
         queries = [sum_3(), sum_4()]
 
-        skip_optimizations = {"MultiaryOperatorFixer"}
+        skip_optimizations = {"MultiaryAdditionFixer"}
         observed = BMGInference().to_dot(
             queries, observations, skip_optimizations=skip_optimizations
         )
@@ -139,7 +139,7 @@ digraph "graph" {
         queries = [sum_3(), sum_4()]
         num_samples = 1000
 
-        skip_optimizations = {"MultiaryOperatorFixer"}
+        skip_optimizations = {"MultiaryAdditionFixer"}
         posterior_wo_opt = BMGInference().infer(
             queries, observations, num_samples, skip_optimizations=skip_optimizations
         )

--- a/src/beanmachine/ppl/compiler/tests/fix_logsumexp_perf_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_logsumexp_perf_test.py
@@ -102,7 +102,7 @@ infer:(1) -- ms
     AdditionFixer:(1) -- ms
     BoolComparisonFixer:(1) -- ms
     UnsupportedNodeFixer:(1) -- ms
-    MultiaryOperatorFixer:(1) -- ms
+    MultiaryAdditionFixer:(1) -- ms
     LogSumExpFixer:(1) -- ms
     MultiaryMultiplicationFixer:(1) -- ms
     RequirementsFixer:(1) -- ms
@@ -163,7 +163,7 @@ infer:(1) -- ms
     AdditionFixer:(1) -- ms
     BoolComparisonFixer:(1) -- ms
     UnsupportedNodeFixer:(1) -- ms
-    MultiaryOperatorFixer:(1) -- ms
+    MultiaryAdditionFixer:(1) -- ms
     MultiaryMultiplicationFixer:(1) -- ms
     RequirementsFixer:(1) -- ms
     ObservationsFixer:(1) -- ms

--- a/src/beanmachine/ppl/compiler/tests/perf_report_test.py
+++ b/src/beanmachine/ppl/compiler/tests/perf_report_test.py
@@ -82,7 +82,7 @@ infer:(1) -- ms
     AdditionFixer:(1) -- ms
     BoolComparisonFixer:(1) -- ms
     UnsupportedNodeFixer:(1) -- ms
-    MultiaryOperatorFixer:(1) -- ms
+    MultiaryAdditionFixer:(1) -- ms
     LogSumExpFixer:(1) -- ms
     MultiaryMultiplicationFixer:(1) -- ms
     RequirementsFixer:(1) -- ms


### PR DESCRIPTION
Summary: Renamed `MultiaryOperatorFixer` to `MultiaryAdditionFixer` to be consistent with the implementation; fixed the associated tests.

Reviewed By: horizon-blue

Differential Revision: D29718781

