### PR TITLE
Compiler now correctly handles jit-compiling functions closed over outer variables

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/bm_to_bmg_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bm_to_bmg_test.py
@@ -183,11 +183,17 @@ digraph "graph" {
         #   it will not rewrite super() to x = [] / super(*x).
         # * the bm_to_bmg rewriter does not rewrite calls to super
         #   into bmg.handle_function.
-        # * we generate an outer variable __class__ which is initialized
-        #   to the same value as the original function's outer variable
-        #   __class__, if it has one, None otherwise.
+        # * if the original function has an outer variable __class__ then
+        #   we generate a new outer variable with the same name and value.
 
-        bmgast, _ = _bm_function_to_bmg_ast(d.foo, "foo_helper")
+        # Obtain the random variable for d.foo()
+        rv = d.foo()
+
+        # The random variable has a reference to the original *undecorated*
+        # D.foo, which has an outer variable __class__. Verify that we
+        # correctly recreate that outer variable in the rewritten function:
+
+        bmgast, _ = _bm_function_to_bmg_ast(rv.function, "foo_helper")
         observed = astor.to_source(bmgast)
         expected = """
 def foo_helper(bmg, __class__):

--- a/src/beanmachine/ppl/compiler/tests/comparison_rewriting_test.py
+++ b/src/beanmachine/ppl/compiler/tests/comparison_rewriting_test.py
@@ -45,10 +45,10 @@ class ComparisonRewritingTest(unittest.TestCase):
 
         self.assertTrue(y.is_random_variable)
 
-        bmgast, _ = _bm_function_to_bmg_ast(y, "y_helper")
+        bmgast, _ = _bm_function_to_bmg_ast(y().function, "y_helper")
         observed = astor.to_source(bmgast)
         expected = """
-def y_helper(bmg, __class__):
+def y_helper(bmg):
 
     def y():
         a1 = 0.0


### PR DESCRIPTION
Summary:
We now correctly handle the scenario where the compiler is asked to jit-compile a function which is closed over outer variables.

A variable used in a nested function which is not local to that function is called "free" in Python; by "outer" variable I specifically mean a free variable which is a local (or formal parameter) of the enclosing function. These are implemented as a pair of tuples, one containing outer variable names and one containing the corresponding cells -- cells being what Python calls references to variables.

Unfortunately, when we rewrite a function we cannot simply copy those tuples to the new function because those properties are read-only. Instead we cause the Python runtime itself to create new cells and then fill in their values accordingly.

See the large comment in bm_to_bmg.py in this diff for more details.

This change eliminates the need for a special case to handle the `__class__` outer variable.

----

This gets us quite a ways farther along the path of correctly supporting calls to different kinds of code containers, but there is still a fair amount of work to do:

* We do not yet support random variables which *are* lambdas.
* We do not yet correctly support random variables which *call* lambdas that are not nested inside the random variable.
* We do not yet correctly support random variables which *call* lambdas or nested functions that are nested inside the random variable.

I'll add support for those scenarios in upcoming diffs.

Reviewed By: wtaha

Differential Revision: D32010927

