### PR TITLE
Expose target accept prob configuration API

### DIFF
--- a/src/beanmachine/ppl/experimental/global_inference/hmc_inference.py
+++ b/src/beanmachine/ppl/experimental/global_inference/hmc_inference.py
@@ -16,6 +16,7 @@ class GlobalHamiltonianMonteCarlo(BaseInference):
     initial_step_size: float = 1.0
     adapt_step_size: bool = True
     adapt_mass_matrix: bool = True
+    target_accept_prob: float = 0.8
 
     def get_proposer(self, world: SimpleWorld) -> HMCProposer:
         return HMCProposer(world, **dataclasses.asdict(self))
@@ -29,6 +30,7 @@ class GlobalNoUTurnSampler(BaseInference):
     adapt_step_size: bool = True
     adapt_mass_matrix: bool = True
     multinomial_sampling: bool = True
+    target_accept_prob: float = 0.8
 
     def get_proposer(self, world: SimpleWorld) -> NUTSProposer:
         return NUTSProposer(world, **dataclasses.asdict(self))

--- a/src/beanmachine/ppl/experimental/global_inference/proposer/hmc_proposer.py
+++ b/src/beanmachine/ppl/experimental/global_inference/proposer/hmc_proposer.py
@@ -40,6 +40,7 @@ class HMCProposer(BaseProposer):
         initial_step_size: float = 1.0,
         adapt_step_size: bool = True,
         adapt_mass_matrix: bool = True,
+        target_accept_prob: float = 0.8,
     ):
         self.world = initial_world
         # cache pe and pe_grad to prevent re-computation
@@ -56,7 +57,9 @@ class HMCProposer(BaseProposer):
             self.step_size = self._find_reasonable_step_size(
                 initial_step_size, self.world, self._pe, self._pe_grad
             )
-            self._step_size_adapter = DualAverageAdapter(self.step_size)
+            self._step_size_adapter = DualAverageAdapter(
+                self.step_size, target_accept_prob
+            )
         else:
             self.step_size = initial_step_size
         # alpha will store the accept prob and will be used to adapt step size

--- a/src/beanmachine/ppl/experimental/global_inference/proposer/hmc_utils.py
+++ b/src/beanmachine/ppl/experimental/global_inference/proposer/hmc_utils.py
@@ -69,12 +69,12 @@ class DualAverageAdapter:
         https://arxiv.org/abs/1111.4246
     """
 
-    def __init__(self, initial_epsilon: float):
+    def __init__(self, initial_epsilon: float, delta: float = 0.8):
         self._log_avg_epsilon = 0.0
         self._H = 0.0
         self._mu = math.log(10 * initial_epsilon)
         self._t0 = 10
-        self._delta = 0.8  # target mean accept prob
+        self._delta = delta  # target mean accept prob
         self._gamma = 0.05
         self._kappa = 0.75
         self._m = 1.0  # iteration count

--- a/src/beanmachine/ppl/experimental/global_inference/proposer/nuts_proposer.py
+++ b/src/beanmachine/ppl/experimental/global_inference/proposer/nuts_proposer.py
@@ -63,6 +63,7 @@ class NUTSProposer(HMCProposer):
         adapt_step_size: bool = True,
         adapt_mass_matrix: bool = True,
         multinomial_sampling: bool = True,
+        target_accept_prob: float = 0.8,
     ):
         # note that trajectory_length is not used in NUTS
         super().__init__(
@@ -71,6 +72,7 @@ class NUTSProposer(HMCProposer):
             initial_step_size=initial_step_size,
             adapt_step_size=adapt_step_size,
             adapt_mass_matrix=adapt_mass_matrix,
+            target_accept_prob=target_accept_prob,
         )
         self._max_tree_depth = max_tree_depth
         self._max_delta_energy = max_delta_energy

--- a/src/beanmachine/ppl/experimental/global_inference/proposer/tests/hmc_utils_test.py
+++ b/src/beanmachine/ppl/experimental/global_inference/proposer/tests/hmc_utils_test.py
@@ -31,6 +31,17 @@ def test_dual_average_adapter():
     assert epsilon2 < adapter.finalize() < epsilon1
 
 
+def test_dual_average_with_different_delta():
+    adapter1 = DualAverageAdapter(1.0, delta=0.8)
+    adapter2 = DualAverageAdapter(1.0, delta=0.2)
+    prob = torch.tensor(0.5)
+    # prob > delta means we can increase the step size, wherease prob < delta means
+    # we need to decrease the step size
+    epsilon1 = adapter1.step(prob)
+    epsilon2 = adapter2.step(prob)
+    assert epsilon1 < epsilon2
+
+
 def test_small_window_scheme():
     num_adaptive_samples = 10
     scheme = WindowScheme(num_adaptive_samples)


### PR DESCRIPTION
Summary: Per OpenTeams' request, it would be quite convenient if we let users configure the target accept probability for NUTS and HMC :D. All this diff does is to connect the wires and make the API publicly available. A small unit test is also added to ensure that the target probs work as expected.

Differential Revision: D30735168

