### PR TITLE
Add Makefile to bm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+all: lint docs test
+
+install: FORCE
+	pip install -e .[dev]
+
+lint: FORCE
+	flake8 . && usort check . &&  black --check .
+
+test: lint FORCE
+	pytest -vs .
+
+docs: FORCE
+	$(MAKE) -C sphinx html
+
+FORCE:


### PR DESCRIPTION
Summary: Adds a makefile to BM. `pyre` is not included because it requires a config I can't yet find, but at least `make` will run everything our CI runs AFAICT.

Reviewed By: neerajprad

Differential Revision: D32193655

