### PR TITLE
Make stochastic control flows using if statements illegal

### DIFF
--- a/src/beanmachine/ppl/compiler/runtime.py
+++ b/src/beanmachine/ppl/compiler/runtime.py
@@ -993,6 +993,15 @@ class BMGRuntime:
         )
 
     #
+    # Control flow
+    #
+
+    def handle_if(self, test: Any) -> None:
+        if isinstance(test, BMGNode):
+            # TODO: Better error
+            raise ValueError("Stochastic control flows are not yet implemented.")
+
+    #
     # Function calls
     #
 

--- a/src/beanmachine/ppl/compiler/tests/comparison_rewriting_test.py
+++ b/src/beanmachine/ppl/compiler/tests/comparison_rewriting_test.py
@@ -56,6 +56,7 @@ def y_helper(bmg, __class__):
         r7 = {}
         a3 = bmg.handle_function(x, r4, r7)
         a5 = bmg.handle_less_than(a1, a3)
+        bmg.handle_if(a5)
         if a5:
             a6 = 2.0
             z = bmg.handle_less_than(a3, a6)

--- a/src/beanmachine/ppl/compiler/tests/stochastic_control_flow_test.py
+++ b/src/beanmachine/ppl/compiler/tests/stochastic_control_flow_test.py
@@ -40,6 +40,15 @@ def spike_and_slab(n):
         return Normal(0, 1)
 
 
+@bm.functional
+def if_statement():
+    # Stochastic control flows using "if" statements are not yet implemented
+    if flip():
+        return flips(0)
+    else:
+        return flips(1)
+
+
 # Try out a stochastic control flow where we choose
 # a mean from one of two distributions depending on
 # a coin flip.
@@ -379,6 +388,17 @@ digraph "graph" {
 }
 """
         self.assertEqual(expected.strip(), observed.strip())
+
+    def test_stochastic_control_flow_5(self) -> None:
+        self.maxDiff = None
+
+        queries = [if_statement()]
+        observations = {}
+        with self.assertRaises(ValueError) as ex:
+            BMGRuntime().accumulate_graph(queries, observations)
+        # TODO: Better error message
+        expected = "Stochastic control flows are not yet implemented."
+        self.assertEqual(expected, str(ex.exception))
 
 
 # TODO: Test that shows what happens when multiple graph node


### PR DESCRIPTION
Summary: The compiler does not support stochastic control flows involving if statements; this makes them illegal.

Reviewed By: wtaha

Differential Revision: D31918087

