### PR TITLE
Reorganize "Bean Machine Advantages".

### DIFF
--- a/docs/overview/bean_machine_advantages/bean_machine_advantages.md
+++ b/docs/overview/bean_machine_advantages/bean_machine_advantages.md
@@ -1,16 +1,13 @@
 ---
 id: bean_machine_advantages
-title: Bean Machine Advantages
-sidebar_label: Bean Machine Advantages
+title: Bean Machine within Probabilistic Programming
+sidebar_label: Bean Machine within Probabilistic Programming
+slug: '/bean_machine_within_probabilistic_programming'
 ---
 
-:::tip
+The [Overview](../why_bean_machine) gave reasons for using Bean Machine that are common to most probabilistic programming systems, namely the convenience of writing code for generative probabilistic models that is separate from inference itself. Here we provide some reasons that are more specific to Bean Machine within the set of probabilistic programming systems.
 
-If you're new to probabilistic programming languages, we recommend you skip to the [next page](../quick_start/quick_start.md)!
-
-:::
-
-By building on top of PyTorch with a declarative modeling syntax, Bean Machine can be simultaneously performant and intuitive for building probabilistic models. Bean Machine provides further value by implementing cutting-edge inference algorithms and allowing the user to select and program custom inferences for different problems and subproblems.
+Bean Machine builds on top of PyTorch with a declarative modeling syntax, being therefore simultaneously performant and intuitive for building probabilistic models. It provides further value by implementing cutting-edge inference algorithms and allowing the user to select and program custom inferences for different problems and subproblems.
 
 ## Site-based inference
 
@@ -20,7 +17,7 @@ Bean Machine uses a site-based inference engine. "Sites" are random variable fam
 
 The simplest form of site-based inference is called "single-site" inference. In the single-site paradigm, models are built up from random variables that can be reasoned about individually. Bean Machine can exploit this modularity to update random variables one-at-a-time, reducing unnecessary computation and enabling posterior updates that might not be possible if processing the entire model in one go.
 
-Bean Machine also supports "multi-site" inference, in which multiple sites are reasoned about jointly. This increases complexity during inference, but it allows the engine to exploit inter-site correlations when fitting the posterior distribution.
+Bean Machine also supports "multi-site" inference, in which sites are families of multiple random variables are reasoned about jointly. This increases complexity during inference, but it allows the engine to exploit inter-site correlations when fitting the posterior distribution.
 
 Altogether, site-based inference is a flexible pattern for trading off complexity and modularity, and enables the advanced techniques outlined below.
 

--- a/docs/overview/why_bean_machine/why_bean_machine.md
+++ b/docs/overview/why_bean_machine/why_bean_machine.md
@@ -6,6 +6,10 @@ slug: '/why_bean_machine'
 ---
 <!-- @import "../../header.md" -->
 
+:::tip
+This page describes aspects of Bean Machine that are common among probabilistic programming systems in general. For a view of features more specific to Bean Machine proper, check [Bean Machine within Probabilistic Programming](../bean_machine_within_probabilistic_programming).
+:::
+
 Bean Machine is a probabilistic programming language that makes developing and deploying generative probabilistic models intuitive and efficient.
 
 ## Why Generative models?
@@ -63,6 +67,8 @@ In the rest of this Overview we'll introduce you to Bean Machine's syntax, and s
 ## Target Audience
 
 While we hope that the guides you'll find here are relevant to anyone with an ML background, there are excellent resources available if this is your first exposure to Bayesian analysis! We highly recommend the excellent YouTube series _[Statistical Rethinking](https://www.youtube.com/playlist?list=PLDcUM9US4XdNM4Edgs7weiyIguLSToZRI)_, which walks through Bayesian thinking and probabilistic modeling. For a more hands-on experience, you can check out the free, online tutorial _[Bayesian Methods for Hackers](https://camdavidsonpilon.github.io/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/#contents)_.
+
+To get into more details on how Bean Machine is used, continue on to [Quick Start](../quickstart)!
 
 <!-- ## Sneak Peek at Bean Machine Syntax
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -13,7 +13,6 @@ module.exports = {
     {
       Overview: [
         'overview/why_bean_machine/why_bean_machine',
-        'overview/bean_machine_advantages/bean_machine_advantages',
         'overview/quick_start/quick_start',
         'overview/modeling/modeling',
         'overview/inference/inference',
@@ -49,7 +48,10 @@ module.exports = {
           Development: ['framework_topics/development/logging'],
         },
       ],
-      Advanced: ['overview/beanstalk/beanstalk'],
+      Advanced: [
+        'overview/beanstalk/beanstalk',
+        'overview/bean_machine_advantages/bean_machine_advantages',
+        ],
     },
     'overview/tutorials/tutorials',
     // TODO(sepehrakhavan): Re-display this once we have at least one package present.


### PR DESCRIPTION
Summary:
We were splitting explanations of advantages of Bean Machine as those that belong to PPLs in general, and in comparison to other PPLs. Since the latter is of interest to a smaller portion of users, I moved it to "Advanced" but placed a tip on the first page pointing to it.
PS: file names and slugs remain the same, that needs to be re-organized in general.

Differential Revision: D32938541

