### PR TITLE
Revamp Single-Site Uniform Metropolis Hastings

### DIFF
--- a/docs/framework_topics/inference/uniform_metropolis_hastings.md
+++ b/docs/framework_topics/inference/uniform_metropolis_hastings.md
@@ -5,23 +5,34 @@ sidebar_label: 'Single-Site Uniform MH'
 slug: '/uniform_metropolis_hastings'
 ---
 
-Single-Site Uniform Metropolis-Hastings is used to infer over variables that have discrete support, for example random variables with Bernoulli and Categorical distributions. The Single-Site Uniform Sampler works very similarly to the Single-Site Ancestral Metropolis-Hastings. In fact, the only difference arises in Step 1, i.e, in the way that this sampler proposes a new value. Steps 2-4 are the same.
+Single-Site Uniform Metropolis-Hastings is used to infer over variables that have discrete support, for example random variables with Bernoulli and Categorical distributions. It is overall very similar to Ancestral Metropolis-Hastings. However, it is designed so that it will even explore discrete samples that are unlikely under the prior distribution.
 
-In Single-Site Uniform MH, for random variables with discrete support, instead of sampling from the prior, the proposer samples from a distribution which assigns equal probability across all values in support (hence the name, uniform). For any random variables with continuous support, this inference method resorts to Single-Site Ancestral MH.
+## Algorithm
 
-Here is an example of how to use Single-Site Uniform Metropolis-Hastings to perform inference in Bean Machine.
+The Single-Site Uniform Sampler works very similarly to [Single-Site Ancestral Metropolis-Hastings](ancestral_metropolis_hastings.md). In fact, the only difference arises in Step 1 of that inference method's Algorithm; i.e, in the way that this sampler proposes a new value. The remaining steps are unchanged.
+
+In Single-Site Uniform Metropolis-Hastings, for random variables with discrete support, instead of sampling from the prior, the proposer samples from a distribution which assigns equal probability across all values in support (hence the name, uniform). However, the likelihood of this sample _is_ accounted for when computing the [Metropolis acceptance probability](https://en.wikipedia.org/wiki/Metropolis%E2%80%93Hastings_algorithm#Formal_derivation). Thus, even though improbable values may be _proposed_ more than indicated by the prior, they will not be _accepted_ more often than they should according to the posterior.
+
+At first appearance, this sounds undesirable -- why sample an unlikely value in the first place? This arises from the fact that the prior distribution may not be a good reflection of the posterior distribution for a given discrete random variable. A particular value that is unlikely under the prior may, in fact, be quite likely under the posterior. Uniform Metropolis-Hastings ensures that those values have the opportunity to be sampled, and thus can increase sampling efficiency for many problems where the posterior is distant from the prior.
+
+Please note that, if you use this inference method for continuous random variables, it will fall back to Single-Site Ancestral Metropolis-Hastings.
+
+## Usage
 
 ```
-import beanmachine.ppl as bm
-
-mh = bm.SingleSiteUniformMetropolisHastings()
-coin_samples = mh.infer(queries, observations, num_samples, num_chains, run_in_parallel)
+samples = bm.SingleSiteUniformMetropolisHastings().infer(
+    queries,
+    observations,
+    num_samples,
+    num_chains,
+)
 ```
 
-*TODO Remove the explanation of parameters below; they have already been explained in `overview/inference/inference.md`, with the exception of `run_in_paralell`*
+The parameters to `infer` are described below:
 
-```queries ```: List of random variables that we want to get posterior samples for
-```observations```: Dict, where key is the random variable, and value is the value of the random variable
-```num_samples```: number of samples to run inference for
-```num_chains```: number of chains to run inference for
-```run_in_parallel```: True if you want the chains to run in parallel
+| Name | Usage
+| --- | ---
+| `queries` | A `List` of `@bm.random_variable` targets to fit posterior distributions for.
+| `observations` | The `Dict` of observations. Each key is a random variable, and its value is the observed value for that random variable.
+| `num_samples` | Number of samples to build up distributions for the values listed in `queries`.
+| `num_chains` | Number of separate inference runs to use. Multiple chains can be used by diagnostics to verify inference ran correctly.


### PR DESCRIPTION
Summary:
Revamps Uniform MH docs. Overall, these docs are short and sweet already, which is great. The main additions are:

1. Clarification that this method affects _proposal_ but not _acceptance_ probabilities (compared to Ancestral).
2. A paragraph justifying this potentially counter-intuitive method. (It may increase sampling efficiency.)

Differential Revision: D32909134

