### PR TITLE
initialize i.i.d. random effect nodes

### DIFF
--- a/src/beanmachine/applications/hme/abstract_model.py
+++ b/src/beanmachine/applications/hme/abstract_model.py
@@ -321,9 +321,7 @@ class AbstractModel(object, metaclass=ABCMeta):
 
             # otherwise, parse prior configurations for some random effect
             else:
-                self.customized_priors[predictor] = self._parse_re_prior_config(
-                    prior_config, predictor
-                )
+                self.customized_priors[predictor] = prior_config
 
     def _parse_fe_prior_config(self, prior_config: PriorConfig, fe_key: str) -> int:
         """Generates a BMGraph distribution node based on the distribution description.
@@ -381,7 +379,7 @@ class AbstractModel(object, metaclass=ABCMeta):
         ):  # param_value is a 1xn matrix in this case
             return self.g.add_constant_col_simplex_matrix(param_value)
         else:
-            logger.warning(
+            raise ValueError(
                 "Parameter type '{s}' is not supported!".format(s=param_type.str_name)
             )
 

--- a/src/beanmachine/applications/hme/configs.py
+++ b/src/beanmachine/applications/hme/configs.py
@@ -84,7 +84,6 @@ class ModelConfig:
             stderr=None,
             formula="y ~ 1 + (1|x)",
             link="identity",
-            random_effect_distribution="normal",
         ),
         mean_mixture = MixtureConfig(
             use_null_mixture=True,
@@ -93,7 +92,7 @@ class ModelConfig:
             use_partial_asymmetric_modes=True,
         ),
         priors = {
-            "fe": PriorConfig('normal', 'real', [0.0, 1.0]),
+            "fe": PriorConfig('normal', {"mean": 0.0, "scale": 1.0}),
             }
     )
 

--- a/src/beanmachine/applications/hme/tests/test_priors.py
+++ b/src/beanmachine/applications/hme/tests/test_priors.py
@@ -88,26 +88,60 @@ def test_generate_const_node(const_value, const_type, expected_dot):
     [
         (
             PriorConfig("normal", {"scale": 1.0, "mean": 0.0}),
-            'digraph "graph" {\n  N0[label="0"];\n  N1[label="1"];\n  N2[label="Normal"];\n  N0 -> N2;\n  N1 -> N2;\n}\n',
+            """
+digraph "graph" {
+  N0[label="0"];
+  N1[label="1"];
+  N2[label="Normal"];
+  N0 -> N2;
+  N1 -> N2;
+}
+""",
         ),
         (
             PriorConfig("beta", {"alpha": 1.0, "beta": 1.0}),
-            'digraph "graph" {\n  N0[label="1"];\n  N1[label="1"];\n  N2[label="Beta"];\n  N0 -> N2;\n  N1 -> N2;\n}\n',
+            """
+digraph "graph" {
+  N0[label="1"];
+  N1[label="1"];
+  N2[label="Beta"];
+  N0 -> N2;
+  N1 -> N2;
+}
+""",
         ),
         (
             PriorConfig("gamma", {"beta": 1.0, "alpha": 1.0}),
-            'digraph "graph" {\n  N0[label="1"];\n  N1[label="1"];\n  N2[label="Gamma"];\n  N0 -> N2;\n  N1 -> N2;\n}\n',
+            """
+digraph "graph" {
+  N0[label="1"];
+  N1[label="1"];
+  N2[label="Gamma"];
+  N0 -> N2;
+  N1 -> N2;
+}
+""",
         ),
         (
             PriorConfig("t", {"scale": 1.0, "mean": 0.0, "dof": 2.0}),
-            'digraph "graph" {\n  N0[label="2"];\n  N1[label="0"];\n  N2[label="1"];\n  N3[label="StudentT"];\n  N0 -> N3;\n  N1 -> N3;\n  N2 -> N3;\n}\n',
+            """
+digraph "graph" {
+  N0[label="2"];
+  N1[label="0"];
+  N2[label="1"];
+  N3[label="StudentT"];
+  N0 -> N3;
+  N1 -> N3;
+  N2 -> N3;
+}
+""",
         ),
     ],
 )
 def test_parse_fe_prior_config(prior_config, expected_dot):
     model = RealizedModel(data=None, model_config=ModelConfig())
     model._parse_fe_prior_config(prior_config, "test")
-    assert model.g.to_dot() == expected_dot
+    assert model.g.to_dot().strip() == expected_dot.strip()
 
 
 def test_default_priors():
@@ -117,12 +151,7 @@ def test_default_priors():
     )
     model._set_priors()
     model._set_default_priors()
-    expected = {
-        "fixed_effects": 8,
-        "random_effects": (11, {"scale": 10}),
-        "prob_h": 4,
-        "prob_sign": 4,
-    }
+    expected = {"fixed_effects": 8, "prob_h": 4, "prob_sign": 4}
     assert model.default_priors == expected
 
 
@@ -145,11 +174,23 @@ def test_default_priors():
                 "prob_sign": PriorConfig("beta", {"alpha": 1.0, "beta": 1.0}),
             },
             {
-                "x1": 14,
-                "x2": 15,
-                "group": (24, {"dof": 18, "mean": 22}),
-                "prob_h": 27,
-                "prob_sign": 30,
+                "x1": 12,
+                "x2": 13,
+                "group": PriorConfig(
+                    distribution="t",
+                    parameters={
+                        "mean": PriorConfig(
+                            distribution="normal",
+                            parameters={"mean": 2.0, "scale": 1.0},
+                        ),
+                        "dof": PriorConfig(
+                            distribution="half_cauchy", parameters={"scale": 1.0}
+                        ),
+                        "scale": 1.0,
+                    },
+                ),
+                "prob_h": 16,
+                "prob_sign": 19,
             },
         ),
     ],
@@ -174,25 +215,79 @@ def test_customize_priors(priors_desc, expected):
                 "x1": PriorConfig("t", {"dof": 2.0, "scale": 1.0, "mean": 0.0}),
                 "x2": PriorConfig("beta", {"alpha": 1.0, "beta": 1.0}),
             },
-            (
-                'digraph "graph" {\n  N0[label="0"];\n  N1[label="1"];\n  N2[label="2"];\n  N3[label="3"];\n  N4[label="Beta"];\n  '
-                'N5[label="Gamma"];\n  N6[label="HalfCauchy"];\n  N7[label="HalfNormal"];\n  N8[label="Normal"];\n  '
-                'N9[label="StudentT"];\n  N10[label="~"];\n  N11[label="Normal"];\n  N12[label="2"];\n  N13[label="0"];\n  '
-                'N14[label="1"];\n  N15[label="StudentT"];\n  N16[label="1"];\n  N17[label="1"];\n  N18[label="Beta"];\n  '
-                'N19[label="~"];\n  N20[label="~"];\n  N0 -> N8;\n  N0 -> N9;\n  N0 -> N11;\n  N1 -> N4;\n  N1 -> N4;\n  '
-                "N1 -> N5;\n  N1 -> N5;\n  N1 -> N6;\n  N1 -> N7;\n  N2 -> N8;\n  N3 -> N9;\n  N3 -> N9;\n  N7 -> N10;\n  "
-                "N10 -> N11;\n  N12 -> N15;\n  N13 -> N15;\n  N14 -> N15;\n  N15 -> N19;\n  N16 -> N18;\n  N17 -> N18;\n  N18 -> N20;\n}\n"
-            ),
+            """
+digraph "graph" {
+  N0[label="0"];
+  N1[label="1"];
+  N2[label="2"];
+  N3[label="3"];
+  N4[label="Beta"];
+  N5[label="Gamma"];
+  N6[label="HalfCauchy"];
+  N7[label="HalfNormal"];
+  N8[label="Normal"];
+  N9[label="StudentT"];
+  N10[label="2"];
+  N11[label="0"];
+  N12[label="1"];
+  N13[label="StudentT"];
+  N14[label="1"];
+  N15[label="1"];
+  N16[label="Beta"];
+  N17[label="~"];
+  N18[label="~"];
+  N0 -> N8;
+  N0 -> N9;
+  N1 -> N4;
+  N1 -> N4;
+  N1 -> N5;
+  N1 -> N5;
+  N1 -> N6;
+  N1 -> N7;
+  N2 -> N8;
+  N3 -> N9;
+  N3 -> N9;
+  N10 -> N13;
+  N11 -> N13;
+  N12 -> N13;
+  N13 -> N17;
+  N14 -> N16;
+  N15 -> N16;
+  N16 -> N18;
+}
+""",
         ),
         (
             {},
-            (
-                'digraph "graph" {\n  N0[label="0"];\n  N1[label="1"];\n  N2[label="2"];\n  N3[label="3"];\n  N4[label="Beta"];\n  '
-                'N5[label="Gamma"];\n  N6[label="HalfCauchy"];\n  N7[label="HalfNormal"];\n  N8[label="Normal"];\n  N9[label="StudentT"];\n  '
-                'N10[label="~"];\n  N11[label="Normal"];\n  N12[label="~"];\n  N13[label="~"];\n  N0 -> N8;\n  N0 -> N9;\n  N0 -> N11;\n  '
-                "N1 -> N4;\n  N1 -> N4;\n  N1 -> N5;\n  N1 -> N5;\n  N1 -> N6;\n  N1 -> N7;\n  N2 -> N8;\n  N3 -> N9;\n  N3 -> N9;\n  "
-                "N7 -> N10;\n  N8 -> N12;\n  N8 -> N13;\n  N10 -> N11;\n}\n"
-            ),
+            """
+digraph "graph" {
+  N0[label="0"];
+  N1[label="1"];
+  N2[label="2"];
+  N3[label="3"];
+  N4[label="Beta"];
+  N5[label="Gamma"];
+  N6[label="HalfCauchy"];
+  N7[label="HalfNormal"];
+  N8[label="Normal"];
+  N9[label="StudentT"];
+  N10[label="~"];
+  N11[label="~"];
+  N0 -> N8;
+  N0 -> N9;
+  N1 -> N4;
+  N1 -> N4;
+  N1 -> N5;
+  N1 -> N5;
+  N1 -> N6;
+  N1 -> N7;
+  N2 -> N8;
+  N3 -> N9;
+  N3 -> N9;
+  N8 -> N10;
+  N8 -> N11;
+}
+""",
         ),
     ],
 )
@@ -206,7 +301,7 @@ def test_initialize_fixed_effect_nodes(priors_desc, expected_dot):
     )
     model.build_graph()
     model._initialize_fixed_effect_nodes()
-    assert model.g.to_dot() == expected_dot
+    assert model.g.to_dot().strip() == expected_dot.strip()
 
 
 @pytest.mark.parametrize(
@@ -223,25 +318,81 @@ def test_initialize_fixed_effect_nodes(priors_desc, expected_dot):
                     },
                 ),
             },
-            (
-                'digraph "graph" {\n  N0[label="0"];\n  N1[label="1"];\n  N2[label="2"];\n  N3[label="3"];\n  N4[label="Beta"];\n  '
-                'N5[label="Gamma"];\n  N6[label="HalfCauchy"];\n  N7[label="HalfNormal"];\n  N8[label="Normal"];\n  '
-                'N9[label="StudentT"];\n  N10[label="~"];\n  N11[label="Normal"];\n  N12[label="1"];\n  N13[label="HalfNormal"];\n  '
-                'N14[label="~"];\n  N15[label="2"];\n  N16[label="1"];\n  N17[label="Normal"];\n  N18[label="~"];\n  N19[label="1"];\n  '
-                'N20[label="StudentT"];\n  N0 -> N8;\n  N0 -> N9;\n  N0 -> N11;\n  N1 -> N4;\n  N1 -> N4;\n  N1 -> N5;\n  N1 -> N5;\n  '
-                "N1 -> N6;\n  N1 -> N7;\n  N2 -> N8;\n  N3 -> N9;\n  N3 -> N9;\n  N7 -> N10;\n  N10 -> N11;\n  N12 -> N13;\n  "
-                "N13 -> N14;\n  N14 -> N20;\n  N15 -> N17;\n  N16 -> N17;\n  N17 -> N18;\n  N18 -> N20;\n  N19 -> N20;\n}\n"
-            ),
+            """
+digraph "graph" {
+  N0[label="0"];
+  N1[label="1"];
+  N2[label="2"];
+  N3[label="3"];
+  N4[label="Beta"];
+  N5[label="Gamma"];
+  N6[label="HalfCauchy"];
+  N7[label="HalfNormal"];
+  N8[label="Normal"];
+  N9[label="StudentT"];
+  N10[label="1"];
+  N11[label="HalfNormal"];
+  N12[label="~"];
+  N13[label="2"];
+  N14[label="1"];
+  N15[label="Normal"];
+  N16[label="~"];
+  N17[label="1"];
+  N18[label="StudentT"];
+  N0 -> N8;
+  N0 -> N9;
+  N1 -> N4;
+  N1 -> N4;
+  N1 -> N5;
+  N1 -> N5;
+  N1 -> N6;
+  N1 -> N7;
+  N2 -> N8;
+  N3 -> N9;
+  N3 -> N9;
+  N10 -> N11;
+  N11 -> N12;
+  N12 -> N18;
+  N13 -> N15;
+  N14 -> N15;
+  N15 -> N16;
+  N16 -> N18;
+  N17 -> N18;
+}
+""",
         ),
         (
             {},
-            (
-                'digraph "graph" {\n  N0[label="0"];\n  N1[label="1"];\n  N2[label="2"];\n  N3[label="3"];\n  N4[label="Beta"];\n  '
-                'N5[label="Gamma"];\n  N6[label="HalfCauchy"];\n  N7[label="HalfNormal"];\n  N8[label="Normal"];\n  '
-                'N9[label="StudentT"];\n  N10[label="~"];\n  N11[label="Normal"];\n  N0 -> N8;\n  N0 -> N9;\n  N0 -> N11;\n  '
-                "N1 -> N4;\n  N1 -> N4;\n  N1 -> N5;\n  N1 -> N5;\n  N1 -> N6;\n  N1 -> N7;\n  N2 -> N8;\n  N3 -> N9;\n  N3 -> N9;\n  "
-                "N7 -> N10;\n  N10 -> N11;\n}\n"
-            ),
+            """
+digraph "graph" {
+  N0[label="0"];
+  N1[label="1"];
+  N2[label="2"];
+  N3[label="3"];
+  N4[label="Beta"];
+  N5[label="Gamma"];
+  N6[label="HalfCauchy"];
+  N7[label="HalfNormal"];
+  N8[label="Normal"];
+  N9[label="StudentT"];
+  N10[label="~"];
+  N11[label="Normal"];
+  N0 -> N8;
+  N0 -> N9;
+  N0 -> N11;
+  N1 -> N4;
+  N1 -> N4;
+  N1 -> N5;
+  N1 -> N5;
+  N1 -> N6;
+  N1 -> N7;
+  N2 -> N8;
+  N3 -> N9;
+  N3 -> N9;
+  N7 -> N10;
+  N10 -> N11;
+}
+""",
         ),
     ],
 )
@@ -255,7 +406,65 @@ def test_initialize_random_effect_nodes(priors_desc, expected_dot):
     )
     model.build_graph()
     model._initialize_random_effect_nodes()
-    assert model.g.to_dot() == expected_dot
+    assert model.g.to_dot().strip() == expected_dot.strip()
+
+
+@pytest.mark.parametrize(
+    "priors_desc, expected_dot",
+    [
+        (
+            {},
+            """
+digraph "graph" {
+  N0[label="0"];
+  N1[label="1"];
+  N2[label="2"];
+  N3[label="3"];
+  N4[label="Beta"];
+  N5[label="Gamma"];
+  N6[label="HalfCauchy"];
+  N7[label="HalfNormal"];
+  N8[label="Normal"];
+  N9[label="StudentT"];
+  N10[label="~"];
+  N11[label="Normal"];
+  N12[label="~"];
+  N13[label="Normal"];
+  N0 -> N8;
+  N0 -> N9;
+  N0 -> N11;
+  N0 -> N13;
+  N1 -> N4;
+  N1 -> N4;
+  N1 -> N5;
+  N1 -> N5;
+  N1 -> N6;
+  N1 -> N7;
+  N2 -> N8;
+  N3 -> N9;
+  N3 -> N9;
+  N7 -> N10;
+  N7 -> N12;
+  N10 -> N11;
+  N12 -> N13;
+}
+""",
+        ),
+    ],
+)
+def test_iid_random_effect_nodes(priors_desc, expected_dot):
+    model = RealizedLinearModel(
+        data=None,
+        model_config=ModelConfig(
+            mean_regression=RegressionConfig(formula="y~1+(1|group)"),
+            priors=priors_desc,
+        ),
+    )
+    model.build_graph()
+    # generate two separate (i.i.d.) sample nodes from the same hyper-prior
+    model._initialize_random_effect_nodes()
+    model._initialize_random_effect_nodes()
+    assert model.g.to_dot().strip() == expected_dot.strip()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Summary: corrected the implementation of initializing random effect nodes, to generate independently and identically distributed parameter samples from the hyper-priors, instead of identical parameter values derived from one-time sampling.

Differential Revision: D30379582

