### PR TITLE
Add a `bm.seed` utility function

### DIFF
--- a/src/beanmachine/ppl/__init__.py
+++ b/src/beanmachine/ppl/__init__.py
@@ -17,6 +17,7 @@ from .inference import (
     SingleSiteRandomWalk,
     SingleSiteUniformMetropolisHastings,
     empirical,
+    seed,
     simulate,
 )
 from .model import (
@@ -50,6 +51,7 @@ __all__ = [
     "empirical",
     "experimental",
     "functional",
+    "seed",
     "param",
     "r_hat",
     "random_variable",

--- a/src/beanmachine/ppl/conftest.py
+++ b/src/beanmachine/ppl/conftest.py
@@ -1,14 +1,9 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
-import random
-
-import numpy as np
+import beanmachine.ppl as bm
 import pytest
-import torch
 
 
 @pytest.fixture(autouse=True)
-def random_seed():
+def fix_random_seed():
     """Fix the random state for every test in the test suite"""
-    np.random.seed(0)
-    torch.manual_seed(0)
-    random.seed(0)
+    bm.seed(0)

--- a/src/beanmachine/ppl/inference/__init__.py
+++ b/src/beanmachine/ppl/inference/__init__.py
@@ -20,6 +20,7 @@ from beanmachine.ppl.inference.single_site_random_walk import SingleSiteRandomWa
 from beanmachine.ppl.inference.single_site_uniform_mh import (
     SingleSiteUniformMetropolisHastings,
 )
+from beanmachine.ppl.inference.utils import seed
 
 from .single_site_no_u_turn_sampler import SingleSiteNoUTurnSampler
 
@@ -38,5 +39,6 @@ __all__ = [
     "GlobalNoUTurnSampler",
     "Predictive",
     "empirical",
+    "seed",
     "simulate",
 ]

--- a/src/beanmachine/ppl/inference/tests/utils_test.py
+++ b/src/beanmachine/ppl/inference/tests/utils_test.py
@@ -1,0 +1,21 @@
+# Copyright (c) Facebook, Inc. and its affiliates
+import beanmachine.ppl as bm
+import torch
+import torch.distributions as dist
+
+
+@bm.random_variable
+def foo():
+    return dist.Normal(0.0, 1.0)
+
+
+def test_set_random_seed():
+    def sample_with_seed(seed):
+        bm.seed(seed)
+        return bm.SingleSiteAncestralMetropolisHastings().infer(
+            [foo()], {}, num_samples=20, num_chains=1
+        )
+
+    samples1 = sample_with_seed(123)
+    samples2 = sample_with_seed(123)
+    assert torch.allclose(samples1[foo()], samples2[foo()])

--- a/src/beanmachine/ppl/inference/utils.py
+++ b/src/beanmachine/ppl/inference/utils.py
@@ -1,8 +1,10 @@
 # Copyright (c) Facebook, Inc. and its affiliates
+import random
 from dataclasses import dataclass
 from enum import Enum
 from typing import Dict, List
 
+import numpy.random
 import torch
 from beanmachine.ppl.model.rv_identifier import RVIdentifier
 
@@ -58,3 +60,9 @@ def merge_dicts(dicts: List[RVDict], dim: int = 0, stack_not_cat=True) -> RVDict
         return {rv: torch.stack([d[rv] for d in dicts], dim=dim) for rv in rv_keys}
     else:
         return {rv: torch.cat([d[rv] for d in dicts], dim=dim) for rv in rv_keys}
+
+
+def seed(seed: int) -> None:
+    torch.manual_seed(seed)
+    random.seed(seed)
+    numpy.random.seed(seed)


### PR DESCRIPTION
Summary:
Since it's quite common for people to run into the need to set a seed, and since our library depends on a few different RNG internally, I guess it's going to be helpful to have a single utility function called `bm.seed` that set the seed for all of them.

I didn't touch any of the tutorials yet to avoid merge conflict, though it will be nice if the tutorials can use this utility function to make sure that the output do not change when re-running the notebook.

Differential Revision: D32711007

