### PR TITLE
Refactor MultiaryAdditionFixer and MultiaryMultiplicationFixer to inherit from MultiaryOperatorFixer

### DIFF
--- a/src/beanmachine/ppl/compiler/fix_multiary_ops.py
+++ b/src/beanmachine/ppl/compiler/fix_multiary_ops.py
@@ -1,6 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
-from typing import Optional
+from typing import List, Optional
 
 import beanmachine.ppl.compiler.bmg_nodes as bn
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
@@ -8,16 +8,19 @@ from beanmachine.ppl.compiler.fix_problem import ProblemFixerBase
 from beanmachine.ppl.compiler.typer_base import TyperBase
 
 
-class MultiaryAdditionFixer(ProblemFixerBase):
-    """This fixer transforms graphs with long chains of binary addition nodes
-    into multiary additions. This greatly decreases both the number of nodes
+class MultiaryOperatorFixer(ProblemFixerBase):
+    """This fixer transforms graphs with long chains of binary operator nodes
+    into multiary operations. This greatly decreases both the number of nodes
     and the number of edges in the graph, which can lead to performance wins
     during inference."""
 
-    def __init__(self, bmg: BMGraphBuilder, typer: TyperBase) -> None:
-        ProblemFixerBase.__init__(self, bmg, typer)
+    _operator: type
 
-    def _single_output_is_addition(self, n: bn.BMGNode) -> bool:
+    def __init__(self, bmg: BMGraphBuilder, typer: TyperBase, operator: type) -> None:
+        ProblemFixerBase.__init__(self, bmg, typer)
+        self._operator = operator
+
+    def _single_output_is_operator(self, n: bn.BMGNode) -> bool:
         if len(n.outputs.items) != 1:
             # Not exactly one output node.
             return False
@@ -28,23 +31,23 @@ class MultiaryAdditionFixer(ProblemFixerBase):
             return False
 
         o = next(iter(n.outputs.items.keys()))
-        return isinstance(o, bn.AdditionNode)
+        return isinstance(o, self._operator)
 
-    def _addition_single_output_is_addition(self, n: bn.BMGNode) -> bool:
-        if not isinstance(n, bn.AdditionNode):
+    def _addition_single_output_is_operator(self, n: bn.BMGNode) -> bool:
+        if not isinstance(n, self._operator):
             return False
         if len(n.inputs) > 2:
             return False
-        return self._single_output_is_addition(n)
+        return self._single_output_is_operator(n)
 
     def _needs_fixing(self, n: bn.BMGNode) -> bool:
-        # A binary addition is fixable if:
+        # A binary operator is fixable if:
         #
-        # * There is more than one output OR the single output is NOT an addition
-        # * At least one of the left or right inputs is a binary addition with only
+        # * There is more than one output OR the single output is NOT the given operation
+        # * At least one of the left or right inputs is a binary operator with only
         #   one output.
         #
-        # That is, we are looking for stuff like:
+        # Let us say the operator is addition, we are looking for stuff like:
         #
         #  A   B
         #   \ /
@@ -111,14 +114,38 @@ class MultiaryAdditionFixer(ProblemFixerBase):
         # actually doing more math. The bad graph is in every way worse than the
         # desired graph.
         return (
-            isinstance(n, bn.AdditionNode)
+            isinstance(n, self._operator)
             and len(n.inputs) == 2
-            and not self._single_output_is_addition(n)
+            and not self._single_output_is_operator(n)
             and (
-                self._addition_single_output_is_addition(n.inputs[0])
-                or self._addition_single_output_is_addition(n.inputs[1])
+                self._addition_single_output_is_operator(n.inputs[0])
+                or self._addition_single_output_is_operator(n.inputs[1])
             )
         )
+
+    def accumulate_input_nodes(self, n: bn.BMGNode) -> List[bn.BMGNode]:
+        acc = []
+        stack = [n.inputs[1], n.inputs[0]]
+        while len(stack) > 0:
+            c = stack.pop()
+            if self._addition_single_output_is_operator(c):
+                assert isinstance(c, self._operator)
+                assert len(n.inputs) == 2
+                stack.append(c.inputs[1])
+                stack.append(c.inputs[0])
+            else:
+                acc.append(c)
+        return acc
+
+
+class MultiaryAdditionFixer(MultiaryOperatorFixer):
+    """This fixer transforms graphs with long chains of binary addition nodes
+    into multiary additions. This greatly decreases both the number of nodes
+    and the number of edges in the graph, which can lead to performance wins
+    during inference."""
+
+    def __init__(self, bmg: BMGraphBuilder, typer: TyperBase) -> None:
+        MultiaryOperatorFixer.__init__(self, bmg, typer, bn.AdditionNode)
 
     def _get_replacement(self, n: bn.BMGNode) -> Optional[bn.BMGNode]:
         # We require that this algorithm be non-recursive because the
@@ -126,61 +153,19 @@ class MultiaryAdditionFixer(ProblemFixerBase):
         # recursion limit.
         assert isinstance(n, bn.AdditionNode)
         assert len(n.inputs) == 2
-        acc = []
-        stack = [n.inputs[1], n.inputs[0]]
-        while len(stack) > 0:
-            c = stack.pop()
-            if self._addition_single_output_is_addition(c):
-                assert isinstance(c, bn.AdditionNode)
-                assert len(n.inputs) == 2
-                stack.append(c.inputs[1])
-                stack.append(c.inputs[0])
-            else:
-                acc.append(c)
+        acc = self.accumulate_input_nodes(n)
         assert len(acc) >= 3
         return self._bmg.add_multi_addition(*acc)
 
 
-class MultiaryMultiplicationFixer(ProblemFixerBase):
+class MultiaryMultiplicationFixer(MultiaryOperatorFixer):
     """This fixer transforms graphs with long chains of binary multiplication nodes
     into multiary multiplication. This greatly decreases both the number of nodes
     and the number of edges in the graph, which can lead to performance wins
     during inference."""
 
     def __init__(self, bmg: BMGraphBuilder, typer: TyperBase) -> None:
-        ProblemFixerBase.__init__(self, bmg, typer)
-
-    def _single_output_is_multiplication(self, n: bn.BMGNode) -> bool:
-        if len(n.outputs.items) != 1:
-            # Not exactly one output node.
-            return False
-
-        if next(iter(n.outputs.items.values())) != 1:
-            # Exactly one output node, but has two edges going to it.
-            # TODO: This is a bit opaque. Add a helper method for this.
-            return False
-
-        o = next(iter(n.outputs.items.keys()))
-        return isinstance(o, bn.MultiplicationNode)
-
-    def _multiplication_single_output_is_multiplication(self, n: bn.BMGNode) -> bool:
-        if not isinstance(n, bn.MultiplicationNode):
-            return False
-        if len(n.inputs) > 2:
-            return False
-        return self._single_output_is_multiplication(n)
-
-    def _needs_fixing(self, n: bn.BMGNode) -> bool:
-        # This follows the same heuristic as multiary addition
-        return (
-            isinstance(n, bn.MultiplicationNode)
-            and len(n.inputs) == 2
-            and not self._single_output_is_multiplication(n)
-            and (
-                self._multiplication_single_output_is_multiplication(n.inputs[0])
-                or self._multiplication_single_output_is_multiplication(n.inputs[1])
-            )
-        )
+        MultiaryOperatorFixer.__init__(self, bmg, typer, bn.MultiplicationNode)
 
     def _get_replacement(self, n: bn.BMGNode) -> Optional[bn.BMGNode]:
         # We require that this algorithm be non-recursive because the
@@ -188,16 +173,6 @@ class MultiaryMultiplicationFixer(ProblemFixerBase):
         # recursion limit.
         assert isinstance(n, bn.MultiplicationNode)
         assert len(n.inputs) == 2
-        acc = []
-        stack = [n.inputs[1], n.inputs[0]]
-        while len(stack) > 0:
-            c = stack.pop()
-            if self._multiplication_single_output_is_multiplication(c):
-                assert isinstance(c, bn.MultiplicationNode)
-                assert len(n.inputs) == 2
-                stack.append(c.inputs[1])
-                stack.append(c.inputs[0])
-            else:
-                acc.append(c)
+        acc = self.accumulate_input_nodes(n)
         assert len(acc) >= 3
         return self._bmg.add_multi_multiplication(*acc)


### PR DESCRIPTION
Summary: This is a refactoring of D29568019 (https://github.com/facebookresearch/beanmachine/commit/5eab2da36de8e5eac778568bdb526e434f0b0aac). Created a base class `MultiaryOperatorFixer` which is inherited by `MultiaryAdditionFixer` and `MultiaryMultiplicationFixer`. Extracted all common operations to the baseclass; the child class initializes the operator and returns the corresponding multiary replacement node

Differential Revision: D30515280

