### PR TITLE
Disallow stochastic control flows involving "for"

### DIFF
--- a/src/beanmachine/ppl/compiler/bm_to_bmg.py
+++ b/src/beanmachine/ppl/compiler/bm_to_bmg.py
@@ -11,6 +11,7 @@ import astor
 from beanmachine.ppl.compiler.ast_patterns import (
     arguments,
     ast_if,
+    ast_for,
     assign,
     ast_assert,
     ast_domain,
@@ -277,12 +278,29 @@ _handle_if = PatternRule(
     ),
 )
 
+_handle_for = PatternRule(
+    ast_for(iter=name()),
+    lambda a: ListEdit(
+        [
+            ast.Expr(_make_bmg_call("handle_for", [a.iter])),
+            a,
+        ]
+    ),
+)
+
+_control_flow_to_bmg: Rule = first(
+    [
+        _handle_for,
+        _handle_if,
+    ]
+)
+
 # Note that we are NOT attempting to iterate to a fixpoint here; we do a transformation
 # on every statement once.
 _statements_to_bmg: Rule = all_of(
     [
         _top_down(once(_assignments_to_bmg)),
-        _bottom_up(once(_handle_if)),
+        _bottom_up(once(_control_flow_to_bmg)),
     ]
 )
 

--- a/src/beanmachine/ppl/compiler/runtime.py
+++ b/src/beanmachine/ppl/compiler/runtime.py
@@ -996,6 +996,11 @@ class BMGRuntime:
     # Control flow
     #
 
+    def handle_for(self, iter: Any) -> None:
+        if isinstance(iter, BMGNode):
+            # TODO: Better error
+            raise ValueError("Stochastic control flows are not yet implemented.")
+
     def handle_if(self, test: Any) -> None:
         if isinstance(test, BMGNode):
             # TODO: Better error


### PR DESCRIPTION
Summary: We now throw an exception during graph accumulation if a model iterates over a stochastic value with `for`.

Reviewed By: wtaha

Differential Revision: D31942303

