### PR TITLE
Block inference doc update

### DIFF
--- a/docs/framework_topics/custom_inference/block_inference.md
+++ b/docs/framework_topics/custom_inference/block_inference.md
@@ -5,101 +5,108 @@ sidebar_label: 'Block Inference'
 slug: '/block_inference'
 ---
 
-Single-site inference in Bean Machine is a powerful abstraction that allows the inference engine to separately sample values for random variables in your model.
+Single-site inference in Bean Machine is a powerful abstraction that allows the inference engine to separately sample values for random variables in your model. While efficient in sampling high-dimensional models, single-site inference may not be suitable for models with highly correlated random variables. This is where Bean Machine's `CompositionalInference` API becomes handy: it allows us to "block" multiple nodes together and make proposals for them jointly.
 
-While single-site inference is efficient for many types of models, it may not be suitable for models with highly correlated random variables. To understand this better, let's walk through an example. Let's say we have two random variables $X$, $Y$ whose values are $x$ and $y$, and we'd like to move these values to $x'$ and $y'$. Using [single-site Metropolis-Hastings](framework_topics/inference/ancestral_metropolis_hastings.md), we will move from $(x, y)$ to $(x', y')$ with one of these series of updates:
+## Motivation
+
+To understand the issue better, let's walk through an example. Let's say we have two random variables $X$, $Y$ whose values are $x$ and $y$, and we'd like to move these values to $x'$ and $y'$. Using single site inference, we can move from $(x, y)$ to $(x', y')$ with either of these series of updates:
 
 1. $(x, y) \to (x', y) \to (x', y')$
 2. $(x, y) \to (x, y') \to (x', y')$
 
-While this might work, there are times that the move to the intermediate stage (the stage where the values are either $(x', y)$ or $(x, y')$) has a very low acceptance probability. In these cases, we can't move to (x', y') because we can't go through any of the paths above. However, this would have worked fine if we were to directly go from $(x, y) \to (x', y')$. To support this example, the optimal proposal strategy is to group the correlated variables and apply a Metropolis-Hastings update for them together. We refer to this strategy of group updating as _block inference_.
+If $X$ and $Y$ are strongly correlated, e.g., if both $p(x, y)$ and $p(x', y')$ are high, but the intermediate stage $p(x', y)$ and $p(x, y')$ are low, then the single site inference methods can be stuck in $(x, y)$, because the acceptance probability for transitioning out of the initial state is going to be very low for either of these two paths. This can lead to under-exploration of $(x', y')$, which will not happen if we block $X$ and $Y$ together, which can move from $(x, y) \to (x', y')$ in a single Metropolis-Hastings step.
 
-To understand how block inference can be effective, we consider the Hidden Markov Model (HMM) example below.
+
+:::tip
+
+If you haven't already read the docs on [Compositional Inference](compositional_inference.md), please read those first.
+
+:::
+
+## Configuring Block Inference
+
+To understand how to run block inference in Bean Machine, let's consider the discrete Hidden Markov Model (discrete HMM) example below:
 
 ```py
 # alpha, beta, rho, nu, and init are externally-defined constants.
 
-@random_variable
+@bm.random_variable
 def mu(k):
     return Normal(alpha, beta)
 
-@random_variable
+@bm.random_variable
 def sigma(k):
     return Gamma(nu, rho)
 
-@random_variable
+@bm.random_variable
 def theta(k):
     return Dirichlet(kappa)
 
-@random_variable
+@bm.random_variable
 def x(i):
-    if i:
-        return Categorical(theta(x(i - 1)))
-    return Categorical(init)
+    return Categorical(theta(x(i - 1)) if i else init)
 
-@random_variable
+@bm.random_variable
 def y(i):
     return Normal(mu(x(i)), sigma(x(i)))
 ```
 
-<!-- ![HMM diagram](../../../website/static/img/block_inference_hmm.png) -->
-![](/img/block_inference_hmm.png)
+This HMM describes a process with categorical latent states `x`, transition probabilities `theta`, and observed states `y` with emission probabilities determined by `mu` and `sigma`. Depending on the value of `theta`, the hidden state at each time step, `x(i)`, can be hightly correlated with the hidden state at the previous time step, `x(i-1)`. Therefore, we might want to block all instances of $x$ into a single block and propose new values for them jointly. Let's say we also want the parameters for emission probabilities, `mu` and `sigma`, to be updated jointly as well.
 
-This hidden Markov model describes a process with categorical latent states $X$, a transition function $theta$, and emitted values $Y$, whose values are drawn from a Normal distributions that have parameters $\mu$ and $\sigma$ particular to each latent state.
+### Defining a block
 
-In this model, we only observe the `y`'s and we want to infer the properties of the hidden states `x`'s, `mu`'s and `sigma`'s. Using single-site Metropolis-Hastings, when we propose a new value for `x(1)`, it may change `y(1)`'s parents from `mu(0)` and `sigma(0)` to `mu(1)` and `sigma(1)`. The old samples for `mu(1)` and `sigma(1)` likely no longer explain `y(1)`, so this updated world has a low probability.
-
-We can use block inference to address this low probability. In block inference, we can ask the inference engine to group `x`'s, `mu`'s and `sigma`'s to be updated together. Each block update is performed as explained below.
-
-To perform block inference by blocking together `x`, `mu`, and `sigma`, perform the following:
-  1. Propose new `x'` for `x`.
-  2. Update the world.
-  3. Add the Markov blankets for both `x` and `x'` to `markov_blanket`.
-  4. For each `mu` in `markov_blanket`:
-    a. Propose new `mu'` for `mu`.
-    b. Update the world.
-    c. Add the Markov blankets for `mu` and `mu'` to `markov_blanket`.
-  5. For each `sigma` in `markov_blanket`:
-    a. Propose new value `sigma'` for `sigma`.
-    b. Update the world.
-    c. Add the Markov blankets for `sigma` and `sigma'` to `markov_blanket`.
-  6. Accept / reject _all_ proposed values according to the Metropolis-Hastings acceptance ratio.
-
-Note that the accept / reject step is not performed until blocked variables in the Markov blanket are proposed for.
-
-Going back to the HMM example, let's walk through what happens when we run block inference for `x`, `mu`, and `sigma`. Let's imagine we update the value for `x(1)` from 0 to 1, which will cause `y(1)`'s parents to change from `mu(0)` and `sigma(0)` to `mu(1)` and `sigma(1)`. Now, because we've blocked together `x`, `mu`, and `sigma`, inference will try to update all four of `mu(0)`, `mu(1)`, `sigma(0)`, and `sigma(1)` after `x(1)` and accept/reject all five values together.
-
-Note that the user didn't need to tell the inference engine which `mu` and `sigma` to update along with each `x`. The inference engine itself was able to use the Markov blanket to figure out which `mu`'s and `sigma`'s need to be updated together.
-
-This image shows all of the variables that are jointly updated when updating `x(1)`:
-
-<!-- ![HMM diagram](../../../website/static/img/block_inference_hmm_update.png) -->
-![](/img/block_inference_hmm_update.png)
-
-## Single-Site and Block Inference
-
-Please note that once we enable block inference in Bean Machine, the engine will perform both block and single site updates in each inference iteration, so a single random variable might be updated multiple times in the same inference iteration. We shuffle all blocks before running inference, in order to minimize the influence of any particular way that we process the blocks.
-
-Below is how inference works with block inference enabled for a single iteration of inference:
-
-1. Shuffle all blocks.
-2. For each block:
-    a. If block is a single node block, perform single-site update
-    b. If block is multi node block, perform block update
-
-## Usage
-
-To enable block inference in Bean Machine, users can simply use `add_sequential_proposer` as below.
+You may recall that with [Compositional Inference](compositional_inference.md#configuring-your-own-inference), we can mix-and-match inference methods by providing a mapping from random variable families to inference algorithms through the `inference_dict` argument. The syntax for "blocking" multiple nodes together is similar: instead of having a single random variable as a key, you can pass a tuple of random variable families instead. For example:
 
 ```py
-mh = CompositionalInference()
-mh.add_sequential_proposer([x, mu, sigma])
-queries = (
-    [ x(N-1) ] +
-    [ theta(k) for k in range(K) ] +
-    [ mu(k) for k in range(K) ] +
-    [ sigma(k) for k in range(K) ]
-)
-obs = { y(i): data[i] for i in range(N) }
-samples = mh.infer(queries, obs)
+bm.CompositionalInference({
+    (x,): bm.SingleSiteAncestralMetropolisHastings(),
+    (mu, sigma): bm.GlobalNoUTurnSampler(),
+})
 ```
+
+The code snippet above is going to create two blocks: one for all instances of `x`, which will be inferred with `SingleSiteAncestralMetropolisHastings()`, and another for all instances of `mu` and `sigma`, which will be inferred with `GlobalNoUTurnSampler()`. Random variable families that are not specified in the dictionary will fall back to the [default inference methods](compositional_inference.md#default-inference-methods) and run without blocking.
+
+Note that even though single site inference algorithms only update one node at a time, they can still be used to update a block of nodes. What is going to happen internally is that instead of accepting or rejecting a single site proposal immediately after it is made, we condition on it to compute the next proposal, and repeat this process for the remaining nodes in a block. After we are done with all nodes in a block, we then compute the Metropolis-Hastings acceptance probability as if the proposals are made in a single step. (Be aware that many of the single site algorithm only works well when the number of nodes in a block is low, as they might have trouble updating the samples as dimension increases.) On the other hand, multi site inference algorithms, such as `GlobalNoUTurnSampler` that we are using here, can make proposal for a set of nodes in one go and can take advantage of correlation between multiple nodes. To learn more about the distinctions between the two types of inference methods and how to define your own algorithms, see [Custom Proposers](custom_proposers.md).
+
+### Mixing multiple inference methods in a block
+
+Sometimes you might want to use different algorithms to update different random variable families, but stil have them group together in a single block. To do so, you can pass a tuple of inference methods as the value, one for each of the random variable families in the key, for example:
+
+```py
+bm.CompositionalInference({
+    (mu, sigma): (bm.SingleSiteNewtonianMonteCarlo(), bm.SingleSiteAncestralMetropolisHastings()),
+})
+```
+which is equivalent to the following, more verbosed syntax with nested `CompositionalInference`:
+```py
+bm.CompositionalInference({
+    (mu, sigma): CompositionalInference({
+        mu: bm.SingleSiteNewtonianMonteCarlo(),
+        sigma: bm.SingleSiteAncestralMetropolisHastings(),
+    }),
+})
+```
+
+In both of these snippets, we will group all instances of `mu` and `sigma` into a single block, use `SingleSiteNewtonianMonteCarlo()` to update all instances of `mu` and `SingleSiteAncestralMetropolisHastings()` to update all instances of `sigma`. Since `CompositionalInference` itself is just another inference method, you can use it in any places where a inference method is expected.
+
+### Use the default inference method for a block
+
+If you are not planning to change the default inference methods selected by `CompositionalInference` and only want to define a few blocks in your model, you can use Python's `Ellipsis` literal, or equivalently, `...` (three dots), as the value. For example:
+
+```py
+bm.CompositionalInference({
+    (x,): ...,
+    (mu, sigma): ...,
+})
+```
+
+Similar to the previous example, this is also going to create two blocks for our HMM model. However, since we didn't provide any inference method, `CompositionalInference` will use the default method to update each node in the block instead. Note that this is different from having `Ellipsis` on the left hand side of the dictionary, i.e.,
+
+```py
+bm.CompositionalInference({
+    ...: bm.SingleSiteNoUTurnSampler(),
+})
+```
+which is used to override the default inference method and *does not* block the nodes automatically (unless you're using a multi-site algorithm, such as `bm.GlobalNoUTurnSampler()`, which always propose values jointly).
+
+To see a live example of running block inference with `CompositionalInference`, check out our [HMM tutorial](../../overview/tutorials/tutorials.md#hidden-markov-model).


### PR DESCRIPTION
Summary: Updated block inference doc with some examples on how to define blocks. Since this doc assumes that the readers have read about compositional inference, I skipped some basic concepts here

Differential Revision: D33086378

