### PR TITLE
Remove now-unused size property from node class

### DIFF
--- a/src/beanmachine/ppl/compiler/fix_unsupported.py
+++ b/src/beanmachine/ppl/compiler/fix_unsupported.py
@@ -148,7 +148,7 @@ class UnsupportedNodeFixer(ProblemFixerBase):
 
     def _replace_tensor(self, node: bn.TensorNode) -> Optional[bn.BMGNode]:
         # Replace a 1-d or 2-d tensor with a TO_MATRIX node.
-        size = node.size
+        size = node._size
         if len(size) > 2:
             return None
         # This is the row and column count of the torch tensor.

--- a/src/beanmachine/ppl/compiler/lattice_typer.py
+++ b/src/beanmachine/ppl/compiler/lattice_typer.py
@@ -365,7 +365,7 @@ class LatticeTyper(TyperBase[bt.BMGLatticeType]):
         elif t in _constant_matrix_graph_types:
             assert isinstance(node, bn.ConstantTensorNode)
             r = _constant_matrix_graph_types[t]
-            result = r.with_size(node.size)
+            result = r.with_size(node.value.size())
         elif t in self._dispatch:
             result = self._dispatch[t](node)
         else:

--- a/src/beanmachine/ppl/compiler/tests/bm_graph_builder_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bm_graph_builder_test.py
@@ -36,7 +36,7 @@ from beanmachine.ppl.compiler.gen_bmg_graph import to_bmg_graph
 from beanmachine.ppl.compiler.gen_bmg_python import to_bmg_python
 from beanmachine.ppl.compiler.gen_dot import to_dot
 from beanmachine.ppl.compiler.runtime import BMGRuntime
-from torch import Size, Tensor, tensor
+from torch import Tensor, tensor
 from torch.distributions import Bernoulli
 
 
