### PR TITLE
Remove a flaky section from a test

### DIFF
--- a/src/beanmachine/ppl/experimental/global_inference/tests/compositional_infer_test.py
+++ b/src/beanmachine/ppl/experimental/global_inference/tests/compositional_infer_test.py
@@ -177,10 +177,6 @@ def test_block_inference_changing_support():
             assert world[model.component(0)] is old_world[model.component(0)]
         old_world = world
 
-    samples = compositional.infer(queries, {}, num_samples=10, num_chains=1).get_chain()
-    # make sure that we're not getting stuck in a particular value of K
-    assert torch.any(samples[model.K()] != samples[model.K()][0])
-
 
 def test_block_inference_changing_shape():
     model = ChangingShapeModel()


### PR DESCRIPTION
Summary:
I introduced this section of test when migrating compositional inference, which checks if `model.K()` is getting stuck by comparing it against the initial value.

While the test [passes most of the time](https://www.internalfb.com/intern/test/844424980691073?ref_report_id=0), because of its randomness, there are still [a few occasions that the test fails](https://www.internalfb.com/tasks?p_nav=MY_TASKS&t=105763235). We can increase the number of iterations to see if the test passes, but on a second thought, this section isn't checking something important anyways, so it's probably better to just remove it.

A side note: I thought the [conftest.py](https://www.internalfb.com/code/fbsource/[787f08c032ad]/fbcode/beanmachine/beanmachine/ppl/conftest.py) we have is sufficient to ensure that the test are reproducible, but it seems like that's not the case for Buck test. :(

Differential Revision: D32475962

