### PR TITLE
Beanstalk now gives error messages for use of @, mm, matmul

### DIFF
--- a/src/beanmachine/ppl/compiler/bm_to_bmg.py
+++ b/src/beanmachine/ppl/compiler/bm_to_bmg.py
@@ -204,8 +204,7 @@ _math_to_bmg: Rule = _top_down(
                 _handle_unary(ast.UAdd, "handle_uadd"),
                 _handle_unary(ast.USub, "handle_negate"),
                 _handle_binary(ast.Add, "handle_addition"),
-                # Binary operators & | / // << % * ** >> -
-                # TODO: @ (matrix multiplication)
+                # Binary operators & | / // << % * ** >> - @
                 # "and" and "or" are already eliminated by the single
                 # assignment rewriter.
                 _handle_binary(ast.BitAnd, "handle_bitand"),
@@ -214,6 +213,7 @@ _math_to_bmg: Rule = _top_down(
                 _handle_binary(ast.Div, "handle_division"),
                 _handle_binary(ast.FloorDiv, "handle_floordiv"),
                 _handle_binary(ast.LShift, "handle_lshift"),
+                _handle_binary(ast.MatMult, "handle_matrix_multiplication"),
                 _handle_binary(ast.Mod, "handle_mod"),
                 _handle_binary(ast.Mult, "handle_multiplication"),
                 _handle_binary(ast.Pow, "handle_power"),

--- a/src/beanmachine/ppl/compiler/graph_labels.py
+++ b/src/beanmachine/ppl/compiler/graph_labels.py
@@ -76,7 +76,7 @@ _node_labels = {
     bn.LogSumExpTorchNode: "LogSumExp",
     bn.LogSumExpVectorNode: "LogSumExp",
     bn.LShiftNode: "<<",
-    bn.MatrixMultiplicationNode: "*",
+    bn.MatrixMultiplicationNode: "@",
     bn.MatrixScaleNode: "MatrixScale",
     bn.ModNode: "%",
     bn.MultiplicationNode: "*",

--- a/src/beanmachine/ppl/compiler/runtime.py
+++ b/src/beanmachine/ppl/compiler/runtime.py
@@ -131,6 +131,7 @@ known_tensor_instance_functions = [
     "log",
     "logical_not",
     "logsumexp",
+    "matmul",
     "mm",
     "mul",
     "neg",
@@ -292,6 +293,7 @@ class BMGRuntime:
             torch.Tensor.logical_not: self.handle_not,  # pyre-ignore
             torch.Tensor.log: self.handle_log,
             torch.Tensor.logsumexp: self.handle_logsumexp,
+            torch.Tensor.matmul: self.handle_matrix_multiplication,
             torch.Tensor.mm: self.handle_matrix_multiplication,  # pyre-ignore
             torch.Tensor.mul: self.handle_multiplication,
             torch.Tensor.neg: self.handle_negate,
@@ -307,6 +309,7 @@ class BMGRuntime:
             torch.log: self.handle_log,
             torch.logsumexp: self.handle_logsumexp,
             torch.logical_not: self.handle_not,
+            torch.matmul: self.handle_matrix_multiplication,
             torch.mm: self.handle_matrix_multiplication,
             torch.mul: self.handle_multiplication,
             torch.neg: self.handle_negate,
@@ -580,6 +583,8 @@ class BMGRuntime:
         return self._bmg.add_multiplication(input, other)
 
     def handle_matrix_multiplication(self, input: Any, mat2: Any) -> Any:
+        # TODO: We probably need to make a distinction between torch.mm and
+        # torch.matmul because they have different broadcasting behaviors.
         if (not isinstance(input, BMGNode)) and (not isinstance(mat2, BMGNode)):
             return torch.mm(input, mat2)
         if not isinstance(input, BMGNode):

--- a/src/beanmachine/ppl/compiler/tests/matrix_multiplication_test.py
+++ b/src/beanmachine/ppl/compiler/tests/matrix_multiplication_test.py
@@ -1,0 +1,84 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import unittest
+
+import beanmachine.ppl as bm
+from beanmachine.ppl.inference import BMGInference
+from torch import tensor
+from torch.distributions import Normal
+
+
+m1 = tensor([[12.0, 13.0], [14.0, 15.0]])
+m2 = tensor([[22.0, 23.0], [24.0, 25.0]])
+
+
+@bm.random_variable
+def norm():
+    return Normal(0.0, 1.0)
+
+
+@bm.functional
+def mm():
+    return m1.mm(norm()).mm(m2)
+
+
+@bm.functional
+def matmul():
+    return m1.matmul(norm()).matmul(m2)
+
+
+@bm.functional
+def infix():
+    return m1 @ norm() @ m2
+
+
+class MatMulTest(unittest.TestCase):
+    def test_matrix_multiplication(self) -> None:
+        # TODO: Matrix multiplications should be accumulated but they are not
+        # yet type analyzed or transformed into a BMG graph.
+
+        self.maxDiff = None
+
+        expected_accumulation = """
+digraph "graph" {
+  N0[label="[[12.0,13.0],\\\\n[14.0,15.0]]"];
+  N1[label=0.0];
+  N2[label=1.0];
+  N3[label=Normal];
+  N4[label=Sample];
+  N5[label="@"];
+  N6[label="[[22.0,23.0],\\\\n[24.0,25.0]]"];
+  N7[label="@"];
+  N8[label=Query];
+  N0 -> N5;
+  N1 -> N3;
+  N2 -> N3;
+  N3 -> N4;
+  N4 -> N5;
+  N5 -> N7;
+  N6 -> N7;
+  N7 -> N8;
+}"""
+        expected_error = """
+The model uses a @ operation unsupported by Bean Machine Graph.
+The unsupported node is the left of a @.
+The model uses a @ operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a Query.
+        """
+
+        observed = BMGInference().to_dot([mm()], {}, after_transform=False)
+        self.assertEqual(expected_accumulation.strip(), observed.strip())
+        with self.assertRaises(ValueError) as ex:
+            BMGInference().to_dot([mm()], {}, after_transform=True)
+        self.assertEqual(expected_error.strip(), str(ex.exception))
+
+        observed = BMGInference().to_dot([matmul()], {}, after_transform=False)
+        self.assertEqual(expected_accumulation.strip(), observed.strip())
+        with self.assertRaises(ValueError) as ex:
+            BMGInference().to_dot([matmul()], {}, after_transform=True)
+        self.assertEqual(expected_error.strip(), str(ex.exception))
+
+        observed = BMGInference().to_dot([infix()], {}, after_transform=False)
+        self.assertEqual(expected_accumulation.strip(), observed.strip())
+        with self.assertRaises(ValueError) as ex:
+            BMGInference().to_dot([infix()], {}, after_transform=True)
+        self.assertEqual(expected_error.strip(), str(ex.exception))


### PR DESCRIPTION
Summary:
Though BMG supports a matrix multiplication operator, we have not yet written the code to type check and transform an accumulated graph into a BMG-supported graph. However we are now one step closer: we now actually accumulate the graph in models which use `@` (the Python infix matrix multiplication operator), or either of the torch `mm` or `matmul` functions.

(Note that `mm` and `matmul` have different broadcasting behaviors, so we will likely need to keep track of which was intended in order to generate a correct BMG graph.)

I also changed the output of the DOT generator and the error messages to notate matrix multiplications as `@` rather than `*`.

Reviewed By: wtaha

Differential Revision: D31845800

