### PR TITLE
remove predict API redundancy in HME interface

### DIFF
--- a/src/beanmachine/applications/hme/interface.py
+++ b/src/beanmachine/applications/hme/interface.py
@@ -36,3 +36,14 @@ class HME:
             infer_config
         )
         return self.posterior_samples, self.posterior_diagnostics
+
+    def predict(self, new_data: pd.DataFrame) -> pd.DataFrame:
+        """Generates predictive distributions on the new test data according to
+        MCMC posterior samples.
+
+        :param new_data: test data for prediction
+        :return: predictive distributions on the new test data
+        """
+
+        pred_df = self.model.predict(new_data, self.posterior_samples)
+        return pred_df

--- a/src/beanmachine/applications/hme/tests/test_model.py
+++ b/src/beanmachine/applications/hme/tests/test_model.py
@@ -120,7 +120,7 @@ def test_model_predict(data, mean_config, mixture_config, new_data, expected_pre
         InferConfig(n_iter=10000, n_warmup=1000, seed=0)
     )
     actual = tensor(
-        model.model.predict(new_data, post_samples).mean(axis=1),
+        model.predict(new_data).mean(axis=1),
         dtype=torch.float32,
     )
     assert torch.allclose(actual, expected_pred_mean, atol=0.01)


### PR DESCRIPTION
Summary: removed the repeated "model"s from `model.model.predict` by creating a new method in HME interface.

Differential Revision: D30606835

