### PR TITLE
Updated setup to use latest version of FlowTorch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ setup(
         "botorch>=0.3.3",
         "xarray>=0.16.0",
         "arviz>=0.11.0",
-        "flowtorch>=0.2",
+        "flowtorch>=0.3",
         "parameterized>=0.8.1",
     ],
     packages=find_packages("src/"),


### PR DESCRIPTION
Summary:
Updated BeanMachine's setup.py so that it uses FlowTorch >= 0.3.

I am having trouble checking out D30972439, which is identical this this diff, to rerun tests that failed due to unknown infra problems...

The exact error is:
```
This patch cannot be applied:
patching file fbcode/beanmachine/sphinx/source/conf.py
Hunk #1 FAILED at 44
1 out of 1 hunks FAILED -- saving rejects to file fbcode/beanmachine/sphinx/source/conf.py.rej
abort: patch failed to apply```

Reviewed By: ericlippert

Differential Revision: D31025741

