### PR TITLE
Fix the new warnings raised by PyTorch 1.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,6 +119,7 @@ commands:
     steps:
       - run:
           name: "Run unit tests"
+          no_output_timeout: 1h
           command: pytest --cov=. --cov-report term-missing
 
   user_unit_tests:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,11 @@ filterwarnings = [
     # flowtorch warnings
     "ignore:DenseAutoregressive input_dim = 1. Consider using an affine transformation instead.*:UserWarning",
     # statsmodels's deprecation warning
-    "default:the 'unbiased'' keyword is deprecated, use 'adjusted' instead.*:FutureWarning"
+    "default:the 'unbiased'' keyword is deprecated, use 'adjusted' instead.*:FutureWarning",
+    # PyTorch 1.10 warns against creating a tensor from a list of numpy arrays
+    """default:Creating a tensor from a list of numpy.ndarrays is extremely slow. Please
+    consider converting the list to a single numpy.ndarray with numpy.array() before
+    converting to a tensor.*:UserWarning""",
 ]
 
 [tool.usort]

--- a/src/beanmachine/ppl/inference/tests/single_site_random_walk_test.py
+++ b/src/beanmachine/ppl/inference/tests/single_site_random_walk_test.py
@@ -171,6 +171,10 @@ class SingleSiteRandomWalkTest(unittest.TestCase):
         """
         self.assertIn(False, [0 == pred for pred in predictions])
 
+    @unittest.skipIf(
+        torch.__version__.startswith("1.10."),
+        reason="torch.multiprocessing and our code do not currently work together for torch 1.10.*",
+    )
     def test_single_site_random_walk_parallel_full_support(self):
         model = self.RealSupportModel()
         mh = bm.SingleSiteRandomWalk()


### PR DESCRIPTION
Summary:
PyTorch 1.10 causes two additional warnings in BM and has been breaking our CI, and it's the goal of this diff to address both of them :). You can take a look at the log of [this workflow](5-4108-ab10-107f681d4dda/jobs/10711) to see the original error messages.

- On Newtonian Monte Carlo test, we got an `UserWarning: Using backward() with create_graph=True will create a reference cycle between the parameter and its gradient which can cause a memory leak. We recommend using autograd.grad when creating the graph to avoid this. If you have to use this function, make sure to reset the .grad fields of your parameters to None after use to break the cycle and avoid the leak. (Triggered internally at  ../torch/csrc/autograd/engine.cpp:976.)`.
  - This is addressed by using the suggested `autograd.grad` function instead of calling `backward`
- On `BMGInference`, we got `UserWarning: Creating a tensor from a list of numpy.ndarrays is extremely slow. Please consider converting the list to a single numpy.ndarray with numpy.array() before converting to a tensor. (Triggered internally at  ../torch/csrc/utils/tensor_new.cpp:201.)`
  - [Related discussion on GitHub](https://github.com/pytorch/pytorch/issues/13918)
  - I tried addressing the issue using the suggested approach, by casting a list of `numpy.ndarray` to a single numpy array before casting it to a tensor, but I wasn't able to get through our tests.
  - **In particular, [this test](https://fburl.com/code/ntr612d4) seems to expect some samples have dtype=float64 whereas other samples to have dtype=float32**, even though the entire model is defined in float32. I'm wondering why is that an expected behavior and whether we're open to changing it. With the numpy array casting that I am adding in this diff, the tensors will have float64 dtype. We can change this to float32 or something else, though before that I just want make sure that if I am missing anything here... cc. wtaha

Differential Revision: D31910172

