### PR TITLE
Add scikit-learn dependency to tutorial requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,13 +19,14 @@ REQUIRED_MINOR = 7
 
 TEST_REQUIRES = ["pytest", "pytest-cov"]
 TUTORIALS_REQUIRES = [
+    "bokeh",
+    "cma",
+    "ipywidgets",
     "jupyter",
     "matplotlib",
-    "cma",
-    "torchvision",
+    "scikit-learn>=1.0.0",
     "seaborn",
-    "bokeh",
-    "ipywidgets",
+    "torchvision",
 ]
 DEV_REQUIRES = (
     TEST_REQUIRES


### PR DESCRIPTION
Summary: Scikit learn is used by the Sparse Regression tutorial, and provides many useful utilities and metrics that can be useful for tutorial authors. This adds the dependency to our setup file and will be installed with `pip install -e ".[dev]"`.

Differential Revision: D33047076

