### PR TITLE
Fix the link to our GitHub Repo

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -51,7 +51,7 @@ module.exports = {
         // {to: 'blog', label: 'Blog', position: 'left'},
         // Please keep GitHub link to the right for consistency.
         {
-          href: 'https://github.com/facebook/docusaurus',
+          href: 'https://github.com/facebookresearch/beanmachine',
           label: 'GitHub',
           position: 'right',
         },


### PR DESCRIPTION
Summary:
Theu "GitHub" button on our navigation bar brought us to docusaurus's github repo, instead of our Bean Machine repo.

{F685881669}

Differential Revision: D33030049

