### PR TITLE
Start implementing nonrecursive graph node support computation

### DIFF
--- a/src/beanmachine/ppl/compiler/support.py
+++ b/src/beanmachine/ppl/compiler/support.py
@@ -1,0 +1,188 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+# See notes in typer_base.py for how the type computation logic works.
+#
+# This typer computes all possible tensor values that a graph node can
+# possibly have. For example, if we have a random variable:
+#
+# @rv def flips(n):
+#   return Bernoulli(0.5)
+#
+# @functional def sumflips():
+#    return flips(0) + flips(1)
+#
+# Then the sample nodes each have a two-value support {0, 1} --
+# and the addition node has a support {0, 1, 2}.
+#
+# Some nodes -- a sample from a normal, for instance -- have infinite
+# support; we mark those with a special value. Similarly, some nodes
+# have finite but large support, where "large" is a parameter we can
+# choose; to keep graphs relatively small we will refuse to compile
+# a model where there are thousands of samples associated with a
+# particular call. For example, suppose we have K categories:
+#
+# @rv def cat():
+#   return Categorical(tensor([1, 1, 1, 1, 1, ...]))
+#
+# @rv def norm(n):
+#   return Normal(0, 1)
+#
+# @functional toobig():
+#   return whatever(cat())
+#
+# That model generates K normal samples; we want to restrict that
+# to "small" K.
+
+
+import functools
+import itertools
+from math import isnan
+from typing import Callable, Dict
+
+import beanmachine.ppl.compiler.bmg_nodes as bn
+from beanmachine.ppl.compiler.bmg_nodes import SetOfTensors, positive_infinity
+from beanmachine.ppl.compiler.sizer import Sizer
+from beanmachine.ppl.compiler.typer_base import TyperBase
+from torch import tensor
+
+Infinite = SetOfTensors([])
+TooBig = SetOfTensors([])
+Unknown = SetOfTensors([])
+
+_limit = 1000
+
+_always_infinite = {
+    bn.BetaNode,
+    bn.Chi2Node,
+    bn.DirichletNode,
+    bn.FlatNode,
+    bn.GammaNode,
+    bn.HalfCauchyNode,
+    bn.HalfNormalNode,
+    bn.NormalNode,
+    bn.PoissonNode,
+    bn.StudentTNode,
+    bn.UniformNode,
+}
+
+_nan = float("nan")
+
+
+def _set_approximate_size(s: SetOfTensors) -> float:
+    if s is Infinite:
+        return positive_infinity
+    if s is Unknown:
+        return _nan
+    if s is TooBig:
+        return _limit
+    return len(s)
+
+
+def _set_product_approximate_size(x: float, y: SetOfTensors) -> float:
+    # If either size is unknown (NaN), we return NaN.
+    # Otherwise, if either size is infinite, we return infinite.
+    # Otherwise, return the product.
+    return x * _set_approximate_size(y)
+
+
+class ComputeSupport(TyperBase[SetOfTensors]):
+
+    _dispatch: Dict[type, Callable]
+    _sizer: Sizer
+
+    def __init__(self) -> None:
+        TyperBase.__init__(self)
+        self._sizer = Sizer()
+        self._dispatch = {
+            bn.BernoulliLogitNode: self._support_bernoulli,
+            bn.BernoulliNode: self._support_bernoulli,
+            bn.SampleNode: self._support_sample,
+            bn.TensorNode: self._support_tensor,
+        }
+
+    def _product(self, f: Callable, *nodes: bn.BMGNode) -> SetOfTensors:
+        # * We have a sequence of nodes n[0], n[1], ... n[k-1].
+        #
+        # * Each of those nodes has possible values t[x][0], t[x][1] ...
+        #   for x from 0 to k-1.
+        #
+        # * We have a function f which takes k tensors and returns a tensor.
+        #
+        # * We wish to compute the set:
+        #
+        # {
+        #   f(t[0][0], t[1][0], ... t[k-1][0]),
+        #   f(t[0][1], t[1][0], ... t[k-1][0]),
+        #   ...
+        # }
+        #
+        # That is, the Cartesian product of all possible combinations of
+        # values of each node, with each element of the product run through
+        # function f.
+        #
+        # However, we have some problems:
+        #
+        # * The support of a node might be infinite.
+        # * The support of a node might be unknown.
+        # * The support of a node might be finite but large.
+        # * The size of the product might be finite but large.
+        #
+        # In those cases we want to return special values Infinite, Unknown
+        # or TooBig rather than wasting time and memory to compute the set.
+        #
+        # ####
+        #
+        # First thing to do is determine the *approximate* size of the
+        # Cartesian product of possible values.
+
+        size = functools.reduce(
+            lambda acc, node: _set_product_approximate_size(acc, self[node]), nodes, 1.0
+        )
+
+        if size == positive_infinity:
+            return Infinite
+        if isnan(size):
+            return Unknown
+        if size >= _limit:
+            return TooBig
+
+        # If we've made it here then every node had a small support
+        # and the product of the approximate sizes was small too.
+        # We can just take the Cartesian product and call f.
+
+        return SetOfTensors(f(c) for c in itertools.product(*(self[n] for n in nodes)))
+
+    def _support_bernoulli(self, node: bn.BernoulliBase) -> SetOfTensors:
+        # The support of a Bernoulli only depends on the shape of its input,
+        # not on the content of that input. Suppose we have a Bernoulli
+        # of shape [1, 2, 3]; there are 1x2x3 = 6 values in the output
+        # each of which is either 0 or 1, so that's 64 possibilities. If
+        # we have too big a shape then just bail out rather than handling
+        # thousands or millions of possibilities.
+        s = self._sizer[node]
+        p = bn.prod(s)
+        if 2.0 ** p >= _limit:
+            return TooBig
+        return SetOfTensors(
+            tensor(i).reshape(s) for i in itertools.product(*([[0.0, 1.0]] * p))
+        )
+
+    def _support_sample(self, node: bn.SampleNode) -> SetOfTensors:
+        return self[node.operand]
+
+    def _support_tensor(self, node: bn.TensorNode) -> SetOfTensors:
+        return self._product(tensor, *node.inputs)
+
+    # This implements the abstract base type method.
+    def _compute_type_inputs_known(self, node: bn.BMGNode) -> SetOfTensors:
+        if isinstance(node, bn.ConstantNode):
+            return SetOfTensors([node.value])
+        t = type(node)
+        if t in _always_infinite:
+            result = Infinite
+        elif t in self._dispatch:
+            result = self._dispatch[t](node)
+        else:
+            result = Unknown
+
+        return result

