### PR TITLE
Linear Regression tutorial excess logging fix

### DIFF
--- a/tutorials/Linear_Regression.ipynb
+++ b/tutorials/Linear_Regression.ipynb
@@ -663,12 +663,15 @@
    },
    "outputs": [],
    "source": [
+    "import logging\n",
+    "logging.getLogger(\"beanmachine\").setLevel(50) # eliminate excess logging except for progress bars\n",
     "samples_nmc = bm.SingleSiteNewtonianMonteCarlo().infer(\n",
     "    queries=[ beta_1(), beta_0(), epsilon() ],\n",
     "    observations=observations,\n",
     "    num_samples=2000,\n",
     "    num_chains=4,\n",
-    ")"
+    ")\n",
+    "logging.getLogger(\"beanmachine\").setLevel(0) # reset to normal logging level"
    ]
   },
   {
@@ -916,12 +919,15 @@
    "outputs": [],
    "source": [
     "%%time\n",
+    "import logging\n",
+    "logging.getLogger(\"beanmachine\").setLevel(50) # eliminate excess logging except for progress bars\n",
     "samples_nmc = bm.SingleSiteNewtonianMonteCarlo().infer(\n",
     "    queries=[ beta_1(), beta_0(), epsilon() ],\n",
     "    observations=observations,\n",
     "    num_samples=2000,\n",
     "    num_chains=4,\n",
-    ")"
+    ")\n",
+    "logging.getLogger(\"beanmachine\").setLevel(0) # reset to normal logging level"
    ]
   },
   {


### PR DESCRIPTION
### Motivation
Fixes the excess logging for the NMC inferences--both of them--in this tutorial

### Changes proposed
Set log level to 50, so only progress bars are shown/logged during NMC inference, return back to 0 after finished.

### Test Plan
Observe via Colab links.

### Types of changes
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](https://github.com/facebookresearch/beanmachine/blob/main/CONTRIBUTING.md)** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] The title of my pull request is a short description of the requested changes.
