### PR TITLE
Unpin graphviz dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -137,7 +137,7 @@ setup(
         "arviz>=0.11.0",
         "flowtorch>=0.3",
         "parameterized>=0.8.1",
-        "graphviz==0.17",
+        "graphviz>=0.17",
     ],
     packages=find_packages("src"),
     package_dir={"": "src"},

--- a/src/beanmachine/ppl/compiler/tests/neals_funnel_test.py
+++ b/src/beanmachine/ppl/compiler/tests/neals_funnel_test.py
@@ -4,6 +4,7 @@
 import unittest
 
 import beanmachine.ppl as bm
+import graphviz
 from beanmachine.ppl.inference.bmg_inference import BMGInference
 from torch import exp
 from torch.distributions import Normal
@@ -58,7 +59,7 @@ digraph "graph" {
         observations = {}
         queries = [X(), Y()]
 
-        observed = str(type(BMGInference().to_graphviz(queries, observations)))
-        expected = "<class 'graphviz.files.Source'>"
+        observed = type(BMGInference().to_graphviz(queries, observations))
+        expected = graphviz.Source
 
-        self.assertEqual(expected.strip(), observed.strip())
+        self.assertEqual(expected, observed)

--- a/src/beanmachine/ppl/inference/bmg_inference.py
+++ b/src/beanmachine/ppl/inference/bmg_inference.py
@@ -271,7 +271,7 @@ class BMGInference:
         after_transform: bool = True,
         label_edges: bool = False,
         skip_optimizations: Set[str] = default_skip_optimizations,
-    ) -> graphviz.files.Source:
+    ) -> graphviz.Source:
         """Small wrapper to generate an actual graphviz object"""
         s = self.to_dot(
             queries, observations, after_transform, label_edges, skip_optimizations


### PR DESCRIPTION
Summary: Our colab notebook is failing because it uses a more recent version of graphviz which doesn't have the source module. This unpins the graphviz dependency and makes a small change, so that it is easier to manage dependency conflicts. I will follow this up with some changes to the build config and rebuild the wheels for colab.

Differential Revision: D32842270

