### PR TITLE
"facebookincubator/BeanMachine" -> "facebookresearch/beanmachine"

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,7 +17,7 @@ Please provide clear instructions on how the changes were verified. Attach scree
 - [ ] My code follows the code style of this project.
 - [ ] My change requires a change to the documentation.
 - [ ] I have updated the documentation accordingly.
-- [ ] I have read the **[CONTRIBUTING](https://github.com/facebookincubator/BeanMachine/blob/master/CONTRIBUTING.md)** document.
+- [ ] I have read the **[CONTRIBUTING](https://github.com/facebookresearch/beanmachine/blob/master/CONTRIBUTING.md)** document.
 - [ ] I have added tests to cover my changes.
 - [ ] All new and existing tests passed.
 - [ ] The title of my pull request is a short description of the requested changes.

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ setup(
     url="https://beanmachine.org",
     project_urls={
         "Documentation": "https://beanmachine.org",
-        "Source": "https://github.com/facebookincubator/BeanMachine",
+        "Source": "https://github.com/facebookresearch/beanmachine",
     },
     keywords=[
         "Probabilistic Programming Language",

--- a/src/beanmachine/ppl/compiler/tests/n-schools_test.py
+++ b/src/beanmachine/ppl/compiler/tests/n-schools_test.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 # """End-to-end test for n-schools model based on the one in PPL Bench"""
-# See for example https://github.com/facebookresearch/pplbench/blob/master/pplbench/models/n_schools.py
+# See for example https://github.com/facebookresearch/pplbench/blob/main/pplbench/models/n_schools.py
 
 import logging
 import unittest

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -15,7 +15,7 @@ module.exports = {
   title: 'Bean Machine',
   tagline:
     'A universal probabilistic programming language to enable fast and accurate Bayesian analysis',
-  url: 'https://beanmachine.org',  // Change to path for release.
+  url: 'https://beanmachine.org', // Change to path for release.
   baseUrl: '/', // for devserver preview use '/~brianjo/beanmachine/'
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
@@ -41,12 +41,12 @@ module.exports = {
         {
           to: '/docs/tutorials',
           label: 'Tutorials',
-          position: 'left'
+          position: 'left',
         },
         {
           href: 'pathname:///api/index.html',
           label: 'API',
-          position: 'left'
+          position: 'left',
         },
         // {to: 'blog', label: 'Blog', position: 'left'},
         // Please keep GitHub link to the right for consistency.
@@ -151,8 +151,10 @@ module.exports = {
           sidebarPath: require.resolve('./sidebars.js'),
           // Please change this to your repo.
           editUrl: fbContent({
-            internal: 'https://www.internalfb.com/intern/diffusion/FBS/browse/master/fbcode/beanmachine/website/',
-            external: 'https://github.com/facebook/docusaurus/edit/master/website/'
+            internal:
+              'https://www.internalfb.com/intern/diffusion/FBS/browse/master/fbcode/beanmachine/website/',
+            external:
+              'https://github.com/facebookresearch/beanmachine/edit/master/website/',
           }),
           remarkPlugins: [remarkMath],
           rehypePlugins: [rehypeKatex],
@@ -161,9 +163,11 @@ module.exports = {
           showReadingTime: true,
           // Please change this to your repo.
           editUrl: fbContent({
-            internal: 'https://www.internalfb.com/intern/diffusion/FBS/browse/master/fbcode/beanmachine/website/blog/',
-            external: 'https://github.com/facebook/docusaurus/edit/master/website/blog/'
-          })
+            internal:
+              'https://www.internalfb.com/intern/diffusion/FBS/browse/master/fbcode/beanmachine/website/blog/',
+            external:
+              'https://github.com/facebookresearch/beanmachine/edit/master/website/blog/',
+          }),
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
Summary: When preparing for the master -> main branch update, I notice that there're a few places that we still refer to our repo with the old URL. This diff fixes those occurrences as well as making a few small changes.

Differential Revision: D32998703

