### PR TITLE
Test for MatrixMultiplicationNode

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/bmg_nodes_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_nodes_test.py
@@ -9,6 +9,7 @@ from beanmachine.ppl.compiler.bmg_nodes import (
     MultiplicationNode,
     ConstantTensorNode,
     ConstantRealMatrixNode,
+    MatrixMultiplicationNode,
 )
 
 
@@ -57,6 +58,26 @@ class BMGNodesTest(unittest.TestCase):
         self.assertEqual(t42.size, v42.size())
         self.assertEqual(t42.support_size(), 1.0)
         self.assertEqual(list(t42.support()), [v42])
+
+    def test_MatrixMultiplicationNode(self) -> None:
+        v42 = torch.tensor([[42, 43], [44, 45]])
+        mv = torch.mm(v42, v42)
+        t42 = ConstantRealMatrixNode(v42)
+        mt = MatrixMultiplicationNode(t42, t42)
+        # Note: Unlike constants, we cannot inspect the value directly
+        #  self.assertEqual(mt.value[0, 0], mv[0, 0])
+        #  self.assertEqual(mt.value[1, 0], mv[1, 0])
+        # but shortly we will be able to inspect the support
+        self.assertEqual(v42.size(), torch.Size([2, 2]))
+        self.assertEqual(mt.size, mv.size())
+        self.assertEqual(mt.support_size(), 1.0)
+        support_list = list(mt.support())
+        self.assertEqual(len(support_list), 1)
+        support = support_list[0]
+        self.assertEqual(support[0, 0], mv[0, 0])
+        self.assertEqual(support[0, 1], mv[0, 1])
+        self.assertEqual(support[1, 0], mv[1, 0])
+        self.assertEqual(support[1, 1], mv[1, 1])
 
     def test_inputs_and_outputs(self) -> None:
         # We must maintain the invariant that the output set and the


### PR DESCRIPTION
Summary: Simple test for MatrixMultiplicationNode. Mainly confirms that the support method performs the expected computation statically.

Reviewed By: ericlippert

Differential Revision: D30796546

