### PR TITLE
Rename inf_types to node_types

### DIFF
--- a/src/beanmachine/ppl/compiler/gen_dot.py
+++ b/src/beanmachine/ppl/compiler/gen_dot.py
@@ -17,7 +17,7 @@ from beanmachine.ppl.utils.dotbuilder import DotBuilder
 
 def to_dot(
     bmg: BMGraphBuilder,
-    inf_types: bool = False,  # TODO: Rename this to node_types
+    node_types: bool = False,
     edge_requirements: bool = False,
     after_transform: bool = False,
     label_edges: bool = True,
@@ -58,7 +58,7 @@ def to_dot(
     for node, index in nodes.items():
         n = to_id(index)
         node_label = get_node_label(node)
-        if inf_types:
+        if node_types:
             node_label += ":" + lt[node].short_name
         db.with_node(n, node_label)
         for (i, edge_name, req) in zip(

--- a/src/beanmachine/ppl/compiler/tests/bmg_types_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_types_test.py
@@ -151,7 +151,7 @@ class BMGTypesTest(unittest.TestCase):
 
         observed = to_dot(
             bmg,
-            inf_types=True,
+            node_types=True,
             edge_requirements=True,
         )
         expected = """

--- a/src/beanmachine/ppl/compiler/tests/column_index_test.py
+++ b/src/beanmachine/ppl/compiler/tests/column_index_test.py
@@ -29,7 +29,7 @@ class ColumnIndexTest(unittest.TestCase):
 
         observed = to_dot(
             bmg,
-            inf_types=True,
+            node_types=True,
             edge_requirements=True,
             after_transform=True,
             label_edges=True,

--- a/src/beanmachine/ppl/compiler/tests/dirichlet_test.py
+++ b/src/beanmachine/ppl/compiler/tests/dirichlet_test.py
@@ -200,7 +200,7 @@ digraph "graph" {
 }"""
         observed = to_dot(
             bmg,
-            inf_types=True,
+            node_types=True,
             label_edges=False,
             after_transform=True,
         )
@@ -265,7 +265,7 @@ Node 2 type 1 parents [ ] children [ ] matrix<positive real>   1   2
         bmg = BMGRuntime().accumulate_graph(queries, {})
         observed = to_dot(
             bmg,
-            inf_types=True,
+            node_types=True,
             edge_requirements=True,
             after_transform=False,
             label_edges=False,
@@ -364,7 +364,7 @@ digraph "graph" {
         bmg = BMGRuntime().accumulate_graph(queries, observations)
         observed = to_dot(
             bmg,
-            inf_types=True,
+            node_types=True,
             edge_requirements=True,
             after_transform=True,
             label_edges=False,
@@ -394,7 +394,7 @@ digraph "graph" {
         bmg = BMGRuntime().accumulate_graph(queries, {})
         observed = to_dot(
             bmg,
-            inf_types=True,
+            node_types=True,
             edge_requirements=True,
             after_transform=True,
             label_edges=False,

--- a/src/beanmachine/ppl/compiler/tests/fix_problems_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_problems_test.py
@@ -38,7 +38,7 @@ class FixProblemsTest(unittest.TestCase):
 
         observed = to_dot(
             bmg,
-            inf_types=True,
+            node_types=True,
             edge_requirements=True,
         )
         expected = """
@@ -72,7 +72,7 @@ digraph "graph" {
         fix_problems(bmg)
         observed = to_dot(
             bmg,
-            inf_types=True,
+            node_types=True,
             edge_requirements=True,
         )
         expected = """
@@ -147,7 +147,7 @@ digraph "graph" {
 
         observed = to_dot(
             bmg,
-            inf_types=True,
+            node_types=True,
             edge_requirements=True,
         )
         expected = """
@@ -178,7 +178,7 @@ digraph "graph" {
         fix_problems(bmg)
         observed = to_dot(
             bmg,
-            inf_types=True,
+            node_types=True,
             edge_requirements=True,
         )
         expected = """
@@ -291,7 +291,7 @@ The sigma of a Normal is required to be a positive real but is a negative real.
 
         observed = to_dot(
             bmg,
-            inf_types=True,
+            node_types=True,
             edge_requirements=True,
         )
 
@@ -327,7 +327,7 @@ digraph "graph" {
 
         observed = to_dot(
             bmg,
-            inf_types=True,
+            node_types=True,
             edge_requirements=True,
         )
 
@@ -393,7 +393,7 @@ digraph "graph" {
 
         observed = to_dot(
             bmg,
-            inf_types=True,
+            node_types=True,
             edge_requirements=True,
         )
 
@@ -456,7 +456,7 @@ digraph "graph" {
 
         observed = to_dot(
             bmg,
-            inf_types=True,
+            node_types=True,
             edge_requirements=True,
         )
 
@@ -487,7 +487,7 @@ digraph "graph" {
 
         observed = to_dot(
             bmg,
-            inf_types=True,
+            node_types=True,
             edge_requirements=True,
         )
         expected = """
@@ -577,7 +577,7 @@ The unsupported node is the operand of a Sample.
 
         observed = to_dot(
             bmg,
-            inf_types=True,
+            node_types=True,
             edge_requirements=True,
         )
 
@@ -603,7 +603,7 @@ digraph "graph" {
 
         observed = to_dot(
             bmg,
-            inf_types=True,
+            node_types=True,
             edge_requirements=True,
         )
 
@@ -660,7 +660,7 @@ digraph "graph" {
 
         observed = to_dot(
             bmg,
-            inf_types=True,
+            node_types=True,
             edge_requirements=True,
         )
 
@@ -696,7 +696,7 @@ digraph "graph" {
 
         observed = to_dot(
             bmg,
-            inf_types=True,
+            node_types=True,
             edge_requirements=True,
         )
 
@@ -761,7 +761,7 @@ digraph "graph" {
 
         observed = to_dot(
             bmg,
-            inf_types=True,
+            node_types=True,
             edge_requirements=True,
         )
 
@@ -794,7 +794,7 @@ digraph "graph" {
 
         observed = to_dot(
             bmg,
-            inf_types=True,
+            node_types=True,
             edge_requirements=True,
         )
 
@@ -849,7 +849,7 @@ digraph "graph" {
 
         observed = to_dot(
             bmg,
-            inf_types=True,
+            node_types=True,
             edge_requirements=True,
         )
 
@@ -879,7 +879,7 @@ digraph "graph" {
 
         observed = to_dot(
             bmg,
-            inf_types=True,
+            node_types=True,
             edge_requirements=True,
         )
 
@@ -976,7 +976,7 @@ A Binomial distribution is observed to have value 5.25 but only produces samples
         self.assertEqual(str(error_report).strip(), "")
         observed = to_dot(
             bmg,
-            inf_types=True,
+            node_types=True,
             edge_requirements=True,
         )
 
@@ -1037,7 +1037,7 @@ digraph "graph" {
         self.assertEqual(str(error_report).strip(), "")
         observed = to_dot(
             bmg,
-            inf_types=True,
+            node_types=True,
             edge_requirements=True,
         )
 

--- a/src/beanmachine/ppl/compiler/tests/to_matrix_test.py
+++ b/src/beanmachine/ppl/compiler/tests/to_matrix_test.py
@@ -47,7 +47,7 @@ class ToMatrixTest(unittest.TestCase):
         bmg = BMGRuntime().accumulate_graph([f1by2()], {})
         observed = to_dot(
             bmg,
-            inf_types=True,
+            node_types=True,
             edge_requirements=True,
             after_transform=True,
             label_edges=True,
@@ -159,7 +159,7 @@ digraph "graph" {
         bmg = BMGRuntime().accumulate_graph([f2by1()], {})
         observed = to_dot(
             bmg,
-            inf_types=True,
+            node_types=True,
             edge_requirements=True,
             after_transform=True,
             label_edges=True,
@@ -271,7 +271,7 @@ digraph "graph" {
         bmg = BMGRuntime().accumulate_graph([f2by3()], {})
         observed = to_dot(
             bmg,
-            inf_types=True,
+            node_types=True,
             edge_requirements=True,
             after_transform=True,
             label_edges=True,
@@ -345,7 +345,7 @@ digraph "graph" {
 
         observed = to_dot(
             bmg,
-            inf_types=True,
+            node_types=True,
             edge_requirements=True,
             after_transform=True,
             label_edges=True,
@@ -495,7 +495,7 @@ The unsupported node is the operator of a Query."""
         with self.assertRaises(ValueError) as ex:
             to_dot(
                 bmg,
-                inf_types=True,
+                node_types=True,
                 edge_requirements=True,
                 after_transform=True,
                 label_edges=True,


### PR DESCRIPTION
Summary:
When I originally designed the lattice typing system to analyze graphs I referred to the node's type as its "inf type", since we were finding the infimum type in the lattice that the node was compatible with.  Several refactorings later, I no longer need to call out that detail so I've been removing uses of the term from the codebase.

In this diff I just rename the parameter on `to_dot` that controls whether node types are displayed.

Reviewed By: feynmanliang

Differential Revision: D29949299

