### PR TITLE
Fix KeyError when querying bm.functional in global inference

### DIFF
--- a/src/beanmachine/ppl/experimental/global_inference/base_inference.py
+++ b/src/beanmachine/ppl/experimental/global_inference/base_inference.py
@@ -70,7 +70,7 @@ class BaseInference(metaclass=ABCMeta):
                 world = next(sampler)
                 # Extract samples
                 for query in queries:
-                    samples[query].append(world[query])
+                    samples[query].append(world.call(query))
 
             samples = {node: torch.stack(val) for node, val in samples.items()}
             chain_results.append(samples)

--- a/src/beanmachine/ppl/experimental/global_inference/tests/inference_test.py
+++ b/src/beanmachine/ppl/experimental/global_inference/tests/inference_test.py
@@ -19,11 +19,15 @@ class SampleModel:
     def bar(self):
         return dist.Normal(self.foo(), 1.0)
 
+    @bm.functional
+    def baz(self):
+        return self.bar() * 2.0
+
 
 def test_inference():
     model = SampleModel()
     nuts = bm.GlobalNoUTurnSampler()
-    queries = [model.foo()]
+    queries = [model.foo(), model.baz()]
     observations = {model.bar(): torch.tensor(0.5)}
     num_samples = 30
     num_chains = 2


### PR DESCRIPTION
Summary:
As titled. This diff addresses an issue when collecting `bm.functional` in global inference framework, as uncovered by Aishwarya's notebook: N993496.

(As a reference, here is how single site collect the samples: https://fburl.com/code/y9wz5yrn)

Differential Revision: D30083933

