### PR TITLE
Add table type for marginals

### DIFF
--- a/src/beanmachine/ppl/world/marginal_table.py
+++ b/src/beanmachine/ppl/world/marginal_table.py
@@ -1,0 +1,58 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import dataclasses
+from typing import Set
+
+import torch
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
+
+
+@dataclasses.dataclass
+class Entry:
+    """
+    An entry in the fom of:
+    - RVIdentifier
+    - Maximum support of discrete variable
+    - Set of parents (including itself)
+    - The probabilities associated with the cartesian product of the enumerated
+      parents in a PyTorch Tensor with each entry's indices corresponding to the
+      value of its parents
+    - The above tensor flattened
+    """
+
+    var: RVIdentifier
+    cardinality: int
+    parents: Set
+    values: torch.Tensor
+
+    def __str__(self) -> str:
+        out = "Variable: " + str(self.var) + ", "
+        out += "Cardinality: " + str(self.cardinality) + ", "
+        out += "parents: " + str(self.parents) + ", "
+        out += "values: " + str(self.values)
+        return out
+
+    def __eq__(self, other) -> bool:
+        return (  # pyre-ignore [7]
+            self.var == other.var
+            and self.cardinality == other.cardinality
+            and self.parents == other.parents
+            and (self.values == other.values).all().item()
+        )
+
+    def __hash__(self) -> int:
+        return hash((self.var, self.cardinality))
+
+
+@dataclasses.dataclass
+class Table:
+    """
+    A table representing the marginal distribution of a (discrete) factor graph
+    """
+
+    entries: Set[Entry] = dataclasses.field(default_factory=set)
+
+    def add_entry(self, entry) -> None:
+        self.entries.add(entry)
+
+    def __eq__(self, other) -> bool:
+        return self.entries == other.entries

--- a/src/beanmachine/ppl/world/tests/marginal_table_test.py
+++ b/src/beanmachine/ppl/world/tests/marginal_table_test.py
@@ -1,0 +1,36 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import unittest
+
+import torch
+from beanmachine.ppl import random_variable as rv
+from beanmachine.ppl.world.marginal_table import Table, Entry
+from torch.distributions import Bernoulli
+
+
+class MarginalTableTest(unittest.TestCase):
+    def test_table_equality(self):
+        @rv
+        def a():
+            return Bernoulli(0.5)
+
+        @rv
+        def b():
+            return Bernoulli(a())
+
+        table = Table()
+        vals = torch.tensor([0.5, 0.5])
+        e = Entry(a(), 2, {a()}, vals)
+        table.add_entry(e)
+        vals = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+        e = Entry(b(), 2, {a(), b()}, vals)
+        table.add_entry(e)
+
+        table1 = Table()
+        vals = torch.tensor([0.5, 0.5])
+        e = Entry(a(), 2, {a()}, vals)
+        table1.add_entry(e)
+        self.assertNotEqual(table, table1)
+        vals = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+        e = Entry(b(), 2, {a(), b()}, vals)
+        table1.add_entry(e)
+        self.assertEqual(table, table1)


### PR DESCRIPTION
Summary:
This PR creates a Table type that represents the marginals of a discrete factor graph in the following format:

- RVIdentifer
- max_cardinality
- parents
- table of probabilities in a torch.Tensor
indexed by its parents values

The motivation for this is that the parents and other intermediate fields need to be sets, which are unhashable types in Python.

Reviewed By: rodrigodesalvobraz

Differential Revision: D31570526

