### PR TITLE
Bumping CircleCI to Python 3.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,9 +61,9 @@ commands:
             conda update -q conda
             conda info -a  # print out info that're useful for debug
       - run:
-          name: "Create a new conda environment (Python 3.7)"
+          name: "Create a new conda environment (Python 3.8)"
           command: |
-            conda create -q -n test_env python=3.7
+            conda create -q -n test_env python=3.8
             # activate test_env by default for the subsequent commands
             echo "conda activate test_env" >> /Users/distiller/.bash_profile
 
@@ -148,9 +148,9 @@ commands:
 
 jobs:
 
-  dev_install_test_py37_pip:
+  dev_install_test_py38_pip:
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8
     steps:
       - apt_get_install_deps
       - checkout
@@ -159,9 +159,9 @@ jobs:
       - pip_list
       - dev_unit_tests
 
-  user_install_test_py37_pip:
+  user_install_test_py38_pip:
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8
     steps:
       - apt_get_install_deps
       - checkout
@@ -170,7 +170,7 @@ jobs:
       - pip_list
       - user_unit_tests
 
-  macos_dev_install_test_py37_conda:
+  macos_dev_install_test_py38_conda:
     macos:
       xcode: 12.0
     steps:
@@ -182,9 +182,9 @@ jobs:
       - pip_list
       - dev_unit_tests
 
-  lint_py37_pip:
+  lint_py38_pip:
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8
     steps:
       - checkout
       - pip_lint_install
@@ -194,9 +194,9 @@ jobs:
       - lint_usort
       - lint_black
 
-  nightly_test_py37_pip:
+  nightly_test_py38_pip:
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8
     steps:
       - apt_get_install_deps
       - checkout
@@ -219,16 +219,16 @@ workflows:
 
   lint_and_test:
     jobs:
-      - lint_py37_pip:
+      - lint_py38_pip:
           filters: *exclude_ghpages_fbconfig
 
-      - dev_install_test_py37_pip:
+      - dev_install_test_py38_pip:
           filters: *exclude_ghpages_fbconfig
 
-      - user_install_test_py37_pip:
+      - user_install_test_py38_pip:
           filters: *exclude_ghpages_fbconfig
 
-      - macos_dev_install_test_py37_conda:
+      - macos_dev_install_test_py38_conda:
           filters: *exclude_ghpages_fbconfig
 
   nightly_test:
@@ -240,4 +240,4 @@ workflows:
               only:
                 - master
     jobs:
-      - nightly_test_py37_pip
+      - nightly_test_py38_pip

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import find_packages, setup
 
 
 REQUIRED_MAJOR = 3
-REQUIRED_MINOR = 6
+REQUIRED_MINOR = 8
 
 
 TEST_REQUIRES = ["pytest", "pytest-cov"]

--- a/src/beanmachine/ppl/inference/abstract_infer.py
+++ b/src/beanmachine/ppl/inference/abstract_infer.py
@@ -243,10 +243,11 @@ class AbstractMCInference(AbstractInference, metaclass=ABCMeta):
         self.queries_ = queries
         self.observations_ = observations
         if num_chains > 1 and run_in_parallel:
-            manager = mp.Manager()
+            ctx = mp.get_context("fork")
+            manager = ctx.Manager()
             q = manager.Queue()
             for chain in range(num_chains):
-                p = mp.Process(
+                p = ctx.Process(
                     target=self._parallel_infer,
                     args=(
                         q,


### PR DESCRIPTION
Summary:
Python 3.8 has been the [default Python version in fbcode](https://www.internalfb.com/intern/wiki/Python/Python_Version/#current-default-fbcode) for a while. By bumping CircleCI's version number to match our internal version, we're less likely to run into inconsistent test behaviors. We can also work on re-enabling the previously disabled tests [like these](https://www.internalfb.com/code/fbsource/fbcode/beanmachine/beanmachine/ppl/compiler/tests/ast_tools_test.py?lines=10) which have different behaviors in Python 3.7 vs Python 3.8.

The downside is that we will lose users that for whatever reason only have Python 3.7 and earlier versions installed. Though given that the [official full support for Python 3.7 is already ended](https://en.wikipedia.org/wiki/History_of_Python#Table_of_versions) (in fact, even Python 3.8 is considered an old version), this probably won't be a big issue.

Related: [What's new in Python 3.8](https://docs.python.org/3.8/whatsnew/3.8.html)

Differential Revision: D31557952

