### PR TITLE
Generalize the devectorizer

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/fix_vectorized_models_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_vectorized_models_test.py
@@ -4,7 +4,7 @@ import unittest
 import beanmachine.ppl as bm
 from beanmachine.ppl.inference import BMGInference
 from torch import tensor
-from torch.distributions import Bernoulli, Beta
+from torch.distributions import Bernoulli, Beta, Normal
 
 
 @bm.random_variable
@@ -35,6 +35,14 @@ def flip_const_4():
 @bm.random_variable
 def flip_const_2_3():
     return Bernoulli(tensor([[0.25, 0.75, 0.5], [0.125, 0.875, 0.625]]))
+
+
+@bm.random_variable
+def normal_2_3():
+    mus = flip_const_2_3()  # 2 x 3 tensor of 0 or 1
+    sigmas = tensor([2.0, 3.0, 4.0])
+
+    return Normal(mus, sigmas)
 
 
 class FixVectorizedModelsTest(unittest.TestCase):
@@ -370,4 +378,165 @@ digraph "graph" {
   N12 -> N13;
 }
     """
+        self.assertEqual(expected.strip(), observed.strip())
+
+    def test_fix_vectorized_models_5(self) -> None:
+        self.maxDiff = None
+        observations = {}
+        queries = [normal_2_3()]
+
+        observed = BMGInference().to_dot(queries, observations, after_transform=False)
+
+        # The model before the rewrite:
+
+        expected = """
+digraph "graph" {
+  N0[label="[[0.25,0.75,0.5],\\\\n[0.125,0.875,0.625]]"];
+  N1[label=Bernoulli];
+  N2[label=Sample];
+  N3[label="[2.0,3.0,4.0]"];
+  N4[label=Normal];
+  N5[label=Sample];
+  N6[label=Query];
+  N0 -> N1;
+  N1 -> N2;
+  N2 -> N4;
+  N3 -> N4;
+  N4 -> N5;
+  N5 -> N6;
+}
+"""
+        self.assertEqual(expected.strip(), observed.strip())
+
+        # After:
+
+        observed = BMGInference().to_dot(queries, observations, after_transform=True)
+        expected = """
+digraph "graph" {
+  N00[label=3];
+  N01[label=2];
+  N02[label=0.25];
+  N03[label=Bernoulli];
+  N04[label=Sample];
+  N05[label=0.75];
+  N06[label=Bernoulli];
+  N07[label=Sample];
+  N08[label=0.5];
+  N09[label=Bernoulli];
+  N10[label=Sample];
+  N11[label=0.125];
+  N12[label=Bernoulli];
+  N13[label=Sample];
+  N14[label=0.875];
+  N15[label=Bernoulli];
+  N16[label=Sample];
+  N17[label=0.625];
+  N18[label=Bernoulli];
+  N19[label=Sample];
+  N20[label=ToMatrix];
+  N21[label=0];
+  N22[label=ColumnIndex];
+  N23[label=index];
+  N24[label=ToReal];
+  N25[label=2.0];
+  N26[label=Normal];
+  N27[label=Sample];
+  N28[label=1];
+  N29[label=index];
+  N30[label=ToReal];
+  N31[label=3.0];
+  N32[label=Normal];
+  N33[label=Sample];
+  N34[label=index];
+  N35[label=ToReal];
+  N36[label=4.0];
+  N37[label=Normal];
+  N38[label=Sample];
+  N39[label=ColumnIndex];
+  N40[label=index];
+  N41[label=ToReal];
+  N42[label=Normal];
+  N43[label=Sample];
+  N44[label=index];
+  N45[label=ToReal];
+  N46[label=Normal];
+  N47[label=Sample];
+  N48[label=index];
+  N49[label=ToReal];
+  N50[label=Normal];
+  N51[label=Sample];
+  N52[label=ToMatrix];
+  N53[label=Query];
+  N00 -> N20;
+  N00 -> N52;
+  N01 -> N20;
+  N01 -> N34;
+  N01 -> N48;
+  N01 -> N52;
+  N02 -> N03;
+  N03 -> N04;
+  N04 -> N20;
+  N05 -> N06;
+  N06 -> N07;
+  N07 -> N20;
+  N08 -> N09;
+  N09 -> N10;
+  N10 -> N20;
+  N11 -> N12;
+  N12 -> N13;
+  N13 -> N20;
+  N14 -> N15;
+  N15 -> N16;
+  N16 -> N20;
+  N17 -> N18;
+  N18 -> N19;
+  N19 -> N20;
+  N20 -> N22;
+  N20 -> N39;
+  N21 -> N22;
+  N21 -> N23;
+  N21 -> N40;
+  N22 -> N23;
+  N22 -> N29;
+  N22 -> N34;
+  N23 -> N24;
+  N24 -> N26;
+  N25 -> N26;
+  N25 -> N42;
+  N26 -> N27;
+  N27 -> N52;
+  N28 -> N29;
+  N28 -> N39;
+  N28 -> N44;
+  N29 -> N30;
+  N30 -> N32;
+  N31 -> N32;
+  N31 -> N46;
+  N32 -> N33;
+  N33 -> N52;
+  N34 -> N35;
+  N35 -> N37;
+  N36 -> N37;
+  N36 -> N50;
+  N37 -> N38;
+  N38 -> N52;
+  N39 -> N40;
+  N39 -> N44;
+  N39 -> N48;
+  N40 -> N41;
+  N41 -> N42;
+  N42 -> N43;
+  N43 -> N52;
+  N44 -> N45;
+  N45 -> N46;
+  N46 -> N47;
+  N47 -> N52;
+  N48 -> N49;
+  N49 -> N50;
+  N50 -> N51;
+  N51 -> N52;
+  N52 -> N53;
+}
+
+"""
         self.assertEqual(expected.strip(), observed.strip())


### PR DESCRIPTION
Summary:
In this diff I finally take a big step towards generalizing the devectorizing algorithm I've been prototyping in this stack.

The general algorithm here relies upon a commonality amongst many operators and distributions in our system:

* the output size results from broadcasting all the inputs
* logically, every input is broadcast to that size

The actual algorithm is a little tricky and so I have left comments describing its action on a test case. The basic idea is that we create tensors of integers representing offsets into a list of nodes. By broadcasting those indexing tensors, we can make torch do the work of figuring out the broadcasting semantics for us.

Thus far I have only tried out this new algorithm on normals and Bernoullis, but it works quite nicely. I will add more distributions and operators in upcoming diffs.

The output graph is a valid BMG graph but is highly non-optimal. In an upcoming diff I will add an optimizing pass that eliminates the unnecessary temporary matrix.

Reviewed By: wtaha

Differential Revision: D30883037

