### PR TITLE
Single assignment rewriter now supports matrix multiplication

### DIFF
--- a/src/beanmachine/ppl/compiler/single_assignment.py
+++ b/src/beanmachine/ppl/compiler/single_assignment.py
@@ -132,7 +132,6 @@ _not_in_allowed_functions: Pattern = negate(
     match_any(*[name(id=t.__name__) for t in allowed_functions])
 )
 
-# TODO: Add MatMult to this list
 _binops: Pattern = match_any(
     ast.Add,
     ast.BitAnd,
@@ -141,6 +140,7 @@ _binops: Pattern = match_any(
     ast.Div,
     ast.FloorDiv,
     ast.LShift,
+    ast.MatMult,
     ast.Mod,
     ast.Mult,
     ast.Pow,

--- a/src/beanmachine/ppl/compiler/tests/single_assignment_test.py
+++ b/src/beanmachine/ppl/compiler/tests/single_assignment_test.py
@@ -3519,3 +3519,17 @@ class D(B):
         u2 = a4(*r8, **r10)
         """
         self.check_rewrite(source, expected)
+
+    def test_matrix_multiply_single_assignment(self) -> None:
+        source = """
+def f(x):
+    return x @ (y * z)
+"""
+
+        expected = """
+def f(x):
+    a2 = y * z
+    r1 = x @ a2
+    return r1
+"""
+        self.check_rewrite(source, expected)


### PR DESCRIPTION
Summary: We had previously not gotten around to adding matrix multiplication to the binary operators handled by the single assignment rewriter.  This is now implemented and tested, but adding a `handle_matmult` rewrite during the bm-to-bmg rewriting is not yet implemented.

Reviewed By: wtaha

Differential Revision: D31839462

