### PR TITLE
Eliminate decorators from rewritten functions

### DIFF
--- a/src/beanmachine/ppl/compiler/beanstalk_common.py
+++ b/src/beanmachine/ppl/compiler/beanstalk_common.py
@@ -1,4 +1,6 @@
-allowed_functions = {dict, list, set, super}
+from beanmachine.ppl.model.statistical_model import random_variable, functional
+
+allowed_functions = {dict, list, set, super, random_variable, functional}
 
 # TODO: Allowing these constructions raises additional problems that
 # we have not yet solved. For example, what happens if someone

--- a/src/beanmachine/ppl/compiler/tests/bm_to_bmg_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bm_to_bmg_test.py
@@ -199,21 +199,25 @@ digraph "graph" {
 def foo_helper(bmg, __class__):
 
     def foo(self):
-        a4 = super()
-        a1 = bmg.handle_dot_get(a4, 'foo')
-        r6 = []
-        r8 = {}
-        f = bmg.handle_function(a1, r6, r8)
-        a11 = [DerivedModel]
-        a12 = [self]
-        r10 = bmg.handle_addition(a11, a12)
-        a5 = super(*r10)
-        a2 = bmg.handle_dot_get(a5, 'bar')
+        a5 = super()
+        a1 = bmg.handle_dot_get(a5, 'foo')
         r7 = []
-        r9 = {}
-        b = bmg.handle_function(a2, r7, r9)
+        r10 = {}
+        f = bmg.handle_function(a1, r7, r10)
+        a14 = [DerivedModel]
+        a15 = [self]
+        r13 = bmg.handle_addition(a14, a15)
+        a6 = super(*r13)
+        a2 = bmg.handle_dot_get(a6, 'bar')
+        r8 = []
+        r11 = {}
+        b = bmg.handle_function(a2, r8, r11)
         r3 = bmg.handle_multiplication(f, b)
         return r3
+    a4 = bmg.handle_dot_get(bm, 'functional')
+    r9 = [foo]
+    r12 = {}
+    foo = bmg.handle_function(a4, r9, r12)
     return foo
 """
         self.assertEqual(observed.strip(), expected.strip())

--- a/src/beanmachine/ppl/compiler/tests/comparison_rewriting_test.py
+++ b/src/beanmachine/ppl/compiler/tests/comparison_rewriting_test.py
@@ -52,26 +52,30 @@ def y_helper(bmg):
 
     def y():
         a1 = 0.0
-        r4 = []
-        r7 = {}
-        a3 = bmg.handle_function(x, r4, r7)
-        a5 = bmg.handle_less_than(a1, a3)
-        bmg.handle_if(a5)
-        if a5:
-            a6 = 2.0
-            z = bmg.handle_less_than(a3, a6)
+        r6 = []
+        r10 = {}
+        a4 = bmg.handle_function(x, r6, r10)
+        a7 = bmg.handle_less_than(a1, a4)
+        bmg.handle_if(a7)
+        if a7:
+            a8 = 2.0
+            z = bmg.handle_less_than(a4, a8)
         else:
-            z = a5
-        a13 = 3.0
-        a10 = [a13]
-        a14 = [z]
-        a9 = bmg.handle_addition(a10, a14)
-        a15 = 4.0
-        a11 = [a15]
-        r8 = bmg.handle_addition(a9, a11)
-        r12 = {}
-        r2 = bmg.handle_function(StudentT, r8, r12)
+            z = a7
+        a16 = 3.0
+        a13 = [a16]
+        a17 = [z]
+        a12 = bmg.handle_addition(a13, a17)
+        a18 = 4.0
+        a14 = [a18]
+        r11 = bmg.handle_addition(a12, a14)
+        r15 = {}
+        r2 = bmg.handle_function(StudentT, r11, r15)
         return r2
+    a3 = bmg.handle_dot_get(bm, 'random_variable')
+    r5 = [y]
+    r9 = {}
+    y = bmg.handle_function(a3, r5, r9)
     return y
 """
         self.assertEqual(observed.strip(), expected.strip())

--- a/src/beanmachine/ppl/compiler/tests/jit_test.py
+++ b/src/beanmachine/ppl/compiler/tests/jit_test.py
@@ -214,6 +214,7 @@ class JITTest(unittest.TestCase):
 
         self.assertTrue(norm.is_random_variable)
 
+        # TODO: Stop using _bm_function_to_bmg_ast for testing.
         bmgast = _bm_function_to_bmg_ast(f, "f_helper")
         observed = astor.to_source(bmgast)
         expected = """
@@ -237,14 +238,18 @@ def norm_helper(bmg):
         global counter
         a1 = 1
         counter = bmg.handle_addition(counter, a1)
-        r3 = []
-        a6 = 0.0
-        a5 = dict(loc=a6)
-        a8 = 1.0
-        a7 = dict(scale=a8)
-        r4 = dict(**a5, **a7)
-        r2 = bmg.handle_function(Normal, r3, r4)
+        r4 = []
+        a9 = 0.0
+        a8 = dict(loc=a9)
+        a11 = 1.0
+        a10 = dict(scale=a11)
+        r7 = dict(**a8, **a10)
+        r2 = bmg.handle_function(Normal, r4, r7)
         return r2
+    a3 = bmg.handle_dot_get(bm, 'random_variable')
+    r5 = [norm]
+    r6 = {}
+    norm = bmg.handle_function(a3, r5, r6)
     return norm
 """
         self.assertEqual(observed.strip(), expected.strip())

--- a/src/beanmachine/ppl/compiler/tests/single_assignment_test.py
+++ b/src/beanmachine/ppl/compiler/tests/single_assignment_test.py
@@ -3552,3 +3552,28 @@ def f(x):
     return r1
 """
         self.check_rewrite(source, expected)
+
+    def test_decorator_elimination(self) -> None:
+        source = """
+@x
+@y(z)
+def f():
+    pass
+"""
+
+        expected = """
+def f():
+    pass
+
+
+r3 = [z]
+r6 = {}
+a1 = y(*r3, **r6)
+r4 = [f]
+r7 = {}
+f = a1(*r4, **r7)
+r2 = [f]
+r5 = {}
+f = x(*r2, **r5)
+"""
+        self.check_rewrite(source, expected)


### PR DESCRIPTION
Summary:
In order to more easily analyze models, we begin by reducing the source code of each function called by the model into a much simpler form of Python.

Python function decorators are a simple syntactic sugar, and we can therefore eliminate them by adding a step to the single assignment rewriter.  The syntax

    x
    y
    def z():
       whatever

is by definition just a more concise way to write

    def z():
        whatever
    z = x(y(z))

We now perform this rewrite, thereby eliminating function decorators.

What did we do previously when rewriting a function that had decorators?  We rewrote the function to *ignore* the decorators, but that's wrong; decorators are function calls and we should treat them as function calls, not ignore them.

This change creates a problem.  Suppose we are rewriting a query on `foo()`:

    random_variable
    def foo():
        return Normal(0., 1.)

when we rewrite that function definition we will rewrite it to:

    def foo():
      t1 = 0.
      t2 = 1.
      t3 = [t1, t2]
      t4 = bmg.handle_function(Normal, t3)
      return t4
    t5 = [foo]
    t6 = bmg.handle_function(random_variable, t5)
    foo = t6

What happens when we execute this rewritten code? Two bad things.  First, we *compile* the `random_variable` function! It's a Python function called by a model, so we compile it! But we absolutely do not want to try to compile the internal implementation details of Bean Machine.  I've added a special case to the compiler so that we do not attempt to compile `random_variable` or `functional`.

Second, the rewritten function is now once again a random variable, so when called it will return an `RVID` rather than executing the body of the rewritten `foo`!  We solve this problem by detecting in the runtime execution manager when a rewritten body returns an RVID, and if it does, then we call the underlying wrapped function, which is the rewritten function.

But now consider what happens here:

    def foo(): # No decorator
      return Normal(0., 1.)
    bar = random_variable(foo)

What if we have a query on `bar`?  Now the definition of `foo` does NOT have a decorator because remember we are transforming the original source code, and in the original source code there is no decorator on `def foo`.  Therefore we must be robust in the runtime and deal with the rewriter both producing the rewritten decorated and rewritten undecorated function objects, and we don't know which we'll get.

Reviewed By: wtaha

Differential Revision: D32162021

