### PR TITLE
Return mh logprob in propose

### DIFF
--- a/src/beanmachine/ppl/experimental/global_inference/proposer/base_proposer.py
+++ b/src/beanmachine/ppl/experimental/global_inference/proposer/base_proposer.py
@@ -10,7 +10,7 @@ class BaseProposer(metaclass=ABCMeta):
     def propose(self, world: SimpleWorld) -> Tuple[SimpleWorld, torch.Tensor]:
         raise NotImplementedError
 
-    def do_adaptation(self) -> None:
+    def do_adaptation(self, world, accept_log_prob, *args, **kwargs) -> None:
         ...
 
     def finish_adaptation(self) -> None:

--- a/src/beanmachine/ppl/experimental/global_inference/proposer/hmc_proposer.py
+++ b/src/beanmachine/ppl/experimental/global_inference/proposer/hmc_proposer.py
@@ -263,7 +263,7 @@ class HMCProposer(BaseProposer):
             self._positions, self._pe, self._pe_grad = positions, pe, pe_grad
         return self.world, torch.zeros_like(self._alpha)
 
-    def do_adaptation(self) -> None:
+    def do_adaptation(self, *args, **kwargs) -> None:
         if self._alpha is None:
             return
 

--- a/src/beanmachine/ppl/experimental/global_inference/sampler.py
+++ b/src/beanmachine/ppl/experimental/global_inference/sampler.py
@@ -66,7 +66,7 @@ class Sampler(Generator[SimpleWorld, Optional[SimpleWorld], None]):
                     raise e
 
             if self._num_adaptive_sample_remaining > 0:
-                proposer.do_adaptation()
+                proposer.do_adaptation(world, accept_log_prob)
                 if self._num_samples_remaining == 1:
                     # we just reach the end of adaptation period
                     proposer.finish_adaptation()


### PR DESCRIPTION
Summary: Some proposers like random walk require the acceptance probability, so I return it here as part of the propose step. We can also cache it but since a prob only corresponds to a node/block for a single proposer, it probably makes more sense to return it as part of the new accepted world. It's also useful to return the accept if we want to add to the tqdm bar as suggested by Openteams.

Differential Revision: D32068669

