### PR TITLE
Add arviz inference data as an argument to Predictive.simulate

### DIFF
--- a/src/beanmachine/ppl/inference/monte_carlo_samples.py
+++ b/src/beanmachine/ppl/inference/monte_carlo_samples.py
@@ -245,11 +245,9 @@ class MonteCarloSamples(Mapping[RVIdentifier, torch.Tensor]):
         """
         inference_data = self.to_inference_data(include_adapt_steps)
         if not include_adapt_steps:
-            # pyre-ignore
             return inference_data.posterior
         else:
             return xr.concat(
-                # pyre-ignore
                 [inference_data.warmup_posterior, inference_data.posterior],
                 dim="draw",
             )

--- a/src/beanmachine/ppl/inference/monte_carlo_samples.py
+++ b/src/beanmachine/ppl/inference/monte_carlo_samples.py
@@ -139,7 +139,7 @@ class MonteCarloSamples(Mapping[RVIdentifier, torch.Tensor]):
         rv: RVIdentifier,
         include_adapt_steps: bool = False,
         thinning: int = 1,
-        namespace=None,
+        namespace: Optional[str] = None,
     ) -> torch.Tensor:
         """
         Let C be the number of chains,

--- a/src/beanmachine/ppl/inference/monte_carlo_samples.py
+++ b/src/beanmachine/ppl/inference/monte_carlo_samples.py
@@ -268,15 +268,11 @@ class MonteCarloSamples(Mapping[RVIdentifier, torch.Tensor]):
             posterior = self.namespaces["posterior"].samples
             if self.num_adaptive_samples > 0:
                 warmup_posterior = self.namespaces["posterior"].adaptive_samples
-                warmup_log_likelihood = self.adaptive_log_likelihoods
             else:
                 warmup_posterior = None
-                warmup_log_likelihood = None
         else:
             posterior = None
             warmup_posterior = None
-            log_likelihood = None
-            warmup_log_likelihood = None
 
         if "posterior_predictive" in self.namespaces:
             posterior_predictive = self.namespaces["posterior_predictive"].samples
@@ -302,7 +298,7 @@ class MonteCarloSamples(Mapping[RVIdentifier, torch.Tensor]):
             warmup_posterior_predictive=warmup_posterior_predictive,
             prior_predictive=prior_predictive,
             save_warmup=include_adapt_steps,
-            warmup_log_likelihood=warmup_log_likelihood,
+            warmup_log_likelihood=self.adaptive_log_likelihoods,
             log_likelihood=self.log_likelihoods,
             observed_data=self.observations,
         )

--- a/src/beanmachine/ppl/inference/monte_carlo_samples.py
+++ b/src/beanmachine/ppl/inference/monte_carlo_samples.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict, Iterator, List, Mapping, Optional, Union
+from typing import Any, Dict, Iterator, List, Mapping, Optional, Union, NamedTuple
 
 import arviz as az
 import torch
@@ -13,6 +13,11 @@ from beanmachine.ppl.model.rv_identifier import RVIdentifier
 
 
 RVDict = Dict[RVIdentifier, torch.Tensor]
+
+
+class Samples(NamedTuple):
+    samples: RVDict
+    adaptive_samples: RVDict
 
 
 class MonteCarloSamples(Mapping[RVIdentifier, torch.Tensor]):
@@ -30,7 +35,14 @@ class MonteCarloSamples(Mapping[RVIdentifier, torch.Tensor]):
         logll_results: Optional[Union[List[RVDict], RVDict]] = None,
         observations: Optional[RVDict] = None,
         stack_not_cat: bool = True,
+        default_namespace: str = "posterior",
     ):
+        self.namespaces = {}
+        self.default_namespace = default_namespace
+
+        if default_namespace not in self.namespaces:
+            self.namespaces[default_namespace] = {}
+
         if isinstance(chain_results, list):
             self.num_chains = len(chain_results)
             chain_results = merge_dicts(chain_results, 0, stack_not_cat)
@@ -38,8 +50,7 @@ class MonteCarloSamples(Mapping[RVIdentifier, torch.Tensor]):
             self.num_chains = next(iter(chain_results.values())).shape[0]
         self.num_adaptive_samples = num_adaptive_samples
 
-        self.adaptive_samples = {}
-        self.samples = {}
+        self.namespaces[default_namespace] = Samples({}, {})
         for rv, val in chain_results.items():
             self.adaptive_samples[rv] = val[:, :num_adaptive_samples]
             self.samples[rv] = val[:, num_adaptive_samples:]
