### PR TITLE
Unify SS interface

### DIFF
--- a/src/beanmachine/ppl/experimental/global_inference/single_site_ancestral_mh.py
+++ b/src/beanmachine/ppl/experimental/global_inference/single_site_ancestral_mh.py
@@ -1,31 +1,11 @@
-from typing import List, Set
-
-from beanmachine.ppl.experimental.global_inference.base_inference import BaseInference
-from beanmachine.ppl.experimental.global_inference.proposer.base_proposer import (
-    BaseProposer,
-)
 from beanmachine.ppl.experimental.global_inference.proposer.single_site_ancestral_proposer import (
     SingleSiteAncestralProposer,
 )
-from beanmachine.ppl.experimental.global_inference.simple_world import (
-    SimpleWorld,
+from beanmachine.ppl.experimental.global_inference.single_site_inference import (
+    SingleSiteInference,
 )
-from beanmachine.ppl.model.rv_identifier import RVIdentifier
 
 
-class SingleSiteAncestralMetropolisHastings(BaseInference):
+class SingleSiteAncestralMetropolisHastings(SingleSiteInference):
     def __init__(self):
-        self._proposers = {}
-
-    def get_proposers(
-        self,
-        world: SimpleWorld,
-        target_rvs: Set[RVIdentifier],
-        num_adaptive_sample: int,
-    ) -> List[BaseProposer]:
-        proposers = []
-        for node in target_rvs:
-            if node not in self._proposers:
-                self._proposers[node] = SingleSiteAncestralProposer(node)
-            proposers.append(self._proposers[node])
-        return proposers
+        super().__init__(SingleSiteAncestralProposer)

--- a/src/beanmachine/ppl/experimental/global_inference/single_site_inference.py
+++ b/src/beanmachine/ppl/experimental/global_inference/single_site_inference.py
@@ -1,0 +1,32 @@
+from typing import List, Set, Type
+
+from beanmachine.ppl.experimental.global_inference.base_inference import BaseInference
+from beanmachine.ppl.experimental.global_inference.proposer.base_proposer import (
+    BaseProposer,
+)
+from beanmachine.ppl.experimental.global_inference.proposer.base_single_site_proposer import (
+    BaseSingleSiteMHProposer,
+)
+from beanmachine.ppl.experimental.global_inference.simple_world import (
+    SimpleWorld,
+)
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
+
+
+class SingleSiteInference(BaseInference):
+    def __init__(self, proposer_class: Type[BaseSingleSiteMHProposer], *args, **kwargs):
+        self.proposer_class = proposer_class
+        self._proposers = {}
+
+    def get_proposers(
+        self,
+        world: SimpleWorld,
+        target_rvs: Set[RVIdentifier],
+        num_adaptive_sample: int,
+    ) -> List[BaseProposer]:
+        proposers = []
+        for node in target_rvs:
+            if node not in self._proposers:
+                self._proposers[node] = self.proposer_class(node)  # pyre-ignore [45]
+            proposers.append(self._proposers[node])
+        return proposers

--- a/src/beanmachine/ppl/experimental/global_inference/single_site_uniform_mh.py
+++ b/src/beanmachine/ppl/experimental/global_inference/single_site_uniform_mh.py
@@ -1,31 +1,11 @@
-from typing import List, Set
-
-from beanmachine.ppl.experimental.global_inference.base_inference import BaseInference
-from beanmachine.ppl.experimental.global_inference.proposer.base_proposer import (
-    BaseProposer,
-)
 from beanmachine.ppl.experimental.global_inference.proposer.single_site_uniform_proposer import (
     SingleSiteUniformProposer,
 )
-from beanmachine.ppl.experimental.global_inference.simple_world import (
-    SimpleWorld,
+from beanmachine.ppl.experimental.global_inference.single_site_inference import (
+    SingleSiteInference,
 )
-from beanmachine.ppl.model.rv_identifier import RVIdentifier
 
 
-class SingleSiteUniformMetropolisHastings(BaseInference):
+class SingleSiteUniformMetropolisHastings(SingleSiteInference):
     def __init__(self):
-        self._proposers = {}
-
-    def get_proposers(
-        self,
-        world: SimpleWorld,
-        target_rvs: Set[RVIdentifier],
-        num_adaptive_sample: int,
-    ) -> List[BaseProposer]:
-        proposers = []
-        for node in target_rvs:
-            if node not in self._proposers:
-                self._proposers[node] = SingleSiteUniformProposer(node)
-            proposers.append(self._proposers[node])
-        return proposers
+        super().__init__(SingleSiteUniformProposer)


### PR DESCRIPTION
Summary: Pure refactoring. Unifying the ss inference interfaces since get_proposers should all assign one proposer per target_rv.

Differential Revision: D32092641

