### PR TITLE
Temporarily disabling Numba to suppress warnings in az.plot_posterior

### DIFF
--- a/tutorials/Item_Response_Theory.ipynb
+++ b/tutorials/Item_Response_Theory.ipynb
@@ -3778,22 +3778,8 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "name": "python"
   }
  },
  "nbformat": 4,

--- a/tutorials/Item_Response_Theory.ipynb
+++ b/tutorials/Item_Response_Theory.ipynb
@@ -83,12 +83,14 @@
    "outputs": [],
    "source": [
     "import sys\n",
-    "if 'google.colab' in sys.modules and 'beanmachine' not in sys.modules:\n",
+    "\n",
+    "if \"google.colab\" in sys.modules and \"beanmachine\" not in sys.modules:\n",
     "    !pip install beanmachine\n",
     "import warnings\n",
     "import os\n",
     "\n",
     "import arviz as az\n",
+    "from arviz.utils import Numba\n",
     "import torch\n",
     "import torch.distributions as dist\n",
     "from bokeh.io import output_notebook\n",
@@ -99,7 +101,8 @@
     "from beanmachine.ppl.model import RVIdentifier\n",
     "from beanmachine.tutorials.utils import nba\n",
     "\n",
-    "smoke_test = ('SANDCASTLE_NEXUS' in os.environ or 'CI' in os.environ)"
+    "Numba.disable_numba()\n",
+    "smoke_test = \"SANDCASTLE_NEXUS\" in os.environ or \"CI\" in os.environ"
    ]
   },
   {
@@ -3775,8 +3778,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
### Motivation
This disables Numba in the IRT notebook which seems to be causing warnings when calling arviz functions

### Changes proposed
Outline the proposed changes and alternatives considered.

### Test Plan
Please provide clear instructions on how the changes were verified. Attach screenshots if applicable.

### Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](https://github.com/facebookresearch/beanmachine/blob/main/CONTRIBUTING.md)** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] The title of my pull request is a short description of the requested changes.
