### PR TITLE
Update copyright headers for `beanmachine.ppl.compiler`

### DIFF
--- a/src/beanmachine/ppl/compiler/ast_patterns.py
+++ b/src/beanmachine/ppl/compiler/ast_patterns.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """Pattern matching for ASTs"""
 import ast
 import math

--- a/src/beanmachine/ppl/compiler/ast_tools.py
+++ b/src/beanmachine/ppl/compiler/ast_tools.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """Debugging tools for working with ASTs"""
 
 # This module just has some helpful tools that can be used for visualizing

--- a/src/beanmachine/ppl/compiler/beanstalk_common.py
+++ b/src/beanmachine/ppl/compiler/beanstalk_common.py
@@ -1,3 +1,8 @@
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 from beanmachine.ppl.model.statistical_model import random_variable, functional
 
 allowed_functions = {dict, list, set, super, random_variable, functional}

--- a/src/beanmachine/ppl/compiler/bm_graph_builder.py
+++ b/src/beanmachine/ppl/compiler/bm_graph_builder.py
@@ -1,4 +1,7 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import math
 from typing import Any, Callable, Dict, List, Optional

--- a/src/beanmachine/ppl/compiler/bm_to_bmg.py
+++ b/src/beanmachine/ppl/compiler/bm_to_bmg.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """Tools to transform Bean Machine programs to Bean Machine Graph"""
 
 import ast

--- a/src/beanmachine/ppl/compiler/bmg_node_types.py
+++ b/src/beanmachine/ppl/compiler/bmg_node_types.py
@@ -1,9 +1,12 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 # TODO: For reasons unknown, Pyre is unable to find type information about
 # TODO: beanmachine.graph from beanmachine.ppl.  I'll figure out why later;
 # TODO: for now, we'll just turn off error checking in this module.
 # pyre-ignore-all-errors
-
 
 from typing import Any, Tuple
 

--- a/src/beanmachine/ppl/compiler/bmg_nodes.py
+++ b/src/beanmachine/ppl/compiler/bmg_nodes.py
@@ -1,4 +1,7 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 from abc import ABC, ABCMeta
 from typing import Any, Iterable, List

--- a/src/beanmachine/ppl/compiler/bmg_requirements.py
+++ b/src/beanmachine/ppl/compiler/bmg_requirements.py
@@ -1,4 +1,7 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 # In lattice_typer.py we assign a type to every node in a graph.
 # If the node or any ancestor node is unsupported in BMG then the node

--- a/src/beanmachine/ppl/compiler/bmg_types.py
+++ b/src/beanmachine/ppl/compiler/bmg_types.py
@@ -1,4 +1,7 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 from abc import abstractmethod
 from typing import Any, Union

--- a/src/beanmachine/ppl/compiler/error_report.py
+++ b/src/beanmachine/ppl/compiler/error_report.py
@@ -1,4 +1,7 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 """This module declares types used for error detection and reporting
 when compiling Bean Machine models to Bean Machine Graph."""

--- a/src/beanmachine/ppl/compiler/fix_additions.py
+++ b/src/beanmachine/ppl/compiler/fix_additions.py
@@ -1,4 +1,7 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 from typing import Optional
 

--- a/src/beanmachine/ppl/compiler/fix_beta_conjugate_prior.py
+++ b/src/beanmachine/ppl/compiler/fix_beta_conjugate_prior.py
@@ -1,4 +1,7 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 from abc import abstractmethod
 from typing import List, Optional, Tuple

--- a/src/beanmachine/ppl/compiler/fix_bool_arithmetic.py
+++ b/src/beanmachine/ppl/compiler/fix_bool_arithmetic.py
@@ -1,4 +1,7 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 from typing import Optional
 

--- a/src/beanmachine/ppl/compiler/fix_bool_comparisons.py
+++ b/src/beanmachine/ppl/compiler/fix_bool_comparisons.py
@@ -1,4 +1,7 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 from typing import Optional
 

--- a/src/beanmachine/ppl/compiler/fix_logsumexp.py
+++ b/src/beanmachine/ppl/compiler/fix_logsumexp.py
@@ -1,4 +1,7 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 from typing import Optional
 

