### PR TITLE
Reducing runtime to avoid timeouts in sandcastle

### DIFF
--- a/src/beanmachine/ppl/diagnostics/tests/diagnostics_test.py
+++ b/src/beanmachine/ppl/diagnostics/tests/diagnostics_test.py
@@ -3,6 +3,7 @@ from typing import Dict
 
 import beanmachine.ppl as bm
 import beanmachine.ppl.diagnostics.common_statistics as common_statistics
+import numpy as np
 import pandas as pd
 import torch
 import torch.distributions as dist
@@ -86,7 +87,7 @@ class DiagnosticsTest(unittest.TestCase):
                             val,
                             res[i].item(),
                             msg=f"query {query_res.index[i]} for {col}",
-                            delta=0.2,
+                            delta=0.5,
                         )
 
         def _test_plot_object(diag, query, query_samples):
@@ -120,7 +121,7 @@ class DiagnosticsTest(unittest.TestCase):
             for i in range(num_samples):
                 expected_acf = acf(
                     query_samples[:, i].detach().numpy(),
-                    unbiased=True,
+                    True,
                     nlags=num_samples - 1,
                     fft=False,
                 )
@@ -130,15 +131,16 @@ class DiagnosticsTest(unittest.TestCase):
                         expected_acf[ns],
                         msg=f"autocorr data for {diag._stringify_query(query)}\
                               is not correct",
-                        delta=0.11,
+                        delta=0.3,
                     )
                 index += 1
 
+        np.random.seed(123)
         torch.manual_seed(123)
         mh = bm.SingleSiteAncestralMetropolisHastings()
         query_list = [beta(0), diri(1, 5), normal()]
         num_chains = 2
-        samples = mh.infer(query_list, {}, 1500, num_chains)
+        samples = mh.infer(query_list, {}, 200, num_chains)
 
         out_df = Diagnostics(samples).summary()
         _inference_evaulation(out_df)


### PR DESCRIPTION
Summary:
This diff modifies a test with the purpose of reducing its runtime (*). On sandcastle the stress test version of this test was timing out after 10 minutes (600 seconds) consistently. The test takes takes about 40 seconds in opt mode on my server, but 8 minutes (!) in dev mode. The stress test mode on sandcastle runs using dev mode, and has 10 versions of the test running in parallel. Reducing the sample size reduced runtime from 8 minutes to about 1.5 minutes, and required change to a few tolerances in the test. Some additional points and details:

- It was noted that the test was non-deterministic (and still is). That is, repeated runs produce different results. For this the import numpy was added and the numpy seed was set. Unfortunately, this did not seem to make it deterministic.

- The test is disabled on sandcastle, but seems to still run on CircleCI (and cause a timeout error there). Maybe it could be good to have CircleCI not run the tests that are disabled on sandcastle

- For reference, the TestX report can be found at: https://www.internalfb.com/intern/test/281475011761034?ref_report_id=0

- On that report, the command for the stress test is: `buck test mode/dev //beanmachine/beanmachine/ppl:test-ppl -- --exact 'beanmachine/beanmachine/ppl:test-ppl - diagnostics_test.py::DiagnosticsTest::test_basic_diagnostics' --run-disabled --jobs 18 --stress-runs 10 --record-results`

- Judging by what one sees using the linux top command, it seems that the `--stress-runs 10` option runs 10 versions of the test in parallel on the machine. With single runtime of 3 minutes, the stress run timeout all ten runs (with two of them not even with sample collection) at 10 minutes. This means that we should probably aim for runtimes of about 1 minute or less.

- In the stress test on my devserver machine the 10 runs finished between 230-290 seconds, so, hopefully, if the sandcastle machines are comparable and similarly (lightly) loaded, these tests should pass there.

(*) Postscript: This diff was also amended to remove the keyword parameter "unbiased" from the call to acf. It seems that that package has deprecated that parameter, and that was in fact one of the reasons why this test was failing in the CircleCI build check called `user_install_test_py37_pip`.

Differential Revision: D31443629

