### PR TITLE
Compute tensor sizes associated with graph nodes

### DIFF
--- a/src/beanmachine/ppl/compiler/gen_dot.py
+++ b/src/beanmachine/ppl/compiler/gen_dot.py
@@ -12,12 +12,14 @@ from beanmachine.ppl.compiler.fix_problems import (
 )
 from beanmachine.ppl.compiler.graph_labels import get_edge_labels, get_node_label
 from beanmachine.ppl.compiler.lattice_typer import LatticeTyper
+from beanmachine.ppl.compiler.sizer import Sizer, size_to_str
 from beanmachine.ppl.utils.dotbuilder import DotBuilder
 
 
 def to_dot(
     bmg: BMGraphBuilder,
     node_types: bool = False,
+    node_sizes: bool = False,
     edge_requirements: bool = False,
     after_transform: bool = False,
     label_edges: bool = True,
@@ -27,6 +29,7 @@ def to_dot(
     orphans, as a DOT graph description; nodes are enumerated in the order
     they were created."""
     lt = LatticeTyper()
+    sizer = Sizer()
     reqs = EdgeRequirements(lt)
     db = DotBuilder()
 
@@ -60,6 +63,8 @@ def to_dot(
         node_label = get_node_label(node)
         if node_types:
             node_label += ":" + lt[node].short_name
+        if node_sizes:
+            node_label += ":" + size_to_str(sizer[node])
         db.with_node(n, node_label)
         for (i, edge_name, req) in zip(
             node.inputs, get_edge_labels(node), reqs.requirements(node)

--- a/src/beanmachine/ppl/compiler/sizer.py
+++ b/src/beanmachine/ppl/compiler/sizer.py
@@ -1,0 +1,258 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+# See notes in typer_base.py for how the type computation logic works.
+#
+# This typer identifies the tensor size associated with a graph node.
+# For example, if we have a random variable:
+#
+# @rv def flips():
+#   return Bernoulli(coin())
+#
+# Then we need to know if coin() is a single probability or, if multiple,
+# what shape the tensor is. BMG only supports two-dimensional arrays
+# and there are restrictions on how we can produce multi-valued samples,
+# multiply matrices, and so on.
+#
+# Every node must have a *consistent* size; consider for example this
+# unlikely but legal model:
+#
+# @rv def weird(n):
+#   if n == 0:
+#     return Bernoulli(tensor([0.5, 0.5])) # two values
+#   else:
+#     return Normal(0.0, 1.0) # one value
+#
+# @rv def flip():
+#   return Bernoulli(0.5)
+#
+# @fun problem():
+#   return weird(flip())
+#
+# What is the size of the node associated with "problem"? It does not have a consistent
+# size, so we will mark it as unsized.
+#
+# The purpose of this is to avoid doing work to guess at what
+# the sizes of nodes are in graphs where there is no possibility of this
+# graph being legal. We also wish to avoid reporting confusing cascading
+# errors based on incorrect guesses as to what the size of the node "should"
+# be. Descendents of unsized nodes are also unsized; this is a clear
+# and easily implemented rule.
+#
+# We use this logic in two main places in the compiler. First, when computing
+# supports for stochastic control flow. If we have something like:
+#
+# @rv def flip_two():
+#   return Bernoulli([0.5, 0.5])
+#
+# @rv def normal(n):
+#   return Normal(0, 1)
+#
+# ...
+# x = normal(flip_two())
+#
+# then we need to know that there are four samples from normal() and we are stochastically
+# choosing one of them in x.
+#
+# Second, when doing various rewrites of the graph we need to know what node sizes are
+# so that we can either rewrite operations that cannot be represented in BMG into
+# unvectorized operations, or produce sensible error messages if we cannot.
+
+from functools import reduce
+from typing import Callable, Dict, Set
+
+import beanmachine.ppl.compiler.bmg_nodes as bn
+import torch
+from beanmachine.ppl.compiler.typer_base import TyperBase
+from torch import Size
+
+
+# We use an impossible value as a marker for unsizable:
+Unsized = Size([-1])
+Scalar = Size([])
+
+# These nodes are always scalars no matter what their input:
+_always_scalar: Set[type] = {
+    bn.ExpProductFactorNode,
+    bn.FlatNode,
+    bn.InNode,
+    bn.IsNode,
+    bn.IsNotNode,
+    bn.ItemNode,
+    bn.NotInNode,
+    bn.NotNode,
+    bn.ToIntNode,
+    bn.ToNegativeRealNode,
+    bn.ToRealNode,
+    bn.ToPositiveRealNode,
+    bn.ToProbabilityNode,
+}
+
+# The size of these nodes is just the size of broadcasting all their inputs.
+_broadcast_the_inputs: Set[type] = {
+    bn.AdditionNode,
+    bn.BernoulliLogitNode,
+    bn.BernoulliNode,
+    bn.BetaNode,
+    bn.BinomialLogitNode,
+    bn.BinomialNode,
+    bn.BitAndNode,
+    bn.BitOrNode,
+    bn.BitXorNode,
+    bn.Chi2Node,
+    bn.ComplementNode,
+    bn.DivisionNode,
+    bn.DirichletNode,
+    bn.EqualNode,
+    bn.ExpM1Node,
+    bn.ExpNode,
+    bn.FloorDivNode,
+    bn.GammaNode,
+    bn.GreaterThanEqualNode,
+    bn.GreaterThanNode,
+    bn.HalfCauchyNode,
+    bn.HalfNormalNode,
+    bn.InvertNode,
+    bn.LessThanEqualNode,
+    bn.LessThanNode,
+    bn.LogisticNode,
+    bn.LogNode,
+    bn.LogSumExpNode,
+    bn.Log1mexpNode,
+    bn.LShiftNode,
+    bn.ModNode,
+    bn.MultiplicationNode,
+    bn.NegateNode,
+    bn.NormalNode,
+    bn.NotEqualNode,
+    bn.Observation,
+    bn.PhiNode,
+    bn.PoissonNode,
+    bn.PowerNode,
+    bn.Query,
+    bn.RShiftNode,
+    bn.SampleNode,
+    bn.StudentTNode,
+    bn.ToPositiveRealMatrixNode,
+    bn.ToRealMatrixNode,
+    bn.UniformNode,
+}
+
+
+def _broadcast_two(x: Size, y: Size) -> Size:
+    # Given two sizes, what is their broadcast size, if any?  Rather than replicate
+    # the logic in torch which does this computation, we simply construct two
+    # all-zero tensors of the given sizes and try to add them. If the addition succeeds
+    # then the size of the sum is the size we want.
+    #
+    # TODO: Is there a better way to do this other than try it and see what happens?
+    if x == Unsized or y == Unsized:
+        return Unsized
+    try:
+        return (torch.zeros(x) + torch.zeros(y)).size()
+    except Exception:
+        return Unsized
+
+
+def _broadcast(*sizes: Size) -> Size:
+    # Many tensor operations in torch have "broadcast" semantics. A brief explanation:
+    #
+    # If we compute tensor([1, 2]) + tensor([20, 30]) we do pairwise addition to get
+    # tensor([21, 32]) as the sum.  But what happens if the dimensions do not match?
+    # In this case we "broadcast" the tensors; we find a tensor size greater than or
+    # equal to the sizes of both operands and duplicate the data as necessary.
+    #
+    # For example, if we are adding tensor([1, 2]) + tensor([3]) then the right summand
+    # is broadcast to tensor([3, 3]), and we get tensor([4, 5]) as the sum.
+    #
+    # Note that not all sizes can be broadcast. Summing tensor([1, 2]) + tensor([10, 20, 30])
+    # is not legal because there is no obvious way to expand [1, 2] to be the same size as
+    # [10, 20, 30].
+    #
+    # We often need to answer the question "given n sizes, what is the size of the broadcast
+    # of all n sizes?" This method does that computation.
+    return reduce(_broadcast_two, sizes)
+
+
+def size_to_str(size: Size) -> str:
+    if size == Unsized:
+        return "unsized"
+    return "[" + ",".join(str(i) for i in size) + "]"
+
+
+class Sizer(TyperBase[Size]):
+
+    _dispatch: Dict[type, Callable]
+
+    def __init__(self) -> None:
+        TyperBase.__init__(self)
+        self._dispatch = {
+            bn.ChoiceNode: self._size_choice,
+            bn.IfThenElseNode: self._size_if,
+            bn.SwitchNode: self._size_switch,
+            bn.ToMatrixNode: self._size_to_matrix,
+        }
+        # TODO:
+        # ColumnIndexNode
+        # IndexNode
+        # LogSumExpTorchNode --
+        #   note that final parameter affects size
+        # MatrixMultiplicationNode --
+        #   remember torch has broadcasting and non-broadcasting operators
+        # VectorIndexNode
+        # LogSumExpVectorNode
+
+    def _size_choice(self, node: bn.ChoiceNode) -> Size:
+        s = self[node.inputs[1]]
+        for i in range(1, len(node.inputs)):
+            if self[node.inputs[i]] != s:
+                return Unsized
+        return s
+
+    def _size_if(self, node: bn.IfThenElseNode) -> Size:
+        consequence = self[node.inputs[1]]
+        alternative = self[node.inputs[2]]
+        if consequence != alternative:
+            return Unsized
+        return consequence
+
+    def _size_switch(self, node: bn.SwitchNode) -> Size:
+        s = self[node.inputs[2]]
+        for i in range(1, (len(node.inputs) - 1) // 2):
+            if self[node.inputs[i * 2 + 2]] != s:
+                return Unsized
+        return s
+
+    def _size_to_matrix(self, node: bn.ToMatrixNode) -> Size:
+        rows = node.inputs[0]
+        assert isinstance(rows, bn.NaturalNode)
+        columns = node.inputs[1]
+        assert isinstance(columns, bn.NaturalNode)
+        return Size([rows.value, columns.value])
+
+    # This implements the abstract base type method.
+    def _compute_type_inputs_known(self, node: bn.BMGNode) -> Size:
+        # If there is any input node whose size cannot be determined, then *none*
+        # of its descendents can be determined, even if a descendent node always
+        # has the same type regardless of its inputs. This ensures that (1) we only
+        # attempt to assign sizes to graphs that are supported by the BMG type system,
+        # and (2) will help us avoid presenting cascading errors to the user in
+        # the event that a graph violates a typing rule.
+        for i in node.inputs:
+            if self[i] == Unsized:
+                return Unsized
+        if isinstance(node, bn.ConstantNode):
+            if isinstance(node.value, torch.Tensor):
+                return node.value.size()
+            return Scalar
+        if hasattr(node, "_size"):
+            return node._size  # pyre-ignore
+        t = type(node)
+        if t in _always_scalar:
+            result = Scalar
+        elif t in _broadcast_the_inputs:
+            result = _broadcast(*(self[i] for i in node.inputs))
+        elif t in self._dispatch:
+            result = self._dispatch[t](node)
+        else:
+            result = Unsized
+        return result

--- a/src/beanmachine/ppl/compiler/tests/sizer_test.py
+++ b/src/beanmachine/ppl/compiler/tests/sizer_test.py
@@ -1,0 +1,49 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import unittest
+
+import beanmachine.ppl as bm
+from beanmachine.ppl.compiler.gen_dot import to_dot
+from beanmachine.ppl.compiler.runtime import BMGRuntime
+from torch import tensor
+from torch.distributions import Bernoulli, Beta
+
+# We need to be able to tell what size the tensor is
+# when a model operates on multi-valued tensors.
+
+
+@bm.random_variable
+def coin():
+    return Beta(tensor([[1.0, 2.0]]), 3.0)
+
+
+@bm.random_variable
+def flip():
+    return Bernoulli(coin())
+
+
+class SizerTest(unittest.TestCase):
+    def test_sizer_1(self) -> None:
+        self.maxDiff = None
+
+        queries = [flip()]
+        observations = {}
+        bmg = BMGRuntime().accumulate_graph(queries, observations)
+        observed = to_dot(bmg, node_sizes=True)
+        expected = """
+digraph "graph" {
+  N0[label="[[1.0,2.0]]:[1,2]"];
+  N1[label="[[3.0,3.0]]:[1,2]"];
+  N2[label="Beta:[1,2]"];
+  N3[label="Sample:[1,2]"];
+  N4[label="Bernoulli:[1,2]"];
+  N5[label="Sample:[1,2]"];
+  N6[label="Query:[1,2]"];
+  N0 -> N2[label=alpha];
+  N1 -> N2[label=beta];
+  N2 -> N3[label=operand];
+  N3 -> N4[label=probability];
+  N4 -> N5[label=operand];
+  N5 -> N6[label=operator];
+}
+"""
+        self.assertEqual(expected.strip(), observed.strip())

--- a/src/beanmachine/ppl/inference/bmg_inference.py
+++ b/src/beanmachine/ppl/inference/bmg_inference.py
@@ -214,12 +214,14 @@ class BMGInference:
     ) -> str:
         """Produce a string containing a program in the GraphViz DOT language
         representing the graph deduced from the model."""
-        inf_types = False
+        node_types = False
+        node_sizes = False
         edge_requirements = False
         bmg = self._accumulate_graph(queries, observations)._bmg
         return to_dot(
             bmg,
-            inf_types,
+            node_types,
+            node_sizes,
             edge_requirements,
             after_transform,
             label_edges,


### PR DESCRIPTION
Summary:
We need to know precisely what tensor size is associated with each node in an accumulated graph. Why? Because we need this information:

(1) to implement multi-dimensional samples and other arithmetic when compiling to BMG, and

(2) to give sensible error messages when we cannot, and

(3) to compute the support of graph nodes when one is used as an argument to an RV

This is essentially the same task as assigning a lattice type to every graph node, and we have the same problem: a graph might have a path more than 1000 edges long, so a recursive solution will blow up Python's small recursion limit.

I therefore am going to remove the recursive size computation from graph nodes themselves -- and besides, that's not a concern of the node -- and move that computation to a class that can perform this computation nonrecursively, caching the results as it goes.

In this diff I create that class; in upcoming diffs I will similarly move support computation to its own class, since it has the same problem.

Reviewed By: wtaha

Differential Revision: D29948346

