### PR TITLE
Devectorize most samples

### DIFF
--- a/src/beanmachine/ppl/compiler/fix_vectorized_models.py
+++ b/src/beanmachine/ppl/compiler/fix_vectorized_models.py
@@ -62,10 +62,23 @@ class VectorizedDistributionFixer(ProblemFixerBase):
     def __init__(self, bmg: BMGraphBuilder, typer: Sizer) -> None:
         ProblemFixerBase.__init__(self, bmg, typer)
         self.fixed_one = False
+        # TODO: categorical
+        # TODO: categorical logit
+        # TODO: dirichlet
         self._factories = {
             bn.BernoulliLogitNode: bmg.add_bernoulli_logit,
             bn.BernoulliNode: bmg.add_bernoulli,
+            bn.BetaNode: bmg.add_beta,
+            bn.BinomialNode: bmg.add_binomial,
+            bn.BinomialLogitNode: bmg.add_binomial_logit,
+            bn.Chi2Node: bmg.add_chi2,
+            bn.GammaNode: bmg.add_gamma,
+            bn.HalfCauchyNode: bmg.add_halfcauchy,
+            bn.HalfNormalNode: bmg.add_halfnormal,
             bn.NormalNode: bmg.add_normal,
+            bn.PoissonNode: bmg.add_poisson,
+            bn.StudentTNode: bmg.add_studentt,
+            bn.UniformNode: bmg.add_uniform,
         }
 
     def _node_to_index_list(self, n: bn.BMGNode) -> List[bn.BMGNode]:

--- a/src/beanmachine/ppl/compiler/tests/fix_vectorized_models_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_vectorized_models_test.py
@@ -4,7 +4,7 @@ import unittest
 import beanmachine.ppl as bm
 from beanmachine.ppl.inference import BMGInference
 from torch import tensor
-from torch.distributions import Bernoulli, Beta, Normal
+from torch.distributions import Bernoulli, Beta, Normal, Uniform, HalfCauchy, StudentT
 
 
 @bm.random_variable
@@ -15,6 +15,26 @@ def beta(n):
 @bm.random_variable
 def flip_beta():
     return Bernoulli(tensor([beta(0), beta(1)]))
+
+
+@bm.random_variable
+def beta_2_2():
+    return Beta(2.0, tensor([3.0, 4.0]))
+
+
+@bm.random_variable
+def flip_beta_2_2():
+    return Bernoulli(beta_2_2())
+
+
+@bm.random_variable
+def uniform_2_2():
+    return Uniform(0.0, tensor([1.0, 1.0]))
+
+
+@bm.random_variable
+def flip_uniform_2_2():
+    return Bernoulli(uniform_2_2())
 
 
 @bm.random_variable
@@ -43,6 +63,16 @@ def normal_2_3():
     sigmas = tensor([2.0, 3.0, 4.0])
 
     return Normal(mus, sigmas)
+
+
+@bm.random_variable
+def hc_3():
+    return HalfCauchy(tensor([1.0, 2.0, 3.0]))
+
+
+@bm.random_variable
+def studentt_2_3():
+    return StudentT(hc_3(), normal_2_3(), hc_3())
 
 
 class FixVectorizedModelsTest(unittest.TestCase):
