### PR TITLE
Update installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,48 +1,55 @@
-Bean Machine
-============
+# Bean Machine
 
-[![CircleCI](https://circleci.com/gh/facebookincubator/beanmachine.svg?style=svg&circle-token=39d1796c9ba26c78bba42dea57a9559742723be5)](https://circleci.com/gh/facebookincubator/workflows/beanmachine)
+[![Lint](https://github.com/facebookresearch/beanmachine/actions/workflows/lint.yml/badge.svg)](https://github.com/facebookresearch/beanmachine/actions/workflows/lint.yml)
+[![Tests](https://github.com/facebookresearch/beanmachine/actions/workflows/test.yml/badge.svg)](https://github.com/facebookresearch/beanmachine/actions/workflows/test.yml)
 
-# Overview
+
+## Overview
 
 Bean Machine is a probabilistic programming language for inference over statistical models written in the Python language using a declarative syntax. Bean Machine is built on top of PyTorch and Bean Machine Graph, a custom C++ backend.
-Check out [our tutorials and Quick Start](http://beanmachine.org/docs/quickstart) to get started! 
+Check out [our tutorials and Quick Start](https://beanmachine.org/docs/quickstart) to get started!
 
-# Installing Bean Machine
+## Installation
 Bean Machine supports Python 3.7+ and PyTorch 1.10.
 
-**Linux**
+### Install the Latest Release with Pip
+
+<!-- TODO: replace this command with a regular pip install after OSS -->
 ```bash
-sudo apt-get install libboost-dev libeigen3-dev
-git clone https://github.com/facebookincubator/beanmachine.git
+pip install --extra-index-url https://test.pypi.org/simple/ beanmachine
+```
+
+### Install from Source
+
+To download the latest Bean Machine source code from GitHub:
+
+```bash
+git clone https://github.com/facebookresearch/beanmachine.git
 cd beanmachine
+```
+
+Then, you can choose from any of the following installation options.
+
+#### Anaconda
+
+We recommend using [conda](https://docs.conda.io/en/latest/) to manage the virtual environment and install the necessary build dependencies.
+
+```bash
+conda create -n {env name} python=3.7; conda activate {env name}
+conda install boost eigen
 pip install .
 ```
 
-**Mac OSX**
-
-We recommend [conda](https://docs.conda.io/en/latest/) as a package manager and [Homebrew](https://brew.sh/) to install the Xcode dependencies:
-
-```bash
-brew install llvm libomp  # Dependencies used for compiling cpp extensions
-
-conda create -n {env name}; conda activate {env name}
-conda install boost eigen
-git clone https://github.com/facebookincubator/beanmachine.git
-cd beanmachine
-CC=clang CXX=clang++ pip install .
-# in dev mode
-CC=clang CXX=clang++ pip install -e '.[dev]'
-```
-
-**Docker**
+#### Docker
 
 ```bash
 docker build -t beanmachine .
 docker run -it beanmachine:latest bash
 ```
 
-Further, if you would like to run the builtin unit tests:
+#### Validate Installation
+
+If you would like to run the builtin unit tests:
 
 ```bash
 pip install pytest


### PR DESCRIPTION
Summary:
- Replaced the CircleCI badge (which has been broken since we moved from `facebookincubator`) with GitHub Action badges
- Added a instruction to install BM with `pip`
- Updated the instruction for installing BM from source
  - BMG used to depends on PyTorch C++ library, so we had to use the same compiler as PyTorch does on each platform. Since we no longer has such dependency, the installation instruction can be greatly simplified. The conda installation instruction is the same as the one we have in CI and should work on MacOS, Windows, and most (if not all) Linux distributions.

Differential Revision: D32398648

