### PR TITLE
Replace `functools.cached_property`

### DIFF
--- a/src/beanmachine/ppl/experimental/global_inference/variable.py
+++ b/src/beanmachine/ppl/experimental/global_inference/variable.py
@@ -1,22 +1,22 @@
 from __future__ import annotations
 
 import dataclasses
-from functools import cached_property
 from typing import Set
 
 import torch
 import torch.distributions as dist
 from beanmachine.ppl.model.rv_identifier import RVIdentifier
+from torch.distributions.utils import lazy_property
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass
 class Variable:
     value: torch.Tensor
     distribution: dist.Distribution
     parents: Set[RVIdentifier] = dataclasses.field(default_factory=set)
     children: Set[RVIdentifier] = dataclasses.field(default_factory=set)
 
-    @cached_property
+    @lazy_property
     def log_prob(self) -> torch.Tensor:
         try:
             return self.distribution.log_prob(self.value)


### PR DESCRIPTION
Summary:
[`functools.cached_property`](https://docs.python.org/3.8/library/functools.html#functools.cached_property) is only available in Python 3.8 and beyond. However, we'd like BM to support Python 3.7 as well. So we have to find an alternative to unblock D31802133.

I noticed that `torch.distributions` have a similar util called [`lazy_property`](https://github.com/pytorch/pytorch/blob/9fdf7ec6a21f1bf9fabccb27ff2b54d94a82c3f3/torch/distributions/utils.py#L95-L112) that works for the earlier Python versions. The only downside is that `lazy_property` can't set the attribute on a frozen dataclass instance. IMO is this an acceptable compromise, since "frozen" is just a guard to ensure that we/users don't accidentally set update `Variable` to an inconsistent state. Making Variables non-frozen shouldn't change their functionality at all.

Differential Revision: D31803066

