### PR TITLE
support AR and RW structured priors specification

### DIFF
--- a/src/beanmachine/applications/hme/configs.py
+++ b/src/beanmachine/applications/hme/configs.py
@@ -74,6 +74,13 @@ class PriorConfig:
 
 
 @dataclass
+class StructuredPriorConfig:
+
+    specification: str
+    category_order: List[str] = field(default_factory=list)
+
+
+@dataclass
 class ModelConfig:
     """A configuration class for integrated models. E.g.,
 


### PR DESCRIPTION
Summary: implemented two structured priors: the autoregressive prior and the random walk, for random effects only, using BMG to add the capability of improving multilevel regression and post-stratification.

Differential Revision: D30284584