@@ -62,6 +73,14 @@ class MonteCarloSamples(Mapping[RVIdentifier, torch.Tensor]):
 
         # single_chain_view is only set when self.get_chain is called
         self.single_chain_view = False
+
+    @property
+    def samples(self):
+        return self.namespaces[self.default_namespace].samples
+
+    @property
+    def adaptive_samples(self):
+        return self.namespaces[self.default_namespace].adaptive_samples
 
     def __getitem__(self, rv: RVIdentifier) -> torch.Tensor:
         """
@@ -109,13 +128,18 @@ class MonteCarloSamples(Mapping[RVIdentifier, torch.Tensor]):
             num_adaptive_samples=self.num_adaptive_samples,
             logll_results=logll,
             observations=self.observations,
+            default_namespace=self.default_namespace,
         )
         new_mcs.single_chain_view = True
 
         return new_mcs
 
     def get_variable(
-        self, rv: RVIdentifier, include_adapt_steps: bool = False, thinning: int = 1
+        self,
+        rv: RVIdentifier,
+        include_adapt_steps: bool = False,
+        thinning: int = 1,
+        namespace=None,
     ) -> torch.Tensor:
         """
         Let C be the number of chains,
@@ -141,10 +165,16 @@ class MonteCarloSamples(Mapping[RVIdentifier, torch.Tensor]):
                 + f"but is of type {type(rv).__name__}."
             )
 
-        samples = self.samples[rv]
+        if namespace is None:
+            namespace = self.default_namespace
+
+        samples = self.namespaces[namespace].samples[rv]
 
         if include_adapt_steps:
-            samples = torch.cat([self.adaptive_samples[rv], samples], dim=1)
+            samples = torch.cat(
+                [self.namespaces[namespace].adaptive_samples[rv], samples],
+                dim=1,
+            )
 
         if thinning > 1:
             samples = samples[:, ::thinning]
@@ -224,21 +254,55 @@ class MonteCarloSamples(Mapping[RVIdentifier, torch.Tensor]):
                 dim="draw",
             )
 
+    def add_groups(self, mcs: "MonteCarloSamples"):
+        for n in mcs.namespaces:
+            if n not in self.namespaces:
+                self.namespaces[n] = mcs.namespaces[n]
+
     def to_inference_data(self, include_adapt_steps: bool = False) -> az.InferenceData:
         """
         Return an az.InferenceData from MonteCarloSamples.
         """
-        if self.num_adaptive_samples > 0:
-            adaptive_samples = self.adaptive_samples
-            adaptive_logll = self.adaptive_log_likelihoods
+
+        if "posterior" in self.namespaces:
+            posterior = self.namespaces["posterior"].samples
+            if self.num_adaptive_samples > 0:
+                warmup_posterior = self.namespaces["posterior"].adaptive_samples
+                warmup_log_likelihood = self.adaptive_log_likelihoods
+            else:
+                warmup_posterior = None
+                warmup_log_likelihood = None
         else:
-            adaptive_samples = None
-            adaptive_logll = None
+            posterior = None
+            warmup_posterior = None
+            log_likelihood = None
+            warmup_log_likelihood = None
+
+        if "posterior_predictive" in self.namespaces:
+            posterior_predictive = self.namespaces["posterior_predictive"].samples
+            if self.num_adaptive_samples > 0:
+                warmup_posterior_predictive = self.namespaces[
+                    "posterior"
+                ].adaptive_samples
+            else:
+                warmup_posterior_predictive = None
+        else:
+            posterior_predictive = None
+            warmup_posterior_predictive = None
+
+        if "prior_predictive" in self.namespaces:
+            prior_predictive = self.namespaces["prior_predictive"].samples
+        else:
+            prior_predictive = None
+
         return az.from_dict(
-            posterior=self.samples,
-            warmup_posterior=adaptive_samples,
+            posterior=posterior,
+            warmup_posterior=warmup_posterior,
+            posterior_predictive=posterior_predictive,
+            warmup_posterior_predictive=warmup_posterior_predictive,
+            prior_predictive=prior_predictive,
             save_warmup=include_adapt_steps,
-            warmup_log_likelihood=adaptive_logll,
+            warmup_log_likelihood=warmup_log_likelihood,
             log_likelihood=self.log_likelihoods,
             observed_data=self.observations,
         )

