### PR TITLE
Fix outcome syntax error

### DIFF
--- a/src/beanmachine/applications/hme/abstract_model.py
+++ b/src/beanmachine/applications/hme/abstract_model.py
@@ -108,9 +108,8 @@ class AbstractModel(object, metaclass=ABCMeta):
         # if outcome is specified by the formula,
         # then we need to compare it with self.model_config.mean_regression.outcome
         if model_desc.lhs_termlist:
-            if (
-                outcome := model_desc.lhs_termlist[0].factors[0].code
-            ) != self.model_config.mean_regression.outcome:
+            outcome = model_desc.lhs_termlist[0].factors[0].code
+            if outcome != self.model_config.mean_regression.outcome:
                 raise ValueError(
                     f"Inconsistent outcome variable encountered! Formula: {outcome}; RegressionConfig: {self.model_config.mean_regression.outcome}."
                 )


### PR DESCRIPTION
Summary: fixed the outcome variable definition syntax error in D29879592 (https://github.com/facebookresearch/beanmachine/commit/4c741a0fbb26ec340b72c9d4a6baaadc2df8a0f0), which is new in Python 3.8 and CI workflow runs on Python 3.7

Differential Revision: D30017616

