### PR TITLE
Move transform logic out of world

### DIFF
--- a/src/beanmachine/ppl/experimental/global_inference/proposer/hmc_proposer.py
+++ b/src/beanmachine/ppl/experimental/global_inference/proposer/hmc_proposer.py
@@ -9,6 +9,7 @@ from beanmachine.ppl.experimental.global_inference.proposer.hmc_utils import (
     DualAverageAdapter,
     MassMatrixAdapter,
     WindowScheme,
+    RealSpaceTransform,
 )
 from beanmachine.ppl.experimental.global_inference.simple_world import (
     RVDict,
@@ -43,8 +44,12 @@ class HMCProposer(BaseProposer):
         target_accept_prob: float = 0.8,
     ):
         self.world = initial_world
+        self._to_unconstrained = RealSpaceTransform(initial_world)
+        self._positions = self._to_unconstrained(
+            {node: initial_world[node] for node in initial_world.latent_nodes}
+        )
         # cache pe and pe_grad to prevent re-computation
-        self._pe, self._pe_grad = self._potential_grads(initial_world)
+        self._pe, self._pe_grad = self._potential_grads(self._positions)
         # initialize parameters
         self.trajectory_length = trajectory_length
         # initialize adapters
@@ -55,7 +60,7 @@ class HMCProposer(BaseProposer):
         self._mass_matrix_adapter = MassMatrixAdapter()
         if self.adapt_step_size:
             self.step_size = self._find_reasonable_step_size(
-                initial_step_size, self.world, self._pe, self._pe_grad
+                initial_step_size, self._positions, self._pe, self._pe_grad
             )
             self._step_size_adapter = DualAverageAdapter(
                 self.step_size, target_accept_prob
@@ -91,29 +96,34 @@ class HMCProposer(BaseProposer):
             grads[node] = mass_inv[node] * r
         return grads
 
-    def _potential_energy(self, world: SimpleWorld) -> torch.Tensor:
+    def _potential_energy(self, positions: RVDict) -> torch.Tensor:
         """Returns the potential energy PE = - L(world) (the joint log likelihood of the
         current values)"""
-        return -world.log_prob()
+        constrained_vals = self._to_unconstrained.inv(positions)
+        log_joint = self.world.replace(constrained_vals).log_prob()
+        log_joint -= self._to_unconstrained.log_abs_det_jacobian(
+            constrained_vals, positions
+        )
+        return -log_joint
 
-    def _potential_grads(self, world: SimpleWorld) -> Tuple[torch.Tensor, RVDict]:
+    def _potential_grads(self, positions: RVDict) -> Tuple[torch.Tensor, RVDict]:
         """Returns potential energy as well as a dictionary of its gradient with
         respect to the value at each site."""
-        nodes = list(world.latent_nodes)
-        values_with_grad = [world.get_transformed(node).clone() for node in nodes]
-        for value in values_with_grad:
+        nodes, values = zip(*positions.items())
+        for value in values:
             value.requires_grad = True
-        world_with_grad = world.replace_transformed(dict(zip(nodes, values_with_grad)))
 
-        pe = self._potential_energy(world_with_grad)
-        grads = torch.autograd.grad(pe, values_with_grad)
+        pe = self._potential_energy(positions)
+        grads = torch.autograd.grad(pe, values)
         grads = dict(zip(nodes, grads))
 
+        for value in values:
+            value.requires_grad = False
         return pe.detach(), grads
 
     def _hamiltonian(
         self,
-        world: SimpleWorld,
+        positions: RVDict,
         momentums: RVDict,
         mass_inv: RVDict,
         pe: Optional[torch.Tensor] = None,
@@ -123,67 +133,63 @@ class HMCProposer(BaseProposer):
         kinetic energy"""
         ke = self._kinetic_energy(momentums, mass_inv)
         if pe is None:
-            pe = self._potential_energy(world)
+            pe = self._potential_energy(positions)
         return pe + ke
 
     def _leapfrog_step(
         self,
-        world: SimpleWorld,
+        positions: RVDict,
         momentums: RVDict,
         step_size: float,
         mass_inv: RVDict,
         pe_grad: Optional[RVDict] = None,
-    ) -> Tuple[SimpleWorld, RVDict, torch.Tensor, RVDict]:
+    ) -> Tuple[RVDict, RVDict, torch.Tensor, RVDict]:
         """Performs a single leapfrog integration (alson known as the velocity Verlet
         method) as described in equation 2.28-2.30 in [1]. If the values of potential
         grads of the current world is provided, then we only needs to compute the
         gradient once per step."""
         if pe_grad is None:
-            _, pe_grad = self._potential_grads(world)
+            _, pe_grad = self._potential_grads(positions)
 
         new_momentums = {}
         for node, r in momentums.items():
             new_momentums[node] = r - step_size * pe_grad[node].flatten() / 2
         ke_grad = self._kinetic_grads(new_momentums, mass_inv)
 
-        new_z = {}
-        for node in world.latent_nodes:
-            # this should override the value of all the latent nodes in new_world
-            # but does not change observations and transforms
-            z = world.get_transformed(node)
-            new_z[node] = z + step_size * ke_grad[node].reshape(z.shape)
-        new_world = world.replace_transformed(new_z)
+        new_positions = {}
+        for node, z in positions.items():
+            new_positions[node] = z + step_size * ke_grad[node].reshape(z.shape)
 
-        pe, pe_grad = self._potential_grads(new_world)
+        pe, pe_grad = self._potential_grads(new_positions)
         for node, r in new_momentums.items():
             new_momentums[node] = r - step_size * pe_grad[node].flatten() / 2
 
-        return new_world, new_momentums, pe, pe_grad
+        return new_positions, new_momentums, pe, pe_grad
 
     def _leapfrog_updates(
         self,
-        world: SimpleWorld,
+        positions: RVDict,
         momentums: RVDict,
         trajectory_length: float,
         step_size: float,
         mass_inv: RVDict,
         pe_grad: Optional[RVDict] = None,
-    ) -> Tuple[SimpleWorld, RVDict, torch.Tensor, RVDict]:
+    ) -> Tuple[RVDict, RVDict, torch.Tensor, RVDict]:
         """Run multiple iterations of leapfrog integration until the length of the
         trajectory is greater than the specified trajectory_length."""
         # we should run at least 1 step
         num_steps = max(math.ceil(trajectory_length / step_size), 1)
         for _ in range(num_steps):
-            world, momentums, pe, pe_grad = self._leapfrog_step(
-                world, momentums, step_size, mass_inv, pe_grad
+            positions, momentums, pe, pe_grad = self._leapfrog_step(
+                positions, momentums, step_size, mass_inv, pe_grad
             )
         # pyre-fixme[61]: `pe` may not be initialized here.
-        return world, momentums, pe, cast(RVDict, pe_grad)
+        return positions, momentums, pe, cast(RVDict, pe_grad)
 
     def _find_reasonable_step_size(
         self,
         initial_step_size: float,
-        world: SimpleWorld,
+        positions: RVDict,
         pe: torch.Tensor,
         pe_grad: RVDict,
     ) -> float:
@@ -193,14 +199,16 @@ class HMCProposer(BaseProposer):
         # the target is log(0.5) in the paper but is log(0.8) on Stan:
         # https://github.com/stan-dev/stan/pull/356
         target = math.log(0.8)
-        momentums = self._initialize_momentums(world)
+        momentums = self._initialize_momentums(positions)
         energy = self._hamiltonian(
-            world, momentums, self._mass_inv, pe
-        )  # -log p(world, momentums)
-        new_world, new_momentums, new_pe, _ = self._leapfrog_step(
-            world, momentums, step_size, self._mass_inv, pe_grad
+            positions, momentums, self._mass_inv, pe
+        )  # -log p(positions, momentums)
+        new_positions, new_momentums, new_pe, _ = self._leapfrog_step(
+            positions, momentums, step_size, self._mass_inv, pe_grad
         )
-        new_energy = self._hamiltonian(new_world, new_momentums, self._mass_inv, new_pe)
+        new_energy = self._hamiltonian(
+            new_positions, new_momentums, self._mass_inv, new_pe
+        )
         # NaN will evaluate to False and set direction to -1
         new_direction = direction = 1 if energy - new_energy > target else -1
         step_size_scale = 2 ** direction
@@ -208,28 +216,31 @@ class HMCProposer(BaseProposer):
             step_size *= step_size_scale
             # not covered in the paper, but both Stan and Pyro re-sample the momentum
             # after each update
-            momentums = self._initialize_momentums(world)
-            energy = self._hamiltonian(world, momentums, self._mass_inv, pe)
-            new_world, new_momentums, new_pe, _ = self._leapfrog_step(
-                world, momentums, step_size, self._mass_inv, pe_grad
+            momentums = self._initialize_momentums(positions)
+            energy = self._hamiltonian(positions, momentums, self._mass_inv, pe)
+            new_positions, new_momentums, new_pe, _ = self._leapfrog_step(
+                positions, momentums, step_size, self._mass_inv, pe_grad
             )
             new_energy = self._hamiltonian(
-                new_world, new_momentums, self._mass_inv, new_pe
+                new_positions, new_momentums, self._mass_inv, new_pe
             )
             new_direction = 1 if energy - new_energy > target else -1
         return step_size
 
     def propose(self, world: Optional[SimpleWorld] = None) -> SimpleWorld:
         if world is not None and world is not self.world:
-            # re-compute cached values in case world was modified by other sources
-            self._pe, self._pe_grad = self._potential_grads(self.world)
+            # re-compute cached values since world was modified by other sources
             self.world = world
-        momentums = self._initialize_momentums(self.world)
+            self._positions = self._to_unconstrained(
+                {node: world[node] for node in world.latent_nodes}
+            )
+            self._pe, self._pe_grad = self._potential_grads(self._positions)
+        momentums = self._initialize_momentums(self._positions)
         current_energy = self._hamiltonian(
-            self.world, momentums, self._mass_inv, self._pe
+            self._positions, momentums, self._mass_inv, self._pe
         )
-        world, momentums, pe, pe_grad = self._leapfrog_updates(
-            self.world,
+        positions, momentums, pe, pe_grad = self._leapfrog_updates(
+            self._positions,
             momentums,
             self.trajectory_length,
             self.step_size,
@@ -237,14 +248,16 @@ class HMCProposer(BaseProposer):
             self._pe_grad,
         )
         new_energy = torch.nan_to_num(
-            self._hamiltonian(self.world, momentums, self._mass_inv, pe), float("inf")
+            self._hamiltonian(positions, momentums, self._mass_inv, pe),
+            float("inf"),
         )
         delta_energy = new_energy - current_energy
         self._alpha = torch.clamp(torch.exp(-delta_energy), max=1.0)
         # accept/reject new world
         if torch.bernoulli(self._alpha):
-            self.world, self._pe, self._pe_grad = world, pe, pe_grad
-
+            self.world = self.world.replace(self._to_unconstrained.inv(positions))
+            # update cache
+            self._positions, self._pe, self._pe_grad = positions, pe, pe_grad
         return self.world
 
     def do_adaptation(self) -> None:
@@ -258,14 +271,17 @@ class HMCProposer(BaseProposer):
             window_scheme = self._window_scheme
             assert window_scheme is not None
             if window_scheme.is_in_window:
-                self._mass_matrix_adapter.step(self.world)
+                self._mass_matrix_adapter.step(self._positions)
                 if window_scheme.is_end_window:
                     # update mass matrix at the end of a window
                     self._mass_matrix_adapter.finalize()
 
                     if self.adapt_step_size:
                         self.step_size = self._find_reasonable_step_size(
-                            self.step_size, self.world, self._pe, self._pe_grad
+                            self.step_size,
+                            self._positions,
+                            self._pe,
+                            self._pe_grad,
                         )
                         self._step_size_adapter = DualAverageAdapter(self.step_size)
             window_scheme.step()

--- a/src/beanmachine/ppl/experimental/global_inference/proposer/nuts_proposer.py
+++ b/src/beanmachine/ppl/experimental/global_inference/proposer/nuts_proposer.py
@@ -11,7 +11,7 @@ from beanmachine.ppl.experimental.global_inference.simple_world import (
 
 
 class _TreeNode(NamedTuple):
-    world: SimpleWorld
+    positions: RVDict
     momentums: RVDict
     pe_grad: RVDict
 
@@ -19,7 +19,7 @@ class _TreeNode(NamedTuple):
 class _Tree(NamedTuple):
     left: _TreeNode
     right: _TreeNode
-    proposal: SimpleWorld
+    proposal: RVDict
     pe: torch.Tensor
     pe_grad: RVDict
     log_weight: torch.Tensor
@@ -94,15 +94,16 @@ class NUTSProposer(HMCProposer):
     def _build_tree_base_case(self, root: _TreeNode, args: _TreeArgs) -> _Tree:
         """Base case of the recursive tree building algorithm: take a single leapfrog
         step in the specified direction and return a subtree."""
-        world, momentums, pe, pe_grad = self._leapfrog_step(
-            root.world,
+        positions, momentums, pe, pe_grad = self._leapfrog_step(
+            root.positions,
             root.momentums,
             args.step_size * args.direction,
             args.mass_inv,
             root.pe_grad,
         )
         new_energy = torch.nan_to_num(
-            self._hamiltonian(world, momentums, args.mass_inv, pe), float("inf")
+            self._hamiltonian(positions, momentums, args.mass_inv, pe),
+            float("inf"),
         )
         # initial_energy == -L(\theta^{m-1}) + 1/2 r_0^2 in Algorithm 6 of [1]
         delta_energy = new_energy - args.initial_energy
@@ -112,11 +113,11 @@ class NUTSProposer(HMCProposer):
             # slice sampling as introduced in the original NUTS paper [1]
             log_weight = (args.log_slice <= -new_energy).log()
 
-        tree_node = _TreeNode(world=world, momentums=momentums, pe_grad=pe_grad)
+        tree_node = _TreeNode(positions=positions, momentums=momentums, pe_grad=pe_grad)
         return _Tree(
             left=tree_node,
             right=tree_node,
-            proposal=world,
+            proposal=positions,
             pe=pe,
             pe_grad=pe_grad,
             log_weight=log_weight,
@@ -241,13 +242,16 @@ class NUTSProposer(HMCProposer):
 
     def propose(self, world: Optional[SimpleWorld] = None) -> SimpleWorld:
         if world is not None and world is not self.world:
-            # re-compute cached values in case world was modified by other sources
-            self._pe, self._pe_grad = self._potential_grads(self.world)
+            # re-compute cached values since world was modified by other sources
             self.world = world
+            self._positions = self._to_unconstrained(
+                {node: world[node] for node in world.latent_nodes}
+            )
+            self._pe, self._pe_grad = self._potential_grads(self._positions)
 
-        momentums = self._initialize_momentums(self.world)
+        momentums = self._initialize_momentums(self._positions)
         current_energy = self._hamiltonian(
-            self.world, momentums, self._mass_inv, self._pe
+            self._positions, momentums, self._mass_inv, self._pe
         )
         if self._multinomial_sampling:
             # log slice is only used to check the divergence
@@ -255,11 +259,11 @@ class NUTSProposer(HMCProposer):
         else:
             # this is a more stable way to sample from log(Uniform(0, exp(-current_energy)))
             log_slice = torch.log1p(-torch.rand(())) - current_energy
-        tree_node = _TreeNode(self.world, momentums, self._pe_grad)
+        tree_node = _TreeNode(self._positions, momentums, self._pe_grad)
         tree = _Tree(
             left=tree_node,
             right=tree_node,
-            proposal=self.world,
+            proposal=self._positions,
             pe=self._pe,
             pe_grad=self._pe_grad,
             log_weight=torch.tensor(0.0),  # log accept prob of staying at current state
@@ -285,6 +289,13 @@ class NUTSProposer(HMCProposer):
             if tree.turned_or_diverged:
                 break
 
-        self.world, self._pe, self._pe_grad = tree.proposal, tree.pe, tree.pe_grad
+        if tree.proposal is not self._positions:
+            self.world = self.world.replace(self._to_unconstrained.inv(tree.proposal))
+            self._positions, self._pe, self._pe_grad = (
+                tree.proposal,
+                tree.pe,
+                tree.pe_grad,
+            )
+
         self._alpha = tree.sum_accept_prob / tree.num_proposals
         return self.world

--- a/src/beanmachine/ppl/experimental/global_inference/proposer/tests/hmc_proposer_test.py
+++ b/src/beanmachine/ppl/experimental/global_inference/proposer/tests/hmc_proposer_test.py
@@ -31,33 +31,33 @@ def hmc(world):
     return hmc_proposer
 
 
-def test_potential_grads(world, hmc):
-    pe, pe_grad = hmc._potential_grads(world)
+def test_potential_grads(hmc):
+    pe, pe_grad = hmc._potential_grads(hmc._positions)
     assert isinstance(pe, torch.Tensor)
     assert pe.numel() == 1
-    for node in world.latent_nodes:
+    for node, z in hmc._positions.items():
         assert node in pe_grad
         assert isinstance(pe_grad[node], torch.Tensor)
-        assert pe_grad[node].shape == world.get_transformed(node).shape
+        assert pe_grad[node].shape == z.shape
 
 
-def test_kinetic_grads(world, hmc):
-    momentums = hmc._initialize_momentums(world)
+def test_kinetic_grads(hmc):
+    momentums = hmc._initialize_momentums(hmc._positions)
     ke = hmc._kinetic_energy(momentums, hmc._mass_inv)
     assert isinstance(ke, torch.Tensor)
     assert ke.numel() == 1
     ke_grad = hmc._kinetic_grads(momentums, hmc._mass_inv)
-    for node in world.latent_nodes:
+    for node, z in hmc._positions.items():
         assert node in ke_grad
         assert isinstance(ke_grad[node], torch.Tensor)
-        assert len(ke_grad[node]) == world.get_transformed(node).numel()
+        assert len(ke_grad[node]) == z.numel()
 
 
-def test_leapfrog_step(world, hmc):
+def test_leapfrog_step(hmc):
     step_size = 0.0
-    momentums = hmc._initialize_momentums(world)
-    new_world, new_momentums, pe, pe_grad = hmc._leapfrog_step(
-        world, momentums, step_size, hmc._mass_inv
+    momentums = hmc._initialize_momentums(hmc._positions)
+    new_positions, new_momentums, pe, pe_grad = hmc._leapfrog_step(
+        hmc._positions, momentums, step_size, hmc._mass_inv
     )
     assert momentums == new_momentums
-    assert new_world == world
+    assert new_positions == hmc._positions

--- a/src/beanmachine/ppl/experimental/global_inference/proposer/tests/nuts_proposer_test.py
+++ b/src/beanmachine/ppl/experimental/global_inference/proposer/tests/nuts_proposer_test.py
@@ -31,14 +31,16 @@ def nuts():
 
 @pytest.fixture
 def tree_node(nuts):
-    momentums = nuts._initialize_momentums(nuts.world)
-    return _TreeNode(world=nuts.world, momentums=momentums, pe_grad=nuts._pe_grad)
+    momentums = nuts._initialize_momentums(nuts._positions)
+    return _TreeNode(
+        positions=nuts._positions, momentums=momentums, pe_grad=nuts._pe_grad
+    )
 
 
 @pytest.fixture
 def tree_args(tree_node, nuts):
     initial_energy = nuts._hamiltonian(
-        nuts.world, tree_node.momentums, nuts._mass_inv, nuts._pe
+        nuts._positions, tree_node.momentums, nuts._mass_inv, nuts._pe
     )
     return _TreeArgs(
         log_slice=-initial_energy,

--- a/src/beanmachine/ppl/experimental/global_inference/tests/simple_world_test.py
+++ b/src/beanmachine/ppl/experimental/global_inference/tests/simple_world_test.py
@@ -70,7 +70,6 @@ def test_basic_operations():
 
     assert len(world) == 2
     assert model.bar() in world
-    assert world.get_variable(model.bar()).transform == dist.identity_transform
     assert world.latent_nodes == {model.foo()}
 
     # edge connection
@@ -79,10 +78,7 @@ def test_basic_operations():
     assert len(world.get_variable(model.bar()).children) == 0
     assert len(world.get_variable(model.foo()).parents) == 0
 
-    transformed_foo = world.get_transformed(model.foo())
-    assert world.get_variable(model.foo()).transform.inv(transformed_foo) == world.call(
-        model.foo()
-    )
+    assert world.get_variable(model.foo()).value == world.call(model.foo())
 
 
 def test_initialization():
@@ -101,7 +97,7 @@ def test_log_prob():
     log_prob1 = world1.log_prob()
 
     # set to a value with extremely small probability
-    world2 = world1.replace_transformed({model.bar(): torch.tensor(100.0)})
+    world2 = world1.replace({model.bar(): torch.tensor(100.0)})
     log_prob2 = world2.log_prob()
 
     assert log_prob1 > log_prob2
@@ -126,7 +122,7 @@ def test_change_parents():
     assert model.bar(1) not in world.get_variable(model.baz()).parents
     assert model.baz() in world.get_variable(model.bar(0)).children
 
-    world2 = world.replace_transformed({model.foo(): torch.tensor(1.0)})
+    world2 = world.replace({model.foo(): torch.tensor(1.0)})
 
     assert model.bar(0) not in world2.get_variable(model.baz()).parents
     assert model.bar(1) in world2.get_variable(model.baz()).parents
@@ -140,8 +136,8 @@ def test_distribution_and_log_prob_update():
         model.bar()
         model.baz()
 
-    world = world.replace_transformed({model.foo(): torch.tensor(0.0)})
-    world2 = world.replace_transformed({model.foo(): torch.tensor(1.0)})
+    world = world.replace({model.foo(): torch.tensor(0.0)})
+    world2 = world.replace({model.foo(): torch.tensor(1.0)})
 
     bar_var = world.get_variable(model.bar())
     assert isinstance(bar_var.distribution, dist.Normal)

--- a/src/beanmachine/ppl/experimental/global_inference/tests/variable_test.py
+++ b/src/beanmachine/ppl/experimental/global_inference/tests/variable_test.py
@@ -4,14 +4,10 @@ from beanmachine.ppl.experimental.global_inference.variable import Variable
 
 
 def test_log_prob():
-    var1 = Variable(
-        transformed_value=torch.zeros(3),
-        transform=dist.identity_transform,
-        distribution=dist.Bernoulli(0.8),
-    )
+    var1 = Variable(value=torch.zeros(3), distribution=dist.Bernoulli(0.8))
     # verify that the cached property `log_prob` is recomputed when we replace the
     # fields of a Variable
-    var2 = var1.replace(transformed_value=torch.ones(3))
+    var2 = var1.replace(value=torch.ones(3))
     assert var1.log_prob.sum() < var2.log_prob.sum()
 
     var3 = var1.replace(distribution=dist.Normal(0.0, 1.0))
@@ -19,3 +15,16 @@ def test_log_prob():
 
     var4 = var1.replace(distribution=dist.Categorical(logits=torch.rand(2, 4)))
     assert torch.all(torch.isinf(var4.log_prob))
+
+    var5 = Variable(
+        value=torch.tensor(10).double(),
+        distribution=dist.Uniform(
+            torch.tensor(0.0).double(), torch.tensor(1.0).double()
+        ),
+    )
+    # Check that the log prob has the right dtype
+    assert var5.log_prob.dtype == torch.double
+    assert torch.isinf(var5.log_prob)
+
+    var6 = var5.replace(value=torch.tensor(1))
+    assert torch.isinf(var6.log_prob)


### PR DESCRIPTION
Summary:
Sorry, this diff touches quite a bit of the codebase XD. Other than the codemods that are necessary to ensure our algorithm can still passing, the main changes are the follows:

- Transform logics are moved to the specific algorithms (in this case, HMC instead of keeping them in the World. This is going to be more useful when we start working on compositional inference; for now, it just makes the world a bit cleaner.
- `Distribution` objects are stored in `Variable` now, similar to the old single site world.

On HMC side:
-  A new `WorldConverter` is introduced that handle the conversion from constrained to unconstrained space (and vice versa). Because HMC doesn't need the explicit graph structure, the converter return a dict instead of a world. Most of the methods are updated to use `dict` as well.
   - I'm pretty bad at naming things. Please feel free to suggest a new name for the "converter" class.
- To compute the potential energy, we need a reference world (think of this as a model with observed values) and the current positions (i.e. the proposal).
  - Internally, we convert the positions to constrained space, then replace the values in the old world. The `replace` method will run the model and return us a new world with newly instantiated distributions (i.e. the "trace" of our model). We then use it to compute the log prob and the gradient. Note that the new world is not returned.

Some clarification on the potentially confusing part:
- Before the change, a leapfrog step takes a world and returns an updated world:
  - `world_0` -> `world_1` -> `world_2` -> ... -> `world_n`
- With the change in this diff, we first convert a world to dict, then the leapfrog step
  - `world_0` -(convert)-> `dict_0` -> `dict_1` -> ... -> `dict_n` -(update `world_0`)-> `world_1`
  - the potential energy at `i`th step is computed by updating `world_0` with `dict_i`

The reasons for this change is that:
1. World is in the original (constrained) space now, whereas the position dict is in the unconstrained space. So it's more natural for the algorithm to work with parameters in the unconstrained space without having to worry about conversion.
2. NNC integration will be easier if we pass `dict` around instead of worlds. In fact, I don't even know if it's possible for a NNC-compiled function to return a new world with a bunch of new distribution objects.

Differential Revision: D31259985

---
Copy-pasting my internal comment in case people read this PR:

Change log for V4: Introduce a `RealSpaceTransform` class that replace the `WorldConverter` in the previous version. This `RealSpaceTransform` only works on dictionary type and does not handle any World conversion logic. The rest of the diff mostly remain the same.
