### PR TITLE
Replace underlying representation of `DoubleMatrix` to `variant` accessed through properties.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ DEV_REQUIRES = (
 if platform.system() == "Windows":
     CPP_COMPILE_ARGS = ["/WX", "/permissive-", "-DEIGEN_HAS_C99_MATH"]
 else:
-    CPP_COMPILE_ARGS = ["-std=c++14", "-Werror"]
+    CPP_COMPILE_ARGS = ["-std=c++17", "-Werror"]
 
 
 # Check for python version

--- a/src/beanmachine/graph/graph.cpp
+++ b/src/beanmachine/graph/graph.cpp
@@ -9,6 +9,7 @@
 #include <random>
 #include <sstream>
 #include <thread>
+#include <variant>
 
 #include "beanmachine/graph/distribution/distribution.h"
 #include "beanmachine/graph/factor/factor.h"
@@ -1237,6 +1238,120 @@ Graph::Graph(const Graph& other) {
   master_graph = other.master_graph;
   agg_type = other.agg_type;
   agg_samples = other.agg_samples;
+}
+
+/// DoubleMatrix
+
+DoubleProperty::DoubleProperty(DoubleMatrix& owner) : owner(&owner) {}
+
+double& DoubleProperty::operator=(const double& d) {
+  owner->std::variant<double, Eigen::MatrixXd>::operator=(d);
+  return std::get<double>(*owner);
+}
+
+DoubleProperty::operator double&() {
+  return std::get<double>(*owner);
+}
+
+DoubleProperty::operator const double&() const {
+  return std::get<double>(*owner);
+}
+
+MatrixProperty::MatrixProperty(DoubleMatrix& owner) : owner(&owner) {}
+
+Eigen::MatrixXd& MatrixProperty::operator=(const Eigen::MatrixXd& m) {
+  owner->std::variant<double, Eigen::MatrixXd>::operator=(m);
+  return std::get<Eigen::MatrixXd>(*owner);
+}
+
+MatrixProperty::operator const Eigen::MatrixXd&() const {
+  return std::get<Eigen::MatrixXd>(*owner);
+}
+
+double MatrixProperty::coeff(Eigen::MatrixXd::Index i) const {
+  return std::get<Eigen::MatrixXd>(*owner).coeff(i);
+}
+
+double& MatrixProperty::operator()(Eigen::MatrixXd::Index i) {
+  return std::get<Eigen::MatrixXd>(*owner)(i);
+}
+
+double& MatrixProperty::operator()(
+    Eigen::MatrixXd::Index row,
+    Eigen::MatrixXd::Index col) {
+  return std::get<Eigen::MatrixXd>(*owner)(row, col);
+}
+
+Eigen::MatrixXd::ColXpr MatrixProperty::col(Eigen::MatrixXd::Index i) {
+  return std::get<Eigen::MatrixXd>(*owner).col(i);
+}
+
+double MatrixProperty::sum() {
+  return std::get<Eigen::MatrixXd>(*owner).sum();
+}
+
+// template <typename Increment>
+// Eigen::MatrixXd& MatrixProperty::operator+=(const Increment& increment) {
+//   return std::get<Eigen::MatrixXd>(*owner) += increment;
+// }
+
+Eigen::MatrixXd& MatrixProperty::operator+=(const Eigen::MatrixXd& increment) {
+  return std::get<Eigen::MatrixXd>(*owner) += increment;
+}
+
+Eigen::MatrixXd& MatrixProperty::operator+=(const DoubleMatrix& increment) {
+  return std::get<Eigen::MatrixXd>(*owner) +=
+      std::get<Eigen::MatrixXd>(increment);
+}
+
+Eigen::MatrixXd& MatrixProperty::operator-=(const Eigen::MatrixXd& increment) {
+  return std::get<Eigen::MatrixXd>(*owner) -= increment;
+}
+
+Eigen::MatrixXd MatrixProperty::operator*(const Eigen::MatrixXd& increment) {
+  return std::get<Eigen::MatrixXd>(*owner) * increment;
+}
+
+Eigen::MatrixXd MatrixProperty::operator*(const DoubleMatrix& increment) {
+  return std::get<Eigen::MatrixXd>(*owner) *
+      std::get<Eigen::MatrixXd>(increment);
+}
+
+Eigen::MatrixXd operator*(
+    const Eigen::MatrixXd& operand,
+    const MatrixProperty& mp) {
+  return operand * std::get<Eigen::MatrixXd>(*mp.owner);
+}
+
+Eigen::MatrixXd operator*(double operand, const MatrixProperty& mp) {
+  return operand * std::get<Eigen::MatrixXd>(*mp.owner);
+}
+
+Eigen::MatrixXd::ColXpr operator+=(
+    Eigen::MatrixXd::ColXpr operand,
+    const MatrixProperty& mp) {
+  return operand += std::get<Eigen::MatrixXd>(*mp.owner);
+}
+
+Eigen::MatrixXd& MatrixProperty::setZero(
+    Eigen::MatrixXd::Index rows,
+    Eigen::MatrixXd::Index cols) {
+  if (not std::holds_alternative<Eigen::MatrixXd>(*owner)) {
+    *this = Eigen::MatrixXd();
+  }
+  return std::get<Eigen::MatrixXd>(*owner).setZero(rows, cols);
+}
+
+Eigen::ArrayWrapper<Eigen::MatrixXd> MatrixProperty::array() {
+  return std::get<Eigen::MatrixXd>(*owner).array();
+}
+
+Eigen::MatrixXd::Scalar* MatrixProperty::data() {
+  return std::get<Eigen::MatrixXd>(*owner).data();
+}
+
+Eigen::MatrixXd::Index MatrixProperty::size() {
+  return std::get<Eigen::MatrixXd>(*owner).size();
 }
 
 } // namespace graph

