### PR TITLE
Making Beanstalk work for Python 3.9+

### DIFF
--- a/src/beanmachine/ppl/compiler/bm_to_bmg.py
+++ b/src/beanmachine/ppl/compiler/bm_to_bmg.py
@@ -24,6 +24,7 @@ from beanmachine.ppl.compiler.ast_patterns import (
     binary_compare,
     binop,
     call,
+    get_value,
     index,
     keyword,
     load,
@@ -196,7 +197,8 @@ def _handle_comparison(p: Pattern, s: str) -> PatternRule:
 _handle_index = PatternRule(
     assign(value=subscript(slice=index())),
     lambda a: ast.Assign(
-        a.targets, _make_bmg_call("handle_index", [a.value.value, a.value.slice.value])
+        a.targets,
+        _make_bmg_call("handle_index", [a.value.value, get_value(a.value.slice)]),
     ),
 )
 
@@ -247,7 +249,7 @@ _handle_subscript_assign_index = PatternRule(
             "handle_subscript_assign",
             [
                 a.targets[0].value,
-                a.targets[0].slice.value,
+                get_value(a.targets[0].slice),
                 _ast_none,
                 _ast_none,
                 a.value,

--- a/src/beanmachine/ppl/compiler/single_assignment.py
+++ b/src/beanmachine/ppl/compiler/single_assignment.py
@@ -81,6 +81,7 @@ from beanmachine.ppl.compiler.ast_patterns import (
     ast_compare,
     ast_dict,
     ast_dictComp,
+    ast_index,
     ast_generator,
     ast_domain,
     ast_for,
@@ -95,6 +96,7 @@ from beanmachine.ppl.compiler.ast_patterns import (
     attribute,
     binop,
     call,
+    get_value,
     expr,
     index,
     keyword,
@@ -1007,10 +1009,10 @@ class SingleAssignment:
         #
         return self._make_right_assignment_rule(
             subscript(value=name(), slice=index(value=_not_identifier)),
-            lambda original_right: original_right.slice.value,
+            lambda original_right: get_value(original_right.slice),
             lambda original_right, new_name: ast.Subscript(
                 value=original_right.value,
-                slice=ast.Index(value=new_name),
+                slice=ast_index(value=new_name),
                 ctx=original_right.ctx,
             ),
             "handle_assign_subscript_slice_index_2",
@@ -2202,10 +2204,10 @@ class SingleAssignment:
         """Rewrites like a[b.c] = z → x = b.c; a[x] = z"""
         return self._make_left_any_assignment_rule(
             subscript(value=name(), slice=index(value=_not_identifier)),
-            lambda original_left: original_left.slice.value,
+            lambda original_left: get_value(original_left.slice),
             lambda original_left, new_name: ast.Subscript(
                 value=original_left.value,
-                slice=ast.Index(
+                slice=ast_index(
                     value=new_name,
                     ctx=ast.Load(),
                 ),
@@ -2346,7 +2348,7 @@ class SingleAssignment:
                         targets=[source_term.targets[0].elts[0]],
                         value=ast.Subscript(
                             value=source_term.value,
-                            slice=ast.Index(value=ast.Num(n=0)),
+                            slice=ast_index(value=ast.Num(n=0)),
                             ctx=ast.Load(),
                         ),
                     ),
@@ -2397,7 +2399,7 @@ class SingleAssignment:
                         targets=[source_term.targets[0].elts[-1]],
                         value=ast.Subscript(
                             value=source_term.value,
-                            slice=ast.Index(value=ast.Num(n=-1)),
+                            slice=ast_index(value=ast.Num(n=-1)),
                             ctx=ast.Load(),
                         ),
                     ),


### PR DESCRIPTION
Summary:
During the OSS release of Bean Machine Neeraj had the foresight to expand testing to include Python 3.9. This revealed (in good time) that the Beanstalk compiler does not yet work with this version of Python. Upon review of the changes from Python 3.8 to 3.9 (https://docs.python.org/3/whatsnew/3.9.html) it was noted that there were changes to the AST, and in particular, the removal of the ast.Index constructor (https://bugs.python.org/issue34822). This diff adds basic versioning support to Beanstalk as well as version-specific patterns and constructors for slices so that the existing rewrite rules can continue to work as intended.

Notes about this can be found at https://fburl.com/beanstalk-py39-notes

Differential Revision: D33357242

