### PR TITLE
Transform categorical switches on atomic value into index operations

### DIFF
--- a/src/beanmachine/ppl/compiler/bmg_types.py
+++ b/src/beanmachine/ppl/compiler/bmg_types.py
@@ -785,3 +785,12 @@ def must_be_matrix(r: Requirement) -> bool:
     if isinstance(t, BMGMatrixType):
         return t.rows != 1 or t.columns != 1
     return False
+
+
+def is_atomic(t: BMGLatticeType) -> bool:
+    return (
+        isinstance(t, BMGMatrixType)
+        and t.rows == 1
+        and t.columns == 1
+        and not isinstance(t, SimplexMatrix)
+    )

--- a/src/beanmachine/ppl/compiler/tests/clara_categorical_test.py
+++ b/src/beanmachine/ppl/compiler/tests/clara_categorical_test.py
@@ -195,10 +195,25 @@ digraph "graph" {
         self.assertEqual(expected.strip(), observed.strip())
 
         # TODO: The obscure "switch" error here is a result of an unsupported
-        # stochastic control flow which we do not correctly detect and therefore
-        # do not produce a sensible error message. Stochastic flows of the form
-        # some_rv(some_categorical_rv()) are not yet implemented correctly. When
-        # they are, revisit this test.
+        # stochastic control flow for which we do not yet produce a useful
+        # error message.
+        #
+        # The unsupported control flow is theta(classifier, category_of_item(item));
+        # category_of_item is a small natural, but theta produces a simplex, and
+        # we have no way yet to build a graph to represent the operation "choose
+        # one of these simplexes from a list of simplexes".
+        #
+        # That is, we have k samples from theta, each of which is of type simplex, and
+        # we have category_of_item, which is a number from 0 to k-1.  But we cannot
+        # use TO_MATRIX on those k samples because TO_MATRIX requires its inputs to be
+        # all atomic values; it does not paste together a bunch of column simplexes into
+        # a column simplex matrix from which we can select a single column via indexing.
+        #
+        # What we need to do is either (1) make TO_MATRIX do that, (2) make a new operation
+        # similar to TO_MATRIX for gluing together columns, or (3) make a generalized
+        # IF_THEN_ELSE that chooses from k choices rather than two choices.  (And of course
+        # it is possible to do more than one of these options; they are more generally useful
+        # than just solving this problem alone.)
 
         # TODO: Raise a better error than a generic ValueError
         # TODO: These error messages are needlessly repetitive.

--- a/src/beanmachine/ppl/compiler/tests/stochastic_control_flow_test.py
+++ b/src/beanmachine/ppl/compiler/tests/stochastic_control_flow_test.py
@@ -193,10 +193,11 @@ digraph "graph" {
         observations = {}
         bmg = BMGRuntime().accumulate_graph(queries, observations)
 
-        # Now we have three possibilities: 0, 1 or 2. We have not yet
-        # written the code to transform this switch into
-        # index(tensor(choices), choice).
-        # TODO: When we have done so, update this test.
+        # TODO: We cannot yet transform this into a legal BMG graph because
+        # the quantity used to make the choice is a sum of Booleans, and
+        # we treat the sum of bools as a real number, not as a natural.
+        # We can only index on naturals.
+
         # TODO: Add a test where we generate supports such as 1, 2, 3
         # or 1, 10, 100.
         observed = to_dot(bmg, after_transform=False, label_edges=True)


### PR DESCRIPTION
Summary:
If we have a stochastic control flow of the form:

    some_rv(some_categorical_rv())

then we can represent this in BMG by obtaining graph nodes for `some_rv(0)`, `some_rv(1)`..., and sticking them all into a `TO_MATRIX`. We can then index that by the sample from `some_categorical_rv()`, which gives us a stochastic choice of random variables.  This diff implements that transformation, so we can now compile models that have this control flow. For example

HOWEVER there are some limitations:

* `some_rv(n)` must produce atomic values, not simplexes or other arrays. We have no ability at this time to use `TO_MATRIX` on anything but atomic values.  This means for instance that we cannot compile a CLARA model that uses a categorical to choose from amongst some number of simplex-valued samples from Dirichlet. A more general solution would be to implement an extension of `IF_THEN_ELSE` that chooses from more than two choices of the same type.
* We do not yet correctly handle nested uses of this pattern. That is, if `some_rv` was itself categorical, then `some_other_rv(some_rv(some_categorical_rv()))` morally ought to work just fine, but at present we crash during graph accumulation. I will fix that in an upcoming diff.
* The inner rv must be *natural-valued* with support 0, 1, 2, ... n.  Note that the BMG type system does not classify the sum of naturals to itself be a natural, which means that we do not support control flows such as `some_rv(flip(0) + flip(1))` to generate 0, 1, 2, ...  by adding bools or naturals. (Sum are classified as reals, negative reals or positive reals only.)  If we need to support compiling control flows with other supports then we need to figure out how to do so.
* Even though we now compile a subset of models that contain this control flow, we cannot yet do inference on them for two reasons. First, because I have not yet implemented the gradient of a categorical correctly, and second, because BMG NMC does not have a discrete sampler yet.

Reviewed By: feynmanliang

Differential Revision: D29739288

