### PR TITLE
GitHub Actions for building and publishing package to Test PyPI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,107 @@
+name: Deployment
+
+on:
+  push:
+    branches: [ export-D32044155 ]
+  # this workflow can only be manually triggered for now.
+  workflow_dispatch:
+
+env:
+  PYTHONUNBUFFERED: 1
+
+jobs:
+  build-wheel:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest]
+        python-version: [3.7]
+    defaults:
+      run:
+        # https://github.com/conda-incubator/setup-miniconda/tree/v2#use-a-default-shell
+        shell: bash -l {0}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Set up Miniconda with Python ${{ matrix.python-version }}
+      uses: conda-incubator/setup-miniconda@v2
+      with:
+        auto-update-conda: true
+        miniconda-version: "latest"
+        python-version: ${{ matrix.python-version }}
+        activate-environment: build_env
+
+    - name: Install dependencies
+      run: |
+        conda install -y eigen boost
+        python -m pip install --upgrade pip
+        pip install -U build
+
+    - name: Building Bean Machine wheel for ${{ matrix.os }}
+      run: python -m build --wheel
+
+    - name: Build Bean Machine source distribution
+      # source distribution only needs to be built on one OS
+      if: matrix.os == 'macos-latest'
+      run: python -m build --sdist
+
+    - name: Sending wheels to the deployment workflow
+      uses: actions/upload-artifact@v2
+      with:
+        name: beanmachine-${{ matrix.os }}
+        path: dist/*
+
+  build-linux-wheel:
+    runs-on: ubuntu-latest
+    container: quay.io/pypa/manylinux2014_x86_64
+    strategy:
+      matrix:
+        python-version: [cp37-cp37m]
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Install dependencies
+      run: |
+        yum install -y boost169-devel eigen3-devel
+        /opt/python/${{ matrix.python-version }}/bin/python -m pip install --upgrade pip
+        /opt/python/${{ matrix.python-version }}/bin/pip install -U build
+
+    - name: Building Bean Machine wheel for Linux
+      run: /opt/python/${{ matrix.python-version }}/bin/python -m build --wheel
+
+    - name: Repair wheel to support manylinux
+      run: auditwheel -v repair dist/*
+
+    - name: Sending wheels to the deployment workflow
+      uses: actions/upload-artifact@v2
+      with:
+        name: beanmachine-manylinux
+        path: wheelhouse/*
+
+  publish-to-pypi:
+    runs-on: ubuntu-latest
+    needs:
+      - build-wheel
+      - build-linux-wheel
+    steps:
+    - name: Download wheels from previous jobs
+      # by default this will download all artifacts
+      uses: actions/download-artifact@v2
+
+    - name: Reorganize file structure
+      # PyPI publish action uploads everything under dist/*
+      run: |
+        ls -R
+        mkdir dist
+        mv beanmachine-*/* dist/
+
+    - name: Publish to Test PyPI
+      uses: pypa/gh-action-pypi-publish@v1.4.2
+      with:
+        password: ${{ secrets.TEST_PYPI_PASSWORD }}
+        repository_url: https://test.pypi.org/legacy/
+        verbose: true

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ if sys.platform.startswith("linux"):
         [
             "/usr/include",
             "/usr/include/eigen3",
+            "/usr/include/boost169/",
             "/usr/include/x86_64-linux-gnu",
         ]
     )


### PR DESCRIPTION
Summary: This diff adds a workflow that, when triggered, build packages on MacOS, Windows, and manylinux. If, and only if, the wheels are successfully built on all of the platforms, the deployment workflow will publish the wheels and the source distributions to TestPyPI.

Differential Revision: D32044155

