### PR TITLE
Devectorize more operators

### DIFF
--- a/src/beanmachine/ppl/compiler/fix_matrix_scale.py
+++ b/src/beanmachine/ppl/compiler/fix_matrix_scale.py
@@ -18,6 +18,9 @@ class MatrixScaleFixer(ProblemFixerBase):
         ProblemFixerBase.__init__(self, bmg, typer)
 
     def _needs_fixing(self, n: bn.BMGNode) -> bool:
+        # See note in fix_unsupported.py for why this is temporarily disabled.
+        return False
+        """
         # A matrix multiplication is fixable (to matrix_scale) if it is
         # a binary multiplication with non-singlton result type
         # and the type of one argument is matrix and the other is scalar
@@ -34,7 +37,7 @@ class MatrixScaleFixer(ProblemFixerBase):
         # If both are matrices, then there is nothing to do
         if all(not (t.is_singleton()) for t in input_types):
             return False  # Both are matrices
-        return True
+        return True"""
 
     def _get_replacement(self, n: bn.BMGNode) -> Optional[bn.BMGNode]:
         # Double check we can proceed, and that exactly one is scalar

--- a/src/beanmachine/ppl/compiler/fix_unsupported.py
+++ b/src/beanmachine/ppl/compiler/fix_unsupported.py
@@ -270,6 +270,20 @@ class UnsupportedNodeFixer(ProblemFixerBase):
         # turn into BMG nodes.
         return None
 
+    def _fix_matrix_scale(self, n: bn.BMGNode) -> bn.BMGNode:
+        # Double check we can proceed, and that exactly one is scalar
+        assert self._fixable_matrix_scale(n)
+        # We'll need to name the inputs and their types
+        left, right = n.inputs
+        left_type, right_type = [self._typer[i] for i in n.inputs]
+        # Let's assume the first is the scalr one
+        scalar, matrix = left, right
+        # Fix it if necessary
+        if right_type.is_singleton():
+            scalar = right
+            matrix = left
+        return self._bmg.add_matrix_scale(scalar, matrix)
+
     def _get_replacement(self, n: bn.BMGNode) -> Optional[bn.BMGNode]:
         # TODO:
         # Not -> Complement
@@ -287,7 +301,31 @@ class UnsupportedNodeFixer(ProblemFixerBase):
             return self._replace_tensor(n)
         if isinstance(n, bn.UniformNode):
             return self._replace_uniform(n)
+
+        # See note in _needs_fixing below.
+        if isinstance(n, bn.MultiplicationNode):
+            return self._fix_matrix_scale(n)
+
         return None
+
+    def _fixable_matrix_scale(self, n: bn.BMGNode) -> bool:
+        # A matrix multiplication is fixable (to matrix_scale) if it is
+        # a binary multiplication with non-singlton result type
+        # and the type of one argument is matrix and the other is scalar
+        if not isinstance(n, bn.MultiplicationNode) or not (len(n.inputs) == 2):
+            return False
+        # The return type of the node should be matrix
+        if not (self._typer[n]).is_singleton():
+            return False
+        # Now let's check the types of the inputs
+        input_types = [self._typer[i] for i in n.inputs]
+        # If both are scalar, then there is nothing to do
+        if all(t.is_singleton() for t in input_types):
+            return False  # Both are scalar
+        # If both are matrices, then there is nothing to do
+        if all(not (t.is_singleton()) for t in input_types):
+            return False  # Both are matrices
+        return True
 
     def _needs_fixing(self, n: bn.BMGNode) -> bool:
         # Constants that can be converted to constant nodes of the appropriate type
@@ -306,6 +344,40 @@ class UnsupportedNodeFixer(ProblemFixerBase):
         if isinstance(n, bn.ConstantNode):
             t = bt.type_of_value(n.value)
             return t == bt.Tensor or t == bt.Untypable
+
+        # TODO: We have an ordering problem in the fixers:
+        # Consider a model with (tensor([[c(), c()],[c(), c()]]) * 10.0).exp() in it,
+        # where c() is a sample from Chi2(1.0).
+        #
+        # The devectorizer skips rewriting the tensor multiplied by scalar operation
+        # because matrix scale rewriter will do so. However it does devectorize the
+        # exp(); it adds index ops to extract the four values from the multiplication.
+        #
+        # Now, which runs first, the unsupported node fixer or the matrix scale fixer?
+        #
+        # * Unsupported node fixer must run first so that the Chi2(1.0) is rewritten into
+        #   supported Gamma(0.5, 0.5) before the matrix scale fixer needs to know the type
+        #   of the multiplication. But...
+        # * Matrix scale fixer must run first so that unsupported node fixer can correctly
+        #   rewrite and optimize the index operations.
+        #
+        # We have a chicken-and-egg problem here.
+        #
+        # The long-term solution is:
+        #
+        # * Extract the error reporting functionality from the unsupported node rewriter
+        #   into its own pass.  Unsupported node rewriter just makes a best effort to rewrite.
+        # * All rewriting passes run in turn making best efforts to rewrite until a fixpoint is
+        #   reached; THEN we check for remaining errors.
+        #
+        # However, that principled solution will require some minor rearchitecting of the
+        # graph rewriters. For now, what we'll do is move the matrix scale fixer INTO the
+        # unsupported node fixer. Since we rewrite from ancestors to descendants, we'll
+        # rewrite the chi2, and then the multiplication, and then the index nodes, which is
+        # the order we need to do them in.
+        if self._fixable_matrix_scale(n):
+            return True
+
         # It's not a constant. If the node is not supported then try to fix it.
         return not is_supported_by_bmg(n)
 

