### PR TITLE
Replace single-site steppers in MH by regular steppers.

### DIFF
--- a/src/beanmachine/graph/mh.h
+++ b/src/beanmachine/graph/mh.h
@@ -15,7 +15,8 @@
 #include "beanmachine/graph/profiler.h"
 #include "beanmachine/graph/proposer/default_initializer.h"
 #include "beanmachine/graph/proposer/proposer.h"
-#include "beanmachine/graph/stepper/single_site/single_site_stepper.h"
+#include "beanmachine/graph/stepper/single_site/single_site_stepping_method.h"
+#include "beanmachine/graph/stepper/stepper.h"
 #include "beanmachine/graph/util.h"
 
 #define NATURAL_TYPE unsigned long long int
@@ -27,7 +28,7 @@ class MH {
  public:
   virtual ~MH();
 
- private:
+ protected:
   Graph* g;
 
   // A graph maintains of a vector of nodes; the index into that vector is
@@ -65,10 +66,12 @@ class MH {
   // of this vector should never be accessed.
   std::vector<uint> unobserved_sto_support_index_by_node_id;
 
-  // Single-site steppers application to nodes in unobserved_supp that are
-  // stochastic; similarly, order matters.
-  std::vector<SingleSiteStepper*> stepper_for_node;
+  // TEMPORARY: we are in the process of moving ad hoc code out of MH.
+  // Eventually MH will receive an arbitray list of steppers (not necessarily
+  // single-site) that will know which random variables they apply to.
+  std::vector<SingleSiteSteppingMethod*> single_site_stepping_methods;
 
+  std::vector<Stepper*> steppers;
   // These vectors are the same size as unobserved_sto_support.
   // The i-th elements are vectors of nodes which are
   // respectively the vector of
@@ -95,7 +98,9 @@ class MH {
 
   std::mt19937 gen;
 
-  MH(Graph* g, uint seed, std::vector<SingleSiteStepper*> single_site_steppers);
+  MH(Graph* g,
+     uint seed,
+     std::vector<SingleSiteSteppingMethod*> single_site_stepping_methods);
 
   void infer(uint num_samples, InferConfig infer_config);
 
@@ -115,7 +120,8 @@ class MH {
 
   void generate_sample();
 
-  SingleSiteStepper* find_applicable_stepper(Node* tgt_node);
+  SingleSiteSteppingMethod* find_applicable_single_site_stepping_method(
+      Node* tgt_node);
 
   void collect_samples(uint num_samples, InferConfig infer_config);
 
@@ -163,11 +169,6 @@ class MH {
   double compute_log_prob_of(const std::vector<Node*>& sto_nodes);
 
   NodeValue sample(const std::unique_ptr<proposer::Proposer>& prop);
-
-  // TEMPORARY: we are in the process of moving ad hoc code out of MH.
-  // Eventually MH will receive an arbitray list of steppers (not necessarily
-  // single-site) that will know which random variables they apply to.
-  std::vector<SingleSiteStepper*> single_site_steppers;
 };
 
 } // namespace graph

--- a/src/beanmachine/graph/nmc.cpp
+++ b/src/beanmachine/graph/nmc.cpp
@@ -12,10 +12,10 @@
 #include "beanmachine/graph/profiler.h"
 #include "beanmachine/graph/proposer/default_initializer.h"
 #include "beanmachine/graph/proposer/proposer.h"
-#include "beanmachine/graph/stepper/single_site/nmc_dirichlet_beta_single_site_stepper.h"
-#include "beanmachine/graph/stepper/single_site/nmc_dirichlet_gamma_single_site_stepper.h"
-#include "beanmachine/graph/stepper/single_site/nmc_scalar_single_site_stepper.h"
-#include "beanmachine/graph/stepper/single_site/single_site_stepper.h"
+#include "beanmachine/graph/stepper/single_site/nmc_dirichlet_beta_single_site_stepping_method.h"
+#include "beanmachine/graph/stepper/single_site/nmc_dirichlet_gamma_single_site_stepping_method.h"
+#include "beanmachine/graph/stepper/single_site/nmc_scalar_single_site_stepping_method.h"
+#include "beanmachine/graph/stepper/single_site/single_site_stepping_method.h"
 #include "beanmachine/graph/util.h"
 
 namespace beanmachine {
@@ -28,12 +28,16 @@ NMC::NMC(Graph* g, uint seed)
          // because DirichletGamma is also applicable to
          // nodes to which Beta is applicable,
          // but we want to give priority to Beta in those cases.
-         std::vector<SingleSiteStepper*>{
-             new NMCScalarSingleSiteStepper(g, this),
-             new NMCDirichletBetaSingleSiteStepper(g, this),
-             new NMCDirichletGammaSingleSiteStepper(g, this)}) {}
+         std::vector<SingleSiteSteppingMethod*>{
+             new NMCScalarSingleSiteSteppingMethod(g, this),
+             new NMCDirichletBetaSingleSiteSteppingMethod(g, this),
+             new NMCDirichletGammaSingleSiteSteppingMethod(g, this)}) {}
 
-NMC::~NMC() {}
+NMC::~NMC() {
+  for (auto single_site_stepping_method : single_site_stepping_methods) {
+    delete single_site_stepping_method;
+  }
+}
 
 std::string NMC::is_not_supported(Node* node) {
   if (node->value.type.variable_type != VariableType::COL_SIMPLEX_MATRIX and

--- a/src/beanmachine/graph/stepper/single_site/default_single_site_stepping_method.cpp
+++ b/src/beanmachine/graph/stepper/single_site/default_single_site_stepping_method.cpp
@@ -14,12 +14,12 @@
 #include "beanmachine/graph/proposer/proposer.h"
 #include "beanmachine/graph/util.h"
 
-#include "beanmachine/graph/stepper/single_site/default_single_site_stepper.h"
+#include "beanmachine/graph/stepper/single_site/default_single_site_stepping_method.h"
 
 namespace beanmachine {
 namespace graph {
 
-void DefaultSingleSiteStepper::step(Node* tgt_node) {
+void DefaultSingleSiteSteppingMethod::step(Node* tgt_node) {
   graph->pd_begin(get_step_profiler_event());
   // Implements a Metropolis-Hastings step using the MH proposer.
   //

--- a/src/beanmachine/graph/stepper/single_site/default_single_site_stepping_method.h
+++ b/src/beanmachine/graph/stepper/single_site/default_single_site_stepping_method.h
@@ -3,23 +3,23 @@
 #include "beanmachine/graph/graph.h"
 #include "beanmachine/graph/mh.h"
 #include "beanmachine/graph/proposer/proposer.h"
-#include "beanmachine/graph/stepper/single_site/single_site_stepper.h"
+#include "beanmachine/graph/stepper/single_site/single_site_stepping_method.h"
 
 namespace beanmachine {
 namespace graph {
 
 /*
- * An abstract default implementation of MH single-site stepper
- * implementing the typical MH step.
+ * An abstract default implementation of MH single-site stepping method
+ * implementing the typical MH stepping method.
  * It uses a proposal provided by method get_proposal_distribution,
  * whose implementation is left to sub-classes.
  * Sub-classes must also implement methods is_applicable_to and
  * get_step_profiler_event.
  */
-class DefaultSingleSiteStepper : public SingleSiteStepper {
+class DefaultSingleSiteSteppingMethod : public SingleSiteSteppingMethod {
  public:
-  DefaultSingleSiteStepper(Graph* graph, MH* mh)
-      : SingleSiteStepper(graph, mh) {}
+  DefaultSingleSiteSteppingMethod(Graph* graph, MH* mh)
+      : SingleSiteSteppingMethod(graph, mh) {}
 
   virtual bool is_applicable_to(graph::Node* tgt_node) override = 0;
 

--- a/src/beanmachine/graph/stepper/single_site/nmc_dirichlet_beta_single_site_stepping_method.cpp
+++ b/src/beanmachine/graph/stepper/single_site/nmc_dirichlet_beta_single_site_stepping_method.cpp
@@ -16,24 +16,26 @@
 #include "beanmachine/graph/proposer/proposer.h"
 #include "beanmachine/graph/util.h"
 
-#include "beanmachine/graph/stepper/single_site/nmc_dirichlet_beta_single_site_stepper.h"
+#include "beanmachine/graph/stepper/single_site/nmc_dirichlet_beta_single_site_stepping_method.h"
 
 namespace beanmachine {
 namespace graph {
 
-bool NMCDirichletBetaSingleSiteStepper::is_applicable_to(
+bool NMCDirichletBetaSingleSiteSteppingMethod::is_applicable_to(
     graph::Node* tgt_node) {
   return tgt_node->value.type.variable_type ==
       VariableType::COL_SIMPLEX_MATRIX and
       tgt_node->value.type.rows == 2;
 }
 
-ProfilerEvent NMCDirichletBetaSingleSiteStepper::get_step_profiler_event() {
+ProfilerEvent
+NMCDirichletBetaSingleSiteSteppingMethod::get_step_profiler_event() {
   return ProfilerEvent::NMC_STEP_DIRICHLET;
 }
 
 std::unique_ptr<proposer::Proposer>
-NMCDirichletBetaSingleSiteStepper::get_proposal_distribution(Node* tgt_node) {
+NMCDirichletBetaSingleSiteSteppingMethod::get_proposal_distribution(
+    Node* tgt_node) {
   assert(tgt_node->value._matrix.size() == 2);
 
   auto sto_tgt_node = static_cast<oper::StochasticOperator*>(tgt_node);

--- a/src/beanmachine/graph/stepper/single_site/nmc_dirichlet_beta_single_site_stepping_method.h
+++ b/src/beanmachine/graph/stepper/single_site/nmc_dirichlet_beta_single_site_stepping_method.h
@@ -2,15 +2,16 @@
 #pragma once
 #include "beanmachine/graph/graph.h"
 #include "beanmachine/graph/proposer/proposer.h"
-#include "beanmachine/graph/stepper/single_site/default_single_site_stepper.h"
+#include "beanmachine/graph/stepper/single_site/default_single_site_stepping_method.h"
 
 namespace beanmachine {
 namespace graph {
 
-class NMCScalarSingleSiteStepper : public DefaultSingleSiteStepper {
+class NMCDirichletBetaSingleSiteSteppingMethod
+    : public DefaultSingleSiteSteppingMethod {
  public:
-  NMCScalarSingleSiteStepper(Graph* graph, MH* mh)
-      : DefaultSingleSiteStepper(graph, mh) {}
+  NMCDirichletBetaSingleSiteSteppingMethod(Graph* graph, MH* mh)
+      : DefaultSingleSiteSteppingMethod(graph, mh) {}
 
   virtual bool is_applicable_to(graph::Node* tgt_node) override;
 

--- a/src/beanmachine/graph/stepper/single_site/nmc_dirichlet_gamma_single_site_stepping_method.cpp
+++ b/src/beanmachine/graph/stepper/single_site/nmc_dirichlet_gamma_single_site_stepping_method.cpp
@@ -15,12 +15,12 @@
 #include "beanmachine/graph/proposer/proposer.h"
 #include "beanmachine/graph/util.h"
 
-#include "beanmachine/graph/stepper/single_site/nmc_dirichlet_gamma_single_site_stepper.h"
+#include "beanmachine/graph/stepper/single_site/nmc_dirichlet_gamma_single_site_stepping_method.h"
 
 namespace beanmachine {
 namespace graph {
 
-bool NMCDirichletGammaSingleSiteStepper::is_applicable_to(
+bool NMCDirichletGammaSingleSiteSteppingMethod::is_applicable_to(
     graph::Node* tgt_node) {
   return tgt_node->value.type.variable_type == VariableType::COL_SIMPLEX_MATRIX;
 }
@@ -31,7 +31,7 @@ divided by their x_sum. i.e. Let X_k ~ Gamma(alpha_k, 1), for k = 1, ..., K,
 Y_k = X_k / x_sum(X), then (Y_1, ..., Y_K) ~ Dirichlet(alphas). We store Y in
 the attribute value, and X in unconstrainted_value.
 */
-void NMCDirichletGammaSingleSiteStepper::step(Node* tgt_node) {
+void NMCDirichletGammaSingleSiteSteppingMethod::step(Node* tgt_node) {
   graph->pd_begin(ProfilerEvent::NMC_STEP_DIRICHLET);
 
   const std::vector<Node*>& det_affected_nodes =
@@ -107,7 +107,8 @@ void NMCDirichletGammaSingleSiteStepper::step(Node* tgt_node) {
   graph->pd_finish(ProfilerEvent::NMC_STEP_DIRICHLET);
 }
 
-double NMCDirichletGammaSingleSiteStepper::compute_sto_affected_nodes_log_prob(
+double
+NMCDirichletGammaSingleSiteSteppingMethod::compute_sto_affected_nodes_log_prob(
     Node* tgt_node,
     double param_a_k,
     NodeValue x_k_value) {
@@ -128,7 +129,7 @@ double NMCDirichletGammaSingleSiteStepper::compute_sto_affected_nodes_log_prob(
 }
 
 std::unique_ptr<proposer::Proposer>
-NMCDirichletGammaSingleSiteStepper::create_proposal_dirichlet_gamma(
+NMCDirichletGammaSingleSiteSteppingMethod::create_proposal_dirichlet_gamma(
     Node* tgt_node,
     double param_a_k,
     double x_sum,

--- a/src/beanmachine/graph/stepper/single_site/nmc_dirichlet_gamma_single_site_stepping_method.h
+++ b/src/beanmachine/graph/stepper/single_site/nmc_dirichlet_gamma_single_site_stepping_method.h
@@ -2,15 +2,16 @@
 #pragma once
 #include "beanmachine/graph/graph.h"
 #include "beanmachine/graph/proposer/proposer.h"
-#include "beanmachine/graph/stepper/single_site/single_site_stepper.h"
+#include "beanmachine/graph/stepper/single_site/single_site_stepping_method.h"
 
 namespace beanmachine {
 namespace graph {
 
-class NMCDirichletGammaSingleSiteStepper : public SingleSiteStepper {
+class NMCDirichletGammaSingleSiteSteppingMethod
+    : public SingleSiteSteppingMethod {
  public:
-  NMCDirichletGammaSingleSiteStepper(Graph* graph, MH* mh)
-      : SingleSiteStepper(graph, mh) {}
+  NMCDirichletGammaSingleSiteSteppingMethod(Graph* graph, MH* mh)
+      : SingleSiteSteppingMethod(graph, mh) {}
   virtual bool is_applicable_to(graph::Node* tgt_node) override;
 
   virtual void step(graph::Node* tgt_node) override;

--- a/src/beanmachine/graph/stepper/single_site/nmc_scalar_single_site_stepping_method.cpp
+++ b/src/beanmachine/graph/stepper/single_site/nmc_scalar_single_site_stepping_method.cpp
@@ -15,16 +15,17 @@
 #include "beanmachine/graph/proposer/proposer.h"
 #include "beanmachine/graph/util.h"
 
-#include "beanmachine/graph/stepper/single_site/nmc_scalar_single_site_stepper.h"
+#include "beanmachine/graph/stepper/single_site/nmc_scalar_single_site_stepping_method.h"
 
 namespace beanmachine {
 namespace graph {
 
-bool NMCScalarSingleSiteStepper::is_applicable_to(graph::Node* tgt_node) {
+bool NMCScalarSingleSiteSteppingMethod::is_applicable_to(
+    graph::Node* tgt_node) {
   return tgt_node->value.type.variable_type == VariableType::SCALAR;
 }
 
-ProfilerEvent NMCScalarSingleSiteStepper::get_step_profiler_event() {
+ProfilerEvent NMCScalarSingleSiteSteppingMethod::get_step_profiler_event() {
   return ProfilerEvent::NMC_STEP;
 }
 
@@ -33,7 +34,7 @@ ProfilerEvent NMCScalarSingleSiteStepper::get_step_profiler_event() {
 // NOTE: assumes that det_affected_nodes's values are already
 // evaluated according to the target node's value.
 std::unique_ptr<proposer::Proposer>
-NMCScalarSingleSiteStepper::get_proposal_distribution(Node* tgt_node) {
+NMCScalarSingleSiteSteppingMethod::get_proposal_distribution(Node* tgt_node) {
   graph->pd_begin(ProfilerEvent::NMC_CREATE_PROP);
 
   tgt_node->grad1 = 1;

--- a/src/beanmachine/graph/stepper/single_site/nmc_scalar_single_site_stepping_method.h
+++ b/src/beanmachine/graph/stepper/single_site/nmc_scalar_single_site_stepping_method.h
@@ -2,15 +2,16 @@
 #pragma once
 #include "beanmachine/graph/graph.h"
 #include "beanmachine/graph/proposer/proposer.h"
-#include "beanmachine/graph/stepper/single_site/default_single_site_stepper.h"
+#include "beanmachine/graph/stepper/single_site/default_single_site_stepping_method.h"
 
 namespace beanmachine {
 namespace graph {
 
-class NMCDirichletBetaSingleSiteStepper : public DefaultSingleSiteStepper {
+class NMCScalarSingleSiteSteppingMethod
+    : public DefaultSingleSiteSteppingMethod {
  public:
-  NMCDirichletBetaSingleSiteStepper(Graph* graph, MH* mh)
-      : DefaultSingleSiteStepper(graph, mh) {}
+  NMCScalarSingleSiteSteppingMethod(Graph* graph, MH* mh)
+      : DefaultSingleSiteSteppingMethod(graph, mh) {}
 
   virtual bool is_applicable_to(graph::Node* tgt_node) override;
 

--- a/src/beanmachine/graph/stepper/single_site/single_site_stepper.h
+++ b/src/beanmachine/graph/stepper/single_site/single_site_stepper.h
@@ -1,26 +1,31 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
 #pragma once
 #include "beanmachine/graph/graph.h"
+#include "beanmachine/graph/stepper/single_site/single_site_stepping_method.h"
+#include "beanmachine/graph/stepper/stepper.h"
 
 namespace beanmachine {
 namespace graph {
 
-class MH;
-
-// An abstraction for code taking a single-site MH step.
-class SingleSiteStepper {
+// A stepper based on a single-site stepping method bound to a specific node.
+class SingleSiteStepper : public Stepper {
  public:
-  SingleSiteStepper(Graph* graph, MH* mh) : graph(graph), mh(mh) {}
+  SingleSiteStepper(
+      SingleSiteSteppingMethod* single_site_stepping_method,
+      Node* node,
+      Graph* graph,
+      MH* mh)
+      : Stepper(graph, mh),
+        single_site_stepping_method(single_site_stepping_method),
+        node(node) {}
 
-  virtual bool is_applicable_to(graph::Node* tgt_node) = 0;
-
-  virtual void step(graph::Node* tgt_node) = 0;
-
-  virtual ~SingleSiteStepper() {}
+  void step() override {
+    single_site_stepping_method->step(node);
+  }
 
  protected:
-  Graph* graph;
-  MH* mh;
+  SingleSiteSteppingMethod* single_site_stepping_method;
+  Node* node;
 };
 
 } // namespace graph

--- a/src/beanmachine/graph/stepper/single_site/single_site_stepping_method.h
+++ b/src/beanmachine/graph/stepper/single_site/single_site_stepping_method.h
@@ -1,0 +1,27 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+#pragma once
+#include "beanmachine/graph/graph.h"
+
+namespace beanmachine {
+namespace graph {
+
+class MH;
+
+// An abstraction for code taking a single-site MH step.
+class SingleSiteSteppingMethod {
+ public:
+  SingleSiteSteppingMethod(Graph* graph, MH* mh) : graph(graph), mh(mh) {}
+
+  virtual bool is_applicable_to(graph::Node* tgt_node) = 0;
+
+  virtual void step(graph::Node* tgt_node) = 0;
+
+  virtual ~SingleSiteSteppingMethod() {}
+
+ protected:
+  Graph* graph;
+  MH* mh;
+};
+
+} // namespace graph
+} // namespace beanmachine

--- a/src/beanmachine/graph/stepper/stepper.cpp
+++ b/src/beanmachine/graph/stepper/stepper.cpp
@@ -1,0 +1,3 @@
+// (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+
+#include "beanmachine/graph/stepper/stepper.h"

--- a/src/beanmachine/graph/stepper/stepper.h
+++ b/src/beanmachine/graph/stepper/stepper.h
@@ -1,0 +1,25 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+#pragma once
+#include "beanmachine/graph/graph.h"
+
+namespace beanmachine {
+namespace graph {
+
+class MH;
+
+// An abstraction for code taking a MH step.
+class Stepper {
+ public:
+  Stepper(Graph* graph, MH* mh) : graph(graph), mh(mh) {}
+
+  virtual void step() = 0;
+
+  virtual ~Stepper() {}
+
+ protected:
+  Graph* graph;
+  MH* mh;
+};
+
+} // namespace graph
+} // namespace beanmachine


### PR DESCRIPTION
Summary:
MH was currently finding the appropriate single-site stepper for each variable, storing that association, and applying these single-site steppers to their variables at each step.

To make MH more flexible, we want it to use steppers (which are not necessarily single-site) instead of only single-site steppers. So here we introduce two new classes: the abstract class `Stepper`, which has a method `step()` without arguments (unlike `SingleSiteStepper` which requires a variable node to be provided), and a class `BoundStepper` which binds a single-site stepper to a variable node, this creating a `Stepper` out of that pair. MH then creates a list of `Stepper`s to apply at each step.

In the next changes, we will abstract the creation of those steppers away from MH.

Reviewed By: yucenli

Differential Revision: D30829721