@@ -383,27 +413,40 @@ digraph "graph" {
     def test_fix_vectorized_models_5(self) -> None:
         self.maxDiff = None
         observations = {}
-        queries = [normal_2_3()]
+        queries = [studentt_2_3()]
 
         observed = BMGInference().to_dot(queries, observations, after_transform=False)
 
-        # The model before the rewrite:
+        # The model before the rewrite. Note that we have a size[3] stochastic input and
+        # a size[2, 3] stochastic input to the StudentT, and we broadcast the three
+        # HalfCauchy samples correctly
 
         expected = """
 digraph "graph" {
-  N0[label="[[0.25,0.75,0.5],\\\\n[0.125,0.875,0.625]]"];
-  N1[label=Bernoulli];
-  N2[label=Sample];
-  N3[label="[2.0,3.0,4.0]"];
-  N4[label=Normal];
-  N5[label=Sample];
-  N6[label=Query];
-  N0 -> N1;
-  N1 -> N2;
-  N2 -> N4;
-  N3 -> N4;
-  N4 -> N5;
-  N5 -> N6;
+  N00[label="[1.0,2.0,3.0]"];
+  N01[label=HalfCauchy];
+  N02[label=Sample];
+  N03[label="[[0.25,0.75,0.5],\\\\n[0.125,0.875,0.625]]"];
+  N04[label=Bernoulli];
+  N05[label=Sample];
+  N06[label="[2.0,3.0,4.0]"];
+  N07[label=Normal];
+  N08[label=Sample];
+  N09[label=StudentT];
+  N10[label=Sample];
+  N11[label=Query];
+  N00 -> N01;
+  N01 -> N02;
+  N02 -> N09;
+  N02 -> N09;
+  N03 -> N04;
+  N04 -> N05;
+  N05 -> N07;
+  N06 -> N07;
+  N07 -> N08;
+  N08 -> N09;
+  N09 -> N10;
+  N10 -> N11;
 }
 """
         self.assertEqual(expected.strip(), observed.strip())
@@ -415,92 +458,244 @@ digraph "graph" {
 digraph "graph" {
   N00[label=3];
   N01[label=2];
-  N02[label=0.25];
-  N03[label=Bernoulli];
+  N02[label=1.0];
+  N03[label=HalfCauchy];
   N04[label=Sample];
-  N05[label=ToReal];
-  N06[label=2.0];
-  N07[label=Normal];
-  N08[label=Sample];
-  N09[label=0.75];
-  N10[label=Bernoulli];
+  N05[label=0.25];
+  N06[label=Bernoulli];
+  N07[label=Sample];
+  N08[label=ToReal];
+  N09[label=2.0];
+  N10[label=Normal];
   N11[label=Sample];
-  N12[label=ToReal];
-  N13[label=3.0];
-  N14[label=Normal];
+  N12[label=StudentT];
+  N13[label=Sample];
+  N14[label=HalfCauchy];
   N15[label=Sample];
-  N16[label=0.5];
+  N16[label=0.75];
   N17[label=Bernoulli];
   N18[label=Sample];
   N19[label=ToReal];
-  N20[label=4.0];
+  N20[label=3.0];
   N21[label=Normal];
   N22[label=Sample];
-  N23[label=0.125];
-  N24[label=Bernoulli];
-  N25[label=Sample];
-  N26[label=ToReal];
-  N27[label=Normal];
-  N28[label=Sample];
-  N29[label=0.875];
-  N30[label=Bernoulli];
-  N31[label=Sample];
-  N32[label=ToReal];
-  N33[label=Normal];
-  N34[label=Sample];
-  N35[label=0.625];
-  N36[label=Bernoulli];
-  N37[label=Sample];
-  N38[label=ToReal];
-  N39[label=Normal];
-  N40[label=Sample];
-  N41[label=ToMatrix];
-  N42[label=Query];
-  N00 -> N41;
-  N01 -> N41;
+  N23[label=StudentT];
+  N24[label=Sample];
+  N25[label=HalfCauchy];
+  N26[label=Sample];
+  N27[label=0.5];
+  N28[label=Bernoulli];
+  N29[label=Sample];
+  N30[label=ToReal];
+  N31[label=4.0];
+  N32[label=Normal];
+  N33[label=Sample];
+  N34[label=StudentT];
+  N35[label=Sample];
+  N36[label=0.125];
+  N37[label=Bernoulli];
+  N38[label=Sample];
+  N39[label=ToReal];
+  N40[label=Normal];
+  N41[label=Sample];
+  N42[label=StudentT];
+  N43[label=Sample];
+  N44[label=0.875];
+  N45[label=Bernoulli];
+  N46[label=Sample];
+  N47[label=ToReal];
+  N48[label=Normal];
+  N49[label=Sample];
+  N50[label=StudentT];
+  N51[label=Sample];
+  N52[label=0.625];
+  N53[label=Bernoulli];
+  N54[label=Sample];
+  N55[label=ToReal];
+  N56[label=Normal];
+  N57[label=Sample];
+  N58[label=StudentT];
+  N59[label=Sample];
+  N60[label=ToMatrix];
+  N61[label=Query];
+  N00 -> N60;
+  N01 -> N60;
   N02 -> N03;
   N03 -> N04;
-  N04 -> N05;
-  N05 -> N07;
+  N04 -> N12;
+  N04 -> N12;
+  N04 -> N42;
+  N04 -> N42;
+  N05 -> N06;
   N06 -> N07;
-  N06 -> N27;
   N07 -> N08;
-  N08 -> N41;
+  N08 -> N10;
   N09 -> N10;
+  N09 -> N14;
+  N09 -> N40;
   N10 -> N11;
   N11 -> N12;
-  N12 -> N14;
-  N13 -> N14;
-  N13 -> N33;
+  N12 -> N13;
+  N13 -> N60;
   N14 -> N15;
-  N15 -> N41;
+  N15 -> N23;
+  N15 -> N23;
+  N15 -> N50;
+  N15 -> N50;
   N16 -> N17;
   N17 -> N18;
   N18 -> N19;
   N19 -> N21;
   N20 -> N21;
-  N20 -> N39;
+  N20 -> N25;
+  N20 -> N48;
   N21 -> N22;
-  N22 -> N41;
+  N22 -> N23;
   N23 -> N24;
-  N24 -> N25;
+  N24 -> N60;
   N25 -> N26;
-  N26 -> N27;
+  N26 -> N34;
+  N26 -> N34;
+  N26 -> N58;
+  N26 -> N58;
   N27 -> N28;
-  N28 -> N41;
+  N28 -> N29;
   N29 -> N30;
-  N30 -> N31;
+  N30 -> N32;
   N31 -> N32;
+  N31 -> N56;
   N32 -> N33;
   N33 -> N34;
-  N34 -> N41;
-  N35 -> N36;
+  N34 -> N35;
+  N35 -> N60;
   N36 -> N37;
   N37 -> N38;
   N38 -> N39;
   N39 -> N40;
   N40 -> N41;
   N41 -> N42;
+  N42 -> N43;
+  N43 -> N60;
+  N44 -> N45;
+  N45 -> N46;
+  N46 -> N47;
+  N47 -> N48;
+  N48 -> N49;
+  N49 -> N50;
+  N50 -> N51;
+  N51 -> N60;
+  N52 -> N53;
+  N53 -> N54;
+  N54 -> N55;
+  N55 -> N56;
+  N56 -> N57;
+  N57 -> N58;
+  N58 -> N59;
+  N59 -> N60;
+  N60 -> N61;
+}
+"""
+        self.assertEqual(expected.strip(), observed.strip())
+
+    def test_fix_vectorized_models_6(self) -> None:
+        self.maxDiff = None
+        observations = {}
+        queries = [flip_beta_2_2(), flip_uniform_2_2()]
+
+        observed = BMGInference().to_dot(queries, observations, after_transform=False)
+
+        # The model before the rewrite: notice that here torch automatically
+        # broadcast the 2.0 to [2.0, 2.0] for us when the node was accumulated,
+        # and similarly for 0.0.
+
+        expected = """
+digraph "graph" {
+  N00[label="[2.0,2.0]"];
+  N01[label="[3.0,4.0]"];
+  N02[label=Beta];
+  N03[label=Sample];
+  N04[label=Bernoulli];
+  N05[label=Sample];
+  N06[label=Query];
+  N07[label="[0.0,0.0]"];
+  N08[label="[1.0,1.0]"];
+  N09[label=Uniform];
+  N10[label=Sample];
+  N11[label=Bernoulli];
+  N12[label=Sample];
+  N13[label=Query];
+  N00 -> N02;
+  N01 -> N02;
+  N02 -> N03;
+  N03 -> N04;
+  N04 -> N05;
+  N05 -> N06;
+  N07 -> N09;
+  N08 -> N09;
+  N09 -> N10;
+  N10 -> N11;
+  N11 -> N12;
+  N12 -> N13;
+}
+"""
+        self.assertEqual(expected.strip(), observed.strip())
+
+        # After: notice that we correctly generate two samples from a Flat distribution
+        # here.
+
+        observed = BMGInference().to_dot(queries, observations, after_transform=True)
+        expected = """
+digraph "graph" {
+  N00[label=2];
+  N01[label=1];
+  N02[label=2.0];
+  N03[label=3.0];
+  N04[label=Beta];
+  N05[label=Sample];
+  N06[label=Bernoulli];
+  N07[label=Sample];
+  N08[label=4.0];
+  N09[label=Beta];
+  N10[label=Sample];
+  N11[label=Bernoulli];
+  N12[label=Sample];
+  N13[label=ToMatrix];
+  N14[label=Query];
+  N15[label=Flat];
+  N16[label=Sample];
+  N17[label=Bernoulli];
+  N18[label=Sample];
+  N19[label=Sample];
+  N20[label=Bernoulli];
+  N21[label=Sample];
+  N22[label=ToMatrix];
+  N23[label=Query];
+  N00 -> N13;
+  N00 -> N22;
+  N01 -> N13;
+  N01 -> N22;
+  N02 -> N04;
+  N02 -> N09;
+  N03 -> N04;
+  N04 -> N05;
+  N05 -> N06;
+  N06 -> N07;
+  N07 -> N13;
+  N08 -> N09;
+  N09 -> N10;
+  N10 -> N11;
+  N11 -> N12;
+  N12 -> N13;
+  N13 -> N14;
+  N15 -> N16;
+  N15 -> N19;
+  N16 -> N17;
+  N17 -> N18;
+  N18 -> N22;
+  N19 -> N20;
+  N20 -> N21;
+  N21 -> N22;
+  N22 -> N23;
 }
 
 """


### PR DESCRIPTION
Summary:
The compiler now implements devectorizing sample operators on most of the distributions supported by BMG; I've left out categorical and Dirichlet distributions because they will require special handling.

Here's a good example from the test cases that shows how we do correct broadcasting and devectorization.

    bm.random_variable
    def flip_const_2_3():
        return Bernoulli(tensor([[0.25, 0.75, 0.5], [0.125, 0.875, 0.625]]))
    bm.random_variable
    def normal_2_3():
        mus = flip_const_2_3()
        sigmas = tensor([2.0, 3.0, 4.0])
        return Normal(mus, sigmas)
    bm.random_variable
    def hc_3():
        return HalfCauchy(tensor([1.0, 2.0, 3.0]))
    bm.random_variable
    def studentt_2_3():
        return StudentT(hc_3(), normal_2_3(), hc_3())

The original graph is:

{F664460121}

So we should have six Bernoulli samples, six Normal samples, three HalfCauchy samples, and six StudentT samples after the devectorization:

{F664460197}

Coming up, we'll extend devectorization to other operators.

Reviewed By: wtaha

Differential Revision: D30997828