--- a/src/beanmachine/ppl/compiler/fix_matrix_scale.py
+++ b/src/beanmachine/ppl/compiler/fix_matrix_scale.py
@@ -1,4 +1,7 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 from typing import Optional
 

--- a/src/beanmachine/ppl/compiler/fix_multiary_ops.py
+++ b/src/beanmachine/ppl/compiler/fix_multiary_ops.py
@@ -1,4 +1,7 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 from typing import List, Optional
 

--- a/src/beanmachine/ppl/compiler/fix_normal_conjugate_prior.py
+++ b/src/beanmachine/ppl/compiler/fix_normal_conjugate_prior.py
@@ -1,4 +1,7 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import math
 from typing import List, Optional

--- a/src/beanmachine/ppl/compiler/fix_observations.py
+++ b/src/beanmachine/ppl/compiler/fix_observations.py
@@ -1,4 +1,7 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
 from beanmachine.ppl.compiler.bmg_types import (

--- a/src/beanmachine/ppl/compiler/fix_observe_true.py
+++ b/src/beanmachine/ppl/compiler/fix_observe_true.py
@@ -1,4 +1,7 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
 from beanmachine.ppl.compiler.bmg_nodes import (

--- a/src/beanmachine/ppl/compiler/fix_problem.py
+++ b/src/beanmachine/ppl/compiler/fix_problem.py
@@ -1,4 +1,7 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 from abc import ABC, abstractmethod
 from typing import Optional

--- a/src/beanmachine/ppl/compiler/fix_problems.py
+++ b/src/beanmachine/ppl/compiler/fix_problems.py
@@ -1,4 +1,7 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 from typing import List, Set, Type
 

--- a/src/beanmachine/ppl/compiler/fix_requirements.py
+++ b/src/beanmachine/ppl/compiler/fix_requirements.py
@@ -1,4 +1,7 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 """This module takes a Bean Machine Graph builder and makes a best
 effort attempt to transform the accumulated graph to meet the

--- a/src/beanmachine/ppl/compiler/fix_unsupported.py
+++ b/src/beanmachine/ppl/compiler/fix_unsupported.py
@@ -1,4 +1,7 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 from typing import Optional
 

--- a/src/beanmachine/ppl/compiler/fix_vectorized_models.py
+++ b/src/beanmachine/ppl/compiler/fix_vectorized_models.py
@@ -1,4 +1,7 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 from typing import Optional, List, Dict, Type, Callable
 

--- a/src/beanmachine/ppl/compiler/gen_bmg_cpp.py
+++ b/src/beanmachine/ppl/compiler/gen_bmg_cpp.py
@@ -1,4 +1,7 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 from typing import Any, Dict, List
 

--- a/src/beanmachine/ppl/compiler/gen_bmg_graph.py
+++ b/src/beanmachine/ppl/compiler/gen_bmg_graph.py
@@ -1,4 +1,7 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 from typing import Dict, List, Set
 

--- a/src/beanmachine/ppl/compiler/gen_bmg_python.py
+++ b/src/beanmachine/ppl/compiler/gen_bmg_python.py
@@ -1,4 +1,7 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 from typing import Dict, List
 

--- a/src/beanmachine/ppl/compiler/gen_builder.py
+++ b/src/beanmachine/ppl/compiler/gen_builder.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """
 Convert a builder into a program that produces a graph builder.
 """

--- a/src/beanmachine/ppl/compiler/gen_dot.py
+++ b/src/beanmachine/ppl/compiler/gen_dot.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """
 Visualize the contents of a builder in the DOT graph language.
 """

--- a/src/beanmachine/ppl/compiler/graph_labels.py
+++ b/src/beanmachine/ppl/compiler/graph_labels.py
@@ -1,4 +1,7 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 from typing import Callable, List
 

--- a/src/beanmachine/ppl/compiler/hint.py
+++ b/src/beanmachine/ppl/compiler/hint.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """Operations that are intended as hints to the Beanstalk compiler"""
 
 import math

--- a/src/beanmachine/ppl/compiler/internal_error.py
+++ b/src/beanmachine/ppl/compiler/internal_error.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """Error reporting for internal compiler errors"""
 
 import os

--- a/src/beanmachine/ppl/compiler/lattice_typer.py
+++ b/src/beanmachine/ppl/compiler/lattice_typer.py
@@ -1,4 +1,7 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 # See notes in typer_base.py for how the type computation logic works.
 # See notes in bmg_types.py for the type lattice documentation.

--- a/src/beanmachine/ppl/compiler/patterns.py
+++ b/src/beanmachine/ppl/compiler/patterns.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """A pattern matching engine"""
 from abc import ABC, ABCMeta, abstractmethod
 from typing import Any, Callable, Dict, List, Optional, Union

--- a/src/beanmachine/ppl/compiler/performance_report.py
+++ b/src/beanmachine/ppl/compiler/performance_report.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import json as json_
 from typing import Any, Optional
 

--- a/src/beanmachine/ppl/compiler/profiler.py
+++ b/src/beanmachine/ppl/compiler/profiler.py
@@ -1,4 +1,7 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import time
 from typing import Dict, List, Optional

--- a/src/beanmachine/ppl/compiler/rules.py
+++ b/src/beanmachine/ppl/compiler/rules.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """A rules engine for tree transformation"""
 from abc import ABC, abstractmethod
 from typing import Any, Callable, Dict, Iterable, List, Tuple

--- a/src/beanmachine/ppl/compiler/runtime.py
+++ b/src/beanmachine/ppl/compiler/runtime.py
@@ -1,5 +1,10 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 # TODO: Update this comment
+
 """A builder for the BeanMachine Graph language
 
 The Beanstalk compiler has, at a high level, five phases.

--- a/src/beanmachine/ppl/compiler/single_assignment.py
+++ b/src/beanmachine/ppl/compiler/single_assignment.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """Tools to transform Bean Machine programs to Bean Machine Graph"""
 
 # TODO: This module is badly named; it really should be "python simplifier" or some

--- a/src/beanmachine/ppl/compiler/sizer.py
+++ b/src/beanmachine/ppl/compiler/sizer.py
@@ -1,4 +1,7 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 # See notes in typer_base.py for how the type computation logic works.
 #

--- a/src/beanmachine/ppl/compiler/support.py
+++ b/src/beanmachine/ppl/compiler/support.py
@@ -1,4 +1,7 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 # See notes in typer_base.py for how the type computation logic works.
 #

--- a/src/beanmachine/ppl/compiler/testlib/__init__.py
+++ b/src/beanmachine/ppl/compiler/testlib/__init__.py
@@ -1,1 +1,4 @@
-# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/testlib/conjugate_models.py
+++ b/src/beanmachine/ppl/compiler/testlib/conjugate_models.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 from typing import Dict
 
 import beanmachine.ppl as bm

--- a/src/beanmachine/ppl/compiler/testlib/tests/fix_beta_conjugacy_test.py
+++ b/src/beanmachine/ppl/compiler/testlib/tests/fix_beta_conjugacy_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """Parameterized test to compare samples from original
    and conjugate prior transformed models"""
 

--- a/src/beanmachine/ppl/compiler/tests/ast_tools_test.py
+++ b/src/beanmachine/ppl/compiler/tests/ast_tools_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """Tests for ast_tools.py"""
 import ast
 import unittest

--- a/src/beanmachine/ppl/compiler/tests/binary_vs_multiary_addition_perf_test.py
+++ b/src/beanmachine/ppl/compiler/tests/binary_vs_multiary_addition_perf_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """Test performance of multiary addition optimization """
 import platform
 import random

--- a/src/beanmachine/ppl/compiler/tests/binary_vs_multiary_multiplication_perf_test.py
+++ b/src/beanmachine/ppl/compiler/tests/binary_vs_multiary_multiplication_perf_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """Test performance of multiary multiplication optimization """
 import platform
 import random

--- a/src/beanmachine/ppl/compiler/tests/bm_graph_builder_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bm_graph_builder_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """Tests for bm_graph_builder.py"""
 import math
 import unittest

--- a/src/beanmachine/ppl/compiler/tests/bm_to_bmg_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bm_to_bmg_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """Tests for bm_to_bmg.py"""
 import unittest
 

--- a/src/beanmachine/ppl/compiler/tests/bma_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bma_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """End-to-end compiler test for Bayesian Meta-Analysis model"""
 
 import platform

--- a/src/beanmachine/ppl/compiler/tests/bmg_arithmetic_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_arithmetic_test.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 # BM -> BMG compiler arithmetic tests
 
 import unittest

--- a/src/beanmachine/ppl/compiler/tests/bmg_bad_models_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_bad_models_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import unittest
 
 import beanmachine.ppl as bm

--- a/src/beanmachine/ppl/compiler/tests/bmg_factor_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_factor_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import unittest
 
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder

--- a/src/beanmachine/ppl/compiler/tests/bmg_infer_interface_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_infer_interface_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """A basic unit test for the Python interface of the BMG C++ Graph.infer method"""
 import unittest
 

--- a/src/beanmachine/ppl/compiler/tests/bmg_nodes_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_nodes_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """Tests for bmg_nodes.py"""
 import unittest
 

--- a/src/beanmachine/ppl/compiler/tests/bmg_query_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_query_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import unittest
 
 import beanmachine.ppl as bm

--- a/src/beanmachine/ppl/compiler/tests/bmg_types_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_types_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """Tests for bmg_types.py"""
 import unittest
 

--- a/src/beanmachine/ppl/compiler/tests/boolean_comparisons_test.py
+++ b/src/beanmachine/ppl/compiler/tests/boolean_comparisons_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import unittest
 
 import beanmachine.ppl as bm

--- a/src/beanmachine/ppl/compiler/tests/categorical_test.py
+++ b/src/beanmachine/ppl/compiler/tests/categorical_test.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 # Categorical compiler tests
 

--- a/src/beanmachine/ppl/compiler/tests/coin_flip_test.py
+++ b/src/beanmachine/ppl/compiler/tests/coin_flip_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """End-to-end test of realistic coin flip model"""
 import unittest
 

--- a/src/beanmachine/ppl/compiler/tests/column_index_test.py
+++ b/src/beanmachine/ppl/compiler/tests/column_index_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import unittest
 
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder

--- a/src/beanmachine/ppl/compiler/tests/comparison_errors_test.py
+++ b/src/beanmachine/ppl/compiler/tests/comparison_errors_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import unittest
 
 import beanmachine.ppl as bm

--- a/src/beanmachine/ppl/compiler/tests/comparison_rewriting_test.py
+++ b/src/beanmachine/ppl/compiler/tests/comparison_rewriting_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """Comparison operators are not supported in BMG yet but we need to be able to detect
 use of them and give an error. Here we verify that we can rewrite code containing
 them correctly."""

--- a/src/beanmachine/ppl/compiler/tests/cycle_detector_test.py
+++ b/src/beanmachine/ppl/compiler/tests/cycle_detector_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import unittest
 
 import beanmachine.ppl as bm

--- a/src/beanmachine/ppl/compiler/tests/dirichlet_test.py
+++ b/src/beanmachine/ppl/compiler/tests/dirichlet_test.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 # Dirichlet compiler tests
 

--- a/src/beanmachine/ppl/compiler/tests/disable_transformations_test.py
+++ b/src/beanmachine/ppl/compiler/tests/disable_transformations_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import unittest
 
 import beanmachine.ppl as bm

--- a/src/beanmachine/ppl/compiler/tests/distribution_half_normal_test.py
+++ b/src/beanmachine/ppl/compiler/tests/distribution_half_normal_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """End-to-end test for an example use of the normal distribution"""
 
 import logging

--- a/src/beanmachine/ppl/compiler/tests/distribution_normal_test.py
+++ b/src/beanmachine/ppl/compiler/tests/distribution_normal_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """End-to-end test for an example use of the normal distribution"""
 
 import logging

--- a/src/beanmachine/ppl/compiler/tests/error_report_test.py
+++ b/src/beanmachine/ppl/compiler/tests/error_report_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """Tests for error_report.py"""
 import unittest
 

--- a/src/beanmachine/ppl/compiler/tests/fix_beta_bernoulli_alpha_rv_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_beta_bernoulli_alpha_rv_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """Beta-Bernoulli model conjugacy transformation check when
    hyperparameter is a random variable."""
 

--- a/src/beanmachine/ppl/compiler/tests/fix_beta_bernoulli_basic_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_beta_bernoulli_basic_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """Compare original and conjugate prior transformed
    Beta-Bernoulli model"""
 

--- a/src/beanmachine/ppl/compiler/tests/fix_beta_bernoulli_const_added_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_beta_bernoulli_const_added_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """Compare original and conjugate prior transformed
    Beta-Bernoulli model with a hyperparameter given
    by calling a non-random_variable function."""

--- a/src/beanmachine/ppl/compiler/tests/fix_beta_bernoulli_ops_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_beta_bernoulli_ops_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """Compare original and conjugate prior transformed
    Beta-Bernoulli model with operations on Bernoulli samples"""
 

--- a/src/beanmachine/ppl/compiler/tests/fix_beta_binomial_basic_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_beta_binomial_basic_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """Compare original and conjugate prior transformed
    Beta-Binomial model"""
 

--- a/src/beanmachine/ppl/compiler/tests/fix_logsumexp_perf_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_logsumexp_perf_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import platform
 import random
 import re

--- a/src/beanmachine/ppl/compiler/tests/fix_logsumexp_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_logsumexp_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import unittest
 
 import beanmachine.ppl as bm

--- a/src/beanmachine/ppl/compiler/tests/fix_matrix_scale_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_matrix_scale_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import unittest
 
 import beanmachine.ppl as bm

--- a/src/beanmachine/ppl/compiler/tests/fix_multiary_ops_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_multiary_ops_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import unittest
 
 import beanmachine.ppl as bm

--- a/src/beanmachine/ppl/compiler/tests/fix_normal_normal_basic_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_normal_normal_basic_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """Compare original and conjugate prior transformed model"""
 
 import random

--- a/src/beanmachine/ppl/compiler/tests/fix_observe_true_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_observe_true_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import unittest
 
 import beanmachine.ppl as bm

--- a/src/beanmachine/ppl/compiler/tests/fix_problems_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_problems_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """Tests for fix_problems.py"""
 import unittest
 

--- a/src/beanmachine/ppl/compiler/tests/fix_vectorized_models_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_vectorized_models_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import unittest
 
 import beanmachine.ppl as bm

--- a/src/beanmachine/ppl/compiler/tests/gaussian_mixture_model_test.py
+++ b/src/beanmachine/ppl/compiler/tests/gaussian_mixture_model_test.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 
 # Suppose we have a mixture of k normal distributions each with standard

--- a/src/beanmachine/ppl/compiler/tests/gen_builder_test.py
+++ b/src/beanmachine/ppl/compiler/tests/gen_builder_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """Tests for gen_builder.py"""
 import unittest
 

--- a/src/beanmachine/ppl/compiler/tests/gmm_1d_2comp_test.py
+++ b/src/beanmachine/ppl/compiler/tests/gmm_1d_2comp_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """End-to-end test for tutorial on GMM with Poisson number of components"""
 # This file is a manual replica of the Bento tutorial with the same name
 # TODO: The disabled test generates the following error:

--- a/src/beanmachine/ppl/compiler/tests/graph_accumulation_test.py
+++ b/src/beanmachine/ppl/compiler/tests/graph_accumulation_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """Tests for bm_to_bmg.py"""
 import unittest
 

--- a/src/beanmachine/ppl/compiler/tests/hint_test.py
+++ b/src/beanmachine/ppl/compiler/tests/hint_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """Tests for hint.py"""
 
 import unittest

--- a/src/beanmachine/ppl/compiler/tests/index_test.py
+++ b/src/beanmachine/ppl/compiler/tests/index_test.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 # BM -> BMG compiler index tests
 
 import unittest

--- a/src/beanmachine/ppl/compiler/tests/item_test.py
+++ b/src/beanmachine/ppl/compiler/tests/item_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import unittest
 
 # The item() member function should be treated as an identity by the compiler

--- a/src/beanmachine/ppl/compiler/tests/jit_test.py
+++ b/src/beanmachine/ppl/compiler/tests/jit_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """Tests for bm_to_bmg.py"""
 import math
 import unittest

--- a/src/beanmachine/ppl/compiler/tests/lattice_typer_test.py
+++ b/src/beanmachine/ppl/compiler/tests/lattice_typer_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import unittest
 
 import beanmachine.ppl.compiler.bmg_types as bt

--- a/src/beanmachine/ppl/compiler/tests/linear_regression_test.py
+++ b/src/beanmachine/ppl/compiler/tests/linear_regression_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """End-to-end test of realistic linear regression model"""
 
 # This is copied from bento workbook N140350, simplified, and

--- a/src/beanmachine/ppl/compiler/tests/log1mexp_test.py
+++ b/src/beanmachine/ppl/compiler/tests/log1mexp_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """End-to-end test for log1mexp"""
 import unittest
 

--- a/src/beanmachine/ppl/compiler/tests/logistic_regression_test.py
+++ b/src/beanmachine/ppl/compiler/tests/logistic_regression_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """End-to-end test of realistic logistic regression model"""
 import unittest
 

--- a/src/beanmachine/ppl/compiler/tests/lse_vector_test.py
+++ b/src/beanmachine/ppl/compiler/tests/lse_vector_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import unittest
 
 import beanmachine.ppl as bm

--- a/src/beanmachine/ppl/compiler/tests/matrix_multiplication_test.py
+++ b/src/beanmachine/ppl/compiler/tests/matrix_multiplication_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import unittest
 
 import beanmachine.ppl as bm

--- a/src/beanmachine/ppl/compiler/tests/n-schools_test.py
+++ b/src/beanmachine/ppl/compiler/tests/n-schools_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 # """End-to-end test for n-schools model based on the one in PPL Bench"""
 # See for example https://github.com/facebookresearch/pplbench/blob/master/pplbench/models/n_schools.py
 

--- a/src/beanmachine/ppl/compiler/tests/neals_funnel_test.py
+++ b/src/beanmachine/ppl/compiler/tests/neals_funnel_test.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import unittest
 

--- a/src/beanmachine/ppl/compiler/tests/patterns_test.py
+++ b/src/beanmachine/ppl/compiler/tests/patterns_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """Tests for patterns.py"""
 import ast
 import re

--- a/src/beanmachine/ppl/compiler/tests/perf_report_test.py
+++ b/src/beanmachine/ppl/compiler/tests/perf_report_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import platform
 import re
 import unittest

--- a/src/beanmachine/ppl/compiler/tests/profiler_test.py
+++ b/src/beanmachine/ppl/compiler/tests/profiler_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import unittest
 
 from beanmachine.ppl.compiler.profiler import ProfilerData

--- a/src/beanmachine/ppl/compiler/tests/query_type_zero_bug_test.py
+++ b/src/beanmachine/ppl/compiler/tests/query_type_zero_bug_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import unittest
 
 import beanmachine.ppl as bm

--- a/src/beanmachine/ppl/compiler/tests/rules_test.py
+++ b/src/beanmachine/ppl/compiler/tests/rules_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """Tests for rules.py"""
 import ast
 import re

--- a/src/beanmachine/ppl/compiler/tests/single_assignment_test.py
+++ b/src/beanmachine/ppl/compiler/tests/single_assignment_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """Tests for single_assignment.py"""
 import ast
 import unittest

--- a/src/beanmachine/ppl/compiler/tests/sizer_test.py
+++ b/src/beanmachine/ppl/compiler/tests/sizer_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import unittest
 
 import beanmachine.ppl as bm

--- a/src/beanmachine/ppl/compiler/tests/stochastic_control_flow_test.py
+++ b/src/beanmachine/ppl/compiler/tests/stochastic_control_flow_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import unittest
 
 import beanmachine.ppl as bm

--- a/src/beanmachine/ppl/compiler/tests/support_test.py
+++ b/src/beanmachine/ppl/compiler/tests/support_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import unittest
 from typing import Any
 

--- a/src/beanmachine/ppl/compiler/tests/tensor_operations_test.py
+++ b/src/beanmachine/ppl/compiler/tests/tensor_operations_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import unittest
 
 import beanmachine.ppl as bm

--- a/src/beanmachine/ppl/compiler/tests/to_matrix_test.py
+++ b/src/beanmachine/ppl/compiler/tests/to_matrix_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import unittest
 
 import beanmachine.ppl as bm

--- a/src/beanmachine/ppl/compiler/tests/to_probability_test.py
+++ b/src/beanmachine/ppl/compiler/tests/to_probability_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import unittest
 
 import beanmachine.ppl as bm

--- a/src/beanmachine/ppl/compiler/tests/tutorial_GMM_with_1_dimensions_and_4_components_test.py
+++ b/src/beanmachine/ppl/compiler/tests/tutorial_GMM_with_1_dimensions_and_4_components_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """End-to-end test for 1D GMM with K > 2 number of components"""
 
 import logging

--- a/src/beanmachine/ppl/compiler/tests/tutorial_GMM_with_2_dimensions_and_4_components_test.py
+++ b/src/beanmachine/ppl/compiler/tests/tutorial_GMM_with_2_dimensions_and_4_components_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """End-to-end test for tutorial on GMM with Poisson number of components"""
 # This file is a manual replica of the Bento tutorial with the same name
 # TODO: The disabled test generates the following error:

--- a/src/beanmachine/ppl/compiler/tests/tutorial_Neals_Funnel_test.py
+++ b/src/beanmachine/ppl/compiler/tests/tutorial_Neals_Funnel_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """End-to-end test for tutorial on Neal's Funnel"""
 # This file is a manual replica of the Bento tutorial with the same name
 # This is a block for Beanstalk OSS readiness

--- a/src/beanmachine/ppl/compiler/tests/tutorial_Robust_Linear_Regression_test.py
+++ b/src/beanmachine/ppl/compiler/tests/tutorial_Robust_Linear_Regression_test.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """End-to-end test for tutorial on Robust Linear Regression"""
 
 # This file is a manual replica of the Bento tutorial with the same name

--- a/src/beanmachine/ppl/compiler/tests/typer_base_test.py
+++ b/src/beanmachine/ppl/compiler/tests/typer_base_test.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import unittest
 

--- a/src/beanmachine/ppl/compiler/typer_base.py
+++ b/src/beanmachine/ppl/compiler/typer_base.py
@@ -1,4 +1,7 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 # Once we have accumulated a graph we often need to associate type information
 # with some or all of the nodes. This presents a number of practical difficulties:


### PR DESCRIPTION
Summary:
I was hoping to update our entire repository at once, but it turns out that the number of changes is too large to the point whether my VS code keep freezing and things can't render nicely on Phrabicator either. Soo.. to make things easier to handle, I'm going to break things done into individual major modules.`

This first diff is about changes in `beanmachine.ppl.compiler` :)

Most of this diffs in this stack are generated by
1. enabling license lint temporarily on my devserver (with this config: D32973474)
2. Run `find ./ -type f -exec sed -i 's/Facebook, Inc\./Meta Platforms, Inc\./g'  {} \;` to replace all occurrences of "Facebook, Inc." with "Meta Platforms, Inc."

Note that I'm not enabling license lint for this repo because license lint hasn't been updated to call the company "Meta" yet.

After the change, all files should have the [Meta specific MIT style header](https://www.internalfb.com/intern/wiki/Open_Source/Licenses/MIT_License/) (I see that we have [MIT license on our repo](https://github.com/facebookresearch/beanmachine/blob/master/LICENSE) so I assume that this is the one we want to go with)

There's some issue with license lint stripping off the comments that were in the top of the file, so in addition to the automatic workflow above, I manually fixed the few files that have more than 1 lines deleted to make sure that we won't losing anythin.

Differential Revision: D32977813

