### PR TITLE
Add a reference to license in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ docker run -it beanmachine:latest bash
 If you would like to run the builtin unit tests:
 
 ```bash
-pip install pytest
+# install pytest 7.0 from GitHub
+pip install git+https://github.com/pytest-dev/pytest.git@7.0.0.dev0
 pytest .
 ```
+
+## License
+Bean Machine is MIT licensed, as found in the [LICENSE](LICENSE) file.


### PR DESCRIPTION
Summary:
A reference to our license file is one of the requirements in out [automatic repo checkup](https://www.internalfb.com/intern/opensource/github/repo/426242671583155/checkup), so I'm adding a section similar to what [BoTorch has in their readme](https://github.com/pytorch/botorch/blob/main/README.md)

(also making a small change to pytest's installation instruction because the current command is guarantee to fail some tests)

Differential Revision: D33007221

