### PR TITLE
Continue implementing augmented assignment syntactic rewriter

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/single_assignment_test.py
+++ b/src/beanmachine/ppl/compiler/tests/single_assignment_test.py
@@ -3345,12 +3345,17 @@ def f(x):
     x *= 456
     x.y.z /= 2
 """
+
         expected = """
 def f(x):
     a1 = 123
     x += a1
     a2 = 456
     x *= a2
-    x.y.z /= 2
+    a3 = x.y
+    a4 = a3.z
+    a5 = 2
+    a4 /= a5
+    a3.z = a4
         """
         self.check_rewrite(source, expected)


### PR DESCRIPTION
Summary:
In this diff I continue the work started in the previous; here we implement two more rules for simplifying augmented assignments. They are:

* `complex.attr += any` is rewritten to `a0 = complex; a0.attr += any`
* `a0.attr += any` is rewritten to `a1 = a0.attr ; a1 += any; a0.attr = a1`

In the previous diff we wrote a rule where `a1 += any` is rewritten to `a2 = any; a1 += a2` and so we now have almost all the rules we need to ensure that every augmented assignment only has identifiers on both sides.

We do not yet implement rules for `a[b] += c` and the like; those will come in a later diff.

Reviewed By: wtaha

Differential Revision: D31293128

