### PR TITLE
Implement transformation that discover beta-bernoulli conjugate pattern

### DIFF
--- a/src/beanmachine/ppl/compiler/bm_graph_builder.py
+++ b/src/beanmachine/ppl/compiler/bm_graph_builder.py
@@ -134,6 +134,22 @@ class BMGraphBuilder:
             i.outputs.remove_item(node)
         del self._nodes[node]
 
+    def remove_node(self, node: BMGNode) -> None:
+        # TODO: This is only used to remove observation sample node that
+        # are factored into posterior computation; restrict it
+        # accordingly. Particularly because this code is not correct with
+        # respect to the memoizers. We could add a node, memoize it,
+        # remove, it, add it again, and the memoizer would hand the node
+        # back without adding it to the graph.
+
+        """This removes a node from the builder, and ensures that the
+        output edges of all its input nodes are removed as well."""
+        if node not in self._nodes:
+            raise ValueError("remove_node called with node from wrong builder")
+        for i in node.inputs.inputs:
+            i.outputs.remove_item(node)
+        del self._nodes[node]
+
     # ####
     # #### Graph accumulation for constant values
     # ####

--- a/src/beanmachine/ppl/compiler/fix_beta_conjugate_prior.py
+++ b/src/beanmachine/ppl/compiler/fix_beta_conjugate_prior.py
@@ -1,0 +1,129 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+from typing import Optional
+
+import beanmachine.ppl.compiler.bmg_nodes as bn
+from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
+from beanmachine.ppl.compiler.fix_problem import ProblemFixerBase
+from beanmachine.ppl.compiler.typer_base import TyperBase
+
+
+class BetaBernoulliConjguateFixer(ProblemFixerBase):
+    """This fixer transforms graphs with Bernoulli likelihood and Beta prior.
+    Since this is a conjugate pair, we analytically update the prior
+    parameters Beta(alpha, beta) using observations to get the posterior
+    parameters Beta(alpha', beta'). Once we update the parameters,
+    we delete the observed samples from the graph. This greatly decreases
+    the number of nodes, the number of edges in the graph, and the Bayesian
+    update is reduced to parameter update which can lead to performance
+    wins during inference."""
+
+    def __init__(self, bmg: BMGraphBuilder, typer: TyperBase) -> None:
+        ProblemFixerBase.__init__(self, bmg, typer)
+
+    def _theta_is_beta_with_real_params(self, n: bn.SampleNode) -> bool:
+        # TODO: For now we support conjugate prior transformation on
+        # priors with constant parameter values. This needs to be removed
+        # if we can update priors that take RVs.
+        beta_node = n.inputs[0]
+        if not isinstance(beta_node, bn.BetaNode):
+            return False
+        alpha = beta_node.inputs[0]
+        beta = beta_node.inputs[1]
+        return isinstance(alpha, bn.ConstantNode) and isinstance(beta, bn.ConstantNode)
+
+    def _theta_is_queried(self, n: bn.SampleNode) -> bool:
+        # TODO: This check can be removed if it is not a necessary condition.
+        return any(isinstance(i, bn.Query) for i in n.outputs.items)
+
+    def _sample_contains_obs(self, n: bn.SampleNode) -> bool:
+        return any(isinstance(o, bn.Observation) for o in n.outputs.items)
+
+    def _bernoulli_is_observed(self, n: bn.BMGNode) -> bool:
+        return any(self._sample_contains_obs(i) for i in n.outputs.items)
+
+    def _needs_fixing(self, n: bn.BMGNode) -> bool:
+        # A graph is beta-bernoulli conjugate fixable if:
+        #
+        # There is a bernoulli node with theta that is sampled
+        # from a beta distribution. Further, the beta is queried and
+        # the bernoulli node has n observations.
+        #
+        # That is we are looking for stuff like:
+        #
+        #   alpha    beta
+        #     \       /
+        #        Beta
+        #         |
+        #       Sample
+        #      /       \
+        #   Bernoulli  Query
+        #      |
+        #    Sample
+        #      |            \
+        #  Observation True ...
+        #
+        #  to turn it into
+        #
+        #  alpha'     beta'
+        #     \       /
+        #        Beta
+        #         |
+        #       Sample
+        #         |
+        #       Query
+
+        if not isinstance(n, bn.BernoulliNode):
+            return False
+        sample = n.inputs[0]
+        if not isinstance(sample, bn.SampleNode):
+            return False
+        return (
+            self._theta_is_beta_with_real_params(sample)
+            and self._theta_is_queried(sample)
+            and self._bernoulli_is_observed(n)
+        )
+
+    def _transform_alpha(self, alpha: bn.ConstantNode, obs_sum: float) -> bn.BMGNode:
+        # Update: alpha' = alpha + obs_sum
+        return self._bmg.add_pos_real(alpha.value + obs_sum)
+
+    def _transform_beta(self, beta: bn.ConstantNode, obs_sum, n) -> bn.BMGNode:
+        # Update: beta' = beta + n - obs_sum
+        return self._bmg.add_pos_real(beta.value + n - obs_sum)
+
+    def _get_replacement(self, n: bn.BMGNode) -> Optional[bn.BMGNode]:
+        assert isinstance(n, bn.BernoulliNode)
+        beta_sample = n.inputs[0]
+        assert isinstance(beta_sample, bn.SampleNode)
+        beta_node = beta_sample.inputs[0]
+        assert isinstance(beta_node, bn.BetaNode)
+
+        obs = []
+        samples_to_remove = []
+        for o in n.outputs.items:
+            if isinstance(o, bn.SampleNode) and self._sample_contains_obs(o):
+                obs.append(next(iter(o.outputs.items.keys())))
+                samples_to_remove.append(o)
+        obs_sum = sum(o.value for o in obs)
+
+        alpha = beta_node.inputs[0]
+        assert isinstance(alpha, bn.ConstantNode)
+        transformed_alpha = self._transform_alpha(alpha, obs_sum)
+
+        beta = beta_node.inputs[1]
+        assert isinstance(beta, bn.ConstantNode)
+        transformed_beta = self._transform_beta(beta, obs_sum, len(obs))
+
+        beta_node.inputs[0] = transformed_alpha
+        beta_node.inputs[1] = transformed_beta
+
+        # We need to remove both the sample and the observation node.
+        for o in obs:
+            self._bmg.remove_leaf(o)
+
+        for s in samples_to_remove:
+            if len(s.outputs.items) == 0:
+                self._bmg.remove_node(s)
+
+        return n

