### PR TITLE
Use internaldocs-fb-helpers to handle missing internal-only pages

### DIFF
--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -6,6 +6,7 @@
  *
  * @format
  */
+const {fbInternalOnly} = require('internaldocs-fb-helpers');
 
 module.exports = {
   someSidebar: {
@@ -30,7 +31,7 @@ module.exports = {
     API: ['overview/api/api'], // #TODO: Brian Johnson will populate this!
     Packages: ['overview/packages/packages'],
     Contributing: ['contributing'],
-    FacebookIntern: ['overview/facebook/facebook'],
+    ...fbInternalOnly({FacebookIntern: ['overview/facebook/facebook']}),
     'Sitemap (formerly TOC)': ['toc'], // Once everyone is used to this being here, we'll remove the "(formerly TOC)" part
   },
 };


### PR DESCRIPTION
Summary: Our [external documentation builder is currently broken](https://github.com/facebookresearch/beanmachine/runs/4038822019?check_suite_focus=true) because our sidebar links to an internal-only page that Docusaurus cannot find. According to the [Docusaurus's documentation](https://www.internalfb.com/intern/staticdocs/staticdocs/docs/documenting/internal-only/), there's this `internaldocs-fb-helpers` plugin that we can use to automatically remove internal-only contents. So I'm going to try that out in this diff to see if it fix the issue without introducing any new error

Differential Revision: D32014598

