### PR TITLE
Remove 'its' from copyright headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates. All Rights Reserved
+# Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved
 
 # beanmachine
 beanmachine.log

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) Meta Platforms, Inc. and its affiliates.
+Copyright (c) Meta Platforms, Inc. and affiliates.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/sphinx/source/conf.py
+++ b/sphinx/source/conf.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/sphinx/source/docs.py
+++ b/sphinx/source/docs.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/__init__.py
+++ b/src/beanmachine/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/applications/clara/nmc.py
+++ b/src/beanmachine/applications/clara/nmc.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/applications/clara/nmc_df.py
+++ b/src/beanmachine/applications/clara/nmc_df.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/applications/clara/tests/nmc_test.py
+++ b/src/beanmachine/applications/clara/tests/nmc_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/applications/hme/__init__.py
+++ b/src/beanmachine/applications/hme/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/applications/hme/abstract_linear_model.py
+++ b/src/beanmachine/applications/hme/abstract_linear_model.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/applications/hme/abstract_model.py
+++ b/src/beanmachine/applications/hme/abstract_model.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/applications/hme/configs.py
+++ b/src/beanmachine/applications/hme/configs.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/applications/hme/interface.py
+++ b/src/beanmachine/applications/hme/interface.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/applications/hme/null_mixture_model.py
+++ b/src/beanmachine/applications/hme/null_mixture_model.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/applications/hme/patsy_mixed.py
+++ b/src/beanmachine/applications/hme/patsy_mixed.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/applications/hme/priors.py
+++ b/src/beanmachine/applications/hme/priors.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/applications/hme/tests/model_test.py
+++ b/src/beanmachine/applications/hme/tests/model_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/applications/hme/tests/test_diagnostics.py
+++ b/src/beanmachine/applications/hme/tests/test_diagnostics.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/applications/hme/tests/test_model.py
+++ b/src/beanmachine/applications/hme/tests/test_model.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/applications/hme/tests/test_parser.py
+++ b/src/beanmachine/applications/hme/tests/test_parser.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/applications/hme/tests/test_priors.py
+++ b/src/beanmachine/applications/hme/tests/test_priors.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/cavi.cpp
+++ b/src/beanmachine/graph/cavi.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/distribution/bernoulli.cpp
+++ b/src/beanmachine/graph/distribution/bernoulli.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/distribution/bernoulli.h
+++ b/src/beanmachine/graph/distribution/bernoulli.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/distribution/bernoulli_logit.cpp
+++ b/src/beanmachine/graph/distribution/bernoulli_logit.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/distribution/bernoulli_logit.h
+++ b/src/beanmachine/graph/distribution/bernoulli_logit.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/distribution/bernoulli_noisy_or.cpp
+++ b/src/beanmachine/graph/distribution/bernoulli_noisy_or.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/distribution/bernoulli_noisy_or.h
+++ b/src/beanmachine/graph/distribution/bernoulli_noisy_or.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/distribution/beta.cpp
+++ b/src/beanmachine/graph/distribution/beta.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/distribution/beta.h
+++ b/src/beanmachine/graph/distribution/beta.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/distribution/bimixture.cpp
+++ b/src/beanmachine/graph/distribution/bimixture.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/distribution/bimixture.h
+++ b/src/beanmachine/graph/distribution/bimixture.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/distribution/binomial.cpp
+++ b/src/beanmachine/graph/distribution/binomial.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/distribution/binomial.h
+++ b/src/beanmachine/graph/distribution/binomial.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/distribution/categorical.cpp
+++ b/src/beanmachine/graph/distribution/categorical.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/distribution/categorical.h
+++ b/src/beanmachine/graph/distribution/categorical.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/distribution/dirichlet.cpp
+++ b/src/beanmachine/graph/distribution/dirichlet.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/distribution/dirichlet.h
+++ b/src/beanmachine/graph/distribution/dirichlet.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/distribution/distribution.cpp
+++ b/src/beanmachine/graph/distribution/distribution.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/distribution/distribution.h
+++ b/src/beanmachine/graph/distribution/distribution.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/distribution/flat.cpp
+++ b/src/beanmachine/graph/distribution/flat.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/distribution/flat.h
+++ b/src/beanmachine/graph/distribution/flat.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/distribution/gamma.cpp
+++ b/src/beanmachine/graph/distribution/gamma.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/distribution/gamma.h
+++ b/src/beanmachine/graph/distribution/gamma.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/distribution/half_cauchy.cpp
+++ b/src/beanmachine/graph/distribution/half_cauchy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/distribution/half_cauchy.h
+++ b/src/beanmachine/graph/distribution/half_cauchy.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/distribution/half_normal.cpp
+++ b/src/beanmachine/graph/distribution/half_normal.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/distribution/half_normal.h
+++ b/src/beanmachine/graph/distribution/half_normal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/distribution/normal.cpp
+++ b/src/beanmachine/graph/distribution/normal.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/distribution/normal.h
+++ b/src/beanmachine/graph/distribution/normal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/distribution/student_t.cpp
+++ b/src/beanmachine/graph/distribution/student_t.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/distribution/student_t.h
+++ b/src/beanmachine/graph/distribution/student_t.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/distribution/tabular.cpp
+++ b/src/beanmachine/graph/distribution/tabular.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/distribution/tabular.h
+++ b/src/beanmachine/graph/distribution/tabular.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/distribution/tests/bernoulli_logit_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/bernoulli_logit_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/distribution/tests/bernoulli_noisy_or_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/bernoulli_noisy_or_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/distribution/tests/beta_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/beta_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/distribution/tests/bimixture_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/bimixture_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/distribution/tests/binomial_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/binomial_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/distribution/tests/categorical_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/categorical_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/distribution/tests/dirichlet_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/dirichlet_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/distribution/tests/distribution_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/distribution_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/distribution/tests/flat_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/flat_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/distribution/tests/gamma_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/gamma_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/distribution/tests/half_cauchy_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/half_cauchy_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/distribution/tests/half_normal_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/half_normal_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/distribution/tests/normal_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/normal_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/distribution/tests/student_t_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/student_t_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/factor/exp_product.cpp
+++ b/src/beanmachine/graph/factor/exp_product.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/factor/exp_product.h
+++ b/src/beanmachine/graph/factor/exp_product.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/factor/factor.cpp
+++ b/src/beanmachine/graph/factor/factor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/factor/factor.h
+++ b/src/beanmachine/graph/factor/factor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/factor/tests/exp_product_test.cpp
+++ b/src/beanmachine/graph/factor/tests/exp_product_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/gibbs.cpp
+++ b/src/beanmachine/graph/gibbs.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/global/global_mh.cpp
+++ b/src/beanmachine/graph/global/global_mh.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/global/global_mh.h
+++ b/src/beanmachine/graph/global/global_mh.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/global/global_state.cpp
+++ b/src/beanmachine/graph/global/global_state.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/global/global_state.h
+++ b/src/beanmachine/graph/global/global_state.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/global/hmc.cpp
+++ b/src/beanmachine/graph/global/hmc.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/global/hmc.h
+++ b/src/beanmachine/graph/global/hmc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/global/nuts.cpp
+++ b/src/beanmachine/graph/global/nuts.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/global/nuts.h
+++ b/src/beanmachine/graph/global/nuts.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/global/proposer/global_proposer.h
+++ b/src/beanmachine/graph/global/proposer/global_proposer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/global/proposer/hmc_proposer.cpp
+++ b/src/beanmachine/graph/global/proposer/hmc_proposer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/global/proposer/hmc_proposer.h
+++ b/src/beanmachine/graph/global/proposer/hmc_proposer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/global/proposer/hmc_util.cpp
+++ b/src/beanmachine/graph/global/proposer/hmc_util.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/global/proposer/hmc_util.h
+++ b/src/beanmachine/graph/global/proposer/hmc_util.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/global/proposer/nuts_proposer.cpp
+++ b/src/beanmachine/graph/global/proposer/nuts_proposer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/global/proposer/nuts_proposer.h
+++ b/src/beanmachine/graph/global/proposer/nuts_proposer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/global/proposer/random_walk_proposer.cpp
+++ b/src/beanmachine/graph/global/proposer/random_walk_proposer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/global/proposer/random_walk_proposer.h
+++ b/src/beanmachine/graph/global/proposer/random_walk_proposer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/global/proposer/tests/hmc_util_test.cpp
+++ b/src/beanmachine/graph/global/proposer/tests/hmc_util_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/global/random_walk.cpp
+++ b/src/beanmachine/graph/global/random_walk.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/global/random_walk.h
+++ b/src/beanmachine/graph/global/random_walk.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/global/tests/conjugate_util_test.cpp
+++ b/src/beanmachine/graph/global/tests/conjugate_util_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/global/tests/conjugate_util_test.h
+++ b/src/beanmachine/graph/global/tests/conjugate_util_test.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/global/tests/global_state_test.cpp
+++ b/src/beanmachine/graph/global/tests/global_state_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/global/tests/hmc_test.cpp
+++ b/src/beanmachine/graph/global/tests/hmc_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/global/tests/nuts_test.cpp
+++ b/src/beanmachine/graph/global/tests/nuts_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/global/tests/random_walk_test.cpp
+++ b/src/beanmachine/graph/global/tests/random_walk_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/global/tests/util_test.cpp
+++ b/src/beanmachine/graph/global/tests/util_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/global/util.cpp
+++ b/src/beanmachine/graph/global/util.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/global/util.h
+++ b/src/beanmachine/graph/global/util.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/graph.cpp
+++ b/src/beanmachine/graph/graph.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/graph.pyi
+++ b/src/beanmachine/graph/graph.pyi
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/mh.cpp
+++ b/src/beanmachine/graph/mh.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/mh.h
+++ b/src/beanmachine/graph/mh.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/nmc.cpp
+++ b/src/beanmachine/graph/nmc.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/nmc.h
+++ b/src/beanmachine/graph/nmc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/nmc_stepper.h
+++ b/src/beanmachine/graph/nmc_stepper.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/operator/backward.cpp
+++ b/src/beanmachine/graph/operator/backward.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/operator/controlop.cpp
+++ b/src/beanmachine/graph/operator/controlop.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/operator/controlop.h
+++ b/src/beanmachine/graph/operator/controlop.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/operator/gradient.cpp
+++ b/src/beanmachine/graph/operator/gradient.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/operator/linalgop.cpp
+++ b/src/beanmachine/graph/operator/linalgop.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/operator/linalgop.h
+++ b/src/beanmachine/graph/operator/linalgop.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/operator/multiaryop.cpp
+++ b/src/beanmachine/graph/operator/multiaryop.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/operator/multiaryop.h
+++ b/src/beanmachine/graph/operator/multiaryop.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/operator/operator.cpp
+++ b/src/beanmachine/graph/operator/operator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/operator/operator.h
+++ b/src/beanmachine/graph/operator/operator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/operator/register.cpp
+++ b/src/beanmachine/graph/operator/register.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/operator/stochasticop.cpp
+++ b/src/beanmachine/graph/operator/stochasticop.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/operator/stochasticop.h
+++ b/src/beanmachine/graph/operator/stochasticop.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/operator/tests/gradient_test.cpp
+++ b/src/beanmachine/graph/operator/tests/gradient_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/operator/tests/operator_test.cpp
+++ b/src/beanmachine/graph/operator/tests/operator_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/operator/unaryop.cpp
+++ b/src/beanmachine/graph/operator/unaryop.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/operator/unaryop.h
+++ b/src/beanmachine/graph/operator/unaryop.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/perf_report.cpp
+++ b/src/beanmachine/graph/perf_report.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/profiler.cpp
+++ b/src/beanmachine/graph/profiler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/profiler.h
+++ b/src/beanmachine/graph/profiler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/proposer/beta.cpp
+++ b/src/beanmachine/graph/proposer/beta.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/proposer/beta.h
+++ b/src/beanmachine/graph/proposer/beta.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/proposer/default_initializer.cpp
+++ b/src/beanmachine/graph/proposer/default_initializer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/proposer/default_initializer.h
+++ b/src/beanmachine/graph/proposer/default_initializer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/proposer/delta.h
+++ b/src/beanmachine/graph/proposer/delta.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/proposer/from_probability_to_dirichlet_proposer_adapter.cpp
+++ b/src/beanmachine/graph/proposer/from_probability_to_dirichlet_proposer_adapter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/proposer/from_probability_to_dirichlet_proposer_adapter.h
+++ b/src/beanmachine/graph/proposer/from_probability_to_dirichlet_proposer_adapter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/proposer/gamma.cpp
+++ b/src/beanmachine/graph/proposer/gamma.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/proposer/gamma.h
+++ b/src/beanmachine/graph/proposer/gamma.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/proposer/mixture.cpp
+++ b/src/beanmachine/graph/proposer/mixture.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/proposer/mixture.h
+++ b/src/beanmachine/graph/proposer/mixture.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/proposer/nmc_proposer.cpp
+++ b/src/beanmachine/graph/proposer/nmc_proposer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/proposer/normal.cpp
+++ b/src/beanmachine/graph/proposer/normal.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/proposer/normal.h
+++ b/src/beanmachine/graph/proposer/normal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/proposer/proposer.h
+++ b/src/beanmachine/graph/proposer/proposer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/proposer/tests/gamma_test.cpp
+++ b/src/beanmachine/graph/proposer/tests/gamma_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/proposer/tests/mixture_test.cpp
+++ b/src/beanmachine/graph/proposer/tests/mixture_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/proposer/tests/trunc_cauchy_test.cpp
+++ b/src/beanmachine/graph/proposer/tests/trunc_cauchy_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/proposer/trunc_cauchy.cpp
+++ b/src/beanmachine/graph/proposer/trunc_cauchy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/proposer/trunc_cauchy.h
+++ b/src/beanmachine/graph/proposer/trunc_cauchy.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/pybindings.cpp
+++ b/src/beanmachine/graph/pybindings.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/pybindings.h
+++ b/src/beanmachine/graph/pybindings.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/rejection.cpp
+++ b/src/beanmachine/graph/rejection.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/stepper/single_site/default_single_site_stepping_method.cpp
+++ b/src/beanmachine/graph/stepper/single_site/default_single_site_stepping_method.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/stepper/single_site/default_single_site_stepping_method.h
+++ b/src/beanmachine/graph/stepper/single_site/default_single_site_stepping_method.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/stepper/single_site/nmc_dirichlet_beta_single_site_stepping_method.cpp
+++ b/src/beanmachine/graph/stepper/single_site/nmc_dirichlet_beta_single_site_stepping_method.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/stepper/single_site/nmc_dirichlet_beta_single_site_stepping_method.h
+++ b/src/beanmachine/graph/stepper/single_site/nmc_dirichlet_beta_single_site_stepping_method.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/stepper/single_site/nmc_dirichlet_gamma_single_site_stepping_method.cpp
+++ b/src/beanmachine/graph/stepper/single_site/nmc_dirichlet_gamma_single_site_stepping_method.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/stepper/single_site/nmc_dirichlet_gamma_single_site_stepping_method.h
+++ b/src/beanmachine/graph/stepper/single_site/nmc_dirichlet_gamma_single_site_stepping_method.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/stepper/single_site/nmc_scalar_single_site_stepping_method.cpp
+++ b/src/beanmachine/graph/stepper/single_site/nmc_scalar_single_site_stepping_method.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/stepper/single_site/nmc_scalar_single_site_stepping_method.h
+++ b/src/beanmachine/graph/stepper/single_site/nmc_scalar_single_site_stepping_method.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/stepper/single_site/sequential_single_site_stepper.cpp
+++ b/src/beanmachine/graph/stepper/single_site/sequential_single_site_stepper.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/stepper/single_site/sequential_single_site_stepper.h
+++ b/src/beanmachine/graph/stepper/single_site/sequential_single_site_stepper.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/stepper/single_site/single_site_stepper.h
+++ b/src/beanmachine/graph/stepper/single_site/single_site_stepper.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/stepper/single_site/single_site_stepping_method.h
+++ b/src/beanmachine/graph/stepper/single_site/single_site_stepping_method.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/stepper/stepper.cpp
+++ b/src/beanmachine/graph/stepper/stepper.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/stepper/stepper.h
+++ b/src/beanmachine/graph/stepper/stepper.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/support.cpp
+++ b/src/beanmachine/graph/support.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/tests/cavi_test.cpp
+++ b/src/beanmachine/graph/tests/cavi_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/tests/cavi_test.py
+++ b/src/beanmachine/graph/tests/cavi_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/tests/graph_test.cpp
+++ b/src/beanmachine/graph/tests/graph_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/tests/graph_test.py
+++ b/src/beanmachine/graph/tests/graph_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/tests/nmc_test.cpp
+++ b/src/beanmachine/graph/tests/nmc_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/tests/nmc_test.py
+++ b/src/beanmachine/graph/tests/nmc_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/tests/operator_test.py
+++ b/src/beanmachine/graph/tests/operator_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/tests/rejection_test.cpp
+++ b/src/beanmachine/graph/tests/rejection_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/tests/support_test.cpp
+++ b/src/beanmachine/graph/tests/support_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/tests/util_test.cpp
+++ b/src/beanmachine/graph/tests/util_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/to_dot.cpp
+++ b/src/beanmachine/graph/to_dot.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/transform/logtransform.cpp
+++ b/src/beanmachine/graph/transform/logtransform.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/transform/transform.h
+++ b/src/beanmachine/graph/transform/transform.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/transform/transform_test.cpp
+++ b/src/beanmachine/graph/transform/transform_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/util.cpp
+++ b/src/beanmachine/graph/util.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/graph/util.h
+++ b/src/beanmachine/graph/util.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/__init__.py
+++ b/src/beanmachine/ppl/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/ast_patterns.py
+++ b/src/beanmachine/ppl/compiler/ast_patterns.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/ast_tools.py
+++ b/src/beanmachine/ppl/compiler/ast_tools.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/beanstalk_common.py
+++ b/src/beanmachine/ppl/compiler/beanstalk_common.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/bm_graph_builder.py
+++ b/src/beanmachine/ppl/compiler/bm_graph_builder.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/bm_to_bmg.py
+++ b/src/beanmachine/ppl/compiler/bm_to_bmg.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/bmg_node_types.py
+++ b/src/beanmachine/ppl/compiler/bmg_node_types.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/bmg_nodes.py
+++ b/src/beanmachine/ppl/compiler/bmg_nodes.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/bmg_requirements.py
+++ b/src/beanmachine/ppl/compiler/bmg_requirements.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/bmg_types.py
+++ b/src/beanmachine/ppl/compiler/bmg_types.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/error_report.py
+++ b/src/beanmachine/ppl/compiler/error_report.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/fix_additions.py
+++ b/src/beanmachine/ppl/compiler/fix_additions.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/fix_beta_conjugate_prior.py
+++ b/src/beanmachine/ppl/compiler/fix_beta_conjugate_prior.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/fix_bool_arithmetic.py
+++ b/src/beanmachine/ppl/compiler/fix_bool_arithmetic.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/fix_bool_comparisons.py
+++ b/src/beanmachine/ppl/compiler/fix_bool_comparisons.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/fix_logsumexp.py
+++ b/src/beanmachine/ppl/compiler/fix_logsumexp.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/fix_matrix_scale.py
+++ b/src/beanmachine/ppl/compiler/fix_matrix_scale.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/fix_multiary_ops.py
+++ b/src/beanmachine/ppl/compiler/fix_multiary_ops.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/fix_normal_conjugate_prior.py
+++ b/src/beanmachine/ppl/compiler/fix_normal_conjugate_prior.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/fix_observations.py
+++ b/src/beanmachine/ppl/compiler/fix_observations.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/fix_observe_true.py
+++ b/src/beanmachine/ppl/compiler/fix_observe_true.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/fix_problem.py
+++ b/src/beanmachine/ppl/compiler/fix_problem.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/fix_problems.py
+++ b/src/beanmachine/ppl/compiler/fix_problems.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/fix_requirements.py
+++ b/src/beanmachine/ppl/compiler/fix_requirements.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/fix_unsupported.py
+++ b/src/beanmachine/ppl/compiler/fix_unsupported.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/fix_vectorized_models.py
+++ b/src/beanmachine/ppl/compiler/fix_vectorized_models.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/gen_bmg_cpp.py
+++ b/src/beanmachine/ppl/compiler/gen_bmg_cpp.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/gen_bmg_graph.py
+++ b/src/beanmachine/ppl/compiler/gen_bmg_graph.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/gen_bmg_python.py
+++ b/src/beanmachine/ppl/compiler/gen_bmg_python.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/gen_builder.py
+++ b/src/beanmachine/ppl/compiler/gen_builder.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/gen_dot.py
+++ b/src/beanmachine/ppl/compiler/gen_dot.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/graph_labels.py
+++ b/src/beanmachine/ppl/compiler/graph_labels.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/hint.py
+++ b/src/beanmachine/ppl/compiler/hint.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/internal_error.py
+++ b/src/beanmachine/ppl/compiler/internal_error.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/lattice_typer.py
+++ b/src/beanmachine/ppl/compiler/lattice_typer.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/patterns.py
+++ b/src/beanmachine/ppl/compiler/patterns.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/performance_report.py
+++ b/src/beanmachine/ppl/compiler/performance_report.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/profiler.py
+++ b/src/beanmachine/ppl/compiler/profiler.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/rules.py
+++ b/src/beanmachine/ppl/compiler/rules.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/runtime.py
+++ b/src/beanmachine/ppl/compiler/runtime.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/single_assignment.py
+++ b/src/beanmachine/ppl/compiler/single_assignment.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/sizer.py
+++ b/src/beanmachine/ppl/compiler/sizer.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/support.py
+++ b/src/beanmachine/ppl/compiler/support.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/testlib/__init__.py
+++ b/src/beanmachine/ppl/compiler/testlib/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/testlib/conjugate_models.py
+++ b/src/beanmachine/ppl/compiler/testlib/conjugate_models.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/testlib/tests/fix_beta_conjugacy_test.py
+++ b/src/beanmachine/ppl/compiler/testlib/tests/fix_beta_conjugacy_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/ast_tools_test.py
+++ b/src/beanmachine/ppl/compiler/tests/ast_tools_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/binary_vs_multiary_addition_perf_test.py
+++ b/src/beanmachine/ppl/compiler/tests/binary_vs_multiary_addition_perf_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/binary_vs_multiary_multiplication_perf_test.py
+++ b/src/beanmachine/ppl/compiler/tests/binary_vs_multiary_multiplication_perf_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/bm_graph_builder_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bm_graph_builder_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/bm_to_bmg_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bm_to_bmg_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/bma_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bma_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/bmg_arithmetic_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_arithmetic_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/bmg_bad_models_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_bad_models_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/bmg_factor_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_factor_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/bmg_infer_interface_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_infer_interface_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/bmg_nodes_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_nodes_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/bmg_query_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_query_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/bmg_types_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_types_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/boolean_comparisons_test.py
+++ b/src/beanmachine/ppl/compiler/tests/boolean_comparisons_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/categorical_test.py
+++ b/src/beanmachine/ppl/compiler/tests/categorical_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/coin_flip_test.py
+++ b/src/beanmachine/ppl/compiler/tests/coin_flip_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/column_index_test.py
+++ b/src/beanmachine/ppl/compiler/tests/column_index_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/comparison_errors_test.py
+++ b/src/beanmachine/ppl/compiler/tests/comparison_errors_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/comparison_rewriting_test.py
+++ b/src/beanmachine/ppl/compiler/tests/comparison_rewriting_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/cycle_detector_test.py
+++ b/src/beanmachine/ppl/compiler/tests/cycle_detector_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/dirichlet_test.py
+++ b/src/beanmachine/ppl/compiler/tests/dirichlet_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/disable_transformations_test.py
+++ b/src/beanmachine/ppl/compiler/tests/disable_transformations_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/distribution_half_normal_test.py
+++ b/src/beanmachine/ppl/compiler/tests/distribution_half_normal_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/distribution_normal_test.py
+++ b/src/beanmachine/ppl/compiler/tests/distribution_normal_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/error_report_test.py
+++ b/src/beanmachine/ppl/compiler/tests/error_report_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/fix_beta_bernoulli_alpha_rv_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_beta_bernoulli_alpha_rv_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/fix_beta_bernoulli_basic_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_beta_bernoulli_basic_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/fix_beta_bernoulli_const_added_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_beta_bernoulli_const_added_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/fix_beta_bernoulli_ops_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_beta_bernoulli_ops_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/fix_beta_binomial_basic_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_beta_binomial_basic_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/fix_logsumexp_perf_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_logsumexp_perf_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/fix_logsumexp_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_logsumexp_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/fix_matrix_scale_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_matrix_scale_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/fix_multiary_ops_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_multiary_ops_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/fix_normal_normal_basic_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_normal_normal_basic_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/fix_observe_true_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_observe_true_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/fix_problems_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_problems_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/fix_vectorized_models_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_vectorized_models_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/gaussian_mixture_model_test.py
+++ b/src/beanmachine/ppl/compiler/tests/gaussian_mixture_model_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/gen_builder_test.py
+++ b/src/beanmachine/ppl/compiler/tests/gen_builder_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/gmm_1d_2comp_test.py
+++ b/src/beanmachine/ppl/compiler/tests/gmm_1d_2comp_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/graph_accumulation_test.py
+++ b/src/beanmachine/ppl/compiler/tests/graph_accumulation_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/hint_test.py
+++ b/src/beanmachine/ppl/compiler/tests/hint_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/index_test.py
+++ b/src/beanmachine/ppl/compiler/tests/index_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/item_test.py
+++ b/src/beanmachine/ppl/compiler/tests/item_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/jit_test.py
+++ b/src/beanmachine/ppl/compiler/tests/jit_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/lattice_typer_test.py
+++ b/src/beanmachine/ppl/compiler/tests/lattice_typer_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/linear_regression_test.py
+++ b/src/beanmachine/ppl/compiler/tests/linear_regression_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/log1mexp_test.py
+++ b/src/beanmachine/ppl/compiler/tests/log1mexp_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/logistic_regression_test.py
+++ b/src/beanmachine/ppl/compiler/tests/logistic_regression_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/lse_vector_test.py
+++ b/src/beanmachine/ppl/compiler/tests/lse_vector_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/matrix_multiplication_test.py
+++ b/src/beanmachine/ppl/compiler/tests/matrix_multiplication_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/n-schools_test.py
+++ b/src/beanmachine/ppl/compiler/tests/n-schools_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/neals_funnel_test.py
+++ b/src/beanmachine/ppl/compiler/tests/neals_funnel_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/patterns_test.py
+++ b/src/beanmachine/ppl/compiler/tests/patterns_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/perf_report_test.py
+++ b/src/beanmachine/ppl/compiler/tests/perf_report_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/profiler_test.py
+++ b/src/beanmachine/ppl/compiler/tests/profiler_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/query_type_zero_bug_test.py
+++ b/src/beanmachine/ppl/compiler/tests/query_type_zero_bug_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/rules_test.py
+++ b/src/beanmachine/ppl/compiler/tests/rules_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/single_assignment_test.py
+++ b/src/beanmachine/ppl/compiler/tests/single_assignment_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/sizer_test.py
+++ b/src/beanmachine/ppl/compiler/tests/sizer_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/stochastic_control_flow_test.py
+++ b/src/beanmachine/ppl/compiler/tests/stochastic_control_flow_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/support_test.py
+++ b/src/beanmachine/ppl/compiler/tests/support_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/tensor_operations_test.py
+++ b/src/beanmachine/ppl/compiler/tests/tensor_operations_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/to_matrix_test.py
+++ b/src/beanmachine/ppl/compiler/tests/to_matrix_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/to_probability_test.py
+++ b/src/beanmachine/ppl/compiler/tests/to_probability_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/tutorial_GMM_with_1_dimensions_and_4_components_test.py
+++ b/src/beanmachine/ppl/compiler/tests/tutorial_GMM_with_1_dimensions_and_4_components_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/tutorial_GMM_with_2_dimensions_and_4_components_test.py
+++ b/src/beanmachine/ppl/compiler/tests/tutorial_GMM_with_2_dimensions_and_4_components_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/tutorial_Neals_Funnel_test.py
+++ b/src/beanmachine/ppl/compiler/tests/tutorial_Neals_Funnel_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/tutorial_Robust_Linear_Regression_test.py
+++ b/src/beanmachine/ppl/compiler/tests/tutorial_Robust_Linear_Regression_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/tests/typer_base_test.py
+++ b/src/beanmachine/ppl/compiler/tests/typer_base_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/compiler/typer_base.py
+++ b/src/beanmachine/ppl/compiler/typer_base.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/conftest.py
+++ b/src/beanmachine/ppl/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/diagnostics/__init__.py
+++ b/src/beanmachine/ppl/diagnostics/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/diagnostics/common_plots.py
+++ b/src/beanmachine/ppl/diagnostics/common_plots.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/diagnostics/common_statistics.py
+++ b/src/beanmachine/ppl/diagnostics/common_statistics.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/diagnostics/diagnostics.py
+++ b/src/beanmachine/ppl/diagnostics/diagnostics.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/diagnostics/tests/diagnostics_test.py
+++ b/src/beanmachine/ppl/diagnostics/tests/diagnostics_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/distribution/__init__.py
+++ b/src/beanmachine/ppl/distribution/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/distribution/flat.py
+++ b/src/beanmachine/ppl/distribution/flat.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/examples/conjugate_models/__init__.py
+++ b/src/beanmachine/ppl/examples/conjugate_models/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/examples/conjugate_models/beta_bernoulli.py
+++ b/src/beanmachine/ppl/examples/conjugate_models/beta_bernoulli.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/examples/conjugate_models/beta_binomial.py
+++ b/src/beanmachine/ppl/examples/conjugate_models/beta_binomial.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/examples/conjugate_models/categorical_dirichlet.py
+++ b/src/beanmachine/ppl/examples/conjugate_models/categorical_dirichlet.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/examples/conjugate_models/gamma_gamma.py
+++ b/src/beanmachine/ppl/examples/conjugate_models/gamma_gamma.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/examples/conjugate_models/gamma_normal.py
+++ b/src/beanmachine/ppl/examples/conjugate_models/gamma_normal.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/examples/conjugate_models/normal_normal.py
+++ b/src/beanmachine/ppl/examples/conjugate_models/normal_normal.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/experimental/abc/abc_infer.py
+++ b/src/beanmachine/ppl/experimental/abc/abc_infer.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/experimental/abc/abc_smc_infer.py
+++ b/src/beanmachine/ppl/experimental/abc/abc_smc_infer.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/experimental/abc/adaptive_abc_smc_infer.py
+++ b/src/beanmachine/ppl/experimental/abc/adaptive_abc_smc_infer.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/experimental/gp/__init__.py
+++ b/src/beanmachine/ppl/experimental/gp/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/experimental/gp/kernels.py
+++ b/src/beanmachine/ppl/experimental/gp/kernels.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/experimental/gp/likelihoods.py
+++ b/src/beanmachine/ppl/experimental/gp/likelihoods.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/experimental/gp/models.py
+++ b/src/beanmachine/ppl/experimental/gp/models.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/experimental/inference_compilation/ic_infer.py
+++ b/src/beanmachine/ppl/experimental/inference_compilation/ic_infer.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/experimental/inference_compilation/utils.py
+++ b/src/beanmachine/ppl/experimental/inference_compilation/utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/experimental/neutra/iafflow.py
+++ b/src/beanmachine/ppl/experimental/neutra/iafflow.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/experimental/neutra/iaflayer.py
+++ b/src/beanmachine/ppl/experimental/neutra/iaflayer.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/experimental/neutra/iafmcmc_infer.py
+++ b/src/beanmachine/ppl/experimental/neutra/iafmcmc_infer.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/experimental/neutra/iafmcmc_proposer.py
+++ b/src/beanmachine/ppl/experimental/neutra/iafmcmc_proposer.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/experimental/neutra/maskedautoencoder.py
+++ b/src/beanmachine/ppl/experimental/neutra/maskedautoencoder.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/experimental/neutra/maskedlinear.py
+++ b/src/beanmachine/ppl/experimental/neutra/maskedlinear.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/experimental/neutra/tests/iaf_conjugate_test_nightly.py
+++ b/src/beanmachine/ppl/experimental/neutra/tests/iaf_conjugate_test_nightly.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/experimental/neutra/tests/iafflow_model_test.py
+++ b/src/beanmachine/ppl/experimental/neutra/tests/iafflow_model_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/experimental/neutra/tests/iaflayer_test.py
+++ b/src/beanmachine/ppl/experimental/neutra/tests/iaflayer_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/experimental/neutra/tests/iafmcmc_do_adaptation_test.py
+++ b/src/beanmachine/ppl/experimental/neutra/tests/iafmcmc_do_adaptation_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/experimental/neutra/tests/iafmcmc_infer_model_test.py
+++ b/src/beanmachine/ppl/experimental/neutra/tests/iafmcmc_infer_model_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/experimental/neutra/tests/iafmcmc_jacobian_test.py
+++ b/src/beanmachine/ppl/experimental/neutra/tests/iafmcmc_jacobian_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/experimental/neutra/tests/maskedautoencoder_test.py
+++ b/src/beanmachine/ppl/experimental/neutra/tests/maskedautoencoder_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/experimental/neutra/tests/maskedlinear_test.py
+++ b/src/beanmachine/ppl/experimental/neutra/tests/maskedlinear_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/experimental/neutra/tests/train_test.py
+++ b/src/beanmachine/ppl/experimental/neutra/tests/train_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/experimental/neutra/train.py
+++ b/src/beanmachine/ppl/experimental/neutra/train.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/experimental/tests/abc_infer_test.py
+++ b/src/beanmachine/ppl/experimental/tests/abc_infer_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/experimental/tests/abc_smc_infer_test.py
+++ b/src/beanmachine/ppl/experimental/tests/abc_smc_infer_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/experimental/tests/adaptive_abc_smc_infer_test.py
+++ b/src/beanmachine/ppl/experimental/tests/adaptive_abc_smc_infer_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/experimental/tests/gp/inference_test.py
+++ b/src/beanmachine/ppl/experimental/tests/gp/inference_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/experimental/tests/gp/kernel_test.py
+++ b/src/beanmachine/ppl/experimental/tests/gp/kernel_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/experimental/tests/gp/likelihood_test.py
+++ b/src/beanmachine/ppl/experimental/tests/gp/likelihood_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/experimental/tests/gp/models_test.py
+++ b/src/beanmachine/ppl/experimental/tests/gp/models_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/experimental/tests/inference_compilation_test.py
+++ b/src/beanmachine/ppl/experimental/tests/inference_compilation_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/experimental/tests/variable_elimination_test.py
+++ b/src/beanmachine/ppl/experimental/tests/variable_elimination_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/experimental/tests/vi/vi_test.py
+++ b/src/beanmachine/ppl/experimental/tests/vi/vi_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/experimental/variable_elimination/__init__.py
+++ b/src/beanmachine/ppl/experimental/variable_elimination/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/experimental/variable_elimination/util.py
+++ b/src/beanmachine/ppl/experimental/variable_elimination/util.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/experimental/variable_elimination/variable_elimination.py
+++ b/src/beanmachine/ppl/experimental/variable_elimination/variable_elimination.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/experimental/vi/mean_field_variational_approximation.py
+++ b/src/beanmachine/ppl/experimental/vi/mean_field_variational_approximation.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/experimental/vi/variational_infer.py
+++ b/src/beanmachine/ppl/experimental/vi/variational_infer.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/__init__.py
+++ b/src/beanmachine/ppl/inference/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/base_inference.py
+++ b/src/beanmachine/ppl/inference/base_inference.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/bmg_inference.py
+++ b/src/beanmachine/ppl/inference/bmg_inference.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/compositional_infer.py
+++ b/src/beanmachine/ppl/inference/compositional_infer.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/hmc_inference.py
+++ b/src/beanmachine/ppl/inference/hmc_inference.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/monte_carlo_samples.py
+++ b/src/beanmachine/ppl/inference/monte_carlo_samples.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/nuts_inference.py
+++ b/src/beanmachine/ppl/inference/nuts_inference.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/predictive.py
+++ b/src/beanmachine/ppl/inference/predictive.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/proposer/base_proposer.py
+++ b/src/beanmachine/ppl/inference/proposer/base_proposer.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/proposer/base_single_site_proposer.py
+++ b/src/beanmachine/ppl/inference/proposer/base_single_site_proposer.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/proposer/hmc_proposer.py
+++ b/src/beanmachine/ppl/inference/proposer/hmc_proposer.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/proposer/hmc_utils.py
+++ b/src/beanmachine/ppl/inference/proposer/hmc_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/proposer/nmc/__init__.py
+++ b/src/beanmachine/ppl/inference/proposer/nmc/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/proposer/nmc/single_site_half_space_nmc_proposer.py
+++ b/src/beanmachine/ppl/inference/proposer/nmc/single_site_half_space_nmc_proposer.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/proposer/nmc/single_site_real_space_nmc_proposer.py
+++ b/src/beanmachine/ppl/inference/proposer/nmc/single_site_real_space_nmc_proposer.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/proposer/nmc/single_site_simplex_space_nmc_proposer.py
+++ b/src/beanmachine/ppl/inference/proposer/nmc/single_site_simplex_space_nmc_proposer.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/proposer/nmc/tests/single_site_half_space_newtonian_monte_carlo_proposer_test.py
+++ b/src/beanmachine/ppl/inference/proposer/nmc/tests/single_site_half_space_newtonian_monte_carlo_proposer_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/proposer/nmc/tests/single_site_real_space_newtonian_monte_carlo_proposer_test.py
+++ b/src/beanmachine/ppl/inference/proposer/nmc/tests/single_site_real_space_newtonian_monte_carlo_proposer_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/proposer/nmc/tests/single_site_simplex_newtonian_monte_carlo_proposer_test.py
+++ b/src/beanmachine/ppl/inference/proposer/nmc/tests/single_site_simplex_newtonian_monte_carlo_proposer_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/proposer/nuts_proposer.py
+++ b/src/beanmachine/ppl/inference/proposer/nuts_proposer.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/proposer/sequential_proposer.py
+++ b/src/beanmachine/ppl/inference/proposer/sequential_proposer.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/proposer/single_site_ancestral_proposer.py
+++ b/src/beanmachine/ppl/inference/proposer/single_site_ancestral_proposer.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/proposer/single_site_random_walk_proposer.py
+++ b/src/beanmachine/ppl/inference/proposer/single_site_random_walk_proposer.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/proposer/single_site_uniform_proposer.py
+++ b/src/beanmachine/ppl/inference/proposer/single_site_uniform_proposer.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/proposer/tests/hmc_proposer_test.py
+++ b/src/beanmachine/ppl/inference/proposer/tests/hmc_proposer_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/proposer/tests/hmc_utils_test.py
+++ b/src/beanmachine/ppl/inference/proposer/tests/hmc_utils_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/proposer/tests/nuts_proposer_test.py
+++ b/src/beanmachine/ppl/inference/proposer/tests/nuts_proposer_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/sampler.py
+++ b/src/beanmachine/ppl/inference/sampler.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/single_site_ancestral_mh.py
+++ b/src/beanmachine/ppl/inference/single_site_ancestral_mh.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/single_site_inference.py
+++ b/src/beanmachine/ppl/inference/single_site_inference.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/single_site_nmc.py
+++ b/src/beanmachine/ppl/inference/single_site_nmc.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/single_site_random_walk.py
+++ b/src/beanmachine/ppl/inference/single_site_random_walk.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/single_site_uniform_mh.py
+++ b/src/beanmachine/ppl/inference/single_site_uniform_mh.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/tests/compositional_infer_conjugate_test_nightly.py
+++ b/src/beanmachine/ppl/inference/tests/compositional_infer_conjugate_test_nightly.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/tests/compositional_infer_test.py
+++ b/src/beanmachine/ppl/inference/tests/compositional_infer_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/tests/hypothesis_testing_nightly.py
+++ b/src/beanmachine/ppl/inference/tests/hypothesis_testing_nightly.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/tests/inference_error_reporting_test.py
+++ b/src/beanmachine/ppl/inference/tests/inference_error_reporting_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/tests/inference_integration_test_nightly.py
+++ b/src/beanmachine/ppl/inference/tests/inference_integration_test_nightly.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/tests/inference_test.py
+++ b/src/beanmachine/ppl/inference/tests/inference_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/tests/monte_carlo_samples_test.py
+++ b/src/beanmachine/ppl/inference/tests/monte_carlo_samples_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/tests/predictive_test.py
+++ b/src/beanmachine/ppl/inference/tests/predictive_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/tests/sampler_test.py
+++ b/src/beanmachine/ppl/inference/tests/sampler_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/tests/single_site_ancestral_mh_conjugate_test_nightly.py
+++ b/src/beanmachine/ppl/inference/tests/single_site_ancestral_mh_conjugate_test_nightly.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/tests/single_site_ancestral_mh_test.py
+++ b/src/beanmachine/ppl/inference/tests/single_site_ancestral_mh_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/tests/single_site_hamiltonian_monte_carlo_conjugate_test_nightly.py
+++ b/src/beanmachine/ppl/inference/tests/single_site_hamiltonian_monte_carlo_conjugate_test_nightly.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/tests/single_site_newtonian_monte_carlo_conjugate_test_nightly.py
+++ b/src/beanmachine/ppl/inference/tests/single_site_newtonian_monte_carlo_conjugate_test_nightly.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/tests/single_site_newtonian_monte_carlo_test.py
+++ b/src/beanmachine/ppl/inference/tests/single_site_newtonian_monte_carlo_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/tests/single_site_no_u_turn_conjugate_test_nightly.py
+++ b/src/beanmachine/ppl/inference/tests/single_site_no_u_turn_conjugate_test_nightly.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/tests/single_site_random_walk_adaptive_conjugate_test_nightly.py
+++ b/src/beanmachine/ppl/inference/tests/single_site_random_walk_adaptive_conjugate_test_nightly.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/tests/single_site_random_walk_conjugate_test_nightly.py
+++ b/src/beanmachine/ppl/inference/tests/single_site_random_walk_conjugate_test_nightly.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/tests/single_site_random_walk_test.py
+++ b/src/beanmachine/ppl/inference/tests/single_site_random_walk_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/tests/single_site_uniform_mh_conjugate_test_nightly.py
+++ b/src/beanmachine/ppl/inference/tests/single_site_uniform_mh_conjugate_test_nightly.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/tests/single_site_uniform_mh_test.py
+++ b/src/beanmachine/ppl/inference/tests/single_site_uniform_mh_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/tests/utils_test.py
+++ b/src/beanmachine/ppl/inference/tests/utils_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/inference/utils.py
+++ b/src/beanmachine/ppl/inference/utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/legacy/__init__.py
+++ b/src/beanmachine/ppl/legacy/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/legacy/inference/__init__.py
+++ b/src/beanmachine/ppl/legacy/inference/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/legacy/inference/abstract_infer.py
+++ b/src/beanmachine/ppl/legacy/inference/abstract_infer.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/legacy/inference/abstract_mh_infer.py
+++ b/src/beanmachine/ppl/legacy/inference/abstract_mh_infer.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/legacy/inference/compositional_infer.py
+++ b/src/beanmachine/ppl/legacy/inference/compositional_infer.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/legacy/inference/proposer/__init__.py
+++ b/src/beanmachine/ppl/legacy/inference/proposer/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/legacy/inference/proposer/abstract_single_site_proposer.py
+++ b/src/beanmachine/ppl/legacy/inference/proposer/abstract_single_site_proposer.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/legacy/inference/proposer/abstract_single_site_single_step_proposer.py
+++ b/src/beanmachine/ppl/legacy/inference/proposer/abstract_single_site_single_step_proposer.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/legacy/inference/proposer/newtonian_monte_carlo_utils.py
+++ b/src/beanmachine/ppl/legacy/inference/proposer/newtonian_monte_carlo_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/legacy/inference/proposer/normal_eig.py
+++ b/src/beanmachine/ppl/legacy/inference/proposer/normal_eig.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/legacy/inference/proposer/single_site_ancestral_proposer.py
+++ b/src/beanmachine/ppl/legacy/inference/proposer/single_site_ancestral_proposer.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/legacy/inference/proposer/single_site_half_space_newtonian_monte_carlo_proposer.py
+++ b/src/beanmachine/ppl/legacy/inference/proposer/single_site_half_space_newtonian_monte_carlo_proposer.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/legacy/inference/proposer/single_site_hamiltonian_monte_carlo_proposer.py
+++ b/src/beanmachine/ppl/legacy/inference/proposer/single_site_hamiltonian_monte_carlo_proposer.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/legacy/inference/proposer/single_site_newtonian_monte_carlo_proposer.py
+++ b/src/beanmachine/ppl/legacy/inference/proposer/single_site_newtonian_monte_carlo_proposer.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/legacy/inference/proposer/single_site_no_u_turn_sampler_proposer.py
+++ b/src/beanmachine/ppl/legacy/inference/proposer/single_site_no_u_turn_sampler_proposer.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/legacy/inference/proposer/single_site_random_walk_proposer.py
+++ b/src/beanmachine/ppl/legacy/inference/proposer/single_site_random_walk_proposer.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/legacy/inference/proposer/single_site_real_space_newtonian_monte_carlo_proposer.py
+++ b/src/beanmachine/ppl/legacy/inference/proposer/single_site_real_space_newtonian_monte_carlo_proposer.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/legacy/inference/proposer/single_site_simplex_newtonian_monte_carlo_proposer.py
+++ b/src/beanmachine/ppl/legacy/inference/proposer/single_site_simplex_newtonian_monte_carlo_proposer.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/legacy/inference/proposer/single_site_uniform_proposer.py
+++ b/src/beanmachine/ppl/legacy/inference/proposer/single_site_uniform_proposer.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/legacy/inference/proposer/tests/abstract_single_site_single_step_proposer_test.py
+++ b/src/beanmachine/ppl/legacy/inference/proposer/tests/abstract_single_site_single_step_proposer_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/legacy/inference/proposer/tests/normal_eig_test.py
+++ b/src/beanmachine/ppl/legacy/inference/proposer/tests/normal_eig_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/legacy/inference/proposer/tests/single_site_hamiltonian_monte_carlo_proposer_test.py
+++ b/src/beanmachine/ppl/legacy/inference/proposer/tests/single_site_hamiltonian_monte_carlo_proposer_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/legacy/inference/proposer/tests/single_site_no_u_turn_sampler_proposer_test.py
+++ b/src/beanmachine/ppl/legacy/inference/proposer/tests/single_site_no_u_turn_sampler_proposer_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/legacy/inference/rejection_sampling_infer.py
+++ b/src/beanmachine/ppl/legacy/inference/rejection_sampling_infer.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/legacy/inference/sampler.py
+++ b/src/beanmachine/ppl/legacy/inference/sampler.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/legacy/inference/single_site_ancestral_mh.py
+++ b/src/beanmachine/ppl/legacy/inference/single_site_ancestral_mh.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/legacy/inference/single_site_hamiltonian_monte_carlo.py
+++ b/src/beanmachine/ppl/legacy/inference/single_site_hamiltonian_monte_carlo.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/legacy/inference/single_site_newtonian_monte_carlo.py
+++ b/src/beanmachine/ppl/legacy/inference/single_site_newtonian_monte_carlo.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/legacy/inference/single_site_no_u_turn_sampler.py
+++ b/src/beanmachine/ppl/legacy/inference/single_site_no_u_turn_sampler.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/legacy/inference/single_site_random_walk.py
+++ b/src/beanmachine/ppl/legacy/inference/single_site_random_walk.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/legacy/inference/single_site_uniform_mh.py
+++ b/src/beanmachine/ppl/legacy/inference/single_site_uniform_mh.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/legacy/inference/tests/compositional_infer_test.py
+++ b/src/beanmachine/ppl/legacy/inference/tests/compositional_infer_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/legacy/inference/tests/rejection_sampling_infer_test.py
+++ b/src/beanmachine/ppl/legacy/inference/tests/rejection_sampling_infer_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/legacy/inference/tests/sampler_test.py
+++ b/src/beanmachine/ppl/legacy/inference/tests/sampler_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/legacy/inference/tests/single_site_hamiltonian_monte_carlo_test.py
+++ b/src/beanmachine/ppl/legacy/inference/tests/single_site_hamiltonian_monte_carlo_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/legacy/inference/utils.py
+++ b/src/beanmachine/ppl/legacy/inference/utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/legacy/world/__init__.py
+++ b/src/beanmachine/ppl/legacy/world/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/legacy/world/diff.py
+++ b/src/beanmachine/ppl/legacy/world/diff.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/legacy/world/diff_stack.py
+++ b/src/beanmachine/ppl/legacy/world/diff_stack.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/legacy/world/marginal_table.py
+++ b/src/beanmachine/ppl/legacy/world/marginal_table.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/legacy/world/tests/diff_stack_test.py
+++ b/src/beanmachine/ppl/legacy/world/tests/diff_stack_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/legacy/world/tests/marginal_table_test.py
+++ b/src/beanmachine/ppl/legacy/world/tests/marginal_table_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/legacy/world/tests/variable_test.py
+++ b/src/beanmachine/ppl/legacy/world/tests/variable_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/legacy/world/tests/world_test.py
+++ b/src/beanmachine/ppl/legacy/world/tests/world_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/legacy/world/variable.py
+++ b/src/beanmachine/ppl/legacy/world/variable.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/legacy/world/world.py
+++ b/src/beanmachine/ppl/legacy/world/world.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/legacy/world/world_vars.py
+++ b/src/beanmachine/ppl/legacy/world/world_vars.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/model/__init__.py
+++ b/src/beanmachine/ppl/model/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/model/rv_identifier.py
+++ b/src/beanmachine/ppl/model/rv_identifier.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/model/statistical_model.py
+++ b/src/beanmachine/ppl/model/statistical_model.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/model/tests/rv_identifier_test.py
+++ b/src/beanmachine/ppl/model/tests/rv_identifier_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/model/tests/statistical_model_test.py
+++ b/src/beanmachine/ppl/model/tests/statistical_model_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/model/utils.py
+++ b/src/beanmachine/ppl/model/utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/testlib/abstract_conjugate.py
+++ b/src/beanmachine/ppl/testlib/abstract_conjugate.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/testlib/hypothesis_testing.py
+++ b/src/beanmachine/ppl/testlib/hypothesis_testing.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/testlib/tests/hypothesis_testing_test.py
+++ b/src/beanmachine/ppl/testlib/tests/hypothesis_testing_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/tests/smoke_test.py
+++ b/src/beanmachine/ppl/tests/smoke_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/utils/__init__.py
+++ b/src/beanmachine/ppl/utils/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/utils/dotbuilder.py
+++ b/src/beanmachine/ppl/utils/dotbuilder.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/utils/equivalence.py
+++ b/src/beanmachine/ppl/utils/equivalence.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/utils/graph.py
+++ b/src/beanmachine/ppl/utils/graph.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/utils/item_counter.py
+++ b/src/beanmachine/ppl/utils/item_counter.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/utils/memoize.py
+++ b/src/beanmachine/ppl/utils/memoize.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/utils/set_of_tensors.py
+++ b/src/beanmachine/ppl/utils/set_of_tensors.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/utils/tensorops.py
+++ b/src/beanmachine/ppl/utils/tensorops.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/utils/tests/dotbuilder_test.py
+++ b/src/beanmachine/ppl/utils/tests/dotbuilder_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/utils/tests/equivalence_test.py
+++ b/src/beanmachine/ppl/utils/tests/equivalence_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/utils/tests/graph_test.py
+++ b/src/beanmachine/ppl/utils/tests/graph_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/utils/tests/item_counter_test.py
+++ b/src/beanmachine/ppl/utils/tests/item_counter_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/utils/tests/memoize_test.py
+++ b/src/beanmachine/ppl/utils/tests/memoize_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/utils/tests/set_of_tensors_test.py
+++ b/src/beanmachine/ppl/utils/tests/set_of_tensors_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/utils/tests/tensorops_test.py
+++ b/src/beanmachine/ppl/utils/tests/tensorops_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/utils/tests/treeprinter_test.py
+++ b/src/beanmachine/ppl/utils/tests/treeprinter_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/utils/treeprinter.py
+++ b/src/beanmachine/ppl/utils/treeprinter.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/utils/unique_name.py
+++ b/src/beanmachine/ppl/utils/unique_name.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/world/__init__.py
+++ b/src/beanmachine/ppl/world/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/world/base_world.py
+++ b/src/beanmachine/ppl/world/base_world.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/world/initialize_fn.py
+++ b/src/beanmachine/ppl/world/initialize_fn.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/world/tests/initialize_fn_test.py
+++ b/src/beanmachine/ppl/world/tests/initialize_fn_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/world/tests/utils_test.py
+++ b/src/beanmachine/ppl/world/tests/utils_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/world/tests/variable_test.py
+++ b/src/beanmachine/ppl/world/tests/variable_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/world/tests/world_test.py
+++ b/src/beanmachine/ppl/world/tests/world_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/world/utils.py
+++ b/src/beanmachine/ppl/world/utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/world/variable.py
+++ b/src/beanmachine/ppl/world/variable.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/world/world.py
+++ b/src/beanmachine/ppl/world/world.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/tutorials/etl.py
+++ b/tutorials/etl.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/tutorials/plots.py
+++ b/tutorials/plots.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/tutorials/utils/__init__.py
+++ b/tutorials/utils/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/tutorials/utils/baseball.py
+++ b/tutorials/utils/baseball.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/tutorials/utils/hearts.py
+++ b/tutorials/utils/hearts.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/tutorials/utils/nba.py
+++ b/tutorials/utils/nba.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/tutorials/utils/radon.py
+++ b/tutorials/utils/radon.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/website/.eslintrc.js
+++ b/website/.eslintrc.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
@@ -38,7 +38,7 @@ module.exports = {
 
       [
         '*',
-        ' * Copyright (c) Meta Platforms, Inc. and its affiliates.',
+        ' * Copyright (c) Meta Platforms, Inc. and affiliates.',
         ' *',
         ' * This source code is licensed under the MIT license found in the',
         ' * LICENSE file in the root directory of this source tree.',

--- a/website/.stylelintrc.js
+++ b/website/.stylelintrc.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/babel.config.js
+++ b/website/babel.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/pages/styles.module.css
+++ b/website/src/pages/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.


### PR DESCRIPTION
Summary:
I notice that our [automated repo checkup still fails](https://www.internalfb.com/intern/opensource/github/repo/426242671583155/checkup) after D32979001 (https://github.com/facebookresearch/beanmachine/commit/28bf0d626c8b29b0e761b783c1cadb9b853eacdb) landed. So it turns out that the new Meta header is slightly different from the Facebook ones (other than the company name change), i.e.:

the old header begins with:
```
Copyright (c) Facebook, Inc. and its affiliates
```
whereas the new header begins with
```
Copyright (c) Meta Platforms, Inc. and affiliates.
```

As you can probably tell, I forgot to remove "its" as part of the update, so the [automatic repo checkup](https://www.internalfb.com/intern/opensource/github/repo/426242671583155/checkup) cannot find the matching regex.

To fix this, I ran the following command on the root of our repo:

```
find ./ -type f -exec sed -i 's/Meta Platforms, Inc\. and its affiliates/Meta Platforms, Inc\. and affiliates/g'  {} \;
```

Reviewed By: jpchen

Differential Revision: D32994567

