### PR TITLE
Create a "natural choice" operator in BMG

### DIFF
--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -319,6 +319,7 @@ enum class OperatorType {
   TO_REAL_MATRIX,
   TO_POS_REAL_MATRIX,
   TO_NEG_REAL,
+  CHOICE,
 };
 
 enum class DistributionType {

--- a/src/beanmachine/graph/operator/backward.cpp
+++ b/src/beanmachine/graph/operator/backward.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
 #include <cmath>
 
+#include "beanmachine/graph/graph.h"
 #include "beanmachine/graph/operator/controlop.h"
 #include "beanmachine/graph/operator/linalgop.h"
 #include "beanmachine/graph/operator/multiaryop.h"
@@ -149,14 +150,17 @@ void LogSumExpVector::backward() {
 
 void IfThenElse::backward() {
   assert(in_nodes.size() == 3);
-  if (in_nodes[0]->value._bool) {
-    if (in_nodes[1]->needs_gradient()) {
-      in_nodes[1]->back_grad1._double += back_grad1._double;
-    }
-  } else {
-    if (in_nodes[2]->needs_gradient()) {
-      in_nodes[2]->back_grad1._double += back_grad1._double;
-    }
+  int choice = in_nodes[0]->value._bool ? 1 : 2;
+  if (in_nodes[choice]->needs_gradient()) {
+    in_nodes[choice]->back_grad1._double += back_grad1._double;
+  }
+}
+
+void Choice::backward() {
+  graph::natural_t choice = in_nodes[0]->value._natural + 1;
+  assert(in_nodes.size() < choice);
+  if (in_nodes[choice]->needs_gradient()) {
+    in_nodes[choice]->back_grad1._double += back_grad1._double;
   }
 }
 

--- a/src/beanmachine/graph/operator/controlop.cpp
+++ b/src/beanmachine/graph/operator/controlop.cpp
@@ -7,17 +7,20 @@ namespace oper {
 
 IfThenElse::IfThenElse(const std::vector<graph::Node*>& in_nodes)
     : Operator(graph::OperatorType::IF_THEN_ELSE) {
-  if (in_nodes.size() != 3 or
-      in_nodes[1]->value.type != in_nodes[2]->value.type) {
+  if (in_nodes.size() != 3) {
     throw std::invalid_argument(
-        "operator IF_THEN_ELSE requires 3 args and arg2.type == arg3.type");
+        "operator IF_THEN_ELSE requires exactly three parents");
   }
   graph::ValueType type0 = in_nodes[0]->value.type;
   if (type0 != graph::AtomicType::BOOLEAN) {
     throw std::invalid_argument(
-        "operator IF_THEN_ELSE requires boolean first argument");
+        "operator IF_THEN_ELSE requires a boolean first parent");
   }
-  value = graph::NodeValue(in_nodes[1]->value.type.atomic_type);
+  if (in_nodes[1]->value.type != in_nodes[2]->value.type) {
+    throw std::invalid_argument(
+        "operator IF_THEN_ELSE requires that the second and third parents have the same type");
+  }
+  value = in_nodes[1]->value;
 }
 
 void IfThenElse::eval(std::mt19937& /* gen */) {
@@ -27,6 +30,38 @@ void IfThenElse::eval(std::mt19937& /* gen */) {
   } else {
     value = in_nodes[2]->value;
   }
+}
+
+Choice::Choice(const std::vector<graph::Node*>& in_nodes)
+    : Operator(graph::OperatorType::CHOICE) {
+  if (in_nodes.size() < 2) {
+    throw std::invalid_argument(
+        "operator CHOICE requires at least two parents");
+  }
+  graph::ValueType type0 = in_nodes[0]->value.type;
+  if (type0 != graph::AtomicType::NATURAL) {
+    throw std::invalid_argument(
+        "operator CHOICE requires a natural first parent");
+  }
+  graph::ValueType type1 = in_nodes[1]->value.type;
+  for (uint i = 2; i < in_nodes.size(); i += 1) {
+    if (in_nodes[i]->value.type != type1) {
+      throw std::invalid_argument(
+          "operator CHOICE requires all parents except the first to have the same type");
+    }
+  }
+  value = in_nodes[1]->value;
+}
+
+void Choice::eval(std::mt19937& /* gen */) {
+  assert(in_nodes.size() >= 2);
+  graph::natural_t choice = in_nodes[0]->value._natural + 1;
+  if (choice > in_nodes.size()) {
+    throw std::runtime_error(
+        "invalid value for CHOICE operator at node_id " +
+        std::to_string(index));
+  }
+  value = in_nodes[choice]->value;
 }
 
 } // namespace oper

--- a/src/beanmachine/graph/operator/controlop.h
+++ b/src/beanmachine/graph/operator/controlop.h
@@ -24,5 +24,24 @@ class IfThenElse : public Operator {
   static bool is_registered;
 };
 
+// This is IfThenElse but the condition is a natural and there are n choices.
+class Choice : public Operator {
+ public:
+  explicit Choice(const std::vector<graph::Node*>& in_nodes);
+  ~Choice() override {}
+
+  void eval(std::mt19937& gen) override;
+  void compute_gradients() override;
+  void backward() override;
+
+  static std::unique_ptr<Operator> new_op(
+      const std::vector<graph::Node*>& in_nodes) {
+    return std::make_unique<Choice>(in_nodes);
+  }
+
+ private:
+  static bool is_registered;
+};
+
 } // namespace oper
 } // namespace beanmachine

