### PR TITLE
Finish implementing support for categorical in compiler

### DIFF
--- a/src/beanmachine/ppl/compiler/bm_graph_builder.py
+++ b/src/beanmachine/ppl/compiler/bm_graph_builder.py
@@ -178,6 +178,11 @@ class BMGraphBuilder:
     def add_constant_of_matrix_type(
         self, value: Any, node_type: bt.BMGMatrixType
     ) -> ConstantNode:
+        # If we need a simplex, add a simplex. Otherwise,
+        # choose which kind of matrix node to create based on
+        # the matrix element type.
+        if isinstance(node_type, bt.SimplexMatrix):
+            return self.add_simplex(value)
         if node_type.element_type == bt.real_element:
             return self.add_real_matrix(value)
         if node_type.element_type == bt.positive_real_element:

--- a/src/beanmachine/ppl/compiler/bmg_node_types.py
+++ b/src/beanmachine/ppl/compiler/bmg_node_types.py
@@ -32,6 +32,7 @@ _dist_types = {
     bn.BernoulliNode: (dt.BERNOULLI, AtomicType.BOOLEAN),
     bn.BetaNode: (dt.BETA, AtomicType.PROBABILITY),
     bn.BinomialNode: (dt.BINOMIAL, AtomicType.NATURAL),
+    bn.CategoricalNode: (dt.CATEGORICAL, AtomicType.NATURAL),
     bn.DirichletNode: (dt.DIRICHLET, None),
     bn.FlatNode: (dt.FLAT, AtomicType.PROBABILITY),
     bn.GammaNode: (dt.GAMMA, AtomicType.POS_REAL),

--- a/src/beanmachine/ppl/compiler/fix_requirements.py
+++ b/src/beanmachine/ppl/compiler/fix_requirements.py
@@ -83,7 +83,9 @@ class RequirementsFixer:
                 result = self.bmg.add_constant_of_matrix_type(node.value, required_type)
             else:
                 result = self.bmg.add_constant_of_type(node.value, required_type)
-            assert self._node_meets_requirement(result, requirement)
+            assert self._node_meets_requirement(
+                result, requirement
+            ), f"{str(result)} {str(requirement)} {str(required_type)} {str(self._typer[result])} {str(self._type_meets_requirement(self._typer[result], requirement))}"
             return result
 
         # We cannot convert this node to any type that meets the requirement.

--- a/src/beanmachine/ppl/compiler/lattice_typer.py
+++ b/src/beanmachine/ppl/compiler/lattice_typer.py
@@ -77,6 +77,7 @@ _requires_nothing: Dict[type, bt.BMGLatticeType] = {
     bn.BernoulliNode: bt.Boolean,
     bn.BetaNode: bt.Probability,
     bn.BinomialNode: bt.Natural,
+    bn.CategoricalNode: bt.Natural,
     bn.FlatNode: bt.Probability,
     bn.GammaNode: bt.PositiveReal,
     bn.HalfCauchyNode: bt.PositiveReal,

--- a/src/beanmachine/ppl/compiler/tests/clara_categorical_test.py
+++ b/src/beanmachine/ppl/compiler/tests/clara_categorical_test.py
@@ -188,8 +188,12 @@ digraph "graph" {
 """
         self.assertEqual(expected.strip(), observed.strip())
 
-        # TODO: We do not yet support Categorical
-        # or map/index nodes in BMG.  Revisit this test when we do.
+        # TODO: The obscure "index" error here is a result of an unsupported
+        # stochastic control flow which we do not correctly detect and therefore
+        # do not produce a sensible error message. Stochastic flows of the form
+        # some_rv(some_categorical_rv()) are not yet implemented correctly. When
+        # they are, revisit this test.
+
         # TODO: Raise a better error than a generic ValueError
         # TODO: These error messages are needlessly repetitive.
         # Deduplicate them.
@@ -199,16 +203,6 @@ digraph "graph" {
             BMGInference().infer(queries, observations, 10)
         observed = str(ex.exception)
         expected = """
-The model uses a Categorical operation unsupported by Bean Machine Graph.
-The unsupported node is the operand of a Sample.
-The model uses a Categorical operation unsupported by Bean Machine Graph.
-The unsupported node is the operand of a Sample.
-The model uses a Categorical operation unsupported by Bean Machine Graph.
-The unsupported node is the operand of a Sample.
-The model uses a Categorical operation unsupported by Bean Machine Graph.
-The unsupported node is the operand of a Sample.
-The model uses a Categorical operation unsupported by Bean Machine Graph.
-The unsupported node is the operand of a Sample.
 The model uses a index operation unsupported by Bean Machine Graph.
 The unsupported node is the probability of a Categorical.
 The model uses a index operation unsupported by Bean Machine Graph.


### PR DESCRIPTION
Summary: We now compile models containing categoricals to BMG.  Though we already had the ability to accumulate categorical nodes into the graph builder, we did not previously do type analysis or emit them as BMG nodes; we do now.

Reviewed By: feynmanliang

Differential Revision: D29505941

