### PR TITLE
Compositional inference doc update

### DIFF
--- a/docs/framework_topics/custom_inference/compositional_inference.md
+++ b/docs/framework_topics/custom_inference/compositional_inference.md
@@ -1,55 +1,90 @@
 ---
 id: compositional_inference
-title: 'Block and Compositional Inference'
-sidebar_label: 'Block and Compositional Inference'
+title: 'Compositional Inference'
+sidebar_label: 'Compositional Inference'
 slug: '/compositional_inference'
 ---
 
-Single-site inference is not always suitable for models with highly correlated variables because, given a global assignment (or a *state*) in the probability distribution, changing the value of only one variable leads to a new, highly unlikely state that will rarely generate a useful sample. In other words, we may end up at a region of the posterior distribution where individual updates proposing a new value for a single random variable and deciding to accept or reject the new value (based on the Metropolis Hasting rule) are not good enough to be accepted. In these examples, however, if we change the values of a group of random variables together, we may be able to successfully change to another likely state, exploring the posterior more efficiently. Block inference allows Bean Machine to overcome the limitations of single site because highly correlated variables are updated together, allowing for states with higher probabilities.
+Sometimes it might be hard to pick a single algorithm that performs well on the entire model. For example, while gradient-based algorithms such as [No-U-Turn Sampler](../inference/no_u_turn_sampler.md) and [Newtonian Monte Carlo](../inference/newtonian_monte_carlo.md) generally yield high number of effective samples, they can only handle random variables with continuous support. On the other hand, while single site algorithms make it easier to update high-dimensional models by proposing only one node at a time, they might have trouble updating models with highly correlated random variables. Fortunately, Bean Machine supports composable inference through the `CompositionalInference` class, which allows us to use different inference methods to update different subset of nodes and to "block" multiple nodes together so that they are accepted/rejected jointly by a single Metropolis-Hastings step. In this doc, we will cover the basics of `CompositionalInference` and how to mix-and-match different inference algorithms. To learn about how to do "block inference" with `CompositionalInference`, see [Block Inference](block_inference.md).
 
-Referring back to the Gaussian Mixture Model (GMM), we have the following:
+## Default Inference Methods
+
+By default, Compositional Inference will pick a single site algorithm to update each of the latent variable in the model based on its support:
+
+| Support | Algorithm
+| --- | ---
+| real | `SingleSiteNewtonianMonteCarlo` (real space proposer)
+| greater than | `SingleSiteNewtonianMonteCarlo` (half space proposer)
+| simplex |`SingleSiteNewtonianMonteCarlo` (simplex space proposer)
+| finite discrete | `SingleSiteUniformMetropolisHastings`
+| everything else | `SingleSiteAncestralMetropolisHastings`
+
+To run `CompositionalInference` with these default inference methods, simply leave the inference argument empty:
+
+```py
+CompositionalInference().infer(
+    queries,
+    observations,
+    num_samples,
+    num_chains,
+    num_adaptive_samples,
+)
+```
+
+The parameters to `infer` are described below:
+
+| Name | Usage
+| --- | ---
+| `queries` | A `List` of `@bm.random_variable` targets to fit posterior distributions for.
+| `observations` | The `Dict` of observations. Each key is a random variable, and its value is the observed value for that random variable.
+| `num_samples` | Number of samples to build up distributions for the values listed in `queries`.
+| `num_chains` | Number of separate inference runs to use. Multiple chains can be used by diagnostics to verify inference ran correctly.
+| `num_adaptive_samples` | The integer number of samples to spend before `num_samples` on tuning the inference algorithm for the `queries`.
+
+
+## Configuring Your Own Inference
+
+`CompositionalInference` also takes an optional dictionary, namely, the `inference_dict`, which can be used to override the default behavior.
+In the following sections, assume that we're working with a toy model with three random variable families, `foo`, `bar`, and `baz`:
 
 ```py
 @bm.random_variable
-def alpha():
-    return dist.Dirichlet(torch.ones(K))
+def foo(i):
+    return dist.Beta(2.0, 2.0)
 
 @bm.random_variable
-def component(i):
-    return dist.Categorical(alpha())
+def bar(i):
+    return dist.Bernoulli(foo(i))
 
 @bm.random_variable
-def mu(c):
-    return dist.MultivariateNormal(
-        loc=torch.zeros(2),
-        covariance_matrix=10.*torch.eye(2)
-   )
-
-@bm.random_variable
-def sigma(c):
-    return dist.Gamma(1, 1)
-
-@bm.random_variable
-def y(i):
-    c = component(i)
-    return dist.MultivariateNormal(
-        loc=mu(c),
-        covariance_matrix=sigma(c)**2*torch.eye(2)
-   )
+def baz(j):
+    return dist.Normal(0.0, 1.0)
 ```
 
-In the model above, we can either:
+### Choosing different inference methods for different random variable families
 
