### PR TITLE
Fix bug in requirements checker

### DIFF
--- a/src/beanmachine/ppl/compiler/bmg_types.py
+++ b/src/beanmachine/ppl/compiler/bmg_types.py
@@ -664,6 +664,18 @@ def is_one(v: Any) -> bool:
     return type_of_value(v) == One
 
 
+def lattice_to_bmg(t: BMGLatticeType) -> BMGLatticeType:
+    # There are situations where we have a Zero or One type in hand
+    # but those are just used for type convertibility analysis;
+    # we sometimes actually need a valid BMG type. In those
+    # situations, choose Boolean.
+    assert t is not Tensor
+    assert t is not Untypable
+    if isinstance(t, OneHotMatrix) or isinstance(t, ZeroMatrix):
+        return BooleanMatrix(t.rows, t.columns)
+    return t
+
+
 # TODO: Move this to bmg_requirements.py
 
 # We need to be able to express requirements on inputs;

--- a/src/beanmachine/ppl/compiler/fix_requirements.py
+++ b/src/beanmachine/ppl/compiler/fix_requirements.py
@@ -76,8 +76,14 @@ class RequirementsFixer:
         # NOTE: By this point we should have already rejected any graph that contains
         # a reachable but untypable constant node.  See comment in fix_unsupported
         # regarding UntypedConstantNode support.
+
         if self._type_meets_requirement(it, bt.upper_bound(requirement)):
-            required_type = bt.requirement_to_type(requirement)
+            if isinstance(requirement, bt.AnyRequirement):
+                # The lattice type of the constant might be Zero or One; in that case,
+                # generate a bool constant node.
+                required_type = bt.lattice_to_bmg(it)
+            else:
+                required_type = bt.requirement_to_type(requirement)
             if bt.must_be_matrix(requirement):
                 assert isinstance(required_type, bt.BMGMatrixType)
                 result = self.bmg.add_constant_of_matrix_type(node.value, required_type)


### PR DESCRIPTION
Summary:
There's a previously unexercised code path in the requirements checker that Walid came across which caused an assertion to fire. This diff fixes that problem.

When we accumulate a graph we mark all the non-stochastic constant nodes as "untyped" initially, and assume that during requirements checking, every untyped constant will have an edge emerging from it that has a specific BMG type as its requirement.  We then replace the untyped constant node with a correctly typed BMG constant node.

This assumption is not necessarily correct; we could have a situation where an edge has an "any" requirement -- that is, allow an input of any type -- and the edge goes from an untyped constant to, say, an operator. In this situation we still need to deduce a type for the constant. Previously this never happened but Walid has created a scenario in which it does.

What if we have an "any" requirement but the node is a constant not representable at all in BMG? That seems bad. But by the type we get to requirements checking we have already rejected constant nodes that are not representable at all in BMG, so we don't need to worry about that. We know the node is representable in BMG; we just need to ensure that we produce a valid constant node.

What we do now is: if we are checking an outgoing edge requirement on a constant, and the requirement is "any", then the required BMG type of the node is the current BMG type of the value. However, there is one wrinkle: the lattice typer will classify False/0 and True/1 as having types Zero and One, to indicate that they are convertible to many other types. In those cases we'll deduce that what the user wants here is a bool constant node.  The requirement is "any" and a boolean meets that requirement.

Reviewed By: wtaha

Differential Revision: D31157835