--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -15,6 +15,7 @@
 #include <set>
 #include <string>
 #include <tuple>
+#include <variant>
 #include <vector>
 #include "beanmachine/graph/profiler.h"
 
@@ -370,9 +371,80 @@ enum class InferenceType { UNKNOWN = 0, REJECTION = 1, GIBBS, NMC };
 
 enum class AggregationType { UNKNOWN = 0, NONE = 1, MEAN };
 
-struct DoubleMatrix {
-  double _double;
-  Eigen::MatrixXd _matrix;
+struct DoubleMatrix;
+
+class DoubleProperty {
+ public:
+  DoubleMatrix* owner;
+
+  explicit DoubleProperty(DoubleMatrix& owner);
+
+  double& operator=(const double& d);
+
+  operator double&();
+
+  operator const double&() const;
+};
+
+class MatrixProperty {
+ public:
+  DoubleMatrix* owner;
+
+  explicit MatrixProperty(DoubleMatrix& owner);
+
+  Eigen::MatrixXd& operator=(const Eigen::MatrixXd& m);
+
+  operator const Eigen::MatrixXd&() const;
+
+  double coeff(Eigen::MatrixXd::Index i) const;
+
+  double& operator()(Eigen::MatrixXd::Index i);
+
+  double& operator()(Eigen::MatrixXd::Index row, Eigen::MatrixXd::Index col);
+
+  Eigen::MatrixXd::ColXpr col(Eigen::MatrixXd::Index i);
+
+  double sum();
+
+  // template <typename Increment>
+  // Eigen::MatrixXd& operator+=(const Increment& increment);
+
+  Eigen::MatrixXd& operator+=(const Eigen::MatrixXd& increment);
+
+  Eigen::MatrixXd& operator+=(const DoubleMatrix& increment);
+
+  Eigen::MatrixXd& operator-=(const Eigen::MatrixXd& increment);
+
+  Eigen::MatrixXd operator*(const Eigen::MatrixXd& operand);
+
+  Eigen::MatrixXd operator*(const DoubleMatrix& operand);
+
+  Eigen::MatrixXd& setZero(
+      Eigen::MatrixXd::Index rows,
+      Eigen::MatrixXd::Index cols);
+
+  Eigen::ArrayWrapper<Eigen::MatrixXd> array();
+
+  Eigen::MatrixXd::Scalar* data();
+
+  Eigen::MatrixXd::Index size();
+};
+
+Eigen::MatrixXd operator*(
+    const Eigen::MatrixXd& operand,
+    const MatrixProperty& mp);
+
+Eigen::MatrixXd operator*(double operand, const MatrixProperty& mp);
+
+Eigen::MatrixXd::ColXpr operator+=(
+    Eigen::MatrixXd::ColXpr operand,
+    const MatrixProperty& mp);
+
+struct DoubleMatrix : public std::variant<double, Eigen::MatrixXd> {
+  DoubleProperty _double;
+  MatrixProperty _matrix;
+
+  DoubleMatrix() : _double(*this), _matrix(*this) {}
 };
 
 struct InferConfig {


### PR DESCRIPTION
Summary:
Note: this summary is particularly detailed because I used a technique that I think will be important in future developments of BMG, namely representing nodes as standard library `std::variant` instead giving them multiple fields, one for each type of value they may carry (scalar and matrix). The advantage of `std::variant` over that is that the access is more transparent, and the variant "knows" which type of data it is currently carrying (it is a "tagged union", that is, it has a "tag" indicating the currently occupied slot). This supports much simpler code (I give an example involving the `Bimixture` distribution below).

Here, we are applying that technique not to nodes, but to a class called `DoubleMatrix` used for representing gradients. It is used in backward differentiation to keep either a scalar (double) or a matrix gradient. It contains two fields, `_double` and `_matrix`, which are acessed directly by client code. This prevents writing generic code that applies to both cases: the client code must know which field is actually being used, and perform different operations in each case.

This came up because the method `Distribution::backward_value` currently takes an `adjunct` parameter that must be multiplied by the resulting gradient represented as a `DoubleMatrix`. In fact `adjunct` is in almost all cases `1.0`, the sole exception being the `Bimixture` distribution, which does use adjunts different from `1.0`. So, it would make more sense not to burden the `backward_value` interface with an extra parameter that is only useful for a single case among many, and instead eliminate it and have `Bimixture` do that multiplication itself.

The problem with that is that `Bimixture` is defined on two distributions of any type, and we don't know if they are scalar-based or matrix-based (`DoubleMatrix` does not carry that information). This is why the previously followed solution was to provide `adjunct` to these two distributions and have these distributions take care of the multiplication (because they know on which type they are based).

A better solution, however, would be to have the `DoubleMatrix` backward gradient object *know* if it is carrying a double or matrix, and to offer a multiplication operator so that we can multiply it by `adjunct` and the multiplication works either way. This way, `Bimixture` can multiply the backward gradient by `adjunct` without knowledge of what is actually inside. In other words, `DoubleMatrix` must be a *tagged* union, that is, a `union` that carries information about which internal type is actually being used. In the C++ standard library, this is realized by the type `std::variant`.

Making `DoubleMatrix` a `variant` would ordinarily require changing all the code that accesses it (since the code accessing it does so through fields `_double` and `_matrix` but that would no longer be the case with a `variant`). This is however very error prone, because it would require implementing the variant version and then updating all client code to use it, without being able to compile and test the code not even once before everything is ready. Since this is a non-trivial change, the chance of getting it right in this one shot is very low (I tried!).

To avoid having to change everything at once, the plan here is instead to have `DoubleMatrix` temporarily support *both* interfaces (field-based and variant-based) so that we can replace field-based access one by one to allow careful testing of variant access, while still supporting field-based access in places in which the code has not yet been updated.

Using both interfaces is very flexible, but tricky: the two types of access must be synchronized. If we assign a value to field `_double`, we must get that same value when accessing `DoubleMatrix` as a variant carrying a double (this is done with `std::get<double>(variant)`. This is difficult to achieve because in principle an assignment to a primitive-typed field such as `backgrad._double = 10` can only simply store value `10` in the field with no other side effect, and in particular it would not be able to update the variant storage (again using `std::get<double>(variant)`, leading them to become out of sync.

We solve this problem by replacing the primitive-typed fields with *properties*. For field-based access and variant access to co-exist,  we must "fake" `_double` and `_matrix` to look like primitive-typed fields but in fact be more complex objects with overloaded operators that store their value in the underlying variant. In other words, they must be "property" objects (in the sense found in other languages such as C# and Python). Since C++ does not provide the concept of properties natively, we instead implement two special classes `DoubleProperty` and `MatrixProperty` to fulfill these roles.

Using these properties will, therefore, provide us with `_double` and `_matrix` that, when used, actually store values using `std::get<double>(variant)` and `std::get<Eigen::MatrixXd>(variant)`, respectively. We will have both interfaces working together.

Again, this will allow us to gradually replace the interface used in the client code, occurrence by occurrence. Once variant access is tested and used everywhere, we can then remove field-based access and leave the interface as variant only.

This first diff merely implements `DoubleMatrix` as a derived class of `std::variant` equipped with such properties. The next diffs will gradually replace client code access with the variant version.

Reviewed By: wtaha, yucenli

Differential Revision: D32715605