--- a/src/beanmachine/ppl/inference/monte_carlo_samples.py
+++ b/src/beanmachine/ppl/inference/monte_carlo_samples.py
@@ -245,10 +245,10 @@ class MonteCarloSamples(Mapping[RVIdentifier, torch.Tensor]):
         """
         inference_data = self.to_inference_data(include_adapt_steps)
         if not include_adapt_steps:
-            return inference_data.posterior
+            return inference_data["posterior"]
         else:
             return xr.concat(
-                [inference_data.warmup_posterior, inference_data.posterior],
+                [inference_data["warmup_posterior"], inference_data["posterior"]],
                 dim="draw",
             )
 

--- a/src/beanmachine/ppl/inference/predictive.py
+++ b/src/beanmachine/ppl/inference/predictive.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from collections import defaultdict
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 import arviz as az
 import torch
@@ -143,7 +143,6 @@ class Predictive(object):
                 return az.from_dict(prior_predictive=prior_pred.samples)
             else:
                 return prior_pred
-
 
     @staticmethod
     def empirical(

--- a/src/beanmachine/ppl/inference/predictive.py
+++ b/src/beanmachine/ppl/inference/predictive.py
@@ -122,7 +122,7 @@ class Predictive(object):
                     sampler.reset()
                 predictives.append(query_dict)
 
-            rv_dict = defaultdict(list)
+            rv_dict = defaultdict(list) # type: ignore
             for k in predictives:
                 for rvid, rv in k.items():
                     if rv.dim() < 2:
@@ -130,7 +130,6 @@ class Predictive(object):
                     rv_dict[rvid].append(rv)
             for k, v in rv_dict.items():
                 rv_dict[k] = torch.cat(v, dim=1)
-            # pyre-ignore
             prior_pred = MonteCarloSamples(
                 dict(rv_dict),
                 default_namespace="prior_predictive",

--- a/src/beanmachine/ppl/inference/predictive.py
+++ b/src/beanmachine/ppl/inference/predictive.py
@@ -4,9 +4,8 @@
 # LICENSE file in the root directory of this source tree.
 
 from collections import defaultdict
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional
 
-import arviz as az
 import torch
 from beanmachine.ppl.inference.monte_carlo_samples import MonteCarloSamples
 from beanmachine.ppl.legacy.inference.single_site_ancestral_mh import (

--- a/src/beanmachine/ppl/inference/predictive.py
+++ b/src/beanmachine/ppl/inference/predictive.py
@@ -125,7 +125,7 @@ class Predictive(object):
             for k in predictives:
                 for rvid, rv in k.items():
                     if rvid not in rv_dict:
-                        rv_dict[rv_dict] = []
+                        rv_dict[rvid] = []
                     if rv.dim() < 2:
                         rv = rv.unsqueeze(0)
                     rv_dict[rvid].append(rv)

--- a/src/beanmachine/ppl/inference/predictive.py
+++ b/src/beanmachine/ppl/inference/predictive.py
@@ -3,7 +3,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from collections import defaultdict
 from typing import Dict, List, Optional
 
 import torch

--- a/src/beanmachine/ppl/inference/predictive.py
+++ b/src/beanmachine/ppl/inference/predictive.py
@@ -58,8 +58,6 @@ class Predictive(object):
         :param posterior: Optional `MonteCarloSamples` of the latent variables.
         :param num_samples: Number of prior predictive samples, defaults to 1. Should
             not be specified if `posterior` is specified.
-        :param return_inference_data: Indicate whether to return the predictives
-            as an InferenceData object
         :returns: `MonteCarloSamples` of the generated predictives.
         """
         assert (
@@ -131,9 +129,8 @@ class Predictive(object):
                         rv = rv.unsqueeze(0)
                     rv_dict[rvid].append(rv)
             for k, v in rv_dict.items():
-                # pyre-ignore
                 rv_dict[k] = torch.cat(v, dim=1)
-            # pyre-fixme
+            # pyre-ignore
             prior_pred = MonteCarloSamples(
                 dict(rv_dict),
                 default_namespace="prior_predictive",

--- a/src/beanmachine/ppl/inference/predictive.py
+++ b/src/beanmachine/ppl/inference/predictive.py
@@ -60,6 +60,8 @@ class Predictive(object):
         :param posterior: Optional `MonteCarloSamples` of the latent variables.
         :param num_samples: Number of prior predictive samples, defaults to 1. Should
             not be specified if `posterior` is specified.
+        :param return_inference_data: Indicate whether to return the predictives
+            as an InferenceData object
         :returns: `MonteCarloSamples` of the generated predictives.
         """
         assert (
@@ -84,7 +86,7 @@ class Predictive(object):
                 post_pred = MonteCarloSamples(query_dict)
                 if return_inference_data:
                     post = posterior.to_inference_data()
-                    post_pred = post_pred.to_inference_data().posterior
+                    post_pred = post_pred.to_inference_data()["posterior"]
                     post.add_groups({"posterior_predictive": post_pred})
                     return post
                 else:
@@ -109,7 +111,7 @@ class Predictive(object):
                 post_pred = MonteCarloSamples(preds)
                 if return_inference_data:
                     post = posterior.to_inference_data()
-                    post_pred = post_pred.to_inference_data().posterior
+                    post_pred = post_pred.to_inference_data()["posterior"]
                     post.add_groups({"posterior_predictive": post_pred})
                     return post
                 else:

--- a/src/beanmachine/ppl/inference/predictive.py
+++ b/src/beanmachine/ppl/inference/predictive.py
@@ -122,16 +122,18 @@ class Predictive(object):
                     sampler.reset()
                 predictives.append(query_dict)
 
-            rv_dict = defaultdict(list)  # type: ignore
+            rv_dict = {}
             for k in predictives:
                 for rvid, rv in k.items():
+                    if rvid not in rv_dict:
+                        rv_dict[rv_dict] = []
                     if rv.dim() < 2:
                         rv = rv.unsqueeze(0)
                     rv_dict[rvid].append(rv)
             for k, v in rv_dict.items():
                 rv_dict[k] = torch.cat(v, dim=1)
             prior_pred = MonteCarloSamples(
-                dict(rv_dict),
+                rv_dict,
                 default_namespace="prior_predictive",
             )
             return prior_pred

--- a/src/beanmachine/ppl/inference/predictive.py
+++ b/src/beanmachine/ppl/inference/predictive.py
@@ -122,7 +122,7 @@ class Predictive(object):
                     sampler.reset()
                 predictives.append(query_dict)
 
-            rv_dict = defaultdict(list) # type: ignore
+            rv_dict = defaultdict(list)  # type: ignore
             for k in predictives:
                 for rvid, rv in k.items():
                     if rv.dim() < 2:

--- a/src/beanmachine/ppl/inference/tests/predictive_test.py
+++ b/src/beanmachine/ppl/inference/tests/predictive_test.py
@@ -170,8 +170,10 @@ class PredictiveTest(unittest.TestCase):
 
         assert post_samples[self.prior_2()].shape == (2, 10, 1, 2)
         predictives = bm.simulate(
-            list(obs.keys()), post_samples, vectorized=True, return_inference_data=True
-        )
+            list(obs.keys()),
+            post_samples,
+            vectorized=True,
+        ).to_inference_data()
         assert "posterior" in predictives
         assert "posterior_predictive" in predictives
         assert predictives.posterior_predictive[self.likelihood_2(0)].shape == (

--- a/src/beanmachine/ppl/inference/tests/predictive_test.py
+++ b/src/beanmachine/ppl/inference/tests/predictive_test.py
@@ -157,3 +157,32 @@ class PredictiveTest(unittest.TestCase):
         assert len(empirical) == 3
         assert empirical[self.likelihood_i(0)].shape == (1, 27)
         assert empirical[self.likelihood_i(1)].shape == (1, 27)
+
+    def test_return_inference_data(self):
+        torch.manual_seed(10)
+        obs = {
+            self.likelihood_2(0): torch.tensor([[1.0, 1.0]]),
+            self.likelihood_2(1): torch.tensor([[0.0, 1.0]]),
+        }
+        post_samples = bm.SingleSiteAncestralMetropolisHastings().infer(
+            [self.prior_2()], obs, num_samples=10, num_chains=2
+        )
+
+        assert post_samples[self.prior_2()].shape == (2, 10, 1, 2)
+        predictives = bm.simulate(
+            list(obs.keys()), post_samples, vectorized=True, return_inference_data=True
+        )
+        assert "posterior" in predictives
+        assert "posterior_predictive" in predictives
+        assert predictives.posterior_predictive[self.likelihood_2(0)].shape == (
+            2,
+            10,
+            1,
+            2,
+        )
+        assert predictives.posterior_predictive[self.likelihood_2(1)].shape == (
+            2,
+            10,
+            1,
+            2,
+        )


### PR DESCRIPTION
### Motivation
Please describe your motivation for the changes. Provide link to any related issues.

### Changes proposed
Outline the proposed changes and alternatives considered.

The following adds a `return_inference_data`  option to `simulate` in `Predictive`. This makes it so the output of `simulate` can be readily used in arviz.

### Test Plan
Please provide clear instructions on how the changes were verified. Attach screenshots if applicable.

### Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](https://github.com/facebookresearch/beanmachine/blob/main/CONTRIBUTING.md)** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] The title of my pull request is a short description of the requested changes.
