### PR TITLE
Compute support of switch nodes to fix nested stochastic control flow

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/categorical_test.py
+++ b/src/beanmachine/ppl/compiler/tests/categorical_test.py
@@ -71,7 +71,11 @@ def c_multi():
     return Categorical(tensor([[0.5, 0.5], [0.5, 0.5]]))
 
 
-# TODO: random variable indexed by categorical
+# NOTE: A random variable indexed by a categorical is tested in
+# stochastic_control_flow_test.py.
+
+# TODO: Once categorical inference is supported in BMG add a test
+# here which demonstrates that.
 
 
 class CategoricalTest(unittest.TestCase):


### PR DESCRIPTION
Summary:
We were throwing an exception when faced with a stochastic control flow of the form:

    some_rv(cat_or_bool_2(cat_or_bool_1()))

That is, the innermost rv samples from a natural or bool valued distribution; that chooses one of finitely many samples from a second natural/bool valued distribution, and THAT chooses the outermost rv.

The reason for the exception was because we did not compute the support of `cat_or_bool_2`; it is represented during graph accumulation as a SwitchNode, and we now compute its support as the union of the supports of all its possible outputs.

Updated test case shows how we generate a valid BMG graph in this case; note the nested `if` nodes:

{F633617771}

Reviewed By: feynmanliang

Differential Revision: D29810043

