### PR TITLE
Start implementing rewrites of augmented assignments

### DIFF
--- a/src/beanmachine/ppl/compiler/ast_patterns.py
+++ b/src/beanmachine/ppl/compiler/ast_patterns.py
@@ -116,6 +116,17 @@ def assign(targets: Pattern = _any, value: Pattern = _any) -> Pattern:
     return type_and_attributes(ast.Assign, {"targets": targets, "value": value})
 
 
+def aug_assign(
+    target: Pattern = _any, op: Pattern = _any, value: Pattern = _any
+) -> Pattern:
+    return type_and_attributes(
+        ast.AugAssign, {"target": target, "op": op, "value": value}
+    )
+
+
+# TODO: what should we do about AnnAssign?
+
+
 def starred(value: Pattern = _any, ctx: Pattern = _any) -> Pattern:
     return type_and_attributes(ast.Starred, {"value": value, "ctx": ctx})
 

--- a/src/beanmachine/ppl/compiler/tests/single_assignment_test.py
+++ b/src/beanmachine/ppl/compiler/tests/single_assignment_test.py
@@ -3336,3 +3336,21 @@ def f(x):
         ]
 
         self.check_rewrites(terms)
+
+    def test_augmented_assignment(self) -> None:
+        """Test rewrites involving += and other augmented assignments."""
+        source = """
+def f(x):
+    x += 123
+    x *= 456
+    x.y.z /= 2
+"""
+        expected = """
+def f(x):
+    a1 = 123
+    x += a1
+    a2 = 456
+    x *= a2
+    x.y.z /= 2
+        """
+        self.check_rewrite(source, expected)


### PR DESCRIPTION
Summary:
The Beanstalk compiler starts by translating model source code into a simpler subset of Python that is more easily instrumented; we do not yet transform augmented assignments (`+=` and so on) into a simpler form.  This diff begins by ensuring that if the left side of an augmented assignment is an identifier then so is the right side.

In upcoming diffs we will ensure that the left side is always an identifier; that in combination with this rule will achieve the desired final state: every augmented assignment has identifiers on both sides.

Reviewed By: wtaha

Differential Revision: D31283089

