### PR TITLE
Finish implementing support for models containing "item" calls

### DIFF
--- a/src/beanmachine/ppl/compiler/fix_unsupported.py
+++ b/src/beanmachine/ppl/compiler/fix_unsupported.py
@@ -133,6 +133,10 @@ class UnsupportedNodeFixer(ProblemFixerBase):
             return self._replace_index_one_column(node)
         return self._replace_index_multi_column(node)
 
+    def _replace_item(self, node: bn.ItemNode) -> Optional[bn.BMGNode]:
+        # "item()" is an identity for our purposes. We just remove it.
+        return node.inputs[0]
+
     def _replace_lse(self, node: bn.LogSumExpTorchNode) -> Optional[bn.BMGNode]:
         # We only support compiling models where dim=0 and keepDims=False.
         if not bn.is_zero(node.inputs[1]) or not bn.is_zero(node.inputs[2]):
@@ -293,6 +297,8 @@ class UnsupportedNodeFixer(ProblemFixerBase):
             return self._replace_division(n)
         if isinstance(n, bn.IndexNode):
             return self._replace_index(n)
+        if isinstance(n, bn.ItemNode):
+            return self._replace_item(n)
         if isinstance(n, bn.LogSumExpTorchNode):
             return self._replace_lse(n)
         if isinstance(n, bn.SwitchNode):

--- a/src/beanmachine/ppl/compiler/graph_labels.py
+++ b/src/beanmachine/ppl/compiler/graph_labels.py
@@ -67,6 +67,7 @@ _node_labels = {
     bn.InvertNode: "Invert",
     bn.IsNode: "Is",
     bn.IsNotNode: "IsNot",
+    bn.ItemNode: "Item",
     bn.LessThanEqualNode: "<=",
     bn.LessThanNode: "<",
     bn.Log1mexpNode: "Log1mexp",

--- a/src/beanmachine/ppl/compiler/support.py
+++ b/src/beanmachine/ppl/compiler/support.py
@@ -97,6 +97,7 @@ _product_of_inputs = {
     bn.GreaterThanEqualNode: torch.Tensor.ge,
     bn.GreaterThanNode: torch.Tensor.gt,
     bn.InvertNode: torch.Tensor.__invert__,  # pyre-ignore
+    bn.ItemNode: lambda x: x,  # item() is an identity
     bn.LessThanEqualNode: torch.Tensor.le,
     bn.LessThanNode: torch.Tensor.lt,
     bn.LogisticNode: torch.Tensor.sigmoid,
@@ -122,7 +123,6 @@ _product_of_inputs = {
 # LogSumExpTorchNode
 # Log1mexpNode
 # IndexNode
-# ItemNode
 # Log1mexpNode
 #
 # We will need to implement computation of the support

--- a/src/beanmachine/ppl/compiler/tests/item_test.py
+++ b/src/beanmachine/ppl/compiler/tests/item_test.py
@@ -1,0 +1,64 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import unittest
+
+# The item() member function should be treated as an identity by the compiler
+# for the purposes of graph generation.
+
+import beanmachine.ppl as bm
+from beanmachine.ppl.inference.bmg_inference import BMGInference
+from torch.distributions import Bernoulli, Beta
+
+
+@bm.random_variable
+def beta():
+    return Beta(2.0, 2.0)
+
+
+@bm.random_variable
+def flip():
+    return Bernoulli(beta().item())
+
+
+class ItemTest(unittest.TestCase):
+    def test_item_member_function(self) -> None:
+
+        self.maxDiff = None
+        observed = BMGInference().to_dot([flip()], {}, after_transform=False)
+        expected = """
+digraph "graph" {
+  N0[label=2.0];
+  N1[label=Beta];
+  N2[label=Sample];
+  N3[label=Item];
+  N4[label=Bernoulli];
+  N5[label=Sample];
+  N6[label=Query];
+  N0 -> N1;
+  N0 -> N1;
+  N1 -> N2;
+  N2 -> N3;
+  N3 -> N4;
+  N4 -> N5;
+  N5 -> N6;
+}
+        """
+        self.assertEqual(expected.strip(), observed.strip())
+
+        observed = BMGInference().to_dot([flip()], {}, after_transform=True)
+        expected = """
+digraph "graph" {
+  N0[label=2.0];
+  N1[label=Beta];
+  N2[label=Sample];
+  N3[label=Bernoulli];
+  N4[label=Sample];
+  N5[label=Query];
+  N0 -> N1;
+  N0 -> N1;
+  N1 -> N2;
+  N2 -> N3;
+  N3 -> N4;
+  N4 -> N5;
+}
+        """
+        self.assertEqual(expected.strip(), observed.strip())


### PR DESCRIPTION
Summary: The "item" member function is an identity for the purposes of generating BMG models from BM models. We now remove it during the unsupported node fixing pass.

Reviewed By: wtaha

Differential Revision: D32445099

