### PR TITLE
rearrange HME module layout

### DIFF
--- a/sphinx/source/beanmachine.applications.hme.rst
+++ b/sphinx/source/beanmachine.applications.hme.rst
@@ -1,13 +1,11 @@
 applications.hme package
 ====================================
 
-Submodules
-----------
 
-beanmachine.applications.hme.abstract\_linear\_model module
------------------------------------------------------------
+beanmachine.applications.hme.configs module
+-------------------------------------------
 
-.. automodule:: beanmachine.applications.hme.abstract_linear_model
+.. automodule:: beanmachine.applications.hme.configs
    :members:
    :undoc-members:
    :show-inheritance:
@@ -20,18 +18,10 @@ beanmachine.applications.hme.abstract\_model module
    :undoc-members:
    :show-inheritance:
 
-beanmachine.applications.hme.configs module
--------------------------------------------
+beanmachine.applications.hme.abstract\_linear\_model module
+-----------------------------------------------------------
 
-.. automodule:: beanmachine.applications.hme.configs
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-beanmachine.applications.hme.interface module
----------------------------------------------
-
-.. automodule:: beanmachine.applications.hme.interface
+.. automodule:: beanmachine.applications.hme.abstract_linear_model
    :members:
    :undoc-members:
    :show-inheritance:
@@ -44,10 +34,10 @@ beanmachine.applications.hme.null\_mixture\_model module
    :undoc-members:
    :show-inheritance:
 
-Module contents
----------------
+beanmachine.applications.hme.interface module
+---------------------------------------------
 
-.. automodule:: beanmachine.applications.hme
+.. automodule:: beanmachine.applications.hme.interface
    :members:
    :undoc-members:
    :show-inheritance:


### PR DESCRIPTION
Summary: rearranged the order of different modules in HME package, and removed `Submodules` and `Module contents` sections.

Reviewed By: brianjo

Differential Revision: D30592384

