### PR TITLE
Sequential proposer

### DIFF
--- a/src/beanmachine/ppl/experimental/global_inference/proposer/base_proposer.py
+++ b/src/beanmachine/ppl/experimental/global_inference/proposer/base_proposer.py
@@ -1,11 +1,13 @@
 from abc import ABCMeta, abstractmethod
+from typing import Tuple
 
+import torch
 from beanmachine.ppl.experimental.global_inference.simple_world import SimpleWorld
 
 
 class BaseProposer(metaclass=ABCMeta):
     @abstractmethod
-    def propose(self, world: SimpleWorld) -> SimpleWorld:
+    def propose(self, world: SimpleWorld) -> Tuple[SimpleWorld, torch.Tensor]:
         raise NotImplementedError
 
     def do_adaptation(self) -> None:

--- a/src/beanmachine/ppl/experimental/global_inference/proposer/hmc_proposer.py
+++ b/src/beanmachine/ppl/experimental/global_inference/proposer/hmc_proposer.py
@@ -230,7 +230,7 @@ class HMCProposer(BaseProposer):
             new_direction = 1 if energy - new_energy > target else -1
         return step_size
 
-    def propose(self, world: SimpleWorld) -> SimpleWorld:
+    def propose(self, world: SimpleWorld) -> Tuple[SimpleWorld, torch.Tensor]:
         if world is not self.world:
             # re-compute cached values since world was modified by other sources
             self.world = world
@@ -261,7 +261,7 @@ class HMCProposer(BaseProposer):
             self.world = self.world.replace(self._to_unconstrained.inv(positions))
             # update cache
             self._positions, self._pe, self._pe_grad = positions, pe, pe_grad
-        return self.world
+        return self.world, torch.zeros_like(self._alpha)
 
     def do_adaptation(self) -> None:
         if self._alpha is None:

--- a/src/beanmachine/ppl/experimental/global_inference/proposer/nuts_proposer.py
+++ b/src/beanmachine/ppl/experimental/global_inference/proposer/nuts_proposer.py
@@ -1,4 +1,4 @@
-from typing import NamedTuple, Set
+from typing import NamedTuple, Set, Tuple
 
 import torch
 from beanmachine.ppl.experimental.global_inference.proposer.hmc_proposer import (
@@ -245,7 +245,7 @@ class NUTSProposer(HMCProposer):
             turned_or_diverged=turned_or_diverged,
         )
 
-    def propose(self, world: SimpleWorld) -> SimpleWorld:
+    def propose(self, world: SimpleWorld) -> Tuple[SimpleWorld, torch.Tensor]:
         if world is not self.world:
             # re-compute cached values since world was modified by other sources
             self.world = world
@@ -303,4 +303,4 @@ class NUTSProposer(HMCProposer):
             )
 
         self._alpha = tree.sum_accept_prob / tree.num_proposals
-        return self.world
+        return self.world, torch.zeros_like(self._alpha)

--- a/src/beanmachine/ppl/experimental/global_inference/proposer/sequential_proposer.py
+++ b/src/beanmachine/ppl/experimental/global_inference/proposer/sequential_proposer.py
@@ -1,0 +1,27 @@
+from typing import List, Tuple, cast
+
+import torch
+from beanmachine.ppl.experimental.global_inference.proposer.base_proposer import (
+    BaseProposer,
+)
+from beanmachine.ppl.experimental.global_inference.simple_world import SimpleWorld
+
+
+class SequentialProposer(BaseProposer):
+    def __init__(self, proposers: List[BaseProposer]):
+        self.proposers = proposers
+
+    def propose(self, world: SimpleWorld) -> Tuple[SimpleWorld, torch.Tensor]:
+        accept_log_prob = 0.0
+        for proposer in self.proposers:
+            world, log_prob = proposer.propose(world)
+            accept_log_prob += log_prob
+        return world, cast(torch.Tensor, accept_log_prob)
+
+    def do_adaptation(self, *args, **kwargs) -> None:
+        for proposer in self.proposers:
+            proposer.do_adaptation(*args, **kwargs)
+
+    def finish_adaptation(self) -> None:
+        for proposer in self.proposers:
+            proposer.finish_adaptation()

--- a/src/beanmachine/ppl/experimental/global_inference/sampler.py
+++ b/src/beanmachine/ppl/experimental/global_inference/sampler.py
@@ -11,6 +11,8 @@ from typing import (
     TYPE_CHECKING,
 )
 
+import torch
+
 
 if TYPE_CHECKING:
     from beanmachine.ppl.experimental.global_inference.base_inference import (
@@ -50,7 +52,9 @@ class Sampler(Generator[SimpleWorld, Optional[SimpleWorld], None]):
 
         for proposer in proposers:
             try:
-                world = proposer.propose(world)
+                new_world, accept_log_prob = proposer.propose(world)
+                if torch.rand_like(accept_log_prob).log() < accept_log_prob:
+                    world = new_world
             except RuntimeError as e:
                 if "singular U" in str(e) or "input is not positive-definite" in str(e):
                     # since it's normal to run into cholesky error during GP, instead of

--- a/src/beanmachine/ppl/experimental/global_inference/single_site_ancestral_mh.py
+++ b/src/beanmachine/ppl/experimental/global_inference/single_site_ancestral_mh.py
@@ -3,9 +3,15 @@ from beanmachine.ppl.experimental.global_inference.proposer.single_site_ancestra
 )
 from beanmachine.ppl.experimental.global_inference.single_site_inference import (
     SingleSiteInference,
+    JointSingleSiteInference,
 )
 
 
 class SingleSiteAncestralMetropolisHastings(SingleSiteInference):
+    def __init__(self):
+        super().__init__(SingleSiteAncestralProposer)
+
+
+class GlobalAncestralMetropolisHastings(JointSingleSiteInference):
     def __init__(self):
         super().__init__(SingleSiteAncestralProposer)


### PR DESCRIPTION
Summary:
This diff adds a `SequentialProposer` class, which accepts a list of proposers and run each of them sequentially. To make it possible to accept/reject a sequence of proposals together, the accept/reject logic is moved out of individual proposers (when possible) so a temporary, low probability state won't be rejected before we finish the sequence.

One of the thing that our old compositional inference algorithm is able to do is to block multiple nodes together, each of which can be updated by a different algorithm. While the "different algorithm in a same block" part is not fully done yet, with the change in this diff, at least it's already possible to block update with the same algorithm. The idea is that for the following model

```
bm.random_variabld
def x(i):
    ...
```
The following setting will spawn a proposer for each of `x(i)`:
```
CompositionalInference({x: SingleSiteAncestralMetropolisHastings})
```
whereas this will jointly update all `x`s together
```
CompositionalInference({x: GlobalAncestralMetropolisHastings})
```
(I'm calling it "global" here just to be consistent with the global NUTS that we have, but perhaps we can remove the prefix altogether so the blocked version are just `AncestralMetropolisHastings` and `NoUTurnSampler`?)

For NUTS, because the accept/reject step happens when the tree is being built and is not straightforward to refactor the process out, I use the same hack as we did in the single site NUTS where we always return an accept prob of 1 so that sampler will accept whatever NUTS returns as the next world.

Some of the changes in this diff are a bit arbitrary so I'd love to hear about people's opinions on them. :)

Differential Revision: D32158333

