### PR TITLE
Add Beta warning to homepage

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -121,6 +121,16 @@ function Home() {
             </div>
           </section>
         )}
+        <div className="container">
+          <p>
+            <i>
+              <b>Status: Beta.  </b>
+              APIs are likely to change. Functionalities are constantly being
+              improved. Bug reports are welcome, but bandwidth is very limited
+              for feature requests.
+            </i>
+          </p>
+        </div>
       </main>
     </Layout>
   );


### PR DESCRIPTION
Summary: My attempt to add a beta warning to the front page of Bean Machine website. I'm terrible at web development so if someone has better skills, please feel free to take over. Bascially, I'd like for us to signal that we're in a Beta state, and that users should expect API changes and for us to not really entertain feature requests. I don't know how to convey this best to the user (e.g. I'm terrible at CSS and aesthetic decision-making), so like I said, feel free to commandeer this and take it over. Or we can land this so that we have __something__, and then patch it up afterwards if someone's better at web development than me.

Differential Revision: D33045798

