### PR TITLE
Skip Python 3.10 in deploy workflow which isn't supported by PyTorch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: ['3.7', '3.8', '3.9']  # TODO: Add python 3.10 with next PyTorch version
     defaults:
       run:
         # https://github.com/conda-incubator/setup-miniconda/tree/v2#use-a-default-shell


### PR DESCRIPTION
Summary:
This adds the following two fixes:
 - Makes sure that Python versions are in string so that `3.10` isn't cast to `3.1` (I overlooked this earlier and this started the workflow for python 3.1 :D).
 - Removes python 3.10 since pytorch doesn't support it yet. We should do a new release with pytorch's next version to support this.

Differential Revision: D32977596

