### PR TITLE
remove redundant param type in docstrings

### DIFF
--- a/src/beanmachine/applications/hme/abstract_linear_model.py
+++ b/src/beanmachine/applications/hme/abstract_linear_model.py
@@ -23,9 +23,7 @@ class AbstractLinearModel(AbstractModel, metaclass=ABCMeta):
     """An abstract class for creating linear mixed effects model using BMGraph.
 
     :param data: observed training data
-    :type data: class:`pd.DataFrame`
     :param model_config: model configuration parameters
-    :type model_config: class:`ModelConfig`
     """
 
     def __init__(self, data: pd.DataFrame, model_config: ModelConfig) -> None:
@@ -169,11 +167,8 @@ class AbstractLinearModel(AbstractModel, metaclass=ABCMeta):
         In the other words, this method returns XB for fixed effects for a given obs (row) from the training data.
 
         :param row: one row of training data with fixed effect covariates
-        :type row: class:`pd.Series`
         :param params: a mapping of fixed effects to their corresponding nodes
-        :type params: dict
         :return: bmgraph node that sums over all fixed effects for a given observation (i.e. a row from the training data)
-        :type: int
         """
 
         if not self.fixed_effects:
@@ -194,11 +189,8 @@ class AbstractLinearModel(AbstractModel, metaclass=ABCMeta):
         In the other words, this method returns XZ for random effects for a given obs (row) from the training data.
 
         :param row: one individual training data with random effect covariates
-        :type row: class:`pd.Series`
         :param params: a tuple of dictionaries, which map random effects to their distribution, and sampled value nodes
-        :type params: (dict, dict)
         :return: BMGraph node that sums over all random effects for a given observation (i.e. a row from the training data).
-        :type: int
         """
 
         if not self.random_effects:
@@ -230,11 +222,8 @@ class AbstractLinearModel(AbstractModel, metaclass=ABCMeta):
         """Generates response variable predictive distribution given new test data.
 
         :param new_row: one individual test data for prediction
-        :type new_row: class:`pd.Series`
         :param post_samples: MCMC posterior inference samples on model parameters
-        :type post_samples: class:`pd.DataFrame`
         :return: response variable predictive distribution
-        :rtype: class:`pd.Series`
         """
 
         pred_val = pd.Series(0.0, index=range(post_samples.shape[0]))

--- a/src/beanmachine/applications/hme/abstract_model.py
+++ b/src/beanmachine/applications/hme/abstract_model.py
@@ -28,9 +28,7 @@ class AbstractModel(object, metaclass=ABCMeta):
     """An abstract class for Bayesian graphical models using BMGraph.
 
     :param data: observed train data
-    :type data: class:`pd.DataFrame`
     :param model_config: model configuration parameters
-    :type model_config: class:`ModelConfig`
     """
 
     def __init__(self, data: pd.DataFrame, model_config: ModelConfig) -> None:
@@ -46,9 +44,7 @@ class AbstractModel(object, metaclass=ABCMeta):
         """Extracts fixed and/or random effects from given statistical formula.
 
         :param formula: statistical formula establishing the relationship between response and predictor variables
-        :type formula: str
         :return: A tuple of fixed and/or random effects lists
-        :rtype: (list, list)
         """
 
         def make_joint_effect(effect):
@@ -102,9 +98,7 @@ class AbstractModel(object, metaclass=ABCMeta):
         """Parses statistical formula as well as performs data pre-processing given statistical formula.
 
         :param formula: statistical formula establishing the relationship between response and predictor variables
-        :type formula: str
         :return: A tuple of fixed and/or random effects lists
-        :rtype: (list, list)
         """
 
         model_desc = evaluate_formula(formula)
@@ -191,11 +185,8 @@ class AbstractModel(object, metaclass=ABCMeta):
         """Helper function of set_queries.
 
         :param prev_key: None, or model parameter names of fixed or random effects
-        :type prev_key: any
         :param queries: a mapping from model parameter to its BMGraph node, or just node itself
-        :type queries: any
         :param query_map: a mapping from model parameter to query-index specified in the graph
-        :type query_map: dict
         """
         if isinstance(queries, dict):
             try:
@@ -212,9 +203,7 @@ class AbstractModel(object, metaclass=ABCMeta):
         """Performs MCMC posterior inference on model parameters.
 
         :param infer_config: configuration settings of posterior inference
-        :type infer_config: class:`InferConfig`
         :return: posterior samples and their diagnostic summary statistics
-        :rtype: (class:`pd.DataFrame`, class:`pd.DataFrame`)
         """
 
         t0 = time.time()
@@ -241,9 +230,7 @@ class AbstractModel(object, metaclass=ABCMeta):
         """Stacks posterior sample lists across different chains and transforms them into a dataframe.
 
         :param dat_list: posterior samples in multiple chains generated from `bmgraph.infer()`
-        :type dat_list: list
         :return: stacked posterior samples with corresponding parameter names
-        :rtype: class:`pd.DataFrame`
         """
 
         df_list = []
@@ -263,9 +250,7 @@ class AbstractModel(object, metaclass=ABCMeta):
         """Checks convergence of MCMC posterior inference results and returns diagnostic summary statistics.
 
         :param samples: posterior samples list generated from `bmgraph.infer()`
-        :type samples: list
         :return: diagnostic summary statistics, including effective sample size, R_hat (when n_chain > 1), sample mean, and acceptance rates (for continuous R.V.)
-        :rtype: class:`pd.DataFrame`
         """
 
         # conversion to torch

