### PR TITLE
Fix bugs in SetOfTensors

### DIFF
--- a/src/beanmachine/ppl/utils/memoize.py
+++ b/src/beanmachine/ppl/utils/memoize.py
@@ -13,6 +13,21 @@ def _tuplify(t: Any) -> Any:
     return t
 
 
+# This returns a tuple or value whose shape is the same as the input tensor.
+# That is:
+#
+# tensor(1)                --> 1
+# tensor([])               --> ()
+# tensor([1])              --> (1,)
+# tensor([1, 2])           --> (1, 2)
+# tensor([[1, 2], [3, 4]]) --> ((1, 2), (3, 4))
+#
+# and so on
+def tensor_to_tuple(t: Tensor) -> Any:
+    result = _tuplify(t.tolist())
+    return result
+
+
 class MemoizationKey:
     # It would be nice to just use a tuple (wrapper, args) for the memoization
     # key, but tensors can only be compared for equality with torch.equal(t1, t2),
@@ -30,7 +45,7 @@ class MemoizationKey:
         self.arguments = (
             wrapper,
             tuple(
-                _tuplify(a.tolist()) if isinstance(a, Tensor) else a for a in arguments
+                tensor_to_tuple(a) if isinstance(a, Tensor) else a for a in arguments
             ),
         )
         self.wrapper = wrapper

--- a/src/beanmachine/ppl/utils/set_of_tensors.py
+++ b/src/beanmachine/ppl/utils/set_of_tensors.py
@@ -1,48 +1,36 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
 import collections
-from typing import List
+from typing import Set, Tuple
 
+from beanmachine.ppl.utils.memoize import tensor_to_tuple
 from torch import Tensor, tensor
 
-# When constructing the support of various nodes we are often
-# having to remove duplicates from a set of possible values.
+# When constructing the support of various nodes we often
+# must remove duplicates from a set of possible values.
 # Unfortunately, it is not easy to do so with torch tensors.
-# This helper class implements a set of tensors.
-
-# TODO: This code is wrong and needs to be fixed. The "in" operator
-# used in the code below throws an exception due to the way that
-# tensors implement equality.  For example:
-#
-# tensor([1, 2]) in [ tensor([2, 1]) ]
-#
-# raises "Boolean value of Tensor with more than one value is ambiguous"
-#
-# We need to implement proper hashing and equality on tensors for the purposes
-# of this set.
-#
-# We should also implement a sublinear set rather than using a list.
+# This helper class implements a set of tensors using the same
+# technique as is used in the function call memoizer: we encode
+# the data in the tensor into a tuple with the same shape. The
+# tuple implements hashing and equality correctly, so we can put
+# it in a set.
 
 
 class SetOfTensors(collections.abc.Set):
-    """Tensors cannot be put into a normal set because tensors that compare as
-    equal do not hash to equal hashes. This is a linear-time set implementation.
-    Most of the time the sets will be very small."""
-
-    elements: List[Tensor]
+    _elements: Set[Tuple]
 
     def __init__(self, iterable):
-        self.elements = []
+        self._elements = set()
         for value in iterable:
             t = value if isinstance(value, Tensor) else tensor(value)
-            if t not in self.elements:
-                self.elements.append(t)
+            self._elements.add(tensor_to_tuple(t))
 
     def __iter__(self):
-        return iter(self.elements)
+        return (tensor(t) for t in self._elements)
 
     def __contains__(self, value):
-        return value in self.elements
+        t = value if isinstance(value, Tensor) else tensor(value)
+        return tensor_to_tuple(t) in self._elements
 
     def __len__(self):
-        return len(self.elements)
+        return len(self._elements)

--- a/src/beanmachine/ppl/utils/tests/set_of_tensors_test.py
+++ b/src/beanmachine/ppl/utils/tests/set_of_tensors_test.py
@@ -1,0 +1,52 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import unittest
+
+from beanmachine.ppl.utils.set_of_tensors import SetOfTensors
+from torch import tensor
+
+
+class SetOfTensorsTest(unittest.TestCase):
+    def test_set_of_tensors_1(self) -> None:
+        self.maxDiff = None
+
+        # Show that we deduplicate these tensors.
+
+        t = [
+            tensor(1.0),
+            tensor([]),
+            tensor([1.0]),
+            tensor([1.0, 2.0]),
+            tensor([1.0, 2.0, 3.0, 4.0]),
+            tensor([[1.0]]),
+            tensor([[1.0], [2.0]]),
+            tensor([[1.0, 2.0]]),
+            tensor([[1.0, 2.0], [3.0, 4.0]]),
+            tensor(1.0),
+            tensor([]),
+            tensor([1.0]),
+            tensor([1.0, 2.0]),
+            tensor([1.0, 2.0, 3.0, 4.0]),
+            tensor([[1.0]]),
+            tensor([[1.0], [2.0]]),
+            tensor([[1.0, 2.0]]),
+            tensor([[1.0, 2.0], [3.0, 4.0]]),
+        ]
+
+        s = SetOfTensors(t)
+
+        self.assertEqual(9, len(s))
+
+        observed = "\n".join(sorted(str(i) for i in s))
+        expected = """
+tensor(1.)
+tensor([1., 2., 3., 4.])
+tensor([1., 2.])
+tensor([1.])
+tensor([[1., 2.],
+        [3., 4.]])
+tensor([[1., 2.]])
+tensor([[1.],
+        [2.]])
+tensor([[1.]])
+tensor([])"""
+        self.assertEqual(expected.strip(), observed.strip())


### PR DESCRIPTION
Summary:
My SetOfTensors class now does what it says on the tin: makes a deduplicated set of tensors.

I have not implemented all the features you'd typically find in a set; I only need construction, length, iteration and membership so that's all I've done.

Because tensors do not implement hashing or equality in the manner necessary to do set membership, I've created a wrapper around a set of tuples or values where the tuples/values have the same "shape" as the corresponding tensor.  I do this because tuples do implement hashing and equality, so I can make a set of tensor equivalents and convert them back to tensors on demand.

Reviewed By: wtaha

Differential Revision: D30115798

