### PR TITLE
Adds TypeError & migrate inference error reporting test

### DIFF
--- a/src/beanmachine/ppl/experimental/global_inference/base_inference.py
+++ b/src/beanmachine/ppl/experimental/global_inference/base_inference.py
@@ -79,7 +79,12 @@ class BaseInference(metaclass=ABCMeta):
             ):
                 # Extract samples
                 for query in queries:
-                    samples[query].append(world.call(query))
+                    raw_val = world.call(query)
+                    if not isinstance(raw_val, torch.Tensor):
+                        raise TypeError(
+                            "The value returned by a queried function must be a tensor."
+                        )
+                    samples[query].append(raw_val)
 
             samples = {node: torch.stack(val) for node, val in samples.items()}
             chain_results.append(samples)

--- a/src/beanmachine/ppl/inference/tests/inference_error_reporting_test.py
+++ b/src/beanmachine/ppl/inference/tests/inference_error_reporting_test.py
@@ -1,11 +1,13 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
-import unittest
 import warnings
 
 import beanmachine.ppl as bm
+import pytest
 import torch
-from torch import tensor
-from torch.distributions import Bernoulli
+import torch.distributions as dist
+from beanmachine.ppl.experimental.global_inference.single_site_ancestral_mh import (
+    SingleSiteAncestralMetropolisHastings,
+)
 
 
 @bm.random_variable
@@ -25,7 +27,7 @@ def h():
 
 @bm.random_variable
 def flip():
-    return Bernoulli(0.5)
+    return dist.Bernoulli(0.5)
 
 
 class ErrorDist(torch.distributions.Distribution):
@@ -51,97 +53,88 @@ def bad():
     return ErrorDist()
 
 
-class InferenceErrorReportingTest(unittest.TestCase):
-    def test_inference_error_reporting(self):
-        mh = bm.SingleSiteAncestralMetropolisHastings()
-        with self.assertRaises(TypeError) as ex:
-            mh.infer(None, {}, 10)
-        self.assertEqual(
-            str(ex.exception),
-            "Parameter 'queries' is required to be a list but is of type NoneType.",
-        )
-        with self.assertRaises(TypeError) as ex:
-            mh.infer([], 123, 10)
-        self.assertEqual(
-            str(ex.exception),
-            "Parameter 'observations' is required to be a dictionary but is of type int.",
-        )
+def test_inference_error_reporting():
+    mh = SingleSiteAncestralMetropolisHastings()
+    with pytest.raises(TypeError) as ex:
+        mh.infer(None, {}, 10)
+    assert (
+        str(ex.value)
+        == "Parameter 'queries' is required to be a list but is of type NoneType."
+    )
 
-        # Should be f():
-        with self.assertRaises(TypeError) as ex:
-            mh.infer([f], {}, 10)
-        self.assertEqual(
-            str(ex.exception),
-            "A query is required to be a random variable but is of type function.",
-        )
+    with pytest.raises(TypeError) as ex:
+        mh.infer([], 123, 10)
+    assert (
+        str(ex.value)
+        == "Parameter 'observations' is required to be a dictionary but is of type int."
+    )
 
-        # Should be f():
-        with self.assertRaises(TypeError) as ex:
-            mh.infer([f()], {f: tensor(True)}, 10)
-        self.assertEqual(
-            str(ex.exception),
-            "An observation is required to be a random variable but is of type function.",
-        )
+    # Should be f():
+    with pytest.raises(TypeError) as ex:
+        mh.infer([f], {}, 10)
+    assert (
+        str(ex.value)
+        == "A query is required to be a random variable but is of type function."
+    )
 
-        # Should be a tensor
-        with self.assertRaises(TypeError) as ex:
-            mh.infer([f()], {f(): 123.0}, 10)
-        self.assertEqual(
-            str(ex.exception),
-            "An observed value is required to be a tensor but is of type float.",
-        )
+    # Should be f():
+    with pytest.raises(TypeError) as ex:
+        mh.infer([f()], {f: torch.tensor(True)}, 10)
+    assert (
+        str(ex.value)
+        == "An observation is required to be a random variable but is of type function."
+    )
 
