### PR TITLE
Correct spelling of Jacobian

### DIFF
--- a/src/beanmachine/ppl/experimental/neutra/iafflow.py
+++ b/src/beanmachine/ppl/experimental/neutra/iafflow.py
@@ -103,7 +103,7 @@ class InverseAutoregressiveFlow(nn.Module):
         len_j = len(x)
         log_jacobian = torch.zeros(len_j)
         for layer_ in self.flows_:
-            # loop through the NN to add log_abs_jacobain to ELBO
+            # loop through the NN to add log_abs_jacobian to ELBO
             tmp = z_f[-1][:]
             x, log_d = layer_.forward(tmp)
             elbo += log_d

--- a/src/beanmachine/ppl/experimental/neutra/tests/iaflayer_test.py
+++ b/src/beanmachine/ppl/experimental/neutra/tests/iaflayer_test.py
@@ -29,7 +29,7 @@ class IAFLayerTest(unittest.TestCase):
         z = x * torch.exp(loga) + (1 - torch.exp(loga)) * mu
         # calculate if x->z is correct.
         self.assertCountEqual(xtrhat.tolist(), z.tolist())
-        # check if jacobain is correct.
+        # check if jacobian is correct.
         self.assertEqual(ja, loga.sum())
 
         # Here we don't expect to have a stable inverse direction,

--- a/src/beanmachine/ppl/experimental/neutra/tests/iafmcmc_jacobian_test.py
+++ b/src/beanmachine/ppl/experimental/neutra/tests/iafmcmc_jacobian_test.py
@@ -14,7 +14,7 @@ from beanmachine.ppl.world.world import TransformType
 from torch import nn, tensor as tensor
 
 
-class IAFJacobainTest(unittest.TestCase):
+class IAFJacobianTest(unittest.TestCase):
     class SampleModel(object):
         @bm.random_variable
         def foo(self):
@@ -47,7 +47,7 @@ class IAFJacobainTest(unittest.TestCase):
             parameters, lr=1e-4, weight_decay=1e-5
         )
 
-    def test_jacobain_for_iaf_proposer(self):
+    def test_jacobian_for_iaf_proposer(self):
         world = World()
         model = self.SampleModel()
         foo_key = model.foo()


### PR DESCRIPTION
Summary: I happened to notice that "Jacobian" was misspelled in a few spots.

Reviewed By: horizon-blue

Differential Revision: D30736525

