### PR TITLE
Stop rewriting super() calls in single assignment rewriter

### DIFF
--- a/src/beanmachine/ppl/compiler/beanstalk_common.py
+++ b/src/beanmachine/ppl/compiler/beanstalk_common.py
@@ -1,4 +1,4 @@
-allowed_functions = {dict, list, set}
+allowed_functions = {dict, list, set, super}
 
 # TODO: Allowing these constructions raises additional problems that
 # we have not yet solved. For example, what happens if someone

--- a/src/beanmachine/ppl/compiler/tests/single_assignment_test.py
+++ b/src/beanmachine/ppl/compiler/tests/single_assignment_test.py
@@ -3481,3 +3481,41 @@ def f(x):
     a4[a8:a12:a16] = a20
        """
         self.check_rewrite(source, expected)
+
+    def test_rewrite_super(self) -> None:
+        # A call to super() with no arguments is very special in Python; it is a syntactic
+        # sugar for a call to super(__class__, self), where self is the leftmost parameter
+        # and __class__ is a magical outer variable automatically initialized to the
+        # declaring class.  We will handle "super()" calls specially later; we must
+        # not rewrite them.  They must stay just an ordinary call to "super()"
+        # rather than being reduced to the standard form
+        #
+        # a = []
+        # b = super(*a)
+        #
+        source = """
+class D(B):
+    def f(self):
+        super(D, self).g()
+        super().h()
+"""
+
+        expected = """
+class D(B):
+
+    def f(self):
+        a12 = [D]
+        a13 = [self]
+        r11 = a12 + a13
+        a5 = super(*r11)
+        a3 = a5.g
+        r7 = []
+        r9 = {}
+        u1 = a3(*r7, **r9)
+        a6 = super()
+        a4 = a6.h
+        r8 = []
+        r10 = {}
+        u2 = a4(*r8, **r10)
+        """
+        self.check_rewrite(source, expected)


### PR DESCRIPTION
Summary:
A call to `super()` is a special syntactic sugar in Python -- when analyzed by the Python runtime it is treated as though it had been written `super(__class__, self)` where `self` is the first parameter to the method.  We need to preserve calls to `super()` in the code and not rewrite them into something like `x = []` / super(*x)` or the like.

In this diff we fix the single assignment rewriter so that it does not rewrite `super()` calls.

Reviewed By: wtaha

Differential Revision: D31808253

