### PR TITLE
Implement transformation that discover and transforms beta-binomial conjugate pattern

### DIFF
--- a/src/beanmachine/ppl/compiler/fix_beta_conjugate_prior.py
+++ b/src/beanmachine/ppl/compiler/fix_beta_conjugate_prior.py
@@ -1,6 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
-from typing import Tuple, List, Optional
+from abc import abstractmethod
+from typing import List, Optional, Tuple
 
 import beanmachine.ppl.compiler.bmg_nodes as bn
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
@@ -61,13 +62,11 @@ class BetaPriorFixer(ProblemFixerBase):
         obs_sum = sum(o.value for o in obs)
         return self._bmg.add_pos_real(alpha.value + obs_sum)
 
+    @abstractmethod
     def _transform_beta(
         self, beta: bn.ConstantNode, obs: List[bn.Observation]
     ) -> bn.BMGNode:
-        # Update: beta' = beta + n - obs_sum
-        obs_sum = sum(o.value for o in obs)
-        n = len(obs)
-        return self._bmg.add_pos_real(beta.value + n - obs_sum)
+        pass
 
 
 class BetaBernoulliConjguateFixer(BetaPriorFixer):
@@ -82,6 +81,14 @@ class BetaBernoulliConjguateFixer(BetaPriorFixer):
 
     def __init__(self, bmg: BMGraphBuilder, typer: TyperBase) -> None:
         BetaPriorFixer.__init__(self, bmg, typer)
+
+    def _transform_beta(
+        self, beta: bn.ConstantNode, obs: List[bn.Observation]
+    ) -> bn.BMGNode:
+        # Update: beta' = beta + n - obs_sum
+        obs_sum = sum(o.value for o in obs)
+        n = len(obs)
+        return self._bmg.add_pos_real(beta.value + n - obs_sum)
 
     def _needs_fixing(self, n: bn.BMGNode) -> bool:
         # A graph is beta-bernoulli conjugate fixable if:
@@ -135,6 +142,97 @@ class BetaBernoulliConjguateFixer(BetaPriorFixer):
         beta = beta_node.inputs[1]
         assert isinstance(beta, bn.ConstantNode)
         transformed_beta = self._transform_beta(beta, obs)
