### PR TITLE
Bind original function's __class__ as outer variable

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/bm_to_bmg_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bm_to_bmg_test.py
@@ -16,18 +16,26 @@ class BaseModel:
 
     @bm.functional
     def foo(self):
-        return self.normal() + 1.0
+        return self.normal() + 2.0
+
+    def bar(self):
+        return 3.0
 
 
 class DerivedModel(BaseModel):
     @bm.functional
     def foo(self):
-        # This call is correct but we handle it wrong.
-        return super().foo() * 2.0
+        f = super().foo()
+        b = super(DerivedModel, self).bar()
+        return f * b  # This should be (n() + 2) * 3
+
+    def bar(self):
+        return 4.0
 
 
 class CompilerTest(unittest.TestCase):
     def test_super_call(self) -> None:
+        self.maxDiff = None
         # A call to super() in Python is not a normal function. Consider:
         def outer(s):
             return s().x()
@@ -56,36 +64,81 @@ class CompilerTest(unittest.TestCase):
         self.assertEqual(D().ordinary(), 2)
         self.assertEqual(D().sup1(), 1)
         self.assertEqual(D().sup2(), 1)
-        try:
+        # What's happening here is: "super()" is a syntactic sugar for "super(__class__, self)"
+        # where __class__ is an automatically-generated outer variable of the method that
+        # contains the call to super(). That variable has the value of the containing class.
+        # When we call D().callout() here, there is no automatically-generated outer variable
+        # when super() is ultimately called, and therefore we get this confusing but expected
+        # exception raised:
+        with self.assertRaises(RuntimeError) as ex:
             D().callout()
-        except RuntimeError as e:
-            # This exception is expected.
-            self.assertEqual("super(): __class__ cell not found", str(e))
+        expected = "super(): __class__ cell not found"
+        observed = str(ex.exception)
+        self.assertEqual(expected.strip(), observed.strip())
+
+        # bm_to_bmg rewrites all random variables, all functionals, and their callees.
+        # We must ensure that all calls to super() are (1) syntactically exactly that;
+        # these calls must not be rewritten to bmg.handle_call, and (2) must have an
+        # outer variable __class__ which is initialized to the class which originally
+        # declared the random variable.
 
         d = DerivedModel()
-        try:
-            BMGInference().to_dot([d.foo()], {})
-        except RuntimeError as e:
-            # This exception is wrong.
-            self.assertEqual("super(): __class__ cell not found", str(e))
+        observed = BMGInference().to_dot([d.foo()], {})
 
-        # What code do we actually generate for this method? We can call
-        # into this internal method to get the transformed code:
+        expected = """
+digraph "graph" {
+  N0[label=0.0];
+  N1[label=1.0];
+  N2[label=Normal];
+  N3[label=Sample];
+  N4[label=2.0];
+  N5[label="+"];
+  N6[label=3.0];
+  N7[label="*"];
+  N8[label=Query];
+  N0 -> N2;
+  N1 -> N2;
+  N2 -> N3;
+  N3 -> N5;
+  N4 -> N5;
+  N5 -> N7;
+  N6 -> N7;
+  N7 -> N8;
+}
+        """
+        self.assertEqual(expected.strip(), observed.strip())
+
+        # We do this by:
+        # * the single assignment rewriter does not fully rewrite
+        #   calls to super to their most general form; in particular
+        #   it will not rewrite super() to x = [] / super(*x).
+        # * the bm_to_bmg rewriter does not rewrite calls to super
+        #   into bmg.handle_function.
+        # * we generate an outer variable __class__ which is initialized
+        #   to the same value as the original function's outer variable
+        #   __class__, if it has one, None otherwise.
 
         bmgast, _ = _bm_function_to_bmg_ast(d.foo, "foo_helper")
         observed = astor.to_source(bmgast)
         expected = """
-def foo_helper(bmg):
+def foo_helper(bmg, __class__):
 
     def foo(self):
-        a5 = super()
-        a3 = bmg.handle_dot_get(a5, 'foo')
+        a4 = super()
+        a1 = bmg.handle_dot_get(a4, 'foo')
         r6 = []
-        r7 = {}
-        a2 = bmg.handle_function(a3, r6, r7)
-        a4 = 2.0
-        r1 = bmg.handle_multiplication(a2, a4)
-        return r1
+        r8 = {}
+        f = bmg.handle_function(a1, r6, r8)
+        a11 = [DerivedModel]
+        a12 = [self]
+        r10 = bmg.handle_addition(a11, a12)
+        a5 = super(*r10)
+        a2 = bmg.handle_dot_get(a5, 'bar')
+        r7 = []
+        r9 = {}
+        b = bmg.handle_function(a2, r7, r9)
+        r3 = bmg.handle_multiplication(f, b)
+        return r3
     return foo
 """
         self.assertEqual(observed.strip(), expected.strip())

--- a/src/beanmachine/ppl/compiler/tests/comparison_rewriting_test.py
+++ b/src/beanmachine/ppl/compiler/tests/comparison_rewriting_test.py
@@ -48,7 +48,7 @@ class ComparisonRewritingTest(unittest.TestCase):
         bmgast, _ = _bm_function_to_bmg_ast(y, "y_helper")
         observed = astor.to_source(bmgast)
         expected = """
-def y_helper(bmg):
+def y_helper(bmg, __class__):
 
     def y():
         a1 = 0.0

--- a/src/beanmachine/ppl/compiler/tests/jit_test.py
+++ b/src/beanmachine/ppl/compiler/tests/jit_test.py
@@ -217,7 +217,7 @@ class JITTest(unittest.TestCase):
         bmgast, _ = _bm_function_to_bmg_ast(f, "f_helper")
         observed = astor.to_source(bmgast)
         expected = """
-def f_helper(bmg):
+def f_helper(bmg, __class__):
 
     def f(x):
         a2 = bmg.handle_dot_get(math, 'exp')
@@ -231,7 +231,7 @@ def f_helper(bmg):
         bmgast, _ = _bm_function_to_bmg_ast(norm, "norm_helper")
         observed = astor.to_source(bmgast)
         expected = """
-def norm_helper(bmg):
+def norm_helper(bmg, __class__):
 
     def norm(n):
         global counter


### PR DESCRIPTION
Summary:
The `super()` function in Python is very special; it is a syntactic sugar for `super(__class__, self)` where `__class__` is an outer variable of the method containing the call to `super()`. Python only automatically generates the closure when a method is known to contain a call to `super()` or use of a variable `__class__`. If you force a call to `super()` using some other syntax, you can trick Python into not generating the closure, and then the call will fail with an obscure `missing __class__ cell` error.

When we transform an original model function into its "lifted" form we close over a variable containing a reference to the "runtime" graph accumulator; we generate code like:

    def foo_helper(bmg):  # bmg refers to the runtime
        def foo(whatever):
            lifted code here can use bmg
        return foo

We then execute foo_helper(bmg) to obtain the inner function bound to the runtime.  But that means that if there was a call to `super()` inside the original function, there is now a call to `super()` inside a completely different function not associated with the original class, and the call will then fail.

What we can do to fix the problem is do the same trick that Python does: **generate an outer variable `__class__` that contains a reference to the original containing class. We already generate an outer helper method; we can simply add a `__class__` parameter to it.

We now do so. See comments in the test case for more details.

Note that this is a special case of a more general problem that we do not yet solve: what happens if an RV (or a callee of an RV) has outer variables?  We lose track of them, and we should not. We'll fix that more general problem in a later diff.

Reviewed By: wtaha

Differential Revision: D31700064