--- a/src/beanmachine/ppl/compiler/tests/support_test.py
+++ b/src/beanmachine/ppl/compiler/tests/support_test.py
@@ -1,12 +1,20 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
-"""Tests for bm_graph_builder.py"""
 import unittest
 from typing import Any
 
+import beanmachine.ppl as bm
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
 from beanmachine.ppl.compiler.bmg_nodes import positive_infinity
+from beanmachine.ppl.compiler.runtime import BMGRuntime
+from beanmachine.ppl.compiler.support import ComputeSupport, Infinite
 from beanmachine.ppl.utils.set_of_tensors import SetOfTensors
 from torch import Size, Tensor, tensor
+from torch.distributions import Bernoulli, Normal
+
+# TODO: The first half of this file tests the support instance method
+# on nodes which we are going to delete and replace with a nonrecursive
+# support computation in its own module.  Delete these tests once
+# that is ready.
 
 
 def tidy(s: str) -> str:
@@ -18,6 +26,26 @@ def tensor_equality(x: Tensor, y: Tensor) -> bool:
     # tensor([1.0, 2.0]). Then x.eq(y) is tensor([True, True]),
     # and x.eq(y).all() is tensor(True).
     return bool(x.eq(y).all())
+
+
+@bm.random_variable
+def flip1(n):
+    return Bernoulli(0.5)
+
+
+@bm.random_variable
+def flip2(n):
+    return Bernoulli(tensor([[0.5, 0.5]]))
+
+
+@bm.functional
+def to_tensor():
+    return tensor([2.5, flip1(0), flip1(1), flip1(2)])
+
+
+@bm.random_variable
+def normal():
+    return Normal(0.0, 1.0)
 
 
 class NodeSupportTest(unittest.TestCase):
@@ -90,3 +118,50 @@ class NodeSupportTest(unittest.TestCase):
         # Exp(normal) has infinite support
         en = bmg.add_exp(n1)
         self.assertEqual(en.support_size(), positive_infinity)
