### PR TITLE
Handle augmented assignment additions in models

### DIFF
--- a/src/beanmachine/ppl/compiler/bm_to_bmg.py
+++ b/src/beanmachine/ppl/compiler/bm_to_bmg.py
@@ -14,6 +14,7 @@ from beanmachine.ppl.compiler.ast_patterns import (
     ast_assert,
     ast_domain,
     attribute,
+    aug_assign,
     binary_compare,
     binop,
     call,
@@ -137,6 +138,27 @@ def _handle_binary(p: Pattern, s: str) -> PatternRule:
     )
 
 
+def _handle_aug_assign(op: Pattern, s: str) -> PatternRule:
+    # A rule which transforms
+    #
+    # x OP= y
+    #
+    # into
+    #
+    # x = bmg.handle_iOP(x, y)
+    #
+    # Note that the x on the left of the assignment must be a Store()
+    # and the one on the right must be a Load().
+
+    return PatternRule(
+        aug_assign(target=name(), value=name(), op=op),
+        lambda a: ast.Assign(
+            [a.target],
+            _make_bmg_call(s, [ast.Name(id=a.target.id, ctx=ast.Load()), a.value]),
+        ),
+    )
+
+
 def _handle_comparison(p: Pattern, s: str) -> PatternRule:
     # A rule which transforms
     #
@@ -204,6 +226,8 @@ _math_to_bmg: Rule = _top_down(
                 _handle_comparison(binary_compare(ast.IsNot), "handle_is_not"),
                 _handle_comparison(binary_compare(ast.In), "handle_in"),
                 _handle_comparison(binary_compare(ast.NotIn), "handle_not_in"),
+                # Augmented assignments
+                _handle_aug_assign(ast.Add, "handle_iadd"),
             ]
         )
     )

--- a/src/beanmachine/ppl/compiler/runtime.py
+++ b/src/beanmachine/ppl/compiler/runtime.py
@@ -47,6 +47,7 @@ three, four and five.
 
 import inspect
 import math
+import operator
 from types import MethodType
 from typing import Any, Callable, Dict, List, Optional, Set
 
@@ -599,6 +600,17 @@ class BMGRuntime:
         if isinstance(input, ConstantNode) and isinstance(other, ConstantNode):
             return input.value + other.value
         return self._bmg.add_addition(input, other)
+
+    def handle_iadd(self, left: Any, right: Any) -> Any:
+        # No graph node implements a mutating augmented assignment. If the left
+        # operand does, then we just mutate the left side regardless of whether
+        # the right side is a graph node.
+        # CONSIDER: Should a mutable left side and a graph node right side be
+        # an error? It seems like asking for trouble.
+        if hasattr(left, "__iadd__"):
+            return operator.iadd(left, right)
+        # Since the left side is not mutating, we can simply add.
+        return self.handle_addition(left, right)
 
     def handle_bitand(self, input: Any, other: Any) -> Any:
         if (not isinstance(input, BMGNode)) and (not isinstance(other, BMGNode)):

--- a/src/beanmachine/ppl/compiler/tests/bmg_arithmetic_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_arithmetic_test.py
@@ -65,8 +65,12 @@ def ordinary_arithmetic(n):
 @bm.random_variable
 def stochastic_arithmetic():
     s = 0.0
-    for n in [0, 1]:
-        s = s + torch.log(torch.tensor(0.01)) * ordinary_arithmetic(n)
+    # Verify that mutating += works on lists normally:
+    items = [0]
+    items += [1]
+    for n in items:
+        # Verify that += works on graph nodes:
+        s += torch.log(torch.tensor(0.01)) * ordinary_arithmetic(n)
     return Bernoulli(1 - torch.exp(input=torch.log(torch.tensor(0.99)) + s))
 
 


### PR DESCRIPTION
Summary:
At long last we correctly extract a graph from models which contain `+=` operators on graph nodes.

This logic is complicated by the fact that `+=` in Python can mean both "mutate the left side" and "add the left side to the right side, assign the result to the left side".

As noted in the comments, it should be rare to have a mutating left side and a graph node right side; we might consider detecting this strange condition and throwing an exception because odds are pretty good that the model is not going to be one we can compile.

If the left side is not mutating then we simply do the addition as normal and return the result.

So far only `+=` is implemented; I'll add `-=` and `*=` and all the rest in an upcoming diff.

Reviewed By: wtaha

Differential Revision: D31382826