+
+        beta_node.inputs[0] = transformed_alpha
+        beta_node.inputs[1] = transformed_beta
+
+        # We need to remove both the sample and the observation node.
+        for o in obs:
+            self._bmg.remove_leaf(o)
+
+        for s in samples_to_remove:
+            if len(s.outputs.items) == 0:
+                self._bmg.remove_node(s)
+
+        return n
+
+
+class BetaBinomialConjguateFixer(BetaPriorFixer):
+    """This fixer transforms graphs with Binomial likelihood and Beta prior.
+    Since this is a conjugate pair, we analytically update the prior
+    parameters Beta(alpha, beta) using observations to get the posterior
+    parameters Beta(alpha', beta'). Once we update the parameters,
+    we delete the observed samples from the graph. This greatly decreases
+    the number of nodes, the number of edges in the graph, and the Bayesian
+    update is reduced to parameter update which can lead to performance
+    wins during inference."""
+
+    def __init__(self, bmg: BMGraphBuilder, typer: TyperBase) -> None:
+        BetaPriorFixer.__init__(self, bmg, typer)
+
+    def _transform_beta(
+        self, beta: bn.ConstantNode, obs: List[bn.Observation], count: float
+    ) -> bn.BMGNode:
+        # Update: beta' = beta + sum count - obs_sum
+        obs_sum = sum(o.value for o in obs)
+        n = len(obs)
+        updated_count = n * count
+        return self._bmg.add_pos_real(beta.value + updated_count - obs_sum)
+
+    def _needs_fixing(self, n: bn.BMGNode) -> bool:
+        # A graph is beta-binomial conjugate fixable if:
+        #
+        # There is a binomial node with theta that is sampled
+        # from a beta distribution. Further, the beta is queried and
+        # the binomial node has n observations.
+        #
+        # That is we are looking for stuff like:
+        #
+        #      alpha            beta
+        #        \              /
+        #             Beta
+        #               |
+        # Count       Sample
+        #   \       /       \
+        #   Binomial       Query
+        #      |
+        #    Sample
+        #      |          \
+        #  Observation 3.0 ...
+        #
+        #  to turn it into
+        #
+        #  alpha'     beta'
+        #     \       /
+        #        Beta
+        #         |
+        #       Sample
+        #         |
+        #       Query
+
+        if not isinstance(n, bn.BinomialNode):
+            return False
+        sample = n.inputs[1]
+        return super()._needs_fixing(sample) and self._liklihood_is_observed(n)
+
+    def _get_replacement(self, n: bn.BMGNode) -> Optional[bn.BMGNode]:
+        assert isinstance(n, bn.BinomialNode)
+        count = n.inputs[0]
+        assert isinstance(count, bn.UntypedConstantNode)
+        beta_sample = n.inputs[1]
+        assert isinstance(beta_sample, bn.SampleNode)
+        beta_node = beta_sample.inputs[0]
+        assert isinstance(beta_node, bn.BetaNode)
+
+        obs, samples_to_remove = self._get_likelihood_obs_samples(n)
+
+        alpha = beta_node.inputs[0]
+        assert isinstance(alpha, bn.ConstantNode)
+        transformed_alpha = self._transform_alpha(alpha, obs)
+
+        beta = beta_node.inputs[1]
+        assert isinstance(beta, bn.ConstantNode)
+        transformed_beta = self._transform_beta(beta, obs, count.value)
 
         beta_node.inputs[0] = transformed_alpha
         beta_node.inputs[1] = transformed_beta

--- a/src/beanmachine/ppl/compiler/fix_problems.py
+++ b/src/beanmachine/ppl/compiler/fix_problems.py
@@ -8,6 +8,7 @@ from beanmachine.ppl.compiler.error_report import ErrorReport
 from beanmachine.ppl.compiler.fix_additions import AdditionFixer
 from beanmachine.ppl.compiler.fix_beta_conjugate_prior import (
     BetaBernoulliConjguateFixer,
+    BetaBinomialConjguateFixer,
 )
 from beanmachine.ppl.compiler.fix_bool_arithmetic import BoolArithmeticFixer
 from beanmachine.ppl.compiler.fix_bool_comparisons import BoolComparisonFixer
@@ -44,11 +45,15 @@ _standard_fixer_types: List[Type] = [
     LogSumExpFixer,
     MultiaryMultiplicationFixer,
     BetaBernoulliConjguateFixer,
+    BetaBinomialConjguateFixer,
     RequirementsFixer,
     ObservationsFixer,
 ]
 
-default_skip_optimizations: Set[str] = {"BetaBernoulliConjguateFixer"}
+default_skip_optimizations: Set[str] = {
+    "BetaBernoulliConjguateFixer",
+    "BetaBinomialConjguateFixer",
+}
 
 
 def fix_problems(

--- a/src/beanmachine/ppl/compiler/tests/binary_vs_multiary_addition_perf_test.py
+++ b/src/beanmachine/ppl/compiler/tests/binary_vs_multiary_addition_perf_test.py
@@ -60,7 +60,10 @@ class BinaryVsMultiaryAdditionPerformanceTest(unittest.TestCase):
         torch.manual_seed(seed)
         random.seed(seed)
 
-        skip_optimizations = {"BetaBernoulliConjguateFixer"}
+        skip_optimizations = {
+            "BetaBernoulliConjguateFixer",
+            "BetaBinomialConjguateFixer",
+        }
         report_w_optimization = get_report(skip_optimizations)
 
         observed_report_w_optimization = str(report_w_optimization)
@@ -121,7 +124,11 @@ infer:(1) -- ms
             tidy(expected_report_w_optimization).strip(),
         )
 
