### PR TITLE
added condition check for valid N_eff

### DIFF
--- a/src/beanmachine/applications/hme/abstract_model.py
+++ b/src/beanmachine/applications/hme/abstract_model.py
@@ -264,24 +264,26 @@ class AbstractModel(object, metaclass=ABCMeta):
         posterior_diagnostics = pd.DataFrame()
         posterior_diagnostics["names"] = np.array(list(self.query_map.keys()))
         posterior_diagnostics["Mean"] = np.array(
-            [bmg_mean[self.query_map[k]] for k in posterior_diagnostics["names"].values]
+            [bmg_mean[self.query_map[k]] for k in posterior_diagnostics["names"]]
         )
         posterior_diagnostics["Acceptance"] = np.array(
             [
                 len(samples[:, :, self.query_map[k]].reshape(-1).unique())
                 / len(samples[:, :, self.query_map[k]].reshape(-1))
-                for k in posterior_diagnostics["names"].values
+                for k in posterior_diagnostics["names"]
             ]
         )
-        posterior_diagnostics["N_Eff"] = np.array(
-            [bmg_neff[self.query_map[k]] for k in posterior_diagnostics["names"].values]
-        )
+
+        if not bmg_neff.size():
+            logger.warning("NaN encountered in computing effective sample size.")
+        else:
+            posterior_diagnostics["N_Eff"] = np.array(
+                [bmg_neff[self.query_map[k]] for k in posterior_diagnostics["names"]]
+            )
+
         if n_chain > 1:
             posterior_diagnostics["R_hat"] = np.array(
-                [
-                    bmg_rhat[self.query_map[k]]
-                    for k in posterior_diagnostics["names"].values
-                ]
+                [bmg_rhat[self.query_map[k]] for k in posterior_diagnostics["names"]]
             )
         else:
             logger.warning("Convergence diagnostic, R_hat, requires more than 1 chain.")

--- a/src/beanmachine/applications/hme/tests/test_diagnostics.py
+++ b/src/beanmachine/applications/hme/tests/test_diagnostics.py
@@ -1,0 +1,35 @@
+# (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+
+import warnings
+
+import pytest
+from beanmachine.applications.hme import ModelConfig
+from beanmachine.applications.hme.abstract_model import AbstractModel
+
+
+class RealizedModel(AbstractModel):
+    def build_graph(self):
+        return super().build_graph()
+
+
+@pytest.mark.parametrize(
+    "post_samples",
+    [
+        [
+            [[1.0, float("nan"), 3.0], [4.0, 5.0, 6.0]],
+            [[0.5, 1.5, 2.5], [3.5, 4.5, 5.5]],
+        ],
+    ],
+)
+def test_get_bmg_diagnostics(post_samples):
+    model = RealizedModel(data=None, model_config=ModelConfig())
+
+    with warnings.catch_warnings(record=True) as w:
+        # Cause all warnings to always be triggered.
+        warnings.simplefilter("always")
+
+        post_diagnostics = model._get_bmg_diagnostics(post_samples)
+
+        assert len(w) == 1
+        assert "NaN encountered" in str(w[-1].message)
+        assert "N_Eff" not in post_diagnostics.columns


### PR DESCRIPTION
Summary: Fixed an error in `_get_bmg_diagnostics` method, where when NaN value encountered in calculating effective sample sizes, BMG will return `tensor(0.0)`, and we cannot incorporate it into the diagnostics data frame. (shape doesn't match with other statistics)

Differential Revision: D30704890

