### PR TITLE
get_proposers: return a list of proposers from a given world

### DIFF
--- a/src/beanmachine/ppl/experimental/global_inference/hmc_inference.py
+++ b/src/beanmachine/ppl/experimental/global_inference/hmc_inference.py
@@ -1,6 +1,9 @@
-import dataclasses
+from typing import List
 
 from beanmachine.ppl.experimental.global_inference.base_inference import BaseInference
+from beanmachine.ppl.experimental.global_inference.proposer.base_proposer import (
+    BaseProposer,
+)
 from beanmachine.ppl.experimental.global_inference.proposer.hmc_proposer import (
     HMCProposer,
 )
@@ -10,27 +13,71 @@ from beanmachine.ppl.experimental.global_inference.proposer.nuts_proposer import
 from beanmachine.ppl.experimental.global_inference.simple_world import SimpleWorld
 
 
-@dataclasses.dataclass
 class GlobalHamiltonianMonteCarlo(BaseInference):
-    trajectory_length: float
-    initial_step_size: float = 1.0
-    adapt_step_size: bool = True
-    adapt_mass_matrix: bool = True
-    target_accept_prob: float = 0.8
+    def __init__(
+        self,
+        trajectory_length: float,
+        initial_step_size: float = 1.0,
+        adapt_step_size: bool = True,
+        adapt_mass_matrix: bool = True,
+        target_accept_prob: float = 0.8,
+    ):
+        self.trajectory_length = trajectory_length
+        self.initial_step_size = initial_step_size
+        self.adapt_step_size = adapt_step_size
+        self.adapt_mass_matrix = adapt_mass_matrix
+        self.target_accept_prob = target_accept_prob
+        self._proposer = None
 
-    def get_proposer(self, world: SimpleWorld) -> HMCProposer:
-        return HMCProposer(world, **dataclasses.asdict(self))
+    def get_proposers(
+        self, world: SimpleWorld, num_adaptive_sample: int
+    ) -> List[BaseProposer]:
+        if self._proposer is None:
+            self._proposer = HMCProposer(
+                world,
+                num_adaptive_sample,
+                self.trajectory_length,
+                self.initial_step_size,
+                self.adapt_step_size,
+                self.adapt_mass_matrix,
+                self.target_accept_prob,
+            )
+        return [self._proposer]
 
 
-@dataclasses.dataclass
 class GlobalNoUTurnSampler(BaseInference):
-    max_tree_depth: int = 10
-    max_delta_energy: float = 1000.0
-    initial_step_size: float = 1.0
-    adapt_step_size: bool = True
-    adapt_mass_matrix: bool = True
-    multinomial_sampling: bool = True
-    target_accept_prob: float = 0.8
+    def __init__(
+        self,
+        max_tree_depth: int = 10,
+        max_delta_energy: float = 1000.0,
+        initial_step_size: float = 1.0,
+        adapt_step_size: bool = True,
+        adapt_mass_matrix: bool = True,
+        multinomial_sampling: bool = True,
+        target_accept_prob: float = 0.8,
+    ):
+        self.max_tree_depth = max_tree_depth
+        self.max_delta_energy = max_delta_energy
+        self.initial_step_size = initial_step_size
+        self.adapt_step_size = adapt_step_size
+        self.adapt_mass_matrix = adapt_mass_matrix
+        self.multinomial_sampling = multinomial_sampling
+        self.target_accept_prob = target_accept_prob
+        self._proposer = None
 
-    def get_proposer(self, world: SimpleWorld) -> NUTSProposer:
-        return NUTSProposer(world, **dataclasses.asdict(self))
+    def get_proposers(
+        self, world: SimpleWorld, num_adaptive_sample: int
+    ) -> List[BaseProposer]:
+        if self._proposer is None:
+            self._proposer = NUTSProposer(
+                world,
+                num_adaptive_sample,
+                self.max_tree_depth,
+                self.max_delta_energy,
+                self.initial_step_size,
+                self.adapt_step_size,
+                self.adapt_mass_matrix,
+                self.multinomial_sampling,
+                self.target_accept_prob,
+            )
+        return [self._proposer]

--- a/src/beanmachine/ppl/experimental/global_inference/proposer/base_proposer.py
+++ b/src/beanmachine/ppl/experimental/global_inference/proposer/base_proposer.py
@@ -1,16 +1,12 @@
 from abc import ABCMeta, abstractmethod
