### PR TITLE
Migrate single site uniform to new base_inference

### DIFF
--- a/src/beanmachine/ppl/experimental/global_inference/proposer/single_site_uniform_proposer.py
+++ b/src/beanmachine/ppl/experimental/global_inference/proposer/single_site_uniform_proposer.py
@@ -1,0 +1,21 @@
+import torch
+import torch.distributions as dist
+from beanmachine.ppl.experimental.global_inference.proposer.base_single_site_proposer import (
+    BaseSingleSiteMHProposer,
+)
+from beanmachine.ppl.experimental.global_inference.simple_world import SimpleWorld
+
+
+class SingleSiteUniformProposer(BaseSingleSiteMHProposer):
+    def get_proposal_distribution(self, world: SimpleWorld) -> dist.Distribution:
+        """Propose a new value for self.node using the prior distribution."""
+        node_dist = world.get_variable(self.node).distribution
+        if isinstance(node_dist, dist.Bernoulli):
+            return dist.Bernoulli(torch.ones(node_dist.param_shape) / 2.0)
+        elif isinstance(node_dist, dist.Categorical):
+            return dist.Categorical(torch.ones(node_dist.param_shape))
+        else:
+            # default to ancestral sampling
+            # TODO: we should sample from a transformed dist
+            # that transforms uniform to the support of the node
+            return node_dist

--- a/src/beanmachine/ppl/experimental/global_inference/single_site_uniform_mh.py
+++ b/src/beanmachine/ppl/experimental/global_inference/single_site_uniform_mh.py
@@ -1,0 +1,31 @@
+from typing import List, Set
+
+from beanmachine.ppl.experimental.global_inference.base_inference import BaseInference
+from beanmachine.ppl.experimental.global_inference.proposer.base_proposer import (
+    BaseProposer,
+)
+from beanmachine.ppl.experimental.global_inference.proposer.single_site_uniform_proposer import (
+    SingleSiteUniformProposer,
+)
+from beanmachine.ppl.experimental.global_inference.simple_world import (
+    SimpleWorld,
+)
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
+
+
+class SingleSiteUniformMetropolisHastings(BaseInference):
+    def __init__(self):
+        self._proposers = {}
+
+    def get_proposers(
+        self,
+        world: SimpleWorld,
+        target_rvs: Set[RVIdentifier],
+        num_adaptive_sample: int,
+    ) -> List[BaseProposer]:
+        proposers = []
+        for node in target_rvs:
+            if node not in self._proposers:
+                self._proposers[node] = SingleSiteUniformProposer(node)
+            proposers.append(self._proposers[node])
+        return proposers

