### PR TITLE
Refactor the function rewriter

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/bm_to_bmg_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bm_to_bmg_test.py
@@ -193,7 +193,7 @@ digraph "graph" {
         # D.foo, which has an outer variable __class__. Verify that we
         # correctly recreate that outer variable in the rewritten function:
 
-        bmgast, _ = _bm_function_to_bmg_ast(rv.function, "foo_helper")
+        bmgast = _bm_function_to_bmg_ast(rv.function, "foo_helper")
         observed = astor.to_source(bmgast)
         expected = """
 def foo_helper(bmg, __class__):

--- a/src/beanmachine/ppl/compiler/tests/comparison_rewriting_test.py
+++ b/src/beanmachine/ppl/compiler/tests/comparison_rewriting_test.py
@@ -45,7 +45,7 @@ class ComparisonRewritingTest(unittest.TestCase):
 
         self.assertTrue(y.is_random_variable)
 
-        bmgast, _ = _bm_function_to_bmg_ast(y().function, "y_helper")
+        bmgast = _bm_function_to_bmg_ast(y().function, "y_helper")
         observed = astor.to_source(bmgast)
         expected = """
 def y_helper(bmg):

--- a/src/beanmachine/ppl/compiler/tests/jit_test.py
+++ b/src/beanmachine/ppl/compiler/tests/jit_test.py
@@ -214,7 +214,7 @@ class JITTest(unittest.TestCase):
 
         self.assertTrue(norm.is_random_variable)
 
-        bmgast, _ = _bm_function_to_bmg_ast(f, "f_helper")
+        bmgast = _bm_function_to_bmg_ast(f, "f_helper")
         observed = astor.to_source(bmgast)
         expected = """
 def f_helper(bmg):
@@ -228,7 +228,7 @@ def f_helper(bmg):
     return f"""
         self.assertEqual(observed.strip(), expected.strip())
 
-        bmgast, _ = _bm_function_to_bmg_ast(norm().function, "norm_helper")
+        bmgast = _bm_function_to_bmg_ast(norm().function, "norm_helper")
         observed = astor.to_source(bmgast)
         expected = """
 def norm_helper(bmg):


### PR DESCRIPTION
Summary:
We have code which transforms a given function object into a new function object that calls back the BMG runtime every time an operation happens.  This code is pretty confusing:

* Many functions were long and did too many tasks that could be broken down into smaller tasks
* Many functions and variables were poorly named
* Functions which did complicated work had insufficient comments to explain their contract

Also, we at present do not correctly handle transformation of lambdas. Reorganizing the code now will make it much easier to add support for lambdas.

Reviewed By: wtaha

Differential Revision: D32082778

