### PR TITLE
Finish removing _required_columns property from Dirichlet node

### DIFF
--- a/src/beanmachine/ppl/compiler/bmg_nodes.py
+++ b/src/beanmachine/ppl/compiler/bmg_nodes.py
@@ -642,16 +642,6 @@ class DirichletNode(DistributionNode):
     def concentration(self) -> BMGNode:
         return self.inputs[0]
 
-    # TODO: Rename this required_rows or required_length
-    @property
-    def _required_columns(self) -> int:
-        # The "max" is needed to handle the degenerate case of
-        # Dirichlet(tensor([])) -- in this case we will say that we require
-        # a single positive real and that the requirement cannot be met.
-        size = self.size
-        dimensions = len(size)
-        return max(1, size[dimensions - 1]) if dimensions > 0 else 1
-
     @property
     def size(self) -> torch.Size:
         return self.concentration.size

--- a/src/beanmachine/ppl/compiler/bmg_requirements.py
+++ b/src/beanmachine/ppl/compiler/bmg_requirements.py
@@ -126,11 +126,24 @@ class EdgeRequirements:
         # not a broadcast matrix. Do some research here; do we actually
         # need the semantics of "always a broadcast matrix" ?
 
-        # TODO: Note that "required_columns" here is misnamed; it should be
-        # "required_length".
+        # To compute the requirement we get the matrix column size of the input.
+
+        input_type = self.typer[node]
+        required_columns = 1
+        required_rows = 1
+
+        # TODO: This will produce a bad error message experience. What we want to
+        # say in the case where the input is not a matrix at all is "we require a
+        # one-column positive real matrix" and not "we require a 1x1 positive real
+        # matrix".
+
+        if isinstance(input_type, bt.BMGMatrixType):
+            required_rows = input_type.rows
 
         return [
-            bt.always_matrix(bt.PositiveReal.with_dimensions(node._required_columns, 1))
+            bt.always_matrix(
+                bt.PositiveReal.with_dimensions(required_rows, required_columns)
+            )
         ]
 
     def _requirements_categorical(

--- a/src/beanmachine/ppl/compiler/lattice_typer.py
+++ b/src/beanmachine/ppl/compiler/lattice_typer.py
@@ -172,7 +172,14 @@ class LatticeTyper(TyperBase[bt.BMGLatticeType]):
         return self[node.operator]
 
     def _type_dirichlet(self, node: bn.DirichletNode) -> bt.BMGLatticeType:
-        return bt.SimplexMatrix(node._required_columns, 1)
+        # The type of a Dirichlet node is a one-column simplex with as many
+        # rows as its input.
+        input_type = self[node.concentration]
+        rows = 1
+        columns = 1
+        if isinstance(input_type, bt.BMGMatrixType):
+            rows = input_type.rows
+        return bt.SimplexMatrix(rows, columns)
 
     def _type_addition(self, node: bn.BMGNode) -> bt.BMGLatticeType:
         op_type = bt.supremum(*[self[i] for i in node.inputs])

--- a/src/beanmachine/ppl/compiler/tests/dirichlet_test.py
+++ b/src/beanmachine/ppl/compiler/tests/dirichlet_test.py
@@ -297,9 +297,9 @@ digraph "graph" {
   N22[label="Sample:S[2,1]"];
   N23[label="Query:S[2,1]"];
   N24[label="[[[4.5,5.0]]]:T"];
-  N25[label="Dirichlet:S[2,1]"];
-  N26[label="Sample:S[2,1]"];
-  N27[label="Query:S[2,1]"];
+  N25[label="Dirichlet:S[1,1]"];
+  N26[label="Sample:S[1,1]"];
+  N27[label="Query:S[1,1]"];
   N28[label="[[5.5,6.0,6.5],\\\\n[7.0,7.5,8.0]]:MR+[3,2]"];
   N29[label="Dirichlet:S[3,1]"];
   N30[label="Sample:S[3,1]"];
@@ -322,8 +322,8 @@ digraph "graph" {
   N20 -> N21[label="MR+[2,1]"];
   N21 -> N22[label="S[2,1]"];
   N22 -> N23[label=any];
-  N24 -> N25[label="MR+[2,1]"];
-  N25 -> N26[label="S[2,1]"];
+  N24 -> N25[label="R+"];
+  N25 -> N26[label="S[1,1]"];
   N26 -> N27[label=any];
   N28 -> N29[label="MR+[3,1]"];
   N29 -> N30[label="S[3,1]"];


### PR DESCRIPTION
Summary:
I have finished removing the incorrectly named, badly located and poorly implemented `_required_columns` property from `DirichletNode`.  The name was wrong because it actually computed required rows; it was badly located because the input requirement is a concern of the BMG requirements module, not the node, and it was poorly implemented because it tried to handle input types unsupported by BMG.

All these problems are now fixed; the logic is no longer in the node so the badly named method no longer exists. The code is now relocated to the lattice type and requirements modules. The implementation now makes no attempt to handle unsupported scenarios; in the case where a model has an unsupported tensor shape as the Dirichlet input we give up on attempting to determine its type and default to "1x1 simplex", and then give an error during requirements checking.

This diff furthers the larger objective of removing the `size` property from node classes.

Reviewed By: wtaha

Differential Revision: D30592028

