### PR TITLE
Add lambda elimination rule to single assignment rewriter

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/single_assignment_test.py
+++ b/src/beanmachine/ppl/compiler/tests/single_assignment_test.py
@@ -3533,3 +3533,22 @@ def f(x):
     return r1
 """
         self.check_rewrite(source, expected)
+
+    def test_lambda_elimination(self) -> None:
+        source = """
+def f(x):
+    return lambda y: x * y + 2
+"""
+
+        expected = """
+def f(x):
+
+    def a2(y):
+        a4 = x * y
+        a5 = 2
+        r3 = a4 + a5
+        return r3
+    r1 = a2
+    return r1
+"""
+        self.check_rewrite(source, expected)


### PR DESCRIPTION
Summary:
The single assignment rewriter seeks to reduce Python programs to equivalent programs in a much smaller subset of Python programs.

This rule rewrites lambda expressions of the form

    x = lambda args: body

to

    def t(args):
      return body
    x = t

and therefore we do not have to worry about (1) encountering lambdas in the rewritten program, or (2) that the lambda body will not be rewritten.

HOWEVER:

* We have no support for handling "top level" lambdas. For example, suppose we had:

    flip = random_variable(lambda x: Bernoulli(0.5))

In this case the lambda is not inside a random variable body; it *is* the random variable. This rewrite does not handle that case.

* A lambda could be outside a random variable; we don't handle that case either yet:

    b = lambda : Bernoulli(0.5)
    random_variable
    def flip():
      return b()

* We have no testing for what happens when the jitter encounters a nested function, and it is probably quite wrong. In particular, we'll lose any closure information.

Reviewed By: wtaha

Differential Revision: D31980547

