### PR TITLE
Skip existing wheels on test pypi

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,16 @@ name: Deployment
 on:
   # this workflow can only be manually triggered for now.
   workflow_dispatch:
+    inputs:
+      deploy:
+        description: 'Where to deploy the artifacts? Only build, deploy to test PyPI, deploy to PyPI.'
+        required: true
+        type: choice
+        default: 'test'
+        options:
+          - build
+          - test
+          - prod
 
 env:
   PYTHONUNBUFFERED: 1
@@ -125,8 +135,17 @@ jobs:
         mv beanmachine-*/* dist/
 
     - name: Publish to Test PyPI
+      if: github.event.inputs.deploy == 'test'
       uses: pypa/gh-action-pypi-publish@v1.4.2
       with:
         password: ${{ secrets.TEST_PYPI_PASSWORD }}
         repository_url: https://test.pypi.org/legacy/
+        skip_existing: true
+        verbose: true
+
+    - name: Publish to PyPI
+      if: github.event.inputs.deploy == 'prod' && startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@v1.4.2
+      with:
+        password: ${{ secrets.PYPI_PASSWORD }}
         verbose: true


### PR DESCRIPTION
Summary:
Uploading to Pypi throws an error if the binary already exists. Pypi doesn't allow for updates to exisiting binaries for obvious reasons, and it requires bumping up the version number. Right now, since we are testing on different python versions, I want to not get an upload failure since some wheels (those for python 3.6) already exist and the `skip_existing` flag lets us do that.

~~ Question for reviewers: We should remove the `skip_existing` flag when we change the url to point to Pypi, or we can have separate configs for test and prod deployment. Which do you prefer? ~~

The deployment workflow takes an input `deploy` (suggestions for better name welcome) which depending on the option either just builds the binaries (default), uploads to test pypi or uploads to pypi. We can use this to pass other arguments, e.g. if we are interested in conda deployment or have a faster deployment that doesn't run unit tests on all binaries, etc.

Differential Revision: D32965547

