### PR TITLE
New single site MH ancestral proposer

### DIFF
--- a/src/beanmachine/ppl/experimental/global_inference/proposer/base_single_site_proposer.py
+++ b/src/beanmachine/ppl/experimental/global_inference/proposer/base_single_site_proposer.py
@@ -1,0 +1,56 @@
+import math
+from abc import abstractmethod
+
+import torch
+import torch.distributions as dist
+from beanmachine.ppl.experimental.global_inference.proposer.base_proposer import (
+    BaseProposer,
+)
+from beanmachine.ppl.experimental.global_inference.simple_world import SimpleWorld
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
+
+
+class BaseSingleSiteMHProposer(BaseProposer):
+    def __init__(self, target_rv: RVIdentifier):
+        self.node = target_rv
+
+    def propose(self, world: SimpleWorld):
+        """Propose a new value for self.node with Metropolis-Hasting algorithm
+        https://en.wikipedia.org/wiki/Metropolis%E2%80%93Hastings_algorithm#Formal_derivation
+        Classes that inherit this proposer should override `get_proposal_distribution`
+        to define the algorithm-specific way to sample the next state.
+        """
+        proposal_dist = forward_dist = self.get_proposal_distribution(world)
+        old_value = world[self.node]
+        # pyre-ignore[20]
+        proposed_value = proposal_dist.sample()
+        new_world = world.replace({self.node: proposed_value})
+        backward_dist = self.get_proposal_distribution(new_world)
+
+        # calculate MH acceptance probability
+        # log P(x, y)
+        old_log_prob = world.log_prob()
+        # log P(x', y)
+        new_log_prob = new_world.log_prob()
+        # log g(x'|x)
+        forward_log_prob = forward_dist.log_prob(proposed_value).sum()
+        # log g(x|x')
+        backward_log_prob = backward_dist.log_prob(old_value).sum()
+
+        # log [(P(x', y) * g(x|x')) / (P(x, y) * g(x'|x))]
+        accept_log_prob = (
+            new_log_prob + backward_log_prob - old_log_prob - forward_log_prob
+        )
+        # model size adjustment log (n/n')
+        accept_log_prob += math.log(len(world)) - math.log(len(new_world))
+
+        if torch.rand_like(accept_log_prob).log() < accept_log_prob:
+            world = new_world
+        return world
+
+    @abstractmethod
+    def get_proposal_distribution(self, world: SimpleWorld) -> dist.Distribution:
+        """Return a probability distribution of moving self.node to a new value
+        conditioned on its current value in world.
+        """
+        raise NotImplementedError

--- a/src/beanmachine/ppl/experimental/global_inference/proposer/single_site_ancestral_proposer.py
+++ b/src/beanmachine/ppl/experimental/global_inference/proposer/single_site_ancestral_proposer.py
@@ -1,0 +1,11 @@
+import torch.distributions as dist
+from beanmachine.ppl.experimental.global_inference.proposer.base_single_site_proposer import (
+    BaseSingleSiteMHProposer,
+)
+from beanmachine.ppl.experimental.global_inference.simple_world import SimpleWorld
+
+
+class SingleSiteAncestralProposer(BaseSingleSiteMHProposer):
+    def get_proposal_distribution(self, world: SimpleWorld) -> dist.Distribution:
+        """Propose a new value for self.node using the prior distribution."""
+        return world.get_variable(self.node).distribution

--- a/src/beanmachine/ppl/experimental/global_inference/single_site_ancestral_mh.py
+++ b/src/beanmachine/ppl/experimental/global_inference/single_site_ancestral_mh.py
@@ -1,0 +1,27 @@
+from typing import List
+
+from beanmachine.ppl.experimental.global_inference.base_inference import BaseInference
+from beanmachine.ppl.experimental.global_inference.proposer.base_proposer import (
+    BaseProposer,
+)
+from beanmachine.ppl.experimental.global_inference.proposer.single_site_ancestral_proposer import (
+    SingleSiteAncestralProposer,
+)
+from beanmachine.ppl.experimental.global_inference.simple_world import (
+    SimpleWorld,
+)
+
+
+class SingleSiteAncestralMetropolisHastings(BaseInference):
+    def __init__(self):
+        self._proposers = {}
+
+    def get_proposers(
+        self, world: SimpleWorld, num_adaptive_sample: int
+    ) -> List[BaseProposer]:
+        proposers = []
+        for node in world.latent_nodes:
+            if node not in self._proposers:
+                self._proposers[node] = SingleSiteAncestralProposer(node)
+            proposers.append(self._proposers[node])
+        return proposers

--- a/src/beanmachine/ppl/inference/tests/single_site_ancestral_mh_conjugate_test_nightly.py
+++ b/src/beanmachine/ppl/inference/tests/single_site_ancestral_mh_conjugate_test_nightly.py
@@ -1,7 +1,9 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import unittest
 
-import beanmachine.ppl as bm
+from beanmachine.ppl.experimental.global_inference.single_site_ancestral_mh import (
+    SingleSiteAncestralMetropolisHastings,
+)
 from beanmachine.ppl.testlib.abstract_conjugate import AbstractConjugateTests
 
 
@@ -9,7 +11,7 @@ class SingleSiteAncestralMetropolisHastingsConjugateTest(
     unittest.TestCase, AbstractConjugateTests
 ):
     def setUp(self):
-        self.mh = bm.SingleSiteAncestralMetropolisHastings()
+        self.mh = SingleSiteAncestralMetropolisHastings()
 
     def test_beta_binomial_conjugate_run(self):
         self.beta_binomial_conjugate_run(self.mh)


### PR DESCRIPTION
Summary:
As titled. This diff re-wrote [`SingleSiteAncestralProposer`](https://www.internalfb.com/code/fbsource/[063faddf325196e7976048b87790ec72a74785fc]/fbcode/beanmachine/beanmachine/ppl/inference/proposer/single_site_ancestral_proposer.py?lines=11) and [its base class](https://www.internalfb.com/code/fbsource/[063faddf325196e7976048b87790ec72a74785fc]/fbcode/beanmachine/beanmachine/ppl/inference/proposer/abstract_single_site_single_step_proposer.py) with the new API.

The plan is to eventually remove the old implementation & swap out all references with the new implementation, though as of this diff there're still a few differences in the inference API. So in this diff I only changed the reference in `single_site_ancestral_mh_test.py`. I will work on unifying the API and old code removal in subsequent diffs (e.g., D31680092); in the mean time, this diff can serve as a reference on how single site algorithms can be migrated into the new infra :D.

Differential Revision: D31132671

