### PR TITLE
Compositional Inference: treat a tuple of keys as a block

### DIFF
--- a/src/beanmachine/ppl/inference/single_site_ancestral_mh.py
+++ b/src/beanmachine/ppl/inference/single_site_ancestral_mh.py
@@ -8,15 +8,9 @@ from beanmachine.ppl.inference.proposer.single_site_ancestral_proposer import (
 )
 from beanmachine.ppl.inference.single_site_inference import (
     SingleSiteInference,
-    JointSingleSiteInference,
 )
 
 
 class SingleSiteAncestralMetropolisHastings(SingleSiteInference):
-    def __init__(self):
-        super().__init__(SingleSiteAncestralProposer)
-
-
-class GlobalAncestralMetropolisHastings(JointSingleSiteInference):
     def __init__(self):
         super().__init__(SingleSiteAncestralProposer)

--- a/src/beanmachine/ppl/inference/single_site_inference.py
+++ b/src/beanmachine/ppl/inference/single_site_inference.py
@@ -3,7 +3,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import random
 from typing import List, Set, Type
 
 from beanmachine.ppl.inference.base_inference import BaseInference
@@ -12,9 +11,6 @@ from beanmachine.ppl.inference.proposer.base_proposer import (
 )
 from beanmachine.ppl.inference.proposer.base_single_site_proposer import (
     BaseSingleSiteMHProposer,
-)
-from beanmachine.ppl.inference.proposer.sequential_proposer import (
-    SequentialProposer,
 )
 from beanmachine.ppl.model.rv_identifier import RVIdentifier
 from beanmachine.ppl.world import World
@@ -47,21 +43,3 @@ class SingleSiteInference(BaseInference):
                 )
             proposers.append(self._proposers[node])
         return proposers
-
-
-class JointSingleSiteInference(SingleSiteInference):
-    """
-    Base class for single site joint inference algorithms.  The primary difference between
-    the Joint version is that proposers are shuffled at each step and a single `SequentialProposer`
-    containing all the individual proposers are returned.
-    """
-
-    def get_proposers(
-        self,
-        world: World,
-        target_rvs: Set[RVIdentifier],
-        num_adaptive_sample: int,
-    ) -> List[BaseProposer]:
-        proposers = super().get_proposers(world, target_rvs, num_adaptive_sample)
-        random.shuffle(proposers)
-        return [SequentialProposer(proposers)]


### PR DESCRIPTION
Summary:
Sorry for the last minute code changes :).

This diff is a follow up of the discussions happened in D32197471 (https://github.com/facebookresearch/beanmachine/commit/89f96b16922eb7dacadafe027201244deaceb5b3). With the change in this diff, any tuple of keys will be considered a "block".

Example 1:
```
CompositionalInference({(foo, bar): SingleSiteAncestralMH()})
```
during inference, all instances of `foo` and `bar` will be accepted/reject jointly by a single `SequentialProposer`, which contains a sequence of single site ancestral mh proposer.

Example 2:
```
CompositionalInference({(foo, bar): ...})
```
with the change in this diff, users can use `Ellipsis` in the place of inference method to denote that they want to use the default inference method for a particular block.

Example 3:
```
CompositionalInference(
    {(foo, bar): (SingleSiteUniformMH(), SingleSiteNewtonianMonteCarlo())}
)
```
this is interpreted the same way as in D32197471 (https://github.com/facebookresearch/beanmachine/commit/89f96b16922eb7dacadafe027201244deaceb5b3), where all instances of `foo` and `bar` are still accepted/reject jointly. All instances of `foo` will be proposed by `SingleSiteUniformMH()`, and all instances of `bar` will be proposed by `SingleSiteNewtonianMonteCarlo()`. To simply the logic in `get_proposers`, the above example is rewritten into the following equivalent form during preprocessing:
```
CompositionalInference(
    {(foo, bar): CompositionalInference({
        foo: SingleSiteUniformMH(),
        bar: SingleSiteNewtonianMonteCarlo()
    })
)
```
 ---
A bit of explanation on what's different:

Before this diff, there is no difference between the following two configs
```
CompositionalInference({foo: SingleSiteAncestralMH(), bar: SingleSiteAncestralMH()})
CompositionalInference({(foo, bar): SingleSiteAncestralMH()})
```
to propose things jointly, users would have to use one of the "global"/"joint" algorithms. This was my motivation to introduce classes like `GlobalAncestralMetropolisHastings`. However, this turn out to be more confusing than I hope it do be :). Additionally, it wouldn't allow users to block nodes without specifying an algorithm first (as in example 2). This is why I feel the need to change this now.

Differential Revision: D32943468