@@ -1459,54 +1459,6 @@ Node 9 type 3 parents [ 8 ] children [ ] real 0"""
         to_p = bmg.add_to_probability(q)
         # to_probability nodes are deduplicated
         self.assertEqual(bmg.add_to_probability(q), to_p)
-
-    def test_sizes(self) -> None:
-        bmg = BMGraphBuilder()
-        t = bmg.add_constant_tensor(tensor([1.0, 2.0]))
-        z1 = bmg.add_constant_tensor(torch.zeros(1, 2))
-        z2 = bmg.add_constant_tensor(torch.zeros(2, 1))
-        r = bmg.add_real(1.0)
-        bern = bmg.add_bernoulli(t)
-        s = bmg.add_sample(bern)
-        self.assertEqual(t.size, Size([2]))
-        self.assertEqual(r.size, Size([]))
-        self.assertEqual(bern.size, Size([2]))
-        self.assertEqual(s.size, Size([2]))
-        self.assertEqual(bmg.add_matrix_multiplication(z1, z2).size, Size([1, 1]))
-        self.assertEqual(bmg.add_addition(r, r).size, Size([]))
-        self.assertEqual(bmg.add_addition(r, t).size, Size([2]))
-        self.assertEqual(bmg.add_addition(t, r).size, Size([2]))
-        self.assertEqual(bmg.add_addition(t, t).size, Size([2]))
-        self.assertEqual(bmg.add_addition(s, r).size, Size([2]))
-        self.assertEqual(bmg.add_division(r, r).size, Size([]))
-        self.assertEqual(bmg.add_division(r, t).size, Size([2]))
-        self.assertEqual(bmg.add_division(t, r).size, Size([2]))
-        self.assertEqual(bmg.add_division(t, t).size, Size([2]))
-        self.assertEqual(bmg.add_division(s, r).size, Size([2]))
-        self.assertEqual(bmg.add_multiplication(r, r).size, Size([]))
-        self.assertEqual(bmg.add_multiplication(r, t).size, Size([2]))
-        self.assertEqual(bmg.add_multiplication(t, r).size, Size([2]))
-        self.assertEqual(bmg.add_multiplication(t, t).size, Size([2]))
-        self.assertEqual(bmg.add_multiplication(s, r).size, Size([2]))
-        self.assertEqual(bmg.add_power(r, r).size, Size([]))
-        self.assertEqual(bmg.add_power(r, t).size, Size([2]))
-        self.assertEqual(bmg.add_power(t, r).size, Size([2]))
-        self.assertEqual(bmg.add_power(t, t).size, Size([2]))
-        self.assertEqual(bmg.add_power(s, r).size, Size([2]))
-        self.assertEqual(bmg.add_negate(r).size, Size([]))
-        self.assertEqual(bmg.add_negate(t).size, Size([2]))
-        self.assertEqual(bmg.add_negate(s).size, Size([2]))
-        self.assertEqual(bmg.add_exp(r).size, Size([]))
-        self.assertEqual(bmg.add_exp(t).size, Size([2]))
-        self.assertEqual(bmg.add_exp(s).size, Size([2]))
-        self.assertEqual(bmg.add_log(r).size, Size([]))
-        self.assertEqual(bmg.add_log(t).size, Size([2]))
-        self.assertEqual(bmg.add_log(s).size, Size([2]))
-        nr = bmg.add_real(-1.0)
-        nt = bmg.add_constant_tensor(tensor([-1.0, -2.0]))
-        self.assertEqual(bmg.add_log1mexp(nr).size, Size([]))
-        self.assertEqual(bmg.add_log1mexp(nt).size, Size([2]))
-        self.assertEqual(bmg.add_log1mexp(s).size, Size([2]))
 
     def test_if_then_else(self) -> None:
         self.maxDiff = None

--- a/src/beanmachine/ppl/compiler/tests/bmg_nodes_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_nodes_test.py
@@ -11,6 +11,7 @@ from beanmachine.ppl.compiler.bmg_nodes import (
     ConstantRealMatrixNode,
     MatrixMultiplicationNode,
 )
+from beanmachine.ppl.compiler.sizer import Sizer
 from beanmachine.ppl.compiler.support import ComputeSupport
 
 
@@ -18,11 +19,15 @@ def support(n):
     return str(ComputeSupport()[n])
 
 
+def size(n):
+    return Sizer()[n]
+
+
 class BMGNodesTest(unittest.TestCase):
     def test_RealNode(self) -> None:
         r42 = RealNode(42.0)
         self.assertEqual(r42.value, 42.0)
-        self.assertEqual(r42.size, torch.Size([]))
+        self.assertEqual(size(r42), torch.Size([]))
         # Note that support always returns a set of tensors, even though this
         # node is technically scalar valued. In practice we never need to compute
         # the support of a RealNode, so fixing this minor oddity is unnecessary.
@@ -32,7 +37,7 @@ class BMGNodesTest(unittest.TestCase):
         r2 = RealNode(2.0)
         r3 = RealNode(3.0)
         rx = MultiplicationNode([r2, r3])
-        self.assertEqual(rx.size, torch.Size([]))
+        self.assertEqual(size(rx), torch.Size([]))
         self.assertEqual(support(rx), "tensor(6.)")
 
     def test_ConstantTensorNode_1d(self) -> None:
@@ -41,7 +46,7 @@ class BMGNodesTest(unittest.TestCase):
         self.assertEqual(t42.value[0], v42[0])
         self.assertEqual(t42.value[1], v42[1])
         self.assertEqual(v42.size(), torch.Size([2]))
-        self.assertEqual(t42.size, v42.size())
+        self.assertEqual(size(t42), v42.size())
         self.assertEqual(support(t42), "tensor([42, 43])")
 
     def test_ConstantTensorNode_2d(self) -> None:
@@ -50,7 +55,7 @@ class BMGNodesTest(unittest.TestCase):
         self.assertEqual(t42.value[0, 0], v42[0, 0])
         self.assertEqual(t42.value[1, 0], v42[1, 0])
         self.assertEqual(v42.size(), torch.Size([2, 2]))
-        self.assertEqual(t42.size, v42.size())
+        self.assertEqual(size(t42), v42.size())
         expected = """
 tensor([[42, 43],
         [44, 45]])"""
@@ -62,7 +67,7 @@ tensor([[42, 43],
         self.assertEqual(t42.value[0, 0], v42[0, 0])
         self.assertEqual(t42.value[1, 0], v42[1, 0])
         self.assertEqual(v42.size(), torch.Size([2, 2]))
-        self.assertEqual(t42.size, v42.size())
+        self.assertEqual(size(t42), v42.size())
         expected = """
 tensor([[42, 43],
         [44, 45]])"""
@@ -74,7 +79,7 @@ tensor([[42, 43],
         t42 = ConstantRealMatrixNode(v42)
         mt = MatrixMultiplicationNode(t42, t42)
         self.assertEqual(v42.size(), torch.Size([2, 2]))
-        self.assertEqual(mt.size, mv.size())
+        self.assertEqual(size(mt), mv.size())
         expected = """
 tensor([[3656, 3741],
         [3828, 3917]])


### PR DESCRIPTION
Summary:
We need the tensor size of a node during graph rewriting, particularly when devectorizing models.

I wish to move computation of the tensor size of a node out of the node classes; this is not their concern, and the implementation needs to be nonrecursive. All this functionality is now moved to sizer.py and I can delete the dead implementations on the node classes.

Reviewed By: wtaha

Differential Revision: D30811484

