### PR TITLE
Statistics about the performance impact of the compiler

### DIFF
--- a/docs/overview/beanstalk/beanstalk.md
+++ b/docs/overview/beanstalk/beanstalk.md
@@ -18,6 +18,8 @@ The tutorials currently working with Beanstalk are:
 - Gaussian mixture model
 - Neal's funnel
 
+For the above three models, the Beanstalk-compiled version of NMC inference reduces runtime to generate samples of size 10K for the posterior distribution by anywhere between 80x and 250x depending on the model.
+
 ### Model restrictions
 
 Models compiled with Beanstalk have many restrictions. In the current release:


### PR DESCRIPTION
Summary: This diff provides (deliberately brief) information about the performance impact of the Beanstalk compiler on the tutorials that it is currently able to handle. More details about these numbers can be found internall the following URL https://fb.quip.com/8ADDABw1g1Y3

Reviewed By: ericlippert

Differential Revision: D32513605

