### PR TITLE
Add make format-tutorial to clean notebooks before committing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,4 +12,13 @@ test: lint FORCE
 docs: FORCE
 	$(MAKE) -C sphinx html
 
+format-notebook: FORCE
+ifndef nb
+	find tutorials -name "*.ipynb" | xargs jupyter nbconvert --to notebook \
+	--inplace --ClearMetadataPreprocessor.enabled=True
+else
+	jupyter nbconvert --to notebook --inplace \
+		--ClearMetadataPreprocessor.enabled=True $(nb)
+endif
+
 FORCE:


### PR DESCRIPTION
Summary:
Bento adds a lot of metadata to notebooks which is not useful for OS tooling and will not be used by jupyter. This add a command which purges this extra metadata. This also reduces chances of merge conflicts due to metadata related changes. We should ideally run this after making changes to any tutorials.

Refer to [V1](https://www.internalfb.com/diff/D32908147?dst_version_fbid=956753298525560) to see how this looks like on the Bayesian Regression and Coin flipping tutorials for reference. If this looks reasonable, we can run this for all tutorials prior to squashing our commits and releasing to open source. I didn't want to do this right now and create merge conflicts for others who may be working on the tutorials.

Usage:

```
$ make format-notebook  # clean all notebooks in the tutorials folder
$ make format-notebook nb=tutorials/Bayesian_Logistic_Regression.ipynb  # clean single notebook
```

Questions for reviewers:
 - I noticed that some of our tutorials like coin flipping don't have outputs committed whereas others do. Is there consensus on what we'd like to commit to git. Either is fine -- it is useful to have outputs if you want to view the git files on nbviewer or use nbconvert to convert these to html, but there's value in not having output if these tutorials will be updated very frequently (which I doubt will be the case). cc wtaha
 - Any other metadata that we should remove?

Differential Revision: D32908147

