### PR TITLE
Refactor BetaBernoulliConjguateFixer to separate prior and likelihood checks

### DIFF
--- a/src/beanmachine/ppl/compiler/fix_beta_conjugate_prior.py
+++ b/src/beanmachine/ppl/compiler/fix_beta_conjugate_prior.py
@@ -1,6 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
-from typing import Optional
+from typing import Tuple, List, Optional
 
 import beanmachine.ppl.compiler.bmg_nodes as bn
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
@@ -8,23 +8,19 @@ from beanmachine.ppl.compiler.fix_problem import ProblemFixerBase
 from beanmachine.ppl.compiler.typer_base import TyperBase
 
 
-class BetaBernoulliConjguateFixer(ProblemFixerBase):
-    """This fixer transforms graphs with Bernoulli likelihood and Beta prior.
-    Since this is a conjugate pair, we analytically update the prior
-    parameters Beta(alpha, beta) using observations to get the posterior
-    parameters Beta(alpha', beta'). Once we update the parameters,
-    we delete the observed samples from the graph. This greatly decreases
-    the number of nodes, the number of edges in the graph, and the Bayesian
-    update is reduced to parameter update which can lead to performance
-    wins during inference."""
+class BetaPriorFixer(ProblemFixerBase):
+    """Beta distribution is a conjugate prior to Bernoulli, Binomial, Negative
+    Binomial and Geometric distributions. Graph pattern check for the Beta prior
+    is same for all the conjugate pairs. This fixer checks if the prior satisfies
+    required transformation conditions.
+    """
 
     def __init__(self, bmg: BMGraphBuilder, typer: TyperBase) -> None:
         ProblemFixerBase.__init__(self, bmg, typer)
 
     def _theta_is_beta_with_real_params(self, n: bn.SampleNode) -> bool:
         # TODO: For now we support conjugate prior transformation on
-        # priors with constant parameter values. This needs to be removed
-        # if we can update priors that take RVs.
+        # priors with constant parameter values.
         beta_node = n.inputs[0]
         if not isinstance(beta_node, bn.BetaNode):
             return False
@@ -39,8 +35,53 @@ class BetaBernoulliConjguateFixer(ProblemFixerBase):
     def _sample_contains_obs(self, n: bn.SampleNode) -> bool:
         return any(isinstance(o, bn.Observation) for o in n.outputs.items)
 
-    def _bernoulli_is_observed(self, n: bn.BMGNode) -> bool:
+    def _liklihood_is_observed(self, n: bn.BMGNode) -> bool:
         return any(self._sample_contains_obs(i) for i in n.outputs.items)
+
+    def _get_likelihood_obs_samples(
+        self, n: bn.BMGNode
+    ) -> Tuple[List[bn.Observation], List[bn.SampleNode]]:
+        obs = []
+        samples = []
+        for o in n.outputs.items:
+            if isinstance(o, bn.SampleNode) and self._sample_contains_obs(o):
+                obs.append(next(iter(o.outputs.items.keys())))
+                samples.append(o)
+        return obs, samples
+
+    def _needs_fixing(self, n: bn.BMGNode) -> bool:
+        if not isinstance(n, bn.SampleNode):
+            return False
+        return self._theta_is_beta_with_real_params(n) and self._theta_is_queried(n)
+
+    def _transform_alpha(
+        self, alpha: bn.ConstantNode, obs: List[bn.Observation]
+    ) -> bn.BMGNode:
+        # Update: alpha' = alpha + obs_sum
+        obs_sum = sum(o.value for o in obs)
+        return self._bmg.add_pos_real(alpha.value + obs_sum)
+
+    def _transform_beta(
+        self, beta: bn.ConstantNode, obs: List[bn.Observation]
+    ) -> bn.BMGNode:
+        # Update: beta' = beta + n - obs_sum
+        obs_sum = sum(o.value for o in obs)
+        n = len(obs)
+        return self._bmg.add_pos_real(beta.value + n - obs_sum)
+
+
+class BetaBernoulliConjguateFixer(BetaPriorFixer):
+    """This fixer transforms graphs with Bernoulli likelihood and Beta prior.
+    Since this is a conjugate pair, we analytically update the prior
+    parameters Beta(alpha, beta) using observations to get the posterior
+    parameters Beta(alpha', beta'). Once we update the parameters,
+    we delete the observed samples from the graph. This greatly decreases
+    the number of nodes, the number of edges in the graph, and the Bayesian
+    update is reduced to parameter update which can lead to performance
+    wins during inference."""
+
+    def __init__(self, bmg: BMGraphBuilder, typer: TyperBase) -> None:
+        BetaPriorFixer.__init__(self, bmg, typer)
 
     def _needs_fixing(self, n: bn.BMGNode) -> bool:
         # A graph is beta-bernoulli conjugate fixable if:
