### PR TITLE
Choosing default inference for compositional inference based on support

### DIFF
--- a/src/beanmachine/ppl/inference/tests/compositional_infer_conjugate_test_nightly.py
+++ b/src/beanmachine/ppl/inference/tests/compositional_infer_conjugate_test_nightly.py
@@ -1,13 +1,15 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import unittest
 
-import beanmachine.ppl as bm
+from beanmachine.ppl.inference.compositional_infer import (
+    CompositionalInference,
+)
 from beanmachine.ppl.testlib.abstract_conjugate import AbstractConjugateTests
 
 
 class CompositionalInferenceConjugateTest(unittest.TestCase, AbstractConjugateTests):
     def setUp(self):
-        self.mh = bm.CompositionalInference()
+        self.mh = CompositionalInference()
 
     def test_beta_binomial_conjugate_run(self):
         self.beta_binomial_conjugate_run(self.mh)
@@ -15,13 +17,8 @@ class CompositionalInferenceConjugateTest(unittest.TestCase, AbstractConjugateTe
     def test_gamma_gamma_conjugate_run(self):
         self.gamma_gamma_conjugate_run(self.mh)
 
-    # Used new seed because old test failed (but just barely) on default seed
-    # TODO: This test failse about every sixth seed. Needs investigation.
-    #       N_eff in 700-1000 for n 1K.
-    @unittest.skip("Known to fail. Investigating in T77865889.")
     def test_gamma_normal_conjugate_run(self):
-        for i in range(5):  # Fails at range(6)
-            self.gamma_normal_conjugate_run(self.mh, random_seed=1000017 * i)
+        self.gamma_normal_conjugate_run(self.mh)
 
     def test_normal_normal_conjugate_run(self):
         self.normal_normal_conjugate_run(self.mh)


### PR DESCRIPTION
Summary:
Our `CompositionalInference` used to [choose proposers to random variables based on their support](https://www.internalfb.com/code/fbsource/[3f5eaee29db7574db980ef8efcbfeebade8a047c]/fbcode/beanmachine/beanmachine/ppl/legacy/inference/compositional_infer.py?lines=87-113), whereas our new compositional inference has only been using single site ancestral MH.

This diff replicates the old default behavior by introducing a `_DefaultInference` utility class, which chooses the proposers in its `get_proposers` method. From the perspective of `CompositionalInference`, this is just another inference class, and users are free to override it.

Since the logic for choosing the right NMC proposer is the same as what has been implemented in `SingleSiteNewtonianMonteCarlo`, I refactored the common part out into a method called `_init_proposer`.

Differential Revision: D32851185

