### PR TITLE
Compiler gives error for stochastic generator expression

### DIFF
--- a/src/beanmachine/ppl/compiler/ast_patterns.py
+++ b/src/beanmachine/ppl/compiler/ast_patterns.py
@@ -228,6 +228,10 @@ def ast_while(
     )
 
 
+def ast_generator(elt: Pattern = _any, generators: Pattern = _any) -> Pattern:
+    return type_and_attributes(ast.GeneratorExp, {"elt": elt, "generators": generators})
+
+
 def ast_listComp(elt: Pattern = _any, generators: Pattern = _any) -> Pattern:
     return type_and_attributes(ast.ListComp, {"elt": elt, "generators": generators})
 

--- a/src/beanmachine/ppl/compiler/single_assignment.py
+++ b/src/beanmachine/ppl/compiler/single_assignment.py
@@ -63,6 +63,7 @@ from beanmachine.ppl.compiler.ast_patterns import (
     ast_compare,
     ast_dict,
     ast_dictComp,
+    ast_generator,
     ast_domain,
     ast_for,
     ast_if,
@@ -1456,6 +1457,8 @@ class SingleAssignment:
         #          r.append(c)
         #    return r
         # y=p()
+        #
+        # Note that this rewrites both list comprehensions and generator expressions.
         _empty_ast_arguments = ast.arguments(
             posonlyargs=[],
             args=[],
@@ -1466,7 +1469,7 @@ class SingleAssignment:
             defaults=[],
         )
         return PatternRule(
-            assign(value=ast_listComp()),
+            assign(value=match_any(ast_generator(), ast_listComp())),
             lambda term: ListEdit(
                 self.fresh_names(
                     ["p", "r"],

--- a/src/beanmachine/ppl/compiler/tests/stochastic_control_flow_test.py
+++ b/src/beanmachine/ppl/compiler/tests/stochastic_control_flow_test.py
@@ -106,6 +106,13 @@ def dict_comprehension():
     return tensor(len({x: x > 0.5 for x in dirichlet()}))
 
 
+@bm.functional
+def seq_comprehension():
+    # Comprehensions are just a special kind of "for".
+    # We don't support them.
+    return tensor(x * 2.0 for x in dirichlet())
+
+
 # Try out a stochastic control flow where we choose
 # a mean from one of two distributions depending on
 # a coin flip.
@@ -485,14 +492,19 @@ digraph "graph" {
         expected = "Stochastic control flows are not yet implemented."
         self.assertEqual(expected, str(ex.exception))
 
-        queries = [set_comprehension()]
+        queries = [seq_comprehension()]
         with self.assertRaises(ValueError) as ex:
             BMGRuntime().accumulate_graph(queries, observations)
         # TODO: Better error message
         expected = "Stochastic control flows are not yet implemented."
         self.assertEqual(expected, str(ex.exception))
 
-        # TODO: Test sequence comprehensions
+        queries = [set_comprehension()]
+        with self.assertRaises(ValueError) as ex:
+            BMGRuntime().accumulate_graph(queries, observations)
+        # TODO: Better error message
+        expected = "Stochastic control flows are not yet implemented."
+        self.assertEqual(expected, str(ex.exception))
 
 
 # TODO: Test that shows what happens when multiple graph node


### PR DESCRIPTION
Summary: We were not correctly rewriting generator expressions; we can rewrite them exactly as we do list comprehensions.  We now correctly rewrite them and produce an error message if the generator collection is stochastic.

Reviewed By: wtaha

Differential Revision: D31947543

