### PR TITLE
Add constant folding optimization for index operations

### DIFF
--- a/src/beanmachine/ppl/compiler/fix_unsupported.py
+++ b/src/beanmachine/ppl/compiler/fix_unsupported.py
@@ -66,29 +66,41 @@ class UnsupportedNodeFixer(ProblemFixerBase):
         mult = self._bmg.add_multiplication(node.df, half)
         return self._bmg.add_gamma(mult, half)
 
+    def _replace_index_one_column(self, node: bn.IndexNode) -> bn.BMGNode:
+        left = node.left
+        right = node.right
+        typer = self._typer
+        assert isinstance(typer, LatticeTyper)
+
+        # It is possible during rewrites to end up with a constant for both
+        # operands of the index; in that case, fold the index away entirely.
+
+        # If we have a ToMatrix indexed by a constant, we can similarly
+        # eliminate the indexing operation.
+
+        if isinstance(right, bn.ConstantNode) and typer.is_natural(right):
+            r = int(right.value)
+            if isinstance(left, bn.ConstantNode):
+                return self._bmg.add_constant(left.value[r])
+            if isinstance(left, bn.ToMatrixNode):
+                return left.inputs[r + 2]
+
+        # We cannot optimize it away; add a vector index operation.
+        return self._bmg.add_vector_index(left, right)
+
     def _replace_index(self, node: bn.IndexNode) -> Optional[bn.BMGNode]:
         # * If we have an index into a one-column matrix, replace it with
         #   a vector index.
         # * If we have an index into a multi-column matrix, replace it with
         #   a column index
-        # TODO: Consider if there are more optimizations we can make here
-        # if either operand is a constant.
-        typer = self._typer
-        assert isinstance(typer, LatticeTyper)
-        right = node.right
         left = node.left
-        node_type = typer[left]
-        if isinstance(node_type, bt.BMGMatrixType):
-            if node_type.columns == 1:
-                if (
-                    isinstance(left, bn.ToMatrixNode)
-                    and isinstance(right, bn.ConstantNode)
-                    and typer.is_natural(right)
-                ):
-                    return left.inputs[right.value + 2]
-                return self._bmg.add_vector_index(left, right)
-            return self._bmg.add_column_index(left, right)
-        return None
+        node_type = self._typer[left]
+        if not isinstance(node_type, bt.BMGMatrixType):
+            return None
+        right = node.right
+        if node_type.columns == 1:
+            return self._replace_index_one_column(node)
+        return self._bmg.add_column_index(left, right)
 
     def _replace_lse(self, node: bn.LogSumExpTorchNode) -> Optional[bn.BMGNode]:
         # We only support compiling models where dim=0 and keepDims=False.

--- a/src/beanmachine/ppl/compiler/tests/fix_vectorized_models_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_vectorized_models_test.py
@@ -79,16 +79,14 @@ digraph "graph" {
   N09[label=Sample];
   N10[label=ToMatrix];
   N11[label=Query];
-  N12[label="[0.25,0.75]"];
-  N13[label=0];
-  N14[label=index];
-  N15[label=Bernoulli];
-  N16[label=Sample];
-  N17[label=index];
-  N18[label=Bernoulli];
-  N19[label=Sample];
-  N20[label=ToMatrix];
-  N21[label=Query];
+  N12[label=0.25];
+  N13[label=Bernoulli];
+  N14[label=Sample];
+  N15[label=0.75];
+  N16[label=Bernoulli];
+  N17[label=Sample];
+  N18[label=ToMatrix];
+  N19[label=Query];
   N00 -> N01;
   N00 -> N01;
   N01 -> N02;
@@ -96,25 +94,21 @@ digraph "graph" {
   N02 -> N06;
   N03 -> N08;
   N04 -> N10;
-  N04 -> N20;
+  N04 -> N18;
   N05 -> N10;
-  N05 -> N17;
-  N05 -> N20;
+  N05 -> N18;
   N06 -> N07;
   N07 -> N10;
   N08 -> N09;
   N09 -> N10;
   N10 -> N11;
-  N12 -> N14;
-  N12 -> N17;
+  N12 -> N13;
   N13 -> N14;
-  N14 -> N15;
+  N14 -> N18;
   N15 -> N16;
-  N16 -> N20;
+  N16 -> N17;
   N17 -> N18;
   N18 -> N19;
-  N19 -> N20;
-  N20 -> N21;
 }
 """
         self.assertEqual(expected.strip(), observed.strip())


### PR DESCRIPTION
Summary:
When a rewriter generates an indexing operation it is possible to end up with constants for both the collection and the index; in that case we can write a constant folding optimization.  In this diff I refactored the index rewriter to make the logic a bit easier to follow by extracting the code for vector index to its own method, and then added a case for constants for both operands.

Graph before optimization implemented:

{F639574527}

after optimization:

{F639592295}

Reviewed By: wtaha

Differential Revision: D30167970