+
+    def test_bernoulli_support(self) -> None:
+
+        self.maxDiff = None
+
+        rt = BMGRuntime()
+        rt.accumulate_graph([flip2(0)], {})
+        sample = rt._rv_to_node(flip2(0))
+        s = ComputeSupport()
+        observed = str(s[sample])
+        expected = """
+tensor([[0., 0.]])
+tensor([[0., 1.]])
+tensor([[1., 0.]])
+tensor([[1., 1.]])"""
+
+        self.assertEqual(expected.strip(), observed.strip())
+
+    def test_stochastic_tensor_support(self) -> None:
+        self.maxDiff = None
+
+        rt = BMGRuntime()
+        rt.accumulate_graph([to_tensor()], {})
+        tm = rt._rv_to_node(to_tensor())
+        s = ComputeSupport()
+        observed = str(s[tm])
+        expected = """
+tensor([2.5000, 0.0000, 0.0000, 0.0000])
+tensor([2.5000, 0.0000, 0.0000, 1.0000])
+tensor([2.5000, 0.0000, 1.0000, 0.0000])
+tensor([2.5000, 0.0000, 1.0000, 1.0000])
+tensor([2.5000, 1.0000, 0.0000, 0.0000])
+tensor([2.5000, 1.0000, 0.0000, 1.0000])
+tensor([2.5000, 1.0000, 1.0000, 0.0000])
+tensor([2.5000, 1.0000, 1.0000, 1.0000])
+"""
+
+        self.assertEqual(expected.strip(), observed.strip())
+
+    def test_infinite_support(self) -> None:
+        self.maxDiff = None
+        rt = BMGRuntime()
+        rt.accumulate_graph([normal()], {})
+        sample = rt._rv_to_node(normal())
+        s = ComputeSupport()
+        observed = s[sample]
+        self.assertEqual(Infinite, observed)

--- a/src/beanmachine/ppl/utils/set_of_tensors.py
+++ b/src/beanmachine/ppl/utils/set_of_tensors.py
@@ -34,3 +34,6 @@ class SetOfTensors(collections.abc.Set):
 
     def __len__(self):
         return len(self._elements)
+
+    def __str__(self):
+        return "\n".join(sorted(str(t) for t in self))

--- a/src/beanmachine/ppl/utils/tests/set_of_tensors_test.py
+++ b/src/beanmachine/ppl/utils/tests/set_of_tensors_test.py
@@ -36,7 +36,7 @@ class SetOfTensorsTest(unittest.TestCase):
 
         self.assertEqual(9, len(s))
 
-        observed = "\n".join(sorted(str(i) for i in s))
+        observed = str(s)
         expected = """
 tensor(1.)
 tensor([1., 2., 3., 4.])


### PR DESCRIPTION
Summary:
To handle stochastic control flows of the form

    some_rv(some_stochastic_expression_with_finite_support)

we need to enumerate that finite support during graph accumulation. However, there could be thousands of nodes that are ancestors of that stochastic expression, and the support might depend on all of them. We cannot compute the support recursively because if there is a long path through the graph, we blow Python's recursion limit.

We already have a base class which implements non-recursive computation and memoization of a per-node property; this is the base class used by the lattice typer and node sizer. We therefore extend it once more to assign supports to nodes.

We represent a support by a set of tensors. Much of the time this will just be an ordinary deduplicated set of tensors; there are three cases where it is not:

* If the support of a node is infinite -- say, a sample from a normal -- then we represent it as a special Infinite value.
* Some stochastic nodes will have finite but large support. We can estimate the size of the support before we compute it, and if it is likely to be too large, we skip the computation and represent it as a special "too big" value
* Nodes for which we have not yet implemented computation of the support will be represented by an "unknown" value.

In this diff I just implement computing support for:

* samples from infinite-support distributions
* samples from Bernoulli draws of arbitrary tensor size
* construction of stochastic tensors

We'll add the rest in subsequent diffs.

We have an existing implementation of support computation via instance methods which is (1) recursive and (2) frequently wrong. Once all necessary nodes have their support computation added to the new class, I will delete the instance methods.

Reviewed By: wtaha

Differential Revision: D30050828

