### PR TITLE
Start eliminating _required_columns property

### DIFF
--- a/src/beanmachine/ppl/compiler/bmg_node_types.py
+++ b/src/beanmachine/ppl/compiler/bmg_node_types.py
@@ -16,6 +16,8 @@ from beanmachine.graph import (
     ValueType,
     VariableType,
 )
+from beanmachine.ppl.compiler.bmg_types import SimplexMatrix
+from beanmachine.ppl.compiler.lattice_typer import LatticeTyper
 
 
 _factor_types = {
@@ -46,11 +48,13 @@ _dist_types = {
 def dist_type(node: bn.DistributionNode) -> Tuple[dt, Any]:
     t = type(node)
     if t is bn.DirichletNode:
+        simplex = LatticeTyper()[node]
+        assert isinstance(simplex, SimplexMatrix)
         element_type = ValueType(
             VariableType.COL_SIMPLEX_MATRIX,
             AtomicType.PROBABILITY,
-            node._required_columns,
-            1,
+            simplex.rows,
+            simplex.columns,
         )
         return dt.DIRICHLET, element_type
     return _dist_types[t]

--- a/src/beanmachine/ppl/compiler/gen_bmg_python.py
+++ b/src/beanmachine/ppl/compiler/gen_bmg_python.py
@@ -10,8 +10,9 @@ from beanmachine.ppl.compiler.bmg_node_types import (
     factor_type,
     operator_type,
 )
-from beanmachine.ppl.compiler.bmg_types import _size_to_rc
+from beanmachine.ppl.compiler.bmg_types import _size_to_rc, SimplexMatrix
 from beanmachine.ppl.compiler.fix_problems import fix_problems
+from beanmachine.ppl.compiler.lattice_typer import LatticeTyper
 
 
 def _tensor_to_python(t: torch.Tensor) -> str:
@@ -74,13 +75,15 @@ class GeneratedGraphPython:
         self.node_to_graph_id[node] = graph_id
         i = self._inputs(node)
         if isinstance(node, bn.DirichletNode):
+            t = LatticeTyper()[node]
+            assert isinstance(t, SimplexMatrix)
             self._code.append(f"n{graph_id} = g.add_distribution(")
             self._code.append("  graph.DistributionType.DIRICHLET,")
             self._code.append("  graph.ValueType(")
             self._code.append("    graph.VariableType.COL_SIMPLEX_MATRIX,")
             self._code.append("    graph.AtomicType.PROBABILITY,")
-            self._code.append(f"    {node._required_columns},")
-            self._code.append("    1,")
+            self._code.append(f"    {t.rows},")
+            self._code.append(f"    {t.columns},")
             self._code.append("  ),")
             self._code.append(f"  {i},")
             self._code.append(")")


### PR DESCRIPTION
Summary:
I wish to remove the `size` property from all graph nodes, which means first eliminating all code which consumes this property.  The `_required_columns` property on a Dirichlet node uses this property; this does not need to be a property of the node.  We can compute it when we need it in the lattice typer or sizer. (And also the property is misnamed, as it has the semantics of required *rows*.  Might as well delete it instead of fixing the name.)

This diff begins the process of removing usages of this property, starting with the code generators.

Reviewed By: wtaha

Differential Revision: D30586326

