### PR TITLE
Fix custom proposers BM documentation page

### DIFF
--- a/docs/framework_topics/custom_proposers/custom_proposers.md
+++ b/docs/framework_topics/custom_proposers/custom_proposers.md
@@ -4,7 +4,7 @@ Bean Machine is flexible and easily allows users to supply custom Metropolis Has
 
 For each iteration of sampling of variable $X$ with value $x$ using the Metropolis Hastings algorithm, we first sample a new value $x'$ for $X$ using proposal distribution $g$. We then update the world to reflect this change, and use the Metropolis Hastings ratio of
 $$\text{min}\big[1, \frac{p(x')g(x \mid x')}{p(x)g(x' \mid x)}\big]$$
-to decide whether or not to update the value of $X$ from $x$ to $x'$.
+to decide whether to keep the update or to revert to the world as it was before it.
 
 Bean Machine allows users to easily provide custom proposals for $g$, without needing to implement other details such as the calculations for $p(x')$ or the acceptance ratio. All proposers must inherit from the `AbstractSingleSiteProposer` class and implement the following methods:
 ```py
@@ -19,7 +19,7 @@ def post_process(
 #### Propose
 `propose` takes two parameters: the node and the world.
 * node: $X$, the random variable to propose a new value for
-* world: graphical data structure representing variable dependencies and values in the model
+* world: graphical data structure representing variable dependencies and values in the model *before* the proposal is made
 
 The return value of `propose` is a tuple with three values
 * $x'$, the new proposed value for the node
@@ -29,10 +29,14 @@ The return value of `propose` is a tuple with three values
 #### Post Process
 `post_process` take three parameters: the node, the world, and the auxiliary variables dictionary.
 * node: (same as `propose`) $X$, the random variable to propose a new value for
-* world: (same as `propose`) graphical data structure representing variable dependencies and values in the model
-* auxiliary_variables: the same dictionary returned by `propose`
+* world: (same as `propose`, but *updated with the proposed* value for node) graphical data structure representing variable dependencies and values in the model
+* auxiliary variables: the same dictionary returned by `propose`
 
 The return value of `post_process` is $\log[g(x \mid x')]$, the log probability of proposing the original value given the new value.
+
+<!--
+    `post_process` it not a very descriptive name. Why not `reverse_proposal_distribution` or something similar?
+-->
 
 ### Important Methods
 The `node` is of type `RVIdentifier`, which includes only the function and its parameters. To access the `Variable` corresponding to this node in the world, call
@@ -41,9 +45,21 @@ world.get_node_in_world_raise_error(node, False)
 ```
 This returns the associated `Variable` (see Variable API documentation for more details).
 
+<!--
+    It is odd and surprising that world.get_node_in_world_raise_error(node, False) returns a Variable, not a node, in spite of its name.
+    It might be good to rename it.
+-->
+
 ### Sample Custom Proposer
 
-Here, we implement a custom proposer for locating seismic events on Earth as described in [?]. In particular, the simplified version of the model is used, where one seismic event, denoted in the model by `event_attr()`, occurs randomly on the surface of the Earth. This event sends seismic energy in a single wave. There are different seismic stations across the surface of the Earth, and each station will noisily record its attributes of time, azimuth, and slowness, denoted by `det_attr(s)`. The inference problem is to find the `event_attr()` given the `det_attr(s)`.
+<!--
+It might make sense to replace this example.
+It is a bit more complicated than needed, using a Laplace distribution that is not one of the standard ones.
+It involves inverting this distribution but does not actually show the details of doing so.
+Also, the proposal distribution doesn't depend on the current value of the variable, which is a non-typical situation for proposal distributions.
+-->
+
+Here, we implement a custom proposer for locating seismic events on Earth as described in [1]. In particular, the simplified version of the model is used, where one seismic event, denoted in the model by `event_attr()`, occurs randomly on the surface of the Earth. This event sends seismic energy in a single wave. There are different seismic stations across the surface of the Earth, and each station will noisily record its attributes of time, azimuth, and slowness, denoted by `det_attr(s)`. The inference problem is to find the `event_attr()` given the `det_attr(s)`.
 
 ```py
 @bm.random_variable
@@ -56,35 +72,58 @@ def det_attr(station):
     return Laplace(det_loc, scale)
 ```
 
-There is domain knowledge within seismology to mathematically solve for the most likely attributes of an event given the detection attributes for a specific station. Due to the noisy nature of the data, these predicted locations can be inaccurate. However, with enough stations, it is likely that one of the predictions will be close to the true values. With this intuition, we used Bean Machine's easily implementable proposer interface to write a custom proposer for the `event_attr` variable, which inspects the `det_attr(s)` children variables and uses a Gaussian mixture model proposer around the predicted attributes for each of the detections.
+There is domain knowledge within seismology to mathematically solve for the most likely attributes of an event given the detection attributes for a specific station. Due to the noisy nature of the data, these predicted locations can be inaccurate, but this can be mitigated by considering the detections in many stations.
+
+An ideal MH proposer for location values would propose locations according to the exact posterior probability of the location given all stations, but computing this posterior or sampling from it is intractable. A simpler but still effective proposer independently computes one predicted location per individual station, which is an easier problem, and then selects, according to a Gaussian mixture model, one of these predicted locations for being proposed. This is effective because, with enough stations, it is likely that one of the predictions will be close to the true location.
+
+With this intuition, we use Bean Machine’s easily implementable proposer interface to write a custom proposer for the `event_attr` variable, which inspects the `det_attr(s)` children variables and uses a Gaussian mixture model proposer around the predicted attributes for each of the detections:
 
 ```py
 class SingleSiteSeismicProposer(AbstractSingleSiteProposer):
-    def propose(self, node: RVIdentifier, world: World) -> Tuple[Tensor, Tensor, Dict]:
-        node_var = world.get_node_in_world_raise_error(node, False)
-        inverted_detections = []
-        for child in node_var.children:
-            child_var = world.get_node_in_world_raise_error(child, False)
-            child_det_attr = child_var.value
-            inverted_detection = invert(child_det_attr)
-            inverted_detections.append(inverted_detection)
-        gmm = create_gausian_mixture_model(inverted_detections)
-        proposal = gmm.sample()
-        log_prob = gmm.log_prob(proposal)
-        return proposal, log_prob, {}
 
-    def post_process(
-        self, node: RVIdentifier, world: World, auxiliary_variables: Dict
-    ) -> Tensor:
-        node_var = world.get_node_in_world_raise_error(node, False)
-        current_value = node_var.value
-        # compute gmm as before
-        return gmm.log_prob(current_value)
+    def value(self, child: RVIdentifier) -> Tensor:
+        return world.get_node_in_world_raise_error(child, False).value
+
+    def proposal_distribution_of_event_given_children_det_attr(event_node):
+        # instead of computing the probability of the event given
+        # the join detections (a computation exponential in the number of detections),
+        # we compute the probability of the event
+        # given each separate detection and propose to use one of them
+        # by sampling from a Gaussian mixture model.
+        event_var = world.get_node_in_world_raise_error(node, False)
+        inverse_distributions_of_event_given_det_attrs =
+            [inverted_laplace(self.value(child_det_attr))
+            for child_det_attr in event_var.children]
+        return create_gaussian_mixture_model(inverse_distributions_of_event_given_det_attrs)
+
+    def propose(self, event_node: RVIdentifier, world: World) -> Tuple[Tensor, Tensor, Dict]:
+        proposal_distribution = proposal_distribution_of_event_given_children_det_attr(event_node)
+        new_value = proposal_distribution.sample()
+        log_prob = proposal_distribution.log_prob(new_value)
+        return new_value, log_prob, {}
+
+    def post_process(self, event_node: RVIdentifier, world: World, aux_variables: Dict) -> Tensor:
+        proposal_distribution = proposal_distribution_of_event_given_children_det_attr(event_node)
+        old_value = world.get_old_value(event_node)
+        return proposal_distribution.log_prob(old_value)
 ```
+
+Note that the particular above proposer proposes a new value based solely on the values of the *children* of `node`, and does not use the *value* of node.
+Therefore the value $\log[g(x' \mid x)]$ returned by `propose` is independent of the actual value $x$.
+Likewise, the value $\log[g(x \mid x')]$ returned by `post_process` does not use the new value $x'$.
+
+Because the proposal distribution is the same in both `propose` and `post_process` (since it only depends on the children variable which are not modified),
+an important optimization in this sampler could be to add `proposal_distribution` in the auxiliary variables
+returned by `propose` and reuse it in `post_process`.
+
+Also note that in `post_process` we must evaluate the proposal distribution on $x$, which is no longer available from `event_node.value`
+because now the world has been updated with the new value $x'$.
+However the old value is still available from `world.get_old_value(node)` (or `world.get_old_transformed_value(node)` if a transform is being used).
+
 
 ### Gradient-based proposers
 
-The `World` also provides support for gradient-based proposers (see World and Variable API documentation for more details). For all continuous variables, the gradient is tracked for `transformed_value`. Because of the single-site nature of Bean Machine, the only part of the world's likelihood which related to a variable originate from the variable itself and its child nodes, which have distributions dependent on the value of the variable. The likelihood of the relevant parts of the world, also known as the score, can be computed using
+The `World` class also provides support for gradient-based proposers (see World and Variable API documentation for more details). For all continuous variables, the gradient is tracked for `transformed_value`. Because of the locally-structured nature of Bean Machine models, the contribution of a variable to a world's likelihood is determined solely from the values of the variable itself and its child nodes (those nodes whose distributions are directly influenced by the value of the variable). The likelihood of the relevant parts of the world, also known as the score, can be computed using
 ```py
 compute_score(node_var: Variable) -> Tensor
 ```
@@ -96,3 +135,5 @@ score = world.compute_score(node_var)
 first_gradient = grad(score, node_val)
 ```
 The gradient can now be used to obtain a new proposal for the variable.
+
+[1] Arora, Nimar & Russell, Stuart & Sudderth, Erik. (2013). NET-VISA: Network Processing Vertically Integrated Seismic Analysis. The Bulletin of the Seismological Society of America. 103. 709-729. 10.1785/0120120107.


### PR DESCRIPTION
Summary:
The main corrections were:
- `post_process` used `node`'s current value instead of old value;
- the explanations of `propose` and `post_process` did not say that `World` in the latter would be updated with the new value.

Besides that several clarifications and cleaning up of the code were made.

Reviewed By: michaeltingley

Differential Revision: D31190072