@@ -51,16 +92,16 @@ class BetaBernoulliConjguateFixer(ProblemFixerBase):
         #
         # That is we are looking for stuff like:
         #
-        #   alpha    beta
-        #     \       /
-        #        Beta
-        #         |
-        #       Sample
-        #      /       \
-        #   Bernoulli  Query
+        #       alpha            beta
+        #         \              /
+        #               Beta
+        #                |
+        #              Sample
+        #          /                \
+        #  Bernoulli             Query
         #      |
         #    Sample
-        #      |            \
+        #      |          \
         #  Observation True ...
         #
         #  to turn it into
@@ -76,21 +117,7 @@ class BetaBernoulliConjguateFixer(ProblemFixerBase):
         if not isinstance(n, bn.BernoulliNode):
             return False
         sample = n.inputs[0]
-        if not isinstance(sample, bn.SampleNode):
-            return False
-        return (
-            self._theta_is_beta_with_real_params(sample)
-            and self._theta_is_queried(sample)
-            and self._bernoulli_is_observed(n)
-        )
-
-    def _transform_alpha(self, alpha: bn.ConstantNode, obs_sum: float) -> bn.BMGNode:
-        # Update: alpha' = alpha + obs_sum
-        return self._bmg.add_pos_real(alpha.value + obs_sum)
-
-    def _transform_beta(self, beta: bn.ConstantNode, obs_sum, n) -> bn.BMGNode:
-        # Update: beta' = beta + n - obs_sum
-        return self._bmg.add_pos_real(beta.value + n - obs_sum)
+        return super()._needs_fixing(sample) and self._liklihood_is_observed(n)
 
     def _get_replacement(self, n: bn.BMGNode) -> Optional[bn.BMGNode]:
         assert isinstance(n, bn.BernoulliNode)
@@ -99,21 +126,15 @@ class BetaBernoulliConjguateFixer(ProblemFixerBase):
         beta_node = beta_sample.inputs[0]
         assert isinstance(beta_node, bn.BetaNode)
 
-        obs = []
-        samples_to_remove = []
-        for o in n.outputs.items:
-            if isinstance(o, bn.SampleNode) and self._sample_contains_obs(o):
-                obs.append(next(iter(o.outputs.items.keys())))
-                samples_to_remove.append(o)
-        obs_sum = sum(o.value for o in obs)
+        obs, samples_to_remove = self._get_likelihood_obs_samples(n)
 
         alpha = beta_node.inputs[0]
         assert isinstance(alpha, bn.ConstantNode)
-        transformed_alpha = self._transform_alpha(alpha, obs_sum)
+        transformed_alpha = self._transform_alpha(alpha, obs)
 
         beta = beta_node.inputs[1]
         assert isinstance(beta, bn.ConstantNode)
-        transformed_beta = self._transform_beta(beta, obs_sum, len(obs))
+        transformed_beta = self._transform_beta(beta, obs)
 
         beta_node.inputs[0] = transformed_alpha
         beta_node.inputs[1] = transformed_beta


### PR DESCRIPTION
Summary:
Beta distribution is a conjugate prior to a number of likelihood distributions. Beta is a conjugate prior to Bernoulli, Binomial, Negative Binomial and Geometric distributions. The graph pattern check for the prior remains the same for all of the pairs. The only difference across these pairs is in the way we update the beta parameters.

In this diff I separate the conjugate transformation into a `BetaPriorFixer` and `BetaBernoulliConjguateFixer` class such that we can reuse most of the code across different distributions and avoid most code duplication.

In upcoming diffs, I plan to add conjugate transformation support for beta-binomial pair and its test cases. Since we dont support Geometric/Negative Binomial distributions in BMG yet, I will leave this as future work.

Reviewed By: horizon-blue

Differential Revision: D30193254

