### PR TITLE
Fix linter warnings

### DIFF
--- a/src/beanmachine/graph/stepper/nmc_dirichlet_beta_single_site_stepper.h
+++ b/src/beanmachine/graph/stepper/nmc_dirichlet_beta_single_site_stepper.h
@@ -16,7 +16,7 @@ class NMCDirichletBetaSingleSiteStepper : public NMCSingleSiteStepper {
   virtual void step(
       graph::Node* tgt_node,
       const std::vector<graph::Node*>& det_affected_nodes,
-      const std::vector<graph::Node*>& sto_affected_nodes);
+      const std::vector<graph::Node*>& sto_affected_nodes) override;
 
  private:
   std::unique_ptr<proposer::Proposer> create_proposer_dirichlet_beta(

--- a/src/beanmachine/graph/stepper/nmc_dirichlet_gamma_single_site_stepper.h
+++ b/src/beanmachine/graph/stepper/nmc_dirichlet_gamma_single_site_stepper.h
@@ -16,7 +16,7 @@ class NMCDirichletGammaSingleSiteStepper : public NMCSingleSiteStepper {
   virtual void step(
       graph::Node* tgt_node,
       const std::vector<graph::Node*>& det_affected_nodes,
-      const std::vector<graph::Node*>& sto_affected_nodes);
+      const std::vector<graph::Node*>& sto_affected_nodes) override;
 
  private:
   std::unique_ptr<proposer::Proposer> create_proposer_dirichlet_gamma(


### PR DESCRIPTION
Summary: The circle ci linter is complaining that these two virtual methods which implement an abstract base class method are not marked `override`.  This fixes that linter warning.

Differential Revision: D30119594

