### PR TITLE
Small bug fix diff to table containing upper bound calculation for types

### DIFF
--- a/src/beanmachine/ppl/compiler/bmg_types.py
+++ b/src/beanmachine/ppl/compiler/bmg_types.py
@@ -128,6 +128,9 @@ class BMGMatrixType(BMGLatticeType):
         r, c = _size_to_rc(size)
         return self.with_dimensions(c, r)
 
+    def is_singleton(self) -> int:
+        return self.rows * self.columns == 1
+
 
 class BroadcastMatrixType(BMGMatrixType):
     def __init__(self, element_type: BMGElementType, rows: int, columns: int) -> None:
@@ -450,9 +453,9 @@ def _lookup():
             (S, P): ProbabilityMatrix,
             (S, S): SimplexMatrix,
             (S, N): PositiveRealMatrix,
-            (S, B): PositiveRealMatrix,
+            (S, B): ProbabilityMatrix,
             (S, OH): SimplexMatrix,
-            (S, Z): RealMatrix,
+            (S, Z): ProbabilityMatrix,
             (N, R): RealMatrix,
             (N, RP): PositiveRealMatrix,
             (N, RN): RealMatrix,
@@ -484,7 +487,7 @@ def _lookup():
             (Z, RP): PositiveRealMatrix,
             (Z, RN): NegativeRealMatrix,
             (Z, P): ProbabilityMatrix,
-            (Z, S): SimplexMatrix,
+            (Z, S): ProbabilityMatrix,
             (Z, N): NaturalMatrix,
             (Z, B): BooleanMatrix,
             (Z, OH): BooleanMatrix,

--- a/src/beanmachine/ppl/compiler/tests/bmg_types_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_types_test.py
@@ -25,12 +25,36 @@ from beanmachine.ppl.compiler.bmg_types import (
     bottom,
     supremum,
     type_of_value,
+    _lookup,
 )
 from beanmachine.ppl.compiler.gen_dot import to_dot
 from torch import tensor
 
 
 class BMGTypesTest(unittest.TestCase):
+    def test_lookup_table(self) -> None:
+        """Tests _lookup_table for some basic properties"""
+        # This is a simple example of "property based testing"
+        # Since the search space is finite, we can do it exhaustively
+        lookup_table = _lookup()
+        keys = lookup_table.keys()
+        for key in keys:
+            a, b = key
+            class_1 = lookup_table[(a, b)]
+            class_2 = lookup_table[(b, a)]
+            # symmertry
+            self.assertEqual(
+                class_1(1, 1),
+                class_2(1, 1),
+                msg="Table breaks symmertry when inputs are ("
+                + str(a)
+                + ","
+                + str(b)
+                + ")",
+            )
+
+        return
+
     def test_supremum(self) -> None:
         """test_supremum"""
 


### PR DESCRIPTION
Summary: We expect sup(a,b) to be symmetric. That kind of property makes for nice tests, and caught a few minute discrepencies. This diff fixes them.  Would be fun to add a few more diffs like this, such as associativity of this operator.

Differential Revision: D31172843

