### PR TITLE
Clean up tutorials page *

### DIFF
--- a/docs/overview/tutorials/tutorials.md
+++ b/docs/overview/tutorials/tutorials.md
@@ -27,7 +27,7 @@ This tutorial demonstrates modeling and running inference on a simple univariate
 
 [Open in GitHub](https://github.com/facebookresearch/beanmachine/blob/master/tutorials/Bayesian_Logistic_Regression.ipynb) • [Run in Google Colab](https://colab.research.google.com/github/facebookresearch/beanmachine/blob/master/tutorials/Bayesian_Logistic_Regression.ipynb)
 
-The purpose of this tutorial is to show how to build a simple Bayesian model to deduce the line which separates two categories of points.
+This tutorial shows how to build a simple Bayesian model to deduce the line which separates two categories of points.
 
 
 ### Sparse Logistic Regression
@@ -37,44 +37,45 @@ The purpose of this tutorial is to show how to build a simple Bayesian model to 
 This tutorial demonstrates modeling and running inference on a sparse logistic regression model in Bean Machine. This tutorial showcases the inference techniques in Bean Machine, and applies the model to a public dataset to evaluate performance. This tutorial will also introduce the `@bm.functional` decorator, which can be used to deterministically transform random variables. This tutorial uses it for convenient post-processing.
 
 
-### Gaussian Mixture Model
+### Modeling Radon Decay Using a Hierarchical Regression with Continuous Data
 
-[Open in GitHub](https://github.com/facebookresearch/beanmachine/blob/master/tutorials/GMM_with_2_dimensions_and_4_components.ipynb) • [Run in Google Colab](https://colab.research.google.com/github/facebookresearch/beanmachine/blob/master/tutorials/GMM_with_2_dimensions_and_4_components.ipynb)
+[Open in GitHub](https://github.com/facebookresearch/beanmachine/blob/master/tutorials/Hierarchical_regression.ipynb) • [Run in Google Colab](https://colab.research.google.com/github/facebookresearch/beanmachine/blob/master/tutorials/Hierarchical_regression.ipynb)
 
-A simple example of an open universe model is a Gaussian Mixture Model (GMM) where the number of mixture components is unknown. [Mixture models](https://en.wikipedia.org/wiki/Mixture_model) are useful in problems where individuals from multiple sub-populations are aggregated together. A common use case for GMMs is unsupervised clustering, where one seeks to infer which sub-population an individual belongs without any labeled training data. Using the bean machine open universe probabilistic programming language, we are able to provide a Bayesian treatment of this problem and draw posterior samples representing a distribution over not only the cluster assignments but also the number of clusters itself.
+This tutorial explores linear regression in combination with hierarchical priors. We will be using data from Gelman and Hill on radon levels found in buildings in Minnesota; [Hill J and Gelman A](https://pdfs.semanticscholar.org/e6d6/8a23f02485cfbb3e35d6bba862a682a2f160.pdf). This tutorial shows how  to prepare data for running a hierarchical regression with Bean Machine, how to run inference on that regression, and how to use ArviZ diagnostics to understand what Bean Machine is doing.
+
+
+### Modeling MLB Performance Using Hierarchical Modeling with Repeated Binary Trials
+
+[Open in GitHub](https://github.com/facebookresearch/beanmachine/blob/master/tutorials/Hierarchical_modeling.ipynb) • [Run in Google Colab](https://colab.research.google.com/github/facebookresearch/beanmachine/blob/master/tutorials/Hierarchical_modeling.ipynb)
+
+This tutorial demonstrates the application of hierarchical models with data from the 1970 season of [Major League Baseball (MLB)](https://en.wikipedia.org/wiki/Major_League_Baseball) found in the paper by [Efron and Morris 1975](http://www.medicine.mcgill.ca/epidemiology/hanley/bios602/MultilevelData/EfronMorrisJASA1975.pdf). In addition to teaching effective hierarchical modeling techniques for binary data, this tutorial will explore how you can use different pooling techniques to enable strength-borrowing between observations.
+
+
+### Modeling NBA Foul Calls Using Item Response Theory
+
+[Open in GitHub](https://github.com/facebookresearch/beanmachine/blob/master/tutorials/NBA_IRT.ipynb) • [Run in Google Colab](https://colab.research.google.com/github/facebookresearch/beanmachine/blob/master/tutorials/NBA_IRT.ipynb)
+
+This tutorial demonstrates how to use Bean Machine to predict when NBA players will receive a foul call from a referee. This model and exposition is based on [Austin Rochford's 2018 analysis](https://austinrochford.com/posts/2018-02-04-nba-irt-2.html) of the [2015/2016 NBA season games](https://www.basketball-reference.com/leagues/NBA_2016_games.html) data. It will introduce you to Item Response Theory, and demonstrate its advantages over standard regression models. It will also iterate on that model several times, demonstrating how to evolve your model to improve predictive performance.
 
 
 ### Hidden Markov Model
 
 [Open in GitHub](https://github.com/facebookresearch/beanmachine/blob/master/tutorials/Hidden_Markov_model.ipynb) • [Run in Google Colab](https://colab.research.google.com/github/facebookresearch/beanmachine/blob/master/tutorials/Hidden_Markov_model.ipynb)
 
-This tutorial demonstrates modeling and running inference on a hidden Markov model (HMM) in Bean Machine. The flexibility of this model allows us to demonstrate some of the great unique features of Bean Machine, such as block inference, compositional inference, and separation of data from the model.
+This tutorial demonstrates modeling and running inference on a hidden Markov model (HMM) in Bean Machine. The flexibility of this model allows us to demonstrate useful features of Bean Machine, including `CompositionalInference`, multi-site inference, and posterior predictive checks. This model makes use of discrete latent states, and shows how Bean Machine can easily run inference for models comprised of both discrete and continuous latent variables.
+
+
+### Gaussian Mixture Model
+
+[Open in GitHub](https://github.com/facebookresearch/beanmachine/blob/master/tutorials/GMM_with_2_dimensions_and_4_components.ipynb) • [Run in Google Colab](https://colab.research.google.com/github/facebookresearch/beanmachine/blob/master/tutorials/GMM_with_2_dimensions_and_4_components.ipynb)
+
+This tutorial uses Bean Machine to infer which latent clusters observed points are drawn from. It uses a 2-dimensional Gaussian mixture model with 4 mixture components, and shows how Bean Machine can automatically recover the means and variances of these latent components.
+
+[Mixture models](https://en.wikipedia.org/wiki/Mixture_model) are useful in problems where individuals from multiple sub-populations are aggregated together. A common use case for GMMs is unsupervised clustering, where one seeks to infer which sub-population an individual belongs without any labeled training data. Using Bean Machine, we provide a Bayesian treatment of this problem and infer a posterior distribution over cluster parameters and cluster assignments of observations.
 
 
 ### Neal's Funnel
 
 [Open in GitHub](https://github.com/facebookresearch/beanmachine/blob/master/tutorials/Tutorial_Sampling_Neal_funnel_in_Bean_Machine.ipynb) • [Run in Google Colab](https://colab.research.google.com/github/facebookresearch/beanmachine/blob/master/tutorials/Hidden_Markov_model.ipynb)
 
-This tutorial demonstrates modeling and running inference on the so-called Neal's funnel model in Bean Machine.
-Neal's funnel has proven difficult-to-handle for classical inference methods. This tutorial demonstrates how to overcome this by using second-order gradient methods in Bean Machine. It also demonstrates how to implement models with factors in Bean Machine through custom distributions.
-
-
-### Hierarchical Modeling with Repeated Binary Trial Data
-
-[Open in GitHub](https://github.com/facebookresearch/beanmachine/blob/master/tutorials/Hierarchical_modeling.ipynb) • [Run in Google Colab](https://colab.research.google.com/github/facebookresearch/beanmachine/blob/master/tutorials/Hierarchical_modeling.ipynb)
-
-In this tutorial we will demonstrate the application of hierarchical models with data from the 1970 season of [Major League Baseball (MLB)](https://render.githubusercontent.com/view/ipynb?color_mode=light&commit=d5d87c500dc6bf5a37abab41b37757804ac642b8&enc_url=68747470733a2f2f7261772e67697468756275736572636f6e74656e742e636f6d2f66616365626f6f6b72657365617263682f6265616e6d616368696e652f643564383763353030646336626635613337616261623431623337373537383034616336343262382f7475746f7269616c732f48696572617263686963616c5f6d6f64656c696e672e6970796e623f746f6b656e3d41414c4f48354b4e4442363351374456424f554d58364442525641434b&nwo=facebookresearch%2Fbeanmachine&path=tutorials%2FHierarchical_modeling.ipynb&repository_id=201103120&repository_type=Repository#references) found in the paper by [Efron and Morris 1975](https://render.githubusercontent.com/view/ipynb?color_mode=light&commit=d5d87c500dc6bf5a37abab41b37757804ac642b8&enc_url=68747470733a2f2f7261772e67697468756275736572636f6e74656e742e636f6d2f66616365626f6f6b72657365617263682f6265616e6d616368696e652f643564383763353030646336626635613337616261623431623337373537383034616336343262382f7475746f7269616c732f48696572617263686963616c5f6d6f64656c696e672e6970796e623f746f6b656e3d41414c4f48354b4e4442363351374456424f554d58364442525641434b&nwo=facebookresearch%2Fbeanmachine&path=tutorials%2FHierarchical_modeling.ipynb&repository_id=201103120&repository_type=Repository#references).
-
-
-### Hierarchical Regression
-
-[Open in GitHub](https://github.com/facebookresearch/beanmachine/blob/master/tutorials/Hierarchical_regression.ipynb) • [Run in Google Colab](https://colab.research.google.com/github/facebookresearch/beanmachine/blob/master/tutorials/Hierarchical_regression.ipynb)
-
-In this tutorial we will explore linear regression in combination with hierarchical priors. We will be using data from Gelman and Hill on radon levels found in buildings in Minnesota; [Hill J and Gelman A](https://render.githubusercontent.com/view/ipynb?color_mode=light&commit=d5d87c500dc6bf5a37abab41b37757804ac642b8&enc_url=68747470733a2f2f7261772e67697468756275736572636f6e74656e742e636f6d2f66616365626f6f6b72657365617263682f6265616e6d616368696e652f643564383763353030646336626635613337616261623431623337373537383034616336343262382f7475746f7269616c732f48696572617263686963616c5f72656772657373696f6e2e6970796e623f746f6b656e3d41414c4f48354e4936504134354d505242464d53354c4c425256414136&nwo=facebookresearch%2Fbeanmachine&path=tutorials%2FHierarchical_regression.ipynb&repository_id=201103120&repository_type=Repository#references).
-
-
-### Modeling NBA Foul Calls Using Item Response Theory
-
-[Open in GitHub](https://github.com/facebookresearch/beanmachine/blob/master/tutorials/NBA_IRT.ipynb) • Run in Google Colab
-
-This tutorial demonstrates how to use Bean Machine to predict when NBA players will receive a foul call from a referee. This model and exposition is based on [Austin Rochford's 2018 analysis](https://render.githubusercontent.com/view/ipynb?color_mode=light&commit=d5d87c500dc6bf5a37abab41b37757804ac642b8&enc_url=68747470733a2f2f7261772e67697468756275736572636f6e74656e742e636f6d2f66616365626f6f6b72657365617263682f6265616e6d616368696e652f643564383763353030646336626635613337616261623431623337373537383034616336343262382f7475746f7269616c732f4e42415f4952542e6970796e623f746f6b656e3d41414c4f48354c475a43454e4d554d4234324545584733425255375445&nwo=facebookresearch%2Fbeanmachine&path=tutorials%2FNBA_IRT.ipynb&repository_id=201103120&repository_type=Repository#references) of the [2015/2016 NBA season games](https://render.githubusercontent.com/view/ipynb?color_mode=light&commit=d5d87c500dc6bf5a37abab41b37757804ac642b8&enc_url=68747470733a2f2f7261772e67697468756275736572636f6e74656e742e636f6d2f66616365626f6f6b72657365617263682f6265616e6d616368696e652f643564383763353030646336626635613337616261623431623337373537383034616336343262382f7475746f7269616c732f4e42415f4952542e6970796e623f746f6b656e3d41414c4f48354c475a43454e4d554d4234324545584733425255375445&nwo=facebookresearch%2Fbeanmachine&path=tutorials%2FNBA_IRT.ipynb&repository_id=201103120&repository_type=Repository#references) data.
+This tutorial demonstrates modeling and running inference on the Neal's funnel model in Bean Machine. Neal's funnel is a synthetic model in which the posterior distribution is known beforehand, and Bean Machine's inference engine is tasked with automatically recovering that posterior distribution. Neal's funnel has proven difficult-to-handle for classical inference methods due to its unusual topology. This tutorial demonstrates how to overcome this by using second-order gradient methods in Bean Machine. It also demonstrates how to implement models with factors in Bean Machine through custom distributions.


### PR DESCRIPTION
Summary:
# Grab bag of minor edits to the tutorials page

Reorders tutorials so that:
  * The simplest tutorials appear first.
  * The highest quality tutorials appear next.
  * Remaining tutorials are ordered roughly in how they showcase Bean Machine functionality.

Fixes broken links.

Fleshes out tutorial descriptions.

Copy editing and consistency.

Reviewed By: wtaha, jpchen

Differential Revision: D32897420

