### PR TITLE
Pin usort version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install linters
       run: |
         python -m pip install --upgrade pip
-        pip install black==20.8b1 usort flake8
+        pip install black==20.8b1 usort==0.6.4 flake8
 
     - name: Print out package info to help with debug
       run: pip list


### PR DESCRIPTION
### Motivation

Fixes  https://github.com/facebookresearch/beanmachine/runs/4567109442?check_suite_focus=true

### Changes proposed

Pins usort version. Per @neerajprad 

>  I am able to replicate this locally. The issue is that usort was recently updated to 1.0.0 and they seem to have added case insensitivity to the sort order. The command to run is usort check . after upgrading the usort version (see the test run that failed on the last commit: https://github.com/facebookresearch/beanmachine/runs/4567109442?check_suite_focus=true). e.g. diff on a file. Not sure what the reasons are for this change, and I couldn't see a way to change the default in the config either.

### Test Plan

GH actions

### Types of changes
- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](https://github.com/facebookresearch/beanmachine/blob/main/CONTRIBUTING.md)** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] The title of my pull request is a short description of the requested changes.