--- a/src/beanmachine/ppl/compiler/fix_problems.py
+++ b/src/beanmachine/ppl/compiler/fix_problems.py
@@ -6,6 +6,9 @@ import beanmachine.ppl.compiler.profiler as prof
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
 from beanmachine.ppl.compiler.error_report import ErrorReport
 from beanmachine.ppl.compiler.fix_additions import AdditionFixer
+from beanmachine.ppl.compiler.fix_beta_conjugate_prior import (
+    BetaBernoulliConjguateFixer,
+)
 from beanmachine.ppl.compiler.fix_bool_arithmetic import BoolArithmeticFixer
 from beanmachine.ppl.compiler.fix_bool_comparisons import BoolComparisonFixer
 from beanmachine.ppl.compiler.fix_logsumexp import LogSumExpFixer
@@ -40,11 +43,12 @@ _standard_fixer_types: List[Type] = [
     MultiaryAdditionFixer,
     LogSumExpFixer,
     MultiaryMultiplicationFixer,
+    BetaBernoulliConjguateFixer,
     RequirementsFixer,
     ObservationsFixer,
 ]
 
-default_skip_optimizations: Set[str] = set()
+default_skip_optimizations: Set[str] = {"BetaBernoulliConjguateFixer"}
 
 
 def fix_problems(

--- a/src/beanmachine/ppl/compiler/tests/binary_vs_multiary_addition_perf_test.py
+++ b/src/beanmachine/ppl/compiler/tests/binary_vs_multiary_addition_perf_test.py
@@ -60,7 +60,7 @@ class BinaryVsMultiaryAdditionPerformanceTest(unittest.TestCase):
         torch.manual_seed(seed)
         random.seed(seed)
 
-        skip_optimizations = set()
+        skip_optimizations = {"BetaBernoulliConjguateFixer"}
         report_w_optimization = get_report(skip_optimizations)
 
         observed_report_w_optimization = str(report_w_optimization)
@@ -121,7 +121,7 @@ infer:(1) -- ms
             tidy(expected_report_w_optimization).strip(),
         )
 
