### PR TITLE
Test to demonstrate super() compiler bug

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/bm_to_bmg_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bm_to_bmg_test.py
@@ -2,9 +2,9 @@
 """Tests for bm_to_bmg.py"""
 import unittest
 
-
-# from beanmachine.ppl.compiler.bm_to_bmg import to_dot_deprecated
-
+import beanmachine.ppl as bm
+from beanmachine.ppl.inference import BMGInference
+from torch.distributions import Normal
 
 # flake8 does not provide any mechanism to disable warnings in
 # multi-line strings, so just turn it off for this file.
@@ -257,6 +257,23 @@ digraph "graph" {
 """
 
 
+class BaseModel:
+    @bm.random_variable
+    def normal(self):
+        return Normal(0.0, 1.0)
+
+    @bm.functional
+    def foo(self):
+        return self.normal() + 1.0
+
+
+class DerivedModel(BaseModel):
+    @bm.functional
+    def foo(self):
+        # This call is correct but we handle it wrong.
+        return super().foo() * 2.0
+
+
 class CompilerTest(unittest.TestCase):
     def disabled_test_to_dot_10(self) -> None:
         # TODO: This crashes; something is broken with matrix multiplication.
@@ -280,3 +297,47 @@ class CompilerTest(unittest.TestCase):
         self.maxDiff = None
         # observed = to_dot_deprecated(source14)
         # self.assertEqual(observed.strip(), expected_dot_14.strip())
+
+    def test_super_call(self) -> None:
+        # A call to super() in Python is not a normal function. Consider:
+        def outer(s):
+            return s().x()
+
+        class B:
+            def x(self):
+                return 1
+
+        class D(B):
+            def x(self):
+                return 2
+
+            def ordinary(self):
+                return self.x()  # 2
+
+            def sup1(self):
+                return super().x()  # 1
+
+            def sup2(self):
+                s = super
+                return s().x()  # Doesn't have to be a keyword
+
+            def callout(self):
+                return outer(super)  # but the call to super() needs to be inside D.
+
+        self.assertEqual(D().ordinary(), 2)
+        self.assertEqual(D().sup1(), 1)
+        self.assertEqual(D().sup2(), 1)
+        try:
+            D().callout()
+        except RuntimeError as e:
+            # This exception is expected.
+            self.assertEqual("super(): __class__ cell not found", str(e))
+
+        try:
+            d = DerivedModel()
+            BMGInference().to_dot([d.foo()], {})
+        except RuntimeError as e:
+            # This exception is wrong.
+            self.assertEqual("super(): __class__ cell not found", str(e))
+
+        # TODO: Fix the bug.


### PR DESCRIPTION
Summary:
Models which call super() in a random variable, functional, or callee of a random variable or functional crash; this is due to the way we rewrite function calls.

I've added a test which demonstrates the mechanism of the crash: we handle function calls by intercepting the call, obtaining a reference to the called function, and checking to see if it is one of our known functions. But calls to `super()` cannot be handled this way.

The test also demonstrates the unwanted crash in one of our models. I have not yet come up with a fix for this; a workaround in the meanwhile is to avoid using `super()` and instead do the old fashioned form `super(DerivedClass, self)`

Reviewed By: wtaha

Differential Revision: D31513017