--- a/src/beanmachine/graph/operator/gradient.cpp
+++ b/src/beanmachine/graph/operator/gradient.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
 #include <cmath>
 
+#include "beanmachine/graph/graph.h"
 #include "beanmachine/graph/operator/controlop.h"
 #include "beanmachine/graph/operator/linalgop.h"
 #include "beanmachine/graph/operator/multiaryop.h"
@@ -291,13 +292,16 @@ void LogSumExpVector::compute_gradients() {
 
 void IfThenElse::compute_gradients() {
   assert(in_nodes.size() == 3);
-  if (in_nodes[0]->value._bool) {
-    grad1 = in_nodes[1]->grad1;
-    grad2 = in_nodes[1]->grad2;
-  } else {
-    grad1 = in_nodes[2]->grad1;
-    grad2 = in_nodes[2]->grad2;
-  }
+  int choice = in_nodes[0]->value._bool ? 1 : 2;
+  grad1 = in_nodes[choice]->grad1;
+  grad2 = in_nodes[choice]->grad2;
+}
+
+void Choice::compute_gradients() {
+  graph::natural_t choice = in_nodes[0]->value._natural + 1;
+  assert(in_nodes.size() < choice);
+  grad1 = in_nodes[choice]->grad1;
+  grad2 = in_nodes[choice]->grad2;
 }
 
 void Index::compute_gradients() {

--- a/src/beanmachine/graph/operator/register.cpp
+++ b/src/beanmachine/graph/operator/register.cpp
@@ -14,6 +14,10 @@ bool IfThenElse::is_registered = OperatorFactory::register_op(
     graph::OperatorType::IF_THEN_ELSE,
     &(IfThenElse::new_op));
 
+bool Choice::is_registered = OperatorFactory::register_op(
+    graph::OperatorType::CHOICE,
+    &(Choice::new_op));
+
 // multiary op
 bool Add::is_registered =
     OperatorFactory::register_op(graph::OperatorType::ADD, &(Add::new_op));

--- a/src/beanmachine/graph/pybindings.cpp
+++ b/src/beanmachine/graph/pybindings.cpp
@@ -65,7 +65,8 @@ PYBIND11_MODULE(graph, module) {
       .value("COLUMN_INDEX", OperatorType::COLUMN_INDEX)
       .value("TO_REAL_MATRIX", OperatorType::TO_REAL_MATRIX)
       .value("TO_POS_REAL_MATRIX", OperatorType::TO_POS_REAL_MATRIX)
-      .value("TO_NEG_REAL", OperatorType::TO_NEG_REAL);
+      .value("TO_NEG_REAL", OperatorType::TO_NEG_REAL)
+      .value("CHOICE", OperatorType::CHOICE);
 
   py::enum_<DistributionType>(module, "DistributionType")
       .value("TABULAR", DistributionType::TABULAR)

--- a/src/beanmachine/graph/to_dot.cpp
+++ b/src/beanmachine/graph/to_dot.cpp
@@ -147,6 +147,8 @@ class DOT {
         return "Logistic";
       case OperatorType::IF_THEN_ELSE:
         return "IfThenElse";
+      case OperatorType::CHOICE:
+        return "Choice";
       case OperatorType::LOG1PEXP:
         return "Log1pExp";
       case OperatorType::LOGSUMEXP:

--- a/src/beanmachine/ppl/compiler/tests/graph_accumulation_test.py
+++ b/src/beanmachine/ppl/compiler/tests/graph_accumulation_test.py
@@ -161,10 +161,10 @@ Node 5 type 2 parents [ 3 4 ] children [ 6 ] unknown
 Node 6 type 3 parents [ 5 ] children [ ] real 0
 Node 7 type 1 parents [ ] children [ 9 ] natural 1
 Node 8 type 1 parents [ ] children [ 9 ] natural 0
-Node 9 type 3 parents [ 2 7 8 ] children [ 13 ] natural 0
+Node 9 type 3 parents [ 2 7 8 ] children [ 13 ] natural 1
 Node 10 type 1 parents [ ] children [ 12 ] probability 1
 Node 11 type 1 parents [ ] children [ 12 ] probability 1e-10
-Node 12 type 3 parents [ 2 10 11 ] children [ 13 ] probability 1e-10
+Node 12 type 3 parents [ 2 10 11 ] children [ 13 ] probability 1
 Node 13 type 2 parents [ 9 12 ] children [ 14 ] unknown
 Node 14 type 3 parents [ 13 ] children [ ] natural 0
 """


### PR DESCRIPTION
Summary:
BMG has an `IF_THEN_ELSE` operator which has a Boolean first parent, and then two additional parents of the same type.  I am here adding a `CHOICE` operator which has a natural first parent and n additional parents of the same type. We presume that the support of the first parent is 0 to no more than n-1; if that turns out to be false then inference can crash. (Just as it can if we try to do a stochastic index into a non-existing element of a matrix.)

If we ever support bounded naturals as a type in BMG, we can improve the type safety of this operation; until then we will just insert a check in `eval`.

Since indexing into a matrix is essentially this same operation, why not just use that?  Because a matrix can only be two-dimensional in BMG. That means that to have a stochastic choice amongst, say, ten 2x2 arrays, we would need to index into a 10x2x2 array and we cannot represent such an array.

My intention is to use this operator for representing stochastic choices between random variables when compiling models to BMG; those changes will come in a later diff.

While adding this operator I fixed some typos and made error handling in `IfThenElse` more consistent with the other operators. I also simplified some needlessly repetitious `IfThenElse` code.

Reviewed By: feynmanliang, yucenli

Differential Revision: D29833681

