### PR TITLE
Remove duplicate functionality from dirichlet beta proposer

### DIFF
--- a/src/beanmachine/graph/stepper/nmc_dirichlet_beta_single_site_stepper.h
+++ b/src/beanmachine/graph/stepper/nmc_dirichlet_beta_single_site_stepper.h
@@ -24,8 +24,7 @@ class NMCDirichletBetaSingleSiteStepper : public NMCSingleSiteStepper {
       Node* tgt_node,
       double param_a,
       double param_b,
-      NodeValue value,
-      /* out */ double& logweight);
+      NodeValue value);
 };
 
 } // namespace graph


### PR DESCRIPTION
Summary: create_proposer_dirichlet_beta was being used for bot obtaining a proposer and computing the log prob, even though NMC's compute_log_prob already does that. This has the benefit of removing duplicate code and also giving a more clearly defined function to create_proposer_dirichlet_beta. This is part of making NMC Dirichlet Beta stepper more and more similar to the scalar one so they can be as unified as possible.

Reviewed By: yucenli

Differential Revision: D29996395

