### PR TITLE
Remove deprecated sample and query

### DIFF
--- a/src/beanmachine/ppl/model/__init__.py
+++ b/src/beanmachine/ppl/model/__init__.py
@@ -4,9 +4,7 @@ from beanmachine.ppl.model.statistical_model import (
     StatisticalModel,
     functional,
     param,
-    query,
     random_variable,
-    sample,
 )
 from beanmachine.ppl.model.utils import get_beanmachine_logger
 

--- a/src/beanmachine/ppl/model/statistical_model.py
+++ b/src/beanmachine/ppl/model/statistical_model.py
@@ -45,14 +45,6 @@ class StatisticalModel(object):
         return RVIdentifier(wrapper=wrapper, arguments=arguments)
 
     @staticmethod
-    def sample(f):
-        warnings.warn(
-            "@sample will be deprecated, use @random_variable instead",
-            DeprecationWarning,
-        )
-        return StatisticalModel.random_variable(f)
-
-    @staticmethod
     def random_variable(f):
         """
         Decorator to be used for every stochastic random variable defined in
@@ -71,13 +63,6 @@ class StatisticalModel(object):
         wrapper.is_functional = False
         wrapper.is_random_variable = True
         return wrapper
-
-    @staticmethod
-    def query(f):
-        warnings.warn(
-            "@query will be deprecated, use @functional instead", DeprecationWarning
-        )
-        return StatisticalModel.functional(f)
 
     @staticmethod
     def functional(f):
@@ -120,9 +105,5 @@ class StatisticalModel(object):
 
 
 random_variable = StatisticalModel.random_variable
-sample = random_variable
-
 functional = StatisticalModel.functional
-query = functional
-
 param = StatisticalModel.param


### PR DESCRIPTION
Summary: Removes sample and query primitives. Any notebook using this would be using a very outdated on BM and should be updated or deprecated.

Reviewed By: horizon-blue

Differential Revision: D32229250

