### PR TITLE
Stochastic control flows now generate choice operator in compiler

### DIFF
--- a/src/beanmachine/ppl/compiler/bm_graph_builder.py
+++ b/src/beanmachine/ppl/compiler/bm_graph_builder.py
@@ -630,6 +630,14 @@ class BMGraphBuilder:
         return node
 
     @memoize
+    def add_choice(self, condition: BMGNode, *values: BMGNode) -> bn.ChoiceNode:
+        vs = list(values)
+        assert len(values) >= 2
+        node = bn.ChoiceNode(condition, vs)
+        self.add_node(node)
+        return node
+
+    @memoize
     def add_matrix_multiplication(self, left: BMGNode, right: BMGNode) -> BMGNode:
         if isinstance(left, ConstantNode) and isinstance(right, ConstantNode):
             return self.add_constant(torch.mm(left.value, right.value))

--- a/src/beanmachine/ppl/compiler/bmg_node_types.py
+++ b/src/beanmachine/ppl/compiler/bmg_node_types.py
@@ -58,6 +58,7 @@ def dist_type(node: bn.DistributionNode) -> Tuple[dt, Any]:
 
 _operator_types = {
     bn.AdditionNode: OperatorType.ADD,
+    bn.ChoiceNode: OperatorType.CHOICE,
     bn.ColumnIndexNode: OperatorType.COLUMN_INDEX,
     bn.ComplementNode: OperatorType.COMPLEMENT,
     bn.ExpM1Node: OperatorType.EXPM1,

--- a/src/beanmachine/ppl/compiler/bmg_nodes.py
+++ b/src/beanmachine/ppl/compiler/bmg_nodes.py
@@ -1096,7 +1096,7 @@ class ToMatrixNode(OperatorNode):
 
 
 # ####
-# #### Ternary operators
+# #### Control flow operators
 # ####
 
 
@@ -1145,6 +1145,23 @@ class IfThenElseNode(OperatorNode):
         # We should never need to compute the support of an IfThenElse because
         # this node is not generated until after graph accumulation is complete.
         raise ValueError("support of IfThenElseNode not yet implemented")
+
+
+class ChoiceNode(OperatorNode):
+    """This class represents a stochastic choice between n options, where
+    the condition is a natural."""
+
+    # See comments in SwitchNode for more details.
+
+    def __init__(self, condition: BMGNode, items: List[BMGNode]):
+        assert isinstance(items, list)
+        # We should not generate a choice node if there is only one choice.
+        assert len(items) >= 2
+        c: List[BMGNode] = [condition]
+        BMGNode.__init__(self, c + items)
+
+    def __str__(self) -> str:
+        return "Choice"
 
 
 # ####
@@ -1392,8 +1409,8 @@ class SwitchNode(BMGNode):
     # Note that we do not have a generalized switch in BMG. Rather, we have
     # the simpler cases of (1) the IfThenElse node, where the leftmost input
     # is a Boolean quantity and the other two inputs are the values, and
-    # (2) a TensorNode with an IndexNode, where the index is a natural less
-    # than the number of elements in the tensor.
+    # (2) a ChoiceNode, which takes a natural and then chooses from amongst
+    # n possible values.
     #
     # TODO: Should we implement a general switch node in BMG?
     #

--- a/src/beanmachine/ppl/compiler/bmg_requirements.py
+++ b/src/beanmachine/ppl/compiler/bmg_requirements.py
@@ -76,6 +76,7 @@ class EdgeRequirements:
             bn.DirichletNode: self._requirements_dirichlet,
             # Operators
             bn.AdditionNode: self._requirements_addition,
+            bn.ChoiceNode: self._requirements_choice,
             bn.ColumnIndexNode: self._requirements_column_index,
             bn.ComplementNode: self._same_as_output,
             bn.ExpM1Node: self._same_as_output,
@@ -208,8 +209,17 @@ class EdgeRequirements:
     def _requirements_if(self, node: bn.IfThenElseNode) -> List[bt.Requirement]:
         # The condition has to be Boolean; the consequence and alternative need
         # to be the same.
+        # TODO: Consider what to do if the node type is Tensor.
         it = self.typer[node]
         return [bt.Boolean, it, it]
+
+    def _requirements_choice(self, node: bn.ChoiceNode) -> List[bt.Requirement]:
+        # The condition has to be Natural; the values must all be of the same type.
+        # TODO: Consider what to do if the node type is Tensor.
+        node_type = self.typer[node]
+        c: List[bt.Requirement] = [bt.Natural]
+        v: List[bt.Requirement] = [node_type]
+        return c + v * (len(node.inputs) - 1)
 
     def _requirements_index(self, node: bn.VectorIndexNode) -> List[bt.Requirement]:
         # The index operator introduces an interesting wrinkle into the

--- a/src/beanmachine/ppl/compiler/graph_labels.py
+++ b/src/beanmachine/ppl/compiler/graph_labels.py
@@ -38,6 +38,7 @@ _node_labels = {
     bn.CategoricalLogitNode: "Categorical(logits)",
     bn.CategoricalNode: "Categorical",
     bn.Chi2Node: "Chi2",
+    bn.ChoiceNode: "Choice",
     bn.ColumnIndexNode: "ColumnIndex",
     bn.ComplementNode: "complement",
     bn.ConstantBooleanMatrixNode: _tensor_val,
@@ -126,8 +127,8 @@ def _numbered_or_left_right(node: bn.BMGNode) -> List[str]:
     return _numbers(len(node.inputs))
 
 
-def _to_matrix(node: bn.BMGNode) -> List[str]:
-    return ["rows", "columns"] + _numbers(len(node.inputs) - 2)
+def _prefix_numbered(prefix: List[str]) -> Callable:
+    return lambda node: prefix + _numbers(len(node.inputs) - len(prefix))
 
 
 _edge_labels = {
@@ -140,6 +141,7 @@ _edge_labels = {
     bn.BooleanNode: _none,
     bn.CategoricalNode: _probability,
     bn.Chi2Node: ["df"],
+    bn.ChoiceNode: _prefix_numbered(["condition"]),
     bn.ColumnIndexNode: _left_right,
     bn.ComplementNode: _operand,
     bn.ConstantBooleanMatrixNode: _none,
@@ -191,7 +193,7 @@ _edge_labels = {
     bn.SampleNode: _operand,
     bn.StudentTNode: ["df", "loc", "scale"],
     bn.TensorNode: _numbered_or_left_right,
-    bn.ToMatrixNode: _to_matrix,
+    bn.ToMatrixNode: _prefix_numbered(["rows", "columns"]),
     bn.ToNegativeRealNode: _operand,
     bn.ToPositiveRealMatrixNode: _operand,
     bn.ToPositiveRealNode: _operand,

--- a/src/beanmachine/ppl/compiler/tests/gaussian_mixture_model_test.py
+++ b/src/beanmachine/ppl/compiler/tests/gaussian_mixture_model_test.py
@@ -49,12 +49,6 @@ class GaussianMixtureModelTest(unittest.TestCase):
         # yet implemented because the gradients are not yet computed correctly
         # and because BMG NMC does not yet implement a discrete sampler. Once
         # that work is complete, update this test to actually do inference.
-        #
-        # TODO: We generate the choice step by putting the three samples into
-        # a 3x1 matrix and then indexing into the matrix. This seems like a
-        # bit of a hack, and it does not generalize to choices amongst matrices,
-        # only choices amongst scalars.  We should consider implementing a more
-        # general version of IF_THEN_ELSE that allows more than two choices.
 
         observed = BMGInference().to_dot(queries, observations)
         expected = """
@@ -68,32 +62,26 @@ digraph "graph" {
   N06[label=Sample];
   N07[label=Sample];
   N08[label=Sample];
-  N09[label=3];
-  N10[label=1];
-  N11[label=ToMatrix];
-  N12[label=index];
-  N13[label=2.0];
-  N14[label=Normal];
-  N15[label=Sample];
-  N16[label=Query];
+  N09[label=Choice];
+  N10[label=2.0];
+  N11[label=Normal];
+  N12[label=Sample];
+  N13[label=Query];
   N00 -> N01;
   N01 -> N02;
-  N02 -> N12;
+  N02 -> N09;
   N03 -> N05;
   N04 -> N05;
   N05 -> N06;
   N05 -> N07;
   N05 -> N08;
-  N06 -> N11;
-  N07 -> N11;
-  N08 -> N11;
+  N06 -> N09;
+  N07 -> N09;
+  N08 -> N09;
   N09 -> N11;
   N10 -> N11;
   N11 -> N12;
-  N12 -> N14;
-  N13 -> N14;
-  N14 -> N15;
-  N15 -> N16;
+  N12 -> N13;
 }
 """
         self.assertEqual(expected.strip(), observed.strip())


### PR DESCRIPTION
Summary:
As noted in previous diffs, in BMG we were representing a stochastic choice amongst several values as an index into an array of atomic values. This has several problems; first off, it seems like a hack rather than a purpose-built solution. And second, an array must be two-dimensional in BMG, which makes it hard to use this trick to choose from amongst matrix values.  (This is not an academic concern; our version of the CLARA model which uses categoricals chooses from amongst several possible simplex-valued samples.)

In the previous diff in this stack I added a `CHOICE` operator to BMG; in this diff I:

* add a Python version of that operator in the compiler
* ensure that its type analysis matches the requirements of the BMG node
* update the logic that handles "switch on natural" to generate `CHOICE(c, ...)` rather than `INDEX(TO_MATRIX(...), c)`
* this causes the output of the GMM test to change
* this now allows the categorical CLARA model to compile without error

Reviewed By: feynmanliang

Differential Revision: D29861609