-        skip_optimizations = {"MultiaryAdditionFixer", "BetaBernoulliConjguateFixer"}
+        skip_optimizations = {
+            "MultiaryAdditionFixer",
+            "BetaBernoulliConjguateFixer",
+            "BetaBinomialConjguateFixer",
+        }
         report_wo_optimization = get_report(skip_optimizations)
 
         observed_report_wo_optimization = str(report_wo_optimization)

--- a/src/beanmachine/ppl/compiler/tests/binary_vs_multiary_multiplication_perf_test.py
+++ b/src/beanmachine/ppl/compiler/tests/binary_vs_multiary_multiplication_perf_test.py
@@ -60,7 +60,10 @@ class BinaryVsMultiaryMultiplicationPerformanceTest(unittest.TestCase):
         torch.manual_seed(seed)
         random.seed(seed)
 
-        skip_optimizations = {"BetaBernoulliConjguateFixer"}
+        skip_optimizations = {
+            "BetaBernoulliConjguateFixer",
+            "BetaBinomialConjguateFixer",
+        }
         report_w_optimization = get_report(skip_optimizations)
 
         observed_report_w_optimization = str(report_w_optimization)
@@ -124,6 +127,7 @@ infer:(1) -- ms
         skip_optimizations = {
             "MultiaryMultiplicationFixer",
             "BetaBernoulliConjguateFixer",
+            "BetaBinomialConjguateFixer",
         }
         report_wo_optimization = get_report(skip_optimizations)
 

--- a/src/beanmachine/ppl/compiler/tests/fix_beta_binomial_basic_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_beta_binomial_basic_test.py
@@ -1,0 +1,92 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+"""Compare original and conjugate prior transformed
+   Beta-Binomial model"""
+
+import random
+import unittest
+
+import beanmachine.ppl as bm
+import scipy
+import torch
+from beanmachine.ppl.examples.conjugate_models.beta_binomial import BetaBinomialModel
+from beanmachine.ppl.inference.bmg_inference import BMGInference
+from torch import tensor
+from torch.distributions import Beta
+
+
+class BetaBinomialTransformedModel(BetaBinomialModel):
+    """Closed-form Posterior due to conjugacy"""
+
+    @bm.random_variable
+    def theta_transformed(self):
+        # Analytical posterior Beta(alpha + sum x_i, beta + sum N - sum x_i)
+        return Beta(self.alpha_ + 3.0, self.beta_ + (self.n_ - 3.0))
+
+
+class BetaBinomialConjugateModelTest(unittest.TestCase):
+    def test_beta_binomial_conjugate_graph(self) -> None:
+        original_model = BetaBinomialModel(2.0, 2.0, 4.0)
+        queries = [original_model.theta()]
+        observations = {original_model.x(): tensor(3.0)}
+
+        skip_optimizations = set()
+        bmg = BMGInference()
+        original_graph = bmg.to_dot(
+            queries, observations, skip_optimizations=skip_optimizations
+        )
+
+        transformed_model = BetaBinomialTransformedModel(2.0, 2.0, 4.0)
+        queries_transformed = [transformed_model.theta_transformed()]
+        observations_transformed = {}
+        transformed_graph = bmg.to_dot(queries_transformed, observations_transformed)
+
+        self.assertEqual(original_graph, transformed_graph)
+
+    def test_beta_binomial_conjugate(self) -> None:
+        """
+        KS test to check if theta samples from BetaBinomialModel and
+        BetaBinomialTransformedModel is within a certain bound.
+        We initialize the seed to ensure the test is deterministic.
+        """
+        seed = 0
+        torch.manual_seed(seed)
+        random.seed(seed)
+
+        original_model = BetaBinomialModel(2.0, 2.0, 4.0)
+        queries = [original_model.theta()]
+        observations = {original_model.x(): tensor(3.0)}
+
+        num_samples = 1000
+        bmg = BMGInference()
+
+        posterior_original_model = bmg.infer(queries, observations, num_samples)
+        theta_samples_original = posterior_original_model[original_model.theta()][0]
+
+        transformed_model = BetaBinomialTransformedModel(2.0, 2.0, 4.0)
+        queries_transformed = [transformed_model.theta_transformed()]
+        observations_transformed = {}
+        posterior_transformed_model = bmg.infer(
+            queries_transformed, observations_transformed, num_samples
+        )
+        theta_samples_transformed = posterior_transformed_model[
+            transformed_model.theta_transformed()
+        ][0]
+
+        self.assertEqual(
+            type(theta_samples_original),
+            type(theta_samples_transformed),
+            "Sample type of original and transformed model should be the same.",
+        )
+
+        self.assertEqual(
+            len(theta_samples_original),
+            len(theta_samples_transformed),
+            "Sample size of original and transformed model should be the same.",
+        )
+
+        self.assertGreaterEqual(
+            scipy.stats.ks_2samp(
+                theta_samples_original, theta_samples_transformed
+            ).pvalue,
+            0.05,
+        )

