### PR TITLE
Add total sample count back to progress bar

### DIFF
--- a/src/beanmachine/ppl/experimental/global_inference/base_inference.py
+++ b/src/beanmachine/ppl/experimental/global_inference/base_inference.py
@@ -74,6 +74,7 @@ class BaseInference(metaclass=ABCMeta):
             # Main inference loop
             for world in tqdm(
                 sampler,
+                total=num_samples + num_adaptive_samples,
                 desc="Samples collected",
                 disable=verbose == VerboseLevel.OFF,
             ):


### PR DESCRIPTION
Summary: In D31311147 (https://github.com/facebookresearch/beanmachine/commit/9eadd6a395650cea0245f42ac5fd6a3857cad9c0) the progress bar was changed from `trange(num_samples + num_adaptive_samples, ...)` to `tqdm(sampler, ...)`, which is a bit more concise. However, a downside of this that I failed to notice is that, because `Sampler` class does not have a `__len__` property, `tqdm` cannot determine the total number of samples that we're going to generate. As a result, our progress bar no longer shows the total number of samples. This diff fix the issue by explicitly passing the total number of samples to tqdm

Reviewed By: jpchen

Differential Revision: D32181525

