### PR TITLE
runtime error handling

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/bmg_infer_interface_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_infer_interface_test.py
@@ -5,7 +5,7 @@ import unittest
 import beanmachine.ppl as bm
 from beanmachine.ppl.inference import BMGInference
 from torch import tensor
-from torch.distributions import Bernoulli
+from torch.distributions import Bernoulli, Dirichlet
 
 
 @bm.functional
@@ -130,3 +130,17 @@ tensor([[[ 1.5000, -2.5000]],
         f3 = samples[flip3()]
         f4 = samples[flip4()]
         self.assertEqual(str(f3), str(f4))
+
+    class SampleModel:
+        @bm.random_variable
+        def a(self):
+            return Dirichlet(tensor([0.5, 0.5]))
+
+        @bm.functional
+        def b(self):
+            return self.a()[2]
+
+    def test_infer_interface_runtime_error(self) -> None:
+        model = self.SampleModel()
+        with self.assertRaises(RuntimeError):
+            BMGInference().infer([model.a(), model.b()], {}, 10, 4)

--- a/src/beanmachine/ppl/inference/bmg_inference.py
+++ b/src/beanmachine/ppl/inference/bmg_inference.py
@@ -182,9 +182,16 @@ class BMGInference:
             # specified in pybindings.cpp (and not passing the local one in). In the current
             # code we are explicitly passing in the same default value used in that file (5123401).
             # We really need a way to defer to the value defined in pybindings.py here.
-            raw = g.infer(
-                num_samples, inference_type, 5123401, num_chains, default_config
-            )
+            try:
+                raw = g.infer(
+                    num_samples, inference_type, 5123401, num_chains, default_config
+                )
+            except RuntimeError as e:
+                raise RuntimeError(
+                    "Error during BMG inference\n"
+                    + "Note: the runtime error from BMG may not be interpretable.\n"
+                ) from e
+
             self._finish(prof.graph_infer)
             if produce_report:
                 self._begin(prof.deserialize_perf_report)


### PR DESCRIPTION
Summary:
BMG:
Runtime errors were not being handled properly during multi-processing for multiple chains. I updated each worker thread to have a try catch and set the error on the main thread.

BMGInference through Beanstalk:
I added error handling of BMG runtime errors, with an additional message indicating the error was from BMG.

Differential Revision: D32013726