--- a/src/beanmachine/ppl/compiler/tests/fix_vectorized_models_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_vectorized_models_test.py
@@ -77,7 +77,9 @@ def studentt_2_3():
 
 @bm.functional
 def operators():
-    return beta_2_2() + tensor([[5.0, 6.0], [7.0, 8.0]])
+    # Note that we do NOT devectorize the multiplication; it gets
+    # turned into a MatrixScale.
+    return ((beta_2_2() + tensor([[5.0, 6.0], [7.0, 8.0]])) * 10.0).exp()
 
 
 class FixVectorizedModelsTest(unittest.TestCase):
@@ -723,13 +725,19 @@ digraph "graph" {
   N3[label=Sample];
   N4[label="[[5.0,6.0],\\\\n[7.0,8.0]]"];
   N5[label="+"];
-  N6[label=Query];
+  N6[label=10.0];
+  N7[label="*"];
+  N8[label=Exp];
+  N9[label=Query];
   N0 -> N2;
   N1 -> N2;
   N2 -> N3;
   N3 -> N5;
   N4 -> N5;
-  N5 -> N6;
+  N5 -> N7;
+  N6 -> N7;
+  N7 -> N8;
+  N8 -> N9;
 }
 """
         self.assertEqual(expected.strip(), observed.strip())
@@ -740,49 +748,87 @@ digraph "graph" {
         expected = """
 digraph "graph" {
   N00[label=2];
-  N01[label=2.0];
-  N02[label=3.0];
-  N03[label=Beta];
-  N04[label=Sample];
-  N05[label=ToPosReal];
-  N06[label=5.0];
-  N07[label="+"];
-  N08[label=4.0];
-  N09[label=Beta];
-  N10[label=Sample];
-  N11[label=ToPosReal];
-  N12[label=6.0];
-  N13[label="+"];
-  N14[label=7.0];
-  N15[label="+"];
-  N16[label=8.0];
-  N17[label="+"];
-  N18[label=ToMatrix];
-  N19[label=Query];
-  N00 -> N18;
-  N00 -> N18;
-  N01 -> N03;
-  N01 -> N09;
-  N02 -> N03;
+  N01[label=10.0];
+  N02[label=2.0];
+  N03[label=3.0];
+  N04[label=Beta];
+  N05[label=Sample];
+  N06[label=ToPosReal];
+  N07[label=5.0];
+  N08[label="+"];
+  N09[label=4.0];
+  N10[label=Beta];
+  N11[label=Sample];
+  N12[label=ToPosReal];
+  N13[label=6.0];
+  N14[label="+"];
+  N15[label=7.0];
+  N16[label="+"];
+  N17[label=8.0];
+  N18[label="+"];
+  N19[label=ToMatrix];
+  N20[label=MatrixScale];
+  N21[label=0];
+  N22[label=ColumnIndex];
+  N23[label=index];
+  N24[label=Exp];
+  N25[label=1];
+  N26[label=index];
+  N27[label=Exp];
+  N28[label=ColumnIndex];
+  N29[label=index];
+  N30[label=Exp];
+  N31[label=index];
+  N32[label=Exp];
+  N33[label=ToMatrix];
+  N34[label=Query];
+  N00 -> N19;
+  N00 -> N19;
+  N00 -> N33;
+  N00 -> N33;
+  N01 -> N20;
+  N02 -> N04;
+  N02 -> N10;
   N03 -> N04;
   N04 -> N05;
-  N05 -> N07;
-  N05 -> N15;
-  N06 -> N07;
-  N07 -> N18;
-  N08 -> N09;
+  N05 -> N06;
+  N06 -> N08;
+  N06 -> N16;
+  N07 -> N08;
+  N08 -> N19;
   N09 -> N10;
   N10 -> N11;
-  N11 -> N13;
-  N11 -> N17;
-  N12 -> N13;
-  N13 -> N18;
-  N14 -> N15;
-  N15 -> N18;
-  N16 -> N17;
+  N11 -> N12;
+  N12 -> N14;
+  N12 -> N18;
+  N13 -> N14;
+  N14 -> N19;
+  N15 -> N16;
+  N16 -> N19;
   N17 -> N18;
   N18 -> N19;
+  N19 -> N20;
+  N20 -> N22;
+  N20 -> N28;
+  N21 -> N22;
+  N21 -> N23;
+  N21 -> N29;
+  N22 -> N23;
+  N22 -> N26;
+  N23 -> N24;
+  N24 -> N33;
+  N25 -> N26;
+  N25 -> N28;
+  N25 -> N31;
+  N26 -> N27;
+  N27 -> N33;
+  N28 -> N29;
+  N28 -> N31;
+  N29 -> N30;
+  N30 -> N33;
+  N31 -> N32;
+  N32 -> N33;
+  N33 -> N34;
 }
-
 """
         self.assertEqual(expected.strip(), observed.strip())


### PR DESCRIPTION
Summary:
In this diff I devectorize more of the operators; we now devectorize `+ - * ** / exp log phi logistic` operators. The remaining operators I'll do in a later diff.

As in previous diffs, I've used a table-driven approach to cut down on duplicated code.

While testing I realized that I had forgotten an important case in previous diffs: operations where one operand is a scalar constant. Those constants have have size `[]`, not size `[1]` and my code did not take that into account. It now does and we test this scenario.

Reviewed By: wtaha

Differential Revision: D31034257