-from typing import Optional
 
 from beanmachine.ppl.experimental.global_inference.simple_world import SimpleWorld
 
 
 class BaseProposer(metaclass=ABCMeta):
     @abstractmethod
-    def propose(self, world: Optional[SimpleWorld] = None) -> SimpleWorld:
+    def propose(self, world: SimpleWorld) -> SimpleWorld:
         raise NotImplementedError
-
-    def init_adaptation(self, num_adaptive_samples: int) -> None:
-        ...
 
     def do_adaptation(self) -> None:
         ...

--- a/src/beanmachine/ppl/experimental/global_inference/proposer/nuts_proposer.py
+++ b/src/beanmachine/ppl/experimental/global_inference/proposer/nuts_proposer.py
@@ -1,4 +1,4 @@
-from typing import NamedTuple, Optional
+from typing import NamedTuple
 
 import torch
 from beanmachine.ppl.experimental.global_inference.proposer.hmc_proposer import (
@@ -57,6 +57,7 @@ class NUTSProposer(HMCProposer):
     def __init__(
         self,
         initial_world: SimpleWorld,
+        num_adaptive_sample: int,
         max_tree_depth: int = 10,
         max_delta_energy: float = 1000.0,
         initial_step_size: float = 1.0,
@@ -68,6 +69,7 @@ class NUTSProposer(HMCProposer):
         # note that trajectory_length is not used in NUTS
         super().__init__(
             initial_world,
+            num_adaptive_sample,
             trajectory_length=0.0,
             initial_step_size=initial_step_size,
             adapt_step_size=adapt_step_size,
@@ -240,8 +242,8 @@ class NUTSProposer(HMCProposer):
             turned_or_diverged=turned_or_diverged,
         )
 
-    def propose(self, world: Optional[SimpleWorld] = None) -> SimpleWorld:
-        if world is not None and world is not self.world:
+    def propose(self, world: SimpleWorld) -> SimpleWorld:
+        if world is not self.world:
             # re-compute cached values since world was modified by other sources
             self.world = world
             self._positions = self._to_unconstrained(

--- a/src/beanmachine/ppl/experimental/global_inference/proposer/tests/hmc_proposer_test.py
+++ b/src/beanmachine/ppl/experimental/global_inference/proposer/tests/hmc_proposer_test.py
@@ -27,7 +27,7 @@ def world():
 
 @pytest.fixture
 def hmc(world):
-    hmc_proposer = HMCProposer(world, trajectory_length=1.0)
+    hmc_proposer = HMCProposer(world, 10, trajectory_length=1.0)
     return hmc_proposer
 
 

--- a/src/beanmachine/ppl/experimental/global_inference/proposer/tests/nuts_proposer_test.py
+++ b/src/beanmachine/ppl/experimental/global_inference/proposer/tests/nuts_proposer_test.py
@@ -25,7 +25,7 @@ def bar():
 def nuts():
     world = SimpleWorld(observations={bar(): torch.tensor(0.8)})
     world.call(bar())
-    nuts_proposer = NUTSProposer(world)
+    nuts_proposer = NUTSProposer(world, 10)
     return nuts_proposer
 
 

--- a/src/beanmachine/ppl/experimental/global_inference/sampler.py
+++ b/src/beanmachine/ppl/experimental/global_inference/sampler.py
@@ -1,21 +1,36 @@
-from types import TracebackType
-from typing import Generator, NoReturn, Optional, Type
+from __future__ import annotations
 
-from beanmachine.ppl.experimental.global_inference.proposer.base_proposer import (
-    BaseProposer,
+import random
+from types import TracebackType
+from typing import (
+    Generator,
+    NoReturn,
+    Optional,
+    Type,
+    TYPE_CHECKING,
 )
-from beanmachine.ppl.experimental.global_inference.simple_world import SimpleWorld
+
+
+if TYPE_CHECKING:
+    from beanmachine.ppl.experimental.global_inference.base_inference import (
+        BaseInference,
+    )
+
+from beanmachine.ppl.experimental.global_inference.simple_world import (
+    SimpleWorld,
+)
 
 
 class Sampler(Generator[SimpleWorld, Optional[SimpleWorld], None]):
     def __init__(
         self,
-        proposer: BaseProposer,
+        kernel: BaseInference,
+        initial_world: SimpleWorld,
         num_samples: Optional[int] = None,
         num_adaptive_samples: int = 0,
     ):
-        self.proposer = proposer
-        self.proposer.init_adaptation(num_adaptive_samples)
+        self.kernel = kernel
+        self.world = initial_world
         self._num_samples_remaining = (
             float("inf") if num_samples is None else num_samples
         )
@@ -23,18 +38,33 @@ class Sampler(Generator[SimpleWorld, Optional[SimpleWorld], None]):
         self._num_adaptive_sample_remaining = num_adaptive_samples
 
     def send(self, world: Optional[SimpleWorld] = None) -> SimpleWorld:
-        if self._num_samples_remaining > 0:
-            world = self.proposer.propose(world)
-            if self._num_adaptive_sample_remaining > 0:
-                self.proposer.do_adaptation()
-                self._num_adaptive_sample_remaining -= 1
-                if self._num_samples_remaining == 0:
-                    # we just reach the end of adaptation period
-                    self.proposer.finish_adaptation()
-            self._num_samples_remaining -= 1
-            return world
-        else:
+        if world is None:
+            world = self.world
+
+        if self._num_samples_remaining <= 0:
             raise StopIteration
+
+        proposers = self.kernel.get_proposers(
+            world, self._num_adaptive_sample_remaining
+        )
+        random.shuffle(proposers)
+
+        for proposer in proposers:
+            world = proposer.propose(world)
+
+            if self._num_adaptive_sample_remaining > 0:
+                proposer.do_adaptation()
+                if self._num_samples_remaining == 1:
+                    # we just reach the end of adaptation period
+                    proposer.finish_adaptation()
+
+        # update attributes at last, so that exceptions during inference won't leave
+        # self in an invalid state
+        self.world = world
+        if self._num_adaptive_sample_remaining > 0:
+            self._num_adaptive_sample_remaining -= 1
+        self._num_samples_remaining -= 1
+        return self.world
 
     def throw(
         self,

--- a/src/beanmachine/ppl/experimental/global_inference/tests/inference_test.py
+++ b/src/beanmachine/ppl/experimental/global_inference/tests/inference_test.py
@@ -1,11 +1,8 @@
 import beanmachine.ppl as bm
 import torch
 import torch.distributions as dist
-from beanmachine.ppl.experimental.global_inference.proposer.hmc_proposer import (
-    HMCProposer,
-)
-from beanmachine.ppl.experimental.global_inference.proposer.nuts_proposer import (
-    NUTSProposer,
+from beanmachine.ppl.experimental.global_inference.proposer.base_proposer import (
+    BaseProposer,
 )
 from beanmachine.ppl.experimental.global_inference.simple_world import SimpleWorld
 
@@ -45,14 +42,13 @@ def test_inference():
     assert samples.get_num_samples(include_adapt_steps=True) == num_samples * 2
 
 
-def test_get_proposer():
+def test_get_proposers():
     world = SimpleWorld()
     model = SampleModel()
     world.call(model.bar())
     nuts = bm.GlobalNoUTurnSampler()
-    assert isinstance(nuts.get_proposer(world), NUTSProposer)
-    hmc = bm.GlobalHamiltonianMonteCarlo(1.0)
-    assert isinstance(hmc.get_proposer(world), HMCProposer)
+    proposers = nuts.get_proposers(world, 10)
+    assert all(isinstance(proposer, BaseProposer) for proposer in proposers)
 
 
 def test_initialize_world():


### PR DESCRIPTION
Summary:
This diff implements the spawning of proposers as previously discussed in [this Quip doc](https://fb.quip.com/WSnUAIDqxHyx#temp:C:UfTd7281592b8e24fd3a6185969d).

Before the change, the `get_proposer` method is only invoked once per chain. However, since the number of nods in `World` can change between iterations, we might need to instantiate new proposers in the middle of an inference. Starting from this diff, `get_proposers` is going to be invoked once per iteration, and the inference classes are responsible for deciding how and when to instantiate a new proposer.

The logic inside `Sampler` is also updated to support running a list of proposers. Since a proposer could be instantiate in the middle of an inference, the remaining number of adaptive iteration is also passed to `get_proposers` so that new proposers can be initialized appropriately.

Not sure if pre-generate a list of proposers and execute each of them in random permutation order is the right way to go, but at least this is consistent with our [single site implementation](https://www.internalfb.com/code/fbsource/[7e3f468344bf4e456869f656e80342747d6bb740]/fbcode/beanmachine/beanmachine/ppl/inference/abstract_mh_infer.py?lines=332-334) :). I feel like the proposer generation logic is probably going to change quite a few times in the future as we figure out what's the best thing to do.

Reviewed By: jpchen, neerajprad

Differential Revision: D31311147