-  * Use single site inference: where we propose a new value for each random variable, and accept/reject them individually using the Metropolis Hastings rule.
-  * Use block inference: where we block random variables together, sequentially propose a new value for the random variables in the block and accept/reject all proposed values together. For instance, if the proposed value of component(i), which is the component assignment for the ith data point, is to go from c to c', then y(i) is no longer a child of mu(c) and sigma(c) and is instead a child of mu(c') and sigma(c'). The likelihood of the world with the component(i)‘s new proposal alone is low, because, all mu(c), sigma(c), mu(c') and sigma(c') are all sampled with the assumption that y(i) was observed from component, c. Our solution here is to propose new values for mu(c), sigma(c), mu(c'), sigma(c') and component(i) and accept/reject all 5 values together.
-
-To run block inference, you can:
+To select an inference algorithm for a particular random variable family, pass the random variable family as the key and an instance of the inference algorithm as value.
+For example, the following snippet tells `CompositionalInference` to use `SingleSiteNoUTurnSampler()` to update all instances of `foo` and `SingleSiteHamiltonianMonteCarlo(1.0)` to update all instance of `baz`.
+Nodes that are not specified, such as instances of `bar`, will fall back to the default inference methods mentioned above.
 
 ```py
-mh = bm.CompositionalInference()
-mh.add_sequential_proposer([component, sigma, mu])
-
-samples = mh.infer(queries, observations, n_samples, num_chains)
+bm.CompositionalInference({
+    foo: bm.SingleSiteNoUTurnSampler(),
+    baz: bm.SingleSiteHamiltonianMonteCarlo(trajectory_length=1.0),
+}).infer(**args) # same parameters as shown above
 ```
 
-Note that the user does not need to tell Bean Machine which `mu` and `sigma` need to be grouped with the component. Bean Machine only requires the random variable families to be passed to `add_sequential_proposer`. The Bean Machine inference engine can then use the model dependency structure after re-sampling `component(i)` from $c$ to $c'$ to also re-sample all `mu` and `sigma` in old `component(i)`‘s Markov Blanket, `mu($c$)` and `sigma($c$)` and `mu` and `sigma` in the new Markov Blanket, `mu($c'$)` and `sigma($c'$)`.
+You may notice that we are using what we referred to as "random variable families" like `foo` as keys, which are essentially functions that generates the random variables, instead of using instances of random variables such as `foo(0)` and `foo(1)`. This is because often times the number of random variable is not known ahead of time until an inference starts with some data (you can even have unbounded number of nodes in some model). By using random variable family in the config, we no longer need to explicitly spell out all every instance in a huge dictionary.
+
+### Overriding default inference method
+
+If your model has a large number of nodes and you want to override the default inference method for all of them without listing them all, you can use Python's `Ellipsis` literal, or equivalently, `...` (three dots), as a key to specify the default inference method for nodes that are not specified in the dictionary. For example, the following code snippet tells `CompositionalInference` to use `SingleSiteUniformMetropolisHastings()` to update all instances of `bar` (which are discrete), and use `SingleSiteNoUTurnSampler()` to update the rest of nodes (which are all continuous).
+
+```py
+bm.CompositionalInference({
+    bar: bm.SingleSiteUniformMetropolisHastings(),
+    ...: bm.SingleSiteNoUTurnSampler(),
+}).infer(**args) # same parameters as shown above
+```
+
+Bean Machine provides a great variety of inference methods under [`beanmachine.ppl.inference`](https://beanmachine.org/api/beanmachine.ppl.inference.html) that can be used with the `CompositionalInference` API. To learn more about what else can be done with `CompositionalInference`, see [Block Inference](block_inference.md).

--- a/docs/framework_topics/inference/hamiltonian_monte_carlo.md
+++ b/docs/framework_topics/inference/hamiltonian_monte_carlo.md
@@ -105,8 +105,8 @@ In Bean Machine, inference using HMC can be specified as an inference method for
 
 ```py
 bm.SingleSiteHamiltonianMonteCarlo(
-    path_length=1.0,
-    step_size=0.1,
+    trajectory_length=1.0,
+    initial_step_size=0.1,
 ).infer(
     queries,
     observations,
@@ -119,9 +119,9 @@ bm.SingleSiteHamiltonianMonteCarlo(
 
 ```py
 bm.CompositionalInference({
-    x: SingleSiteHamiltonianMonteCarloProposer(
-        path_length=1.0,
-        step_size=0.1,
+    x: bm.SingleSiteHamiltonianMonteCarlo(
+        trajectory_length=1.0,
+        initial_step_size=0.1,
     ),
 }).infer(
     # Same arguments as above snippet
@@ -133,7 +133,7 @@ All the above will only update one random variable at a time per iteration. To r
 ```py
 bm.GlobalHamiltonianMonteCarlo(
     trajectory_length=1.0,
-    step_size=0.1,
+    initial_step_size=0.1,
 ).infer(
     # Same arguments as above snippet
 )
@@ -143,7 +143,7 @@ Adaptive HMC will be used automatically when no step size is specified:
 
 ```py
 bm.SingleSiteHamiltonianMonteCarlo(
-    path_length=1.0,
+    trajectory_length=1.0,
 ).infer(
     queries,
     observations,

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -37,8 +37,8 @@ module.exports = {
             'framework_topics/custom_inference/custom_proposers',
             // Todo, stale and not fully supported
             // 'framework_topics/custom_inference/transforms',
-            'framework_topics/custom_inference/block_inference',
             'framework_topics/custom_inference/compositional_inference',
+            'framework_topics/custom_inference/block_inference',
           ],
           'Model Evaluation': [
             'framework_topics/model_evaluation/diagnostics',
@@ -48,9 +48,7 @@ module.exports = {
           Development: ['framework_topics/development/logging'],
         },
       ],
-      Advanced: [
-        'overview/beanstalk/beanstalk',
-        ],
+      Advanced: ['overview/beanstalk/beanstalk'],
     },
     'overview/tutorials/tutorials',
     // TODO(sepehrakhavan): Re-display this once we have at least one package present.


### PR DESCRIPTION
Summary:
This diff contains a rewrite of the compositional inference doc. Since we have a page dedicated to block inference, I decided not to talk about blocking in this doc. So this page is just about some explanation on why compositional and how to configure an inference

Because the build error on the base revision, I wasn't able to preview how the page looks like on our website. Though I've been using a basic markdown editor, and hopefully things won't look too differently.

I also noticed that the HMC page have a snippet on compositional inference, so I also updated that page (as well as making a few changes to correct the parameter name). I haven't gave HMC doc a close look yet and probably should do that soon...

Differential Revision: D33056016

