### PR TITLE
Fix MonteCarloSamples.get_variable

### DIFF
--- a/src/beanmachine/ppl/inference/monte_carlo_samples.py
+++ b/src/beanmachine/ppl/inference/monte_carlo_samples.py
@@ -112,7 +112,7 @@ class MonteCarloSamples(Mapping[RVIdentifier, torch.Tensor]):
         samples = self.samples[rv]
 
         if include_adapt_steps:
-            samples = torch.cat([samples, self.adaptive_samples[rv]], dim=1)
+            samples = torch.cat([self.adaptive_samples[rv], samples], dim=1)
 
         if thinning > 1:
             samples = samples[:, ::thinning]

--- a/src/beanmachine/ppl/inference/tests/monte_carlo_samples_test.py
+++ b/src/beanmachine/ppl/inference/tests/monte_carlo_samples_test.py
@@ -165,6 +165,18 @@ class MonteCarloSamplesTest(unittest.TestCase):
         inference_data = samples.to_inference_data()
         self.assertIn(model.foo(), inference_data.posterior)
 
+    def test_get_variable(self):
+        model = self.SampleModel()
+        samples = MonteCarloSamples(
+            [{model.foo(): torch.arange(10)}], num_adaptive_samples=3
+        ).get_chain(0)
+        self.assertTrue(
+            torch.all(samples.get_variable(model.foo()) == torch.arange(3, 10))
+        )
+        self.assertTrue(
+            torch.all(samples.get_variable(model.foo(), True) == torch.arange(10))
+        )
+
     def test_thinning(self):
         model = self.SampleModel()
         mh = bm.SingleSiteAncestralMetropolisHastings()


### PR DESCRIPTION
Summary:
I've been trying to figure out why the log likelihood of my model drops a ton during the last half or so iterations. Whelp, this is why: when calling `samples.get_variable(node, include_adapt_steps=True)`, the adaptive samples are concatenated *after* the actual samples, instead of *before* it.

This bug also affects all algorithms that call `samples.get_chain()`, since `get_chain` invoke `get_variable` internally.

This is one of the predictive log likelihood plots I'm talking about: the sudden drop is where the adaptive iteration begins

{F686154100}

I wrote this line of code 9 months ago. I wonder how many people have been using `get_chain`  without noticing this bug 😢. Hopefully it's not too late to fix it now

Differential Revision: D33047675

