### PR TITLE
Fix init to uniform for discrete distributions without enumerate support

### DIFF
--- a/src/beanmachine/ppl/experimental/global_inference/utils/initialize_fn.py
+++ b/src/beanmachine/ppl/experimental/global_inference/utils/initialize_fn.py
@@ -13,9 +13,12 @@ def init_to_uniform(distribution: dist.Distribution) -> torch.Tensor:
     if distribution.has_enumerate_support:
         support = distribution.enumerate_support(expand=False).flatten()
         return support[torch.randint_like(sample_val, support.numel()).long()]
-    else:
+    elif not distribution.support.is_discrete:
         transform = dist.biject_to(distribution.support)
         return transform(torch.rand_like(transform.inv(sample_val)) * 4 - 2)
+    else:
+        # fall back to sample from prior
+        return init_from_prior(distribution)
 
 
 def init_from_prior(distribution: dist.Distribution) -> torch.Tensor:

--- a/src/beanmachine/ppl/experimental/global_inference/utils/tests/initialize_fn_test.py
+++ b/src/beanmachine/ppl/experimental/global_inference/utils/tests/initialize_fn_test.py
@@ -18,6 +18,7 @@ from beanmachine.ppl.experimental.global_inference.utils.initialize_fn import (
         dist.Dirichlet(torch.tensor([0.5, 0.5])),
         dist.Categorical(logits=torch.randn(5, 10)),
         dist.Bernoulli(0.5).expand((3, 5, 7)),
+        dist.Poisson(rate=2.0),
     ],
 )
 def test_initialize_validness(init_fn, distribution):


### PR DESCRIPTION
Summary: While working on test migration I found that calling `init_to_uniform` on a Poisson distribution throws an exception, which shouldn't happen :). This diff address the issue by letting `init_to_uniform` fall back to `init_from_prior` when we don't have a good solution for it

Differential Revision: D32152084

