### PR TITLE
Detect unsupported stochastic slice operation

### DIFF
--- a/src/beanmachine/ppl/compiler/runtime.py
+++ b/src/beanmachine/ppl/compiler/runtime.py
@@ -772,6 +772,16 @@ class BMGRuntime:
             right = self._bmg.add_constant(right)
         return self._bmg.add_index(left, right)
 
+    def handle_slice(self, left: Any, lower: Any, upper: Any, step: Any) -> Any:
+        if (
+            isinstance(left, BMGNode)
+            or isinstance(lower, BMGNode)
+            or isinstance(upper, BMGNode)
+            or isinstance(step, BMGNode)
+        ):
+            raise ValueError("Stochastic slices are not yet implemented.")
+        return left[lower:upper:step]
+
     def handle_invert(self, input: Any) -> Any:
         if not isinstance(input, BMGNode):
             return ~input


### PR DESCRIPTION
Summary:
We do not yet support slice operations that are in any way stochastic -- if any of the collection, lower, upper or step are stochastic, we give an error and stop accumulating the graph.

We will improve the error messaging here in a later diff.

While I was looking at the indexing logic I noticed that we never test another unsupported scenario: a negative number as an index of a stochastic quantity. We now have a test case that verifies that we get a (bad!) error message. Again, we'll improve the error later.

Reviewed By: wtaha

Differential Revision: D32397024