--- a/src/beanmachine/applications/hme/configs.py
+++ b/src/beanmachine/applications/hme/configs.py
@@ -75,6 +75,11 @@ class PriorConfig:
 
 @dataclass
 class StructuredPriorConfig:
+    """A configuration class for structured prior distributions.
+
+    :param specification: type (e.g., AR, RW, etc) of the structured prior
+    :param category_order: list of categorical covariate levels, specifying its ordinal structure
+    """
 
     specification: str
     category_order: List[str] = field(default_factory=list)
@@ -84,24 +89,24 @@ class StructuredPriorConfig:
 class ModelConfig:
     """A configuration class for integrated models. E.g.,
 
-    ModelConfig(
-        mean_regression = RegressionConfig(
-            distribution="normal",
-            outcome="y",
-            stderr=None,
-            formula="y ~ 1 + (1|x)",
-            link="identity",
-        ),
-        mean_mixture = MixtureConfig(
-            use_null_mixture=True,
-            use_bimodal_alternative=True,
-            use_asymmetric_modes=True,
-            use_partial_asymmetric_modes=True,
-        ),
-        priors = {
-            "fe": PriorConfig('normal', {"mean": 0.0, "scale": 1.0}),
-            }
-    )
+        ModelConfig(
+            mean_regression = RegressionConfig(
+                distribution="normal",
+                outcome="y",
+                stderr=None,
+                formula="y ~ 1 + (1|x)",
+                link="identity",
+            ),
+            mean_mixture = MixtureConfig(
+                use_null_mixture=True,
+                use_bimodal_alternative=True,
+                use_asymmetric_modes=True,
+                use_partial_asymmetric_modes=True,
+            ),
+            priors = {
+                "fe": PriorConfig('normal', {"mean": 0.0, "scale": 1.0}),
+                }
+        )
 
     :param mean_regression: regression model configurations for fixed and random effects components
     :param mean_mixture:  configuration settings for mixture components

--- a/src/beanmachine/applications/hme/interface.py
+++ b/src/beanmachine/applications/hme/interface.py
@@ -12,9 +12,7 @@ class HME:
     """The Hierarchical Mixed Effect model interface.
 
     :param data: observed train data
-    :type data: class:`pd.DataFrame`
     :param model_config: HME model configuration parameters
-    :type model_config: class:`ModelConfig`
     """
 
     def __init__(self, data: pd.DataFrame, model_config: ModelConfig) -> None:
@@ -27,9 +25,7 @@ class HME:
         returns MCMC samples for those parameters registered in the query.
 
         :param infer_config: configuration settings of posterior inference
-        :type infer_config: class:`InferConfig`
         :return: posterior samples and their diagnostic summary statistics
-        :rtype: (class:`pd.DataFrame`, class:`pd.DataFrame`)
         """
 
         self.posterior_samples, self.posterior_diagnostics = self.model.infer(

--- a/src/beanmachine/applications/hme/null_mixture_model.py
+++ b/src/beanmachine/applications/hme/null_mixture_model.py
@@ -18,9 +18,7 @@ class NullMixtureMixedEffectModel(AbstractLinearModel):
     """Represents a generalized linear mixed effects model with optional null mixture.
 
     :param data: observed train data
-    :type data: class:`pd.DataFrame`
     :param model_config: model configuration parameters
-    :type model_config: class:`ModelConfig`
     """
 
     def __init__(self, data: pd.DataFrame, model_config: ModelConfig) -> None:
@@ -138,11 +136,8 @@ class NullMixtureMixedEffectModel(AbstractLinearModel):
         """Returns a multiplicative H1 model as a mixture of both positive and negative effects.
 
         :param mu_parents: BMGraph nodes of positive effect distribution component
-        :type mu_parents: list
         :param mu_neg_parents: BMGraph nodes of negative effect distribution component
-        :type mu_neg_parents: list
         :return: BMGraph node representing a mixtrue of positive and negative effect distribution
-        :rtype: int
         """
 
         log_mu = self.g.add_operator(bmgraph.OperatorType.ADD, mu_parents)
@@ -169,11 +164,8 @@ class NullMixtureMixedEffectModel(AbstractLinearModel):
         """Defines the response variable distribution BMGraph node conditional on the mixed effect node: fere_i.
 
         :param index: train data index
-        :type index: int
         :param row: one realization (aka observed value) of response and predictor variables
-        :type row: class:`pd.Series`
         :param fere_i: mixed effect BMGraph node
-        :type fere_i: int
         """
 
         if self.model_config.mean_mixture.use_null_mixture:
@@ -229,11 +221,8 @@ class NullMixtureMixedEffectModel(AbstractLinearModel):
         """Computes predictive distributions given new test data.
 
         :param new_data: test data for prediction
-        :type new_data: class:`pd.DataFrame`
         :param post_samples: MCMC posterior inference samples on model parameters
-        :type post_samples: class:`pd.DataFrame`
         :return: predictive distributions on the new test data
-        :rtype: class:`pd.Series`
         """
 
         # FIXME: update the method to support customized prediction goal

--- a/src/beanmachine/applications/hme/patsy_mixed.py
+++ b/src/beanmachine/applications/hme/patsy_mixed.py
@@ -57,9 +57,7 @@ def evaluate_formula(formula: str) -> ModelDesc:
     """Given a mixed effects formula, return a model description.
 
     :param formula: mixed effects model formula
-    :type formula: str
     :return: model description including outcome variable (lhs) and fixed and/or random effects (rhs)
-    :rtype: `class:ModelDesc`
     """
 
     # mixed effects specific operators


### PR DESCRIPTION
Summary: removed param type redundancy in existing HME docstrings, since those information has already been contained in Python variable type annotations.

Differential Revision: D30685668