-        skip_optimizations = {"MultiaryAdditionFixer"}
+        skip_optimizations = {"MultiaryAdditionFixer", "BetaBernoulliConjguateFixer"}
         report_wo_optimization = get_report(skip_optimizations)
 
         observed_report_wo_optimization = str(report_wo_optimization)

--- a/src/beanmachine/ppl/compiler/tests/binary_vs_multiary_multiplication_perf_test.py
+++ b/src/beanmachine/ppl/compiler/tests/binary_vs_multiary_multiplication_perf_test.py
@@ -60,7 +60,7 @@ class BinaryVsMultiaryMultiplicationPerformanceTest(unittest.TestCase):
         torch.manual_seed(seed)
         random.seed(seed)
 
-        skip_optimizations = set()
+        skip_optimizations = {"BetaBernoulliConjguateFixer"}
         report_w_optimization = get_report(skip_optimizations)
 
         observed_report_w_optimization = str(report_w_optimization)
@@ -121,7 +121,10 @@ infer:(1) -- ms
             tidy(expected_report_w_optimization).strip(),
         )
 
-        skip_optimizations = {"MultiaryMultiplicationFixer"}
+        skip_optimizations = {
+            "MultiaryMultiplicationFixer",
+            "BetaBernoulliConjguateFixer",
+        }
         report_wo_optimization = get_report(skip_optimizations)
 
         observed_report_wo_optimization = str(report_wo_optimization)

--- a/src/beanmachine/ppl/compiler/tests/fix_logsumexp_perf_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_logsumexp_perf_test.py
@@ -60,7 +60,7 @@ class LogSumExpPerformanceTest(unittest.TestCase):
         torch.manual_seed(seed)
         random.seed(seed)
 
-        skip_optimizations = set()
+        skip_optimizations = {"BetaBernoulliConjguateFixer"}
         report_w_optimization = get_report(skip_optimizations)
 
         observed_report_w_optimization = str(report_w_optimization)
@@ -121,7 +121,7 @@ infer:(1) -- ms
             tidy(expected_report_w_optimization).strip(),
         )
 
-        skip_optimizations = {"LogSumExpFixer"}
+        skip_optimizations = {"LogSumExpFixer", "BetaBernoulliConjguateFixer"}
         report_wo_optimization = get_report(skip_optimizations)
 
         observed_report_wo_optimization = str(report_wo_optimization)


### PR DESCRIPTION
Summary:
This transformation rewrites graphs with Bernoulli likelihood and Beta prior into a graph with an updated Beta prior. Currently this transformation is disabled by default.

Since this is a conjugate pair, we analytically update the prior parameters `Beta(alpha, beta)` using observations to get the posterior parameters `Beta(alpha', beta')`. Once we update the parameters, we delete the observed samples from the graph. This greatly decreases the number of nodes, the number of edges in the graph, and the Bayesian update is reduced to parameter update which can lead to performance wins during inference.

Graph Rewrite (Fixing) Criteria:
We will carry out transformation if we see the following:

1. We encounter a bernoulli node
2. This bernoulli node has an incoming edge which is a sample coming from a Beta
3. The Beta contains two incoming edges which are both constant nodes
4. The beta sample should be queried

Design Choice:
For this transformation, we identify patterns starting at `Bernoulli` node and check for the fixing conditions. An alternate method would be to start with observations and identify a beta-bernoulli pattern. The former would check for the pattern once whereas the latter would check for the same pattern for every observation.

Test:
`beta_binomial_basic_test` shows a simple case of how this rewrite works. We start with the following model

{F637054942}

And after rewrite we get the following

{F637054975}

Test cases that will be tested in future diffs:
1. Models with additional operations on the Beta/Bernoulli RVs
2. Models where Beta parameters themselves are RVs. Eg. Beta(Normal(0.1, 1.0), 5.0) . Note that this would also require change in the graph rewriting logic.
3. Models that use mixture of conjugate priors - e.g. `theta` = `0.25 Beta(1, 1) + 0.75 Beta(5,5)`

Reviewed By: ericlippert

Differential Revision: D30001791

