### PR TITLE
Adding graph structure metadata to the new world

### DIFF
--- a/src/beanmachine/ppl/experimental/global_inference/proposer/tests/hmc_proposer_test.py
+++ b/src/beanmachine/ppl/experimental/global_inference/proposer/tests/hmc_proposer_test.py
@@ -60,4 +60,4 @@ def test_leapfrog_step(world, hmc):
         world, momentums, step_size, hmc._mass_inv
     )
     assert momentums == new_momentums
-    assert new_world._transformed_values == world._transformed_values
+    assert new_world._variables == world._variables

--- a/src/beanmachine/ppl/experimental/global_inference/simple_world.py
+++ b/src/beanmachine/ppl/experimental/global_inference/simple_world.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
-from typing import Dict, Iterator, MutableMapping, Optional, Set
+import dataclasses
+from typing import Dict, Iterator, Mapping, Optional, Set, List
 
 import torch
 import torch.distributions as dist
+from beanmachine.ppl.experimental.global_inference.variable import Variable
 from beanmachine.ppl.model.rv_identifier import RVIdentifier
 from beanmachine.ppl.world.base_world import BaseWorld
 from beanmachine.ppl.world.utils import get_default_transforms
@@ -12,100 +14,112 @@ from beanmachine.ppl.world.utils import get_default_transforms
 RVDict = Dict[RVIdentifier, torch.Tensor]
 
 
-class SimpleWorld(BaseWorld, MutableMapping[RVIdentifier, torch.Tensor]):
+@dataclasses.dataclass
+class _TempVar:
+    node: RVIdentifier
+    parents: Set[RVIdentifier] = dataclasses.field(default_factory=set)
+
+
+class SimpleWorld(BaseWorld, Mapping[RVIdentifier, torch.Tensor]):
     def __init__(
         self,
         observations: Optional[RVDict] = None,
         initialize_from_prior: bool = False,
-        transforms: Optional[Dict[RVIdentifier, dist.Transform]] = None,
     ):
         self.observations: RVDict = observations or {}
         self.initialize_from_prior: bool = initialize_from_prior
-        self._transformed_values: RVDict = {}
-        self.transforms = transforms or {}
+        self._variables: Dict[RVIdentifier, Variable] = {}
+
+        self._call_stack: List[_TempVar] = []
 
     def __getitem__(self, node: RVIdentifier) -> torch.Tensor:
-        return self.transforms[node].inv(self._transformed_values[node])
-
-    def __setitem__(self, node: RVIdentifier, value: torch.Tensor) -> None:
-        assert node in self.transforms
-        if node not in self.observations:
-            self._transformed_values[node] = self.transforms[node](value)
+        node_var = self._variables[node]
+        return node_var.transform.inv(node_var.transformed_value)
 
     def get_transformed(self, node: RVIdentifier) -> torch.Tensor:
         """Return the value of the node in the unconstrained space"""
-        return self._transformed_values[node]
+        return self._variables[node].transformed_value
 
     def set_transformed(self, node: RVIdentifier, value: torch.Tensor) -> None:
         """Set the value of the node in the unconstrained space"""
-        assert node in self.transforms
-        self._transformed_values[node] = value
-
-    def __delitem__(self, node: RVIdentifier) -> None:
-        del self._transformed_values[node]
-        del self.transforms[node]
+        self._variables[node].transformed_value = value
 
     def __iter__(self) -> Iterator[RVIdentifier]:
-        return iter(self._transformed_values)
+        return iter(self._variables)
 
     def __len__(self) -> int:
-        return len(self._transformed_values)
+        return len(self._variables)
 
     @property
     def latent_nodes(self) -> Set[RVIdentifier]:
         """Return a KeysView of all latent nodes in the current world"""
-        return self._transformed_values.keys() - self.observations.keys()
+        return self._variables.keys() - self.observations.keys()
 
     def copy(self) -> SimpleWorld:
         """Returns a shallow copy of the current world"""
-        world_copy = SimpleWorld(
-            self.observations.copy(), self.initialize_from_prior, self.transforms.copy()
-        )
-        world_copy._transformed_values = self._transformed_values.copy()
+        world_copy = SimpleWorld(self.observations.copy(), self.initialize_from_prior)
+        world_copy._variables = {
+            node: var.copy() for node, var in self._variables.items()
+        }
         return world_copy
 
     def initialize_value(self, node: RVIdentifier) -> None:
-        # calling node.function will initialize parent nodes recursively
-        distribution = node.function(*node.arguments)
+        # recursively calls into parent nodes
+        self._call_stack.append(_TempVar(node))
+        with self:
+            distribution = node.function(*node.arguments)
+        temp_var = self._call_stack.pop()
+
         if node in self.observations:
