### PR TITLE
Back out "Add conditional Bean Machine pip install to Sparse Logistic Regression"

### DIFF
--- a/tutorials/Tutorial_Implement_sparse_logistic_regression.ipynb
+++ b/tutorials/Tutorial_Implement_sparse_logistic_regression.ipynb
@@ -67,9 +67,6 @@
    },
    "outputs": [],
    "source": [
-    "import sys\n",
-    "if 'google.colab' in sys.modules and 'beanmachine' not in sys.modules:\n",
-    "    !pip install beanmachine\n",
     "import os\n",
     "import beanmachine.ppl as bm\n",
     "\n",


### PR DESCRIPTION
Summary:
Original commit changeset: 80796f24582a

Original Phabricator Diff: D33046024 (https://github.com/facebookresearch/beanmachine/commit/4bcc07d249493c38351ff28d4522680451974733)

Reviewed By: michaeltingley

Differential Revision: D33046149