--- a/src/beanmachine/ppl/inference/single_site_random_walk.py
+++ b/src/beanmachine/ppl/inference/single_site_random_walk.py
@@ -11,7 +11,7 @@ from beanmachine.ppl.world.world import TransformType
 
 class SingleSiteRandomWalk(AbstractMHInference):
     """
-    Implementation for SingleSiteNewtonianMonteCarlo
+    Implementation for SingleSiteRandomWalk
     """
 
     def __init__(

--- a/src/beanmachine/ppl/inference/tests/single_site_uniform_mh_conjugate_test_nightly.py
+++ b/src/beanmachine/ppl/inference/tests/single_site_uniform_mh_conjugate_test_nightly.py
@@ -1,7 +1,9 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import unittest
 
-import beanmachine.ppl as bm
+from beanmachine.ppl.experimental.global_inference.single_site_uniform_mh import (
+    SingleSiteUniformMetropolisHastings,
+)
 from beanmachine.ppl.testlib.abstract_conjugate import AbstractConjugateTests
 
 
@@ -9,7 +11,7 @@ class SingleSiteUniformMetropolisHastingsConjugateTest(
     unittest.TestCase, AbstractConjugateTests
 ):
     def setUp(self):
-        self.mh = bm.SingleSiteUniformMetropolisHastings()
+        self.mh = SingleSiteUniformMetropolisHastings()
 
     def test_beta_binomial_conjugate_run(self):
         self.beta_binomial_conjugate_run(self.mh)
@@ -17,7 +19,6 @@ class SingleSiteUniformMetropolisHastingsConjugateTest(
     def test_gamma_gamma_conjugate_run(self):
         self.gamma_gamma_conjugate_run(self.mh)
 
-    @unittest.skip("Known to fail. Investigating in T77865889.")
     def test_gamma_normal_conjugate_run(self):
         self.gamma_normal_conjugate_run(self.mh, num_samples=7500)
 

--- a/src/beanmachine/ppl/inference/tests/single_site_uniform_mh_test.py
+++ b/src/beanmachine/ppl/inference/tests/single_site_uniform_mh_test.py
@@ -4,8 +4,8 @@ import unittest
 import beanmachine.ppl as bm
 import torch
 import torch.distributions as dist
-from beanmachine.ppl.inference.proposer.single_site_uniform_proposer import (
-    SingleSiteUniformProposer,
+from beanmachine.ppl.experimental.global_inference.single_site_uniform_mh import (
+    SingleSiteUniformMetropolisHastings,
 )
 
 
@@ -30,35 +30,24 @@ class SingleSiteUniformMetropolisHastingsTest(unittest.TestCase):
 
     def test_single_site_uniform_mh_with_bernoulli(self):
         model = self.SampleBernoulliModel()
-        mh = bm.SingleSiteUniformMetropolisHastings()
+        mh = SingleSiteUniformMetropolisHastings()
         foo_key = model.foo()
         bar_key = model.bar()
-        mh.queries_ = [model.foo()]
-        mh.observations_ = {model.bar(): torch.tensor(0.0)}
-        mh._infer(10)
-        self.assertEqual(isinstance(mh.proposer_, SingleSiteUniformProposer), True)
-        # using _infer instead of infer, as world_ would be reset at the end
-        # infer
-        world_vars = mh.world_.variables_.vars()
-        self.assertEqual(foo_key in world_vars, True)
-        self.assertEqual(bar_key in world_vars, True)
-        self.assertEqual(foo_key in world_vars[bar_key].parent, True)
-        self.assertEqual(bar_key in world_vars[foo_key].children, True)
+        sampler = mh.sampler([foo_key], {bar_key: torch.tensor(0.0)}, num_samples=5)
+        for world in sampler:
+            self.assertTrue(foo_key in world)
+            self.assertTrue(bar_key in world)
+            self.assertTrue(foo_key in world.get_variable(bar_key).parents)
+            self.assertTrue(bar_key in world.get_variable(foo_key).children)
 
     def test_single_site_uniform_mh_with_categorical(self):
         model = self.SampleCategoricalModel()
-        mh = bm.SingleSiteUniformMetropolisHastings()
+        mh = SingleSiteUniformMetropolisHastings()
         foo_key = model.foo()
         bar_key = model.bar()
-        mh.queries_ = [model.foo()]
-        mh.observations_ = {model.bar(): torch.tensor(1.0)}
-        mh._infer(10)
-
-        self.assertEqual(isinstance(mh.proposer_, SingleSiteUniformProposer), True)
-        # using _infer instead of infer, as world_ would be reset at the end
-        # infer
-        world_vars = mh.world_.variables_.vars()
-        self.assertEqual(foo_key in world_vars, True)
-        self.assertEqual(bar_key in world_vars, True)
-        self.assertEqual(foo_key in world_vars[bar_key].parent, True)
-        self.assertEqual(bar_key in world_vars[foo_key].children, True)
+        sampler = mh.sampler([foo_key], {bar_key: torch.tensor(0.0)}, num_samples=5)
+        for world in sampler:
+            self.assertTrue(foo_key in world)
+            self.assertTrue(bar_key in world)
+            self.assertTrue(foo_key in world.get_variable(bar_key).parents)
+            self.assertTrue(bar_key in world.get_variable(foo_key).children)


### PR DESCRIPTION
Summary: Migrate uniform proposer as it is currently implemented in BM. For continuous variables, it defaults to ancestral.

Differential Revision: D31991028