-        # You can't make inferences on rv-of-rv
-        with self.assertRaises(TypeError) as ex:
-            mh.infer([g(f())], {}, 10)
-        self.assertEqual(
-            str(ex.exception),
-            "The arguments to a query must not be random variables.",
-        )
+    # Should be a tensor
+    with pytest.raises(TypeError) as ex:
+        mh.infer([f()], {f(): 123.0}, 10)
+    assert (
+        str(ex.value)
+        == "An observed value is required to be a tensor but is of type float."
+    )
 
-        # You can't make inferences on rv-of-rv
-        with self.assertRaises(TypeError) as ex:
-            mh.infer([f()], {g(f()): tensor(123)}, 10)
-        self.assertEqual(
-            str(ex.exception),
-            "The arguments to an observation must not be random variables.",
-        )
+    # You can't make inferences on rv-of-rv
+    with pytest.raises(TypeError) as ex:
+        mh.infer([g(f())], {}, 10)
+    assert str(ex.value) == "The arguments to a query must not be random variables."
 
-        # SSAMH requires that observations must be of random variables, not
-        # functionals
-        with self.assertRaises(TypeError) as ex:
-            mh.infer([f()], {h(): tensor(123)}, 10)
-        self.assertEqual(
-            str(ex.exception),
-            "An observation must observe a random_variable, not a functional.",
-        )
+    # You can't make inferences on rv-of-rv
+    with pytest.raises(TypeError) as ex:
+        mh.infer([f()], {g(f()): torch.tensor(123)}, 10)
+    assert (
+        str(ex.value) == "The arguments to an observation must not be random variables."
+    )
 
-        # A functional is required to return a tensor.
-        with self.assertRaises(TypeError) as ex:
-            mh.infer([h()], {}, 10)
-        self.assertEqual(
-            str(ex.exception),
-            "The value returned by a queried function must be a tensor.",
-        )
+    # SSAMH requires that observations must be of random variables, not
+    # functionals
+    with pytest.raises(TypeError) as ex:
+        mh.infer([f()], {h(): torch.tensor(123)}, 10)
+    assert (
+        str(ex.value)
+        == "An observation must observe a random_variable, not a functional."
+    )
 
-        # A random_variable is required to return a distribution
-        with self.assertRaises(TypeError) as ex:
-            mh.infer([f()], {}, 10)
-        self.assertEqual(
-            str(ex.exception),
-            "A random_variable is required to return a distribution.",
-        )
+    # A functional is required to return a tensor.
+    with pytest.raises(TypeError) as ex:
+        mh.infer([h()], {}, 10)
+    assert str(ex.value) == "The value returned by a queried function must be a tensor."
 
-        # The lookup key to the samples object is required to be an RVID.
-        with self.assertRaises(TypeError) as ex:
-            mh.infer([flip()], {}, 10)[flip]
-        self.assertEqual(
-            str(ex.exception),
-            "The key is required to be a random variable but is of type function.",
-        )
+    # A random_variable is required to return a distribution
+    with pytest.raises(TypeError) as ex:
+        mh.infer([f()], {}, 10)
+    assert str(ex.value) == "A random_variable is required to return a distribution."
 
-    def test_early_return_on_error(self):
-        warnings.simplefilter("ignore")
-        mh = bm.SingleSiteAncestralMetropolisHastings()
-        samples = mh.infer([bad()], {}, 40, num_chains=1)
-        self.assertEqual(samples[bad()].shape, (1, 9, 1))
+    # The lookup key to the samples object is required to be an RVID.
+    with pytest.raises(TypeError) as ex:
+        mh.infer([flip()], {}, 10)[flip]
+    assert (
+        str(ex.value)
+        == "The key is required to be a random variable but is of type function."
+    )
+
+
+def test_early_return_on_error():
+    warnings.simplefilter("ignore")
+    mh = bm.SingleSiteAncestralMetropolisHastings()
+    samples = mh.infer([bad()], {}, 40, num_chains=1)
+    assert samples[bad()].shape == (1, 9, 1)


### PR DESCRIPTION
Summary: This diff just adds a few type checking and thorws a few `TypeError`s similar to what we did in the single site inference, just so that I can swap out the old implementation with out new one while keeping unit test happy :).

Differential Revision: D31845950