--- a/src/beanmachine/ppl/compiler/tests/fix_logsumexp_perf_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_logsumexp_perf_test.py
@@ -60,7 +60,10 @@ class LogSumExpPerformanceTest(unittest.TestCase):
         torch.manual_seed(seed)
         random.seed(seed)
 
-        skip_optimizations = {"BetaBernoulliConjguateFixer"}
+        skip_optimizations = {
+            "BetaBernoulliConjguateFixer",
+            "BetaBinomialConjguateFixer",
+        }
         report_w_optimization = get_report(skip_optimizations)
 
         observed_report_w_optimization = str(report_w_optimization)
@@ -121,7 +124,11 @@ infer:(1) -- ms
             tidy(expected_report_w_optimization).strip(),
         )
 
-        skip_optimizations = {"LogSumExpFixer", "BetaBernoulliConjguateFixer"}
+        skip_optimizations = {
+            "LogSumExpFixer",
+            "BetaBernoulliConjguateFixer",
+            "BetaBinomialConjguateFixer",
+        }
         report_wo_optimization = get_report(skip_optimizations)
 
         observed_report_wo_optimization = str(report_wo_optimization)


### PR DESCRIPTION
Summary:
This transformation rewrites graphs with Binomial likelihood and Beta prior into a graph with an updated Beta prior. Currently this transformation is disabled by default.

Since this is a conjugate pair, we analytically update the prior parameters `Beta(alpha, beta)` using observations to get the posterior parameters `Beta(alpha', beta')`. Once we update the parameters, we delete the observed samples from the graph. This greatly decreases the number of nodes, the number of edges in the graph, and the Bayesian update is reduced to parameter update which can lead to performance wins during inference.

Graph Rewrite Criteria:
We will carry out transformation if we see the following:
1. We encounter a Binomial node
2. This binomial node has an incoming edge which is a sample coming from a Beta
3. The Beta contains two incoming edges which are both constant nodes
4. The beta sample should be queried

Design Choice:
We have to repeat the graph transformations for each conjugate pair separately, since we do not have equivalences in the type checker yet to hoist bernoulli/binomial etc to a general type and carry out one transformation instead. Also, since we may want to selectively toggle on/off certain conjugate pair transformations, we introduce a new class for each of them.

Test:
`fix_beta_binomial_basic_test` shows a simple case of how this rewrite works. We start with the following model

{F640412771}

After rewrite we get the following:

{F640412842}

In the upcoming diffs, I plan to refactor the conjugate test case models into `beanmachine/ppl/examples/conjugate_models` and use one test case per transformation to test for all of these models.

Reviewed By: horizon-blue

Differential Revision: D30193342

