### PR TITLE
Test BM wheel prior to deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,6 +47,18 @@ jobs:
       if: matrix.os == 'macos-latest'
       run: python -m build --sdist
 
+    - name: Install built Bean Machine dist
+      run: pip install dist/*.whl
+
+    - name: Install pytest 7.0 (with a importlib patch in pytest-dev/pytest#7870)
+      run: pip install git+https://github.com/pytest-dev/pytest.git@7.0.0.dev0
+
+    - name: Print out package info to help with debug
+      run: pip list
+
+    - name: Run unit tests with pytest
+      run: pytest
+
     - name: Sending wheels to the deployment workflow
       uses: actions/upload-artifact@v2
       with:
@@ -76,6 +88,18 @@ jobs:
 
     - name: Repair wheel to support manylinux
       run: auditwheel -v repair dist/*
+
+    - name: Install built Bean Machine dist
+      run: pip install wheelhouse/*.whl
+
+    - name: Install pytest 7.0 (with a importlib patch in pytest-dev/pytest#7870)
+      run: pip install git+https://github.com/pytest-dev/pytest.git@7.0.0.dev0
+
+    - name: Print out package info to help with debug
+      run: pip list
+
+    - name: Run unit tests with pytest
+      run: pytest
 
     - name: Sending wheels to the deployment workflow
       uses: actions/upload-artifact@v2

--- a/src/beanmachine/__init__.py
+++ b/src/beanmachine/__init__.py
@@ -1,3 +1,3 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-__version__ = "0.0.1a1"
+__version__ = "0.0.1a2"


### PR DESCRIPTION
Summary: This runs the unit test suite on the built wheels before deploying. While this adds to the build time, it will give us more confidence before deployment. We can also run a smaller test suite that just exercises all the modules and skips expensive tests, let me know if you have suggestions on that.

Reviewed By: jpchen, horizon-blue

Differential Revision: D32843593