-            value = self.observations[node]
+            transformed_value = self.observations[node]
             transform = dist.identity_transform
         else:
-            transform = self.transforms.get(node, get_default_transforms(distribution))
             sample_val = distribution.sample()
+            transform = get_default_transforms(distribution)
             if self.initialize_from_prior or distribution.has_enumerate_support:
-                value = transform(sample_val)
+                transformed_value = transform(sample_val)
             else:
                 # initialize to Uniform(-2, 2) in unconstrained space
-                value = torch.rand_like(sample_val) * 4 - 2
-        self._transformed_values[node] = value
-        self.transforms[node] = transform
+                transformed_value = torch.rand_like(sample_val) * 4 - 2
+
+        self._variables[node] = Variable(
+            transformed_value=transformed_value,
+            transform=transform,
+            parents=temp_var.parents,
+        )
 
     def update_graph(self, node: RVIdentifier) -> torch.Tensor:
         """This function adds a node to the graph and initialize its value if the node
         is not found in the graph already. It then returns the value of the node stored
         in world (in original space)."""
-        if node not in self._transformed_values:
+        if node not in self._variables:
             self.initialize_value(node)
-        return self.transforms[node].inv(self._transformed_values[node])
+        node_var = self._variables[node]
+        if len(self._call_stack) > 0:
+            tmp_child_var = self._call_stack[-1]
+            tmp_child_var.parents.add(node)
+            node_var.children.add(tmp_child_var.node)
+
+        return node_var.transform.inv(node_var.transformed_value)
 
     def log_prob(self) -> torch.Tensor:
         """Returns the joint log prob of all of the nodes in the current world"""
         log_prob = torch.tensor(0.0)
         with self:
-            for node, y in self._transformed_values.items():
+            for node, node_var in self._variables.items():
                 distribution = node.function(*node.arguments)
-                transform = self.transforms[node]
-                x = transform.inv(y)
+                y = node_var.transformed_value
+                x = node_var.transform.inv(y)
                 log_prob += torch.sum(
-                    distribution.log_prob(x) - transform.log_abs_det_jacobian(x, y)
+                    distribution.log_prob(x)
+                    - node_var.transform.log_abs_det_jacobian(x, y)
                 )
         return log_prob
 
     def enumerate_node(self, node: RVIdentifier) -> torch.Tensor:
         """Returns a tensor enumerating the support of the node"""
         with self:
-            dist = node.function(*node.arguments)
-            if not dist.has_enumerate_support:
+            distribution = node.function(*node.arguments)
+            if not distribution.has_enumerate_support:
                 raise ValueError(str(node) + " is not enumerable")
-            return dist.enumerate_support()
+            return distribution.enumerate_support()

--- a/src/beanmachine/ppl/experimental/global_inference/variable.py
+++ b/src/beanmachine/ppl/experimental/global_inference/variable.py
@@ -1,0 +1,19 @@
+import dataclasses
+from typing import Set
+
+import torch
+import torch.distributions as dist
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
+
+
+@dataclasses.dataclass
+class Variable:
+    transformed_value: torch.Tensor
+    transform: dist.Transform
+    parents: Set[RVIdentifier] = dataclasses.field(default_factory=set)
+    children: Set[RVIdentifier] = dataclasses.field(default_factory=set)
+
+    def copy(self):
+        return dataclasses.replace(
+            self, parents=self.parents.copy(), children=self.children.copy()
+        )


### PR DESCRIPTION
Summary:
In multi-site inference, we often need to compute the joint prob on a small subgraph (since most of the graph is fixed, this is supposed to be more efficient than recomputing the joint prob of the entire graph per proposal).

This diff adds the parent-children metadata similar to what we had in the [single site world](https://www.internalfb.com/code/fbsource/fbcode/beanmachine/beanmachine/ppl/world/world.py). Note that in this diff, an edge is only added during initialization, so it won't capture change in the structure (as this requires re-evaluating the model for every change in the graph -- which will be added in D31039733).

-----

I also decided to make the world immutable by remove the `__setitem__` and `__delitem__` method from world. I kept `set_transform` in this diff because NUTS and HMC still depends on it, but it will also be removed in D31039733.

`__delitem__` doesn't really make sense in this context, because even if we remove a node from a world, the implicit dependency still exist.

`__setitem__` and `set_transform` will be replaced by some corresponding `replace` method, which will return *a new world* with updated graph structure instead of mutating the current one.

Basically, each world represent a snapshot of the current state. With each proposal, we will be getting a new snapshot (instead of keep updating the old one).

-----

This diff is part of the early draft of the multisite inference. The API that are presented here are only temporary and could change a lot with the upcoming diffs. Feel free to make suggestions :)

Differential Revision: D30984120

