### PR TITLE
Adding conftest.py to beanmachine.ppl

### DIFF
--- a/src/beanmachine/ppl/conftest.py
+++ b/src/beanmachine/ppl/conftest.py
@@ -1,0 +1,14 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import random
+
+import numpy as np
+import pytest
+import torch
+
+
+@pytest.fixture(autouse=True)
+def random_seed():
+    """Fix the random state for every test in the test suite"""
+    np.random.seed(0)
+    torch.manual_seed(0)
+    random.seed(0)


### PR DESCRIPTION
Summary: V1 of this diff is just a sanity check: all it does is to throw an error before each test. If things `conftest.py` works correctly, then none of the test under `beanmachine.ppl` should pass

Differential Revision: D30233360

