### PR TITLE
Fix "uniform" initialization for real supported RVs

### DIFF
--- a/src/beanmachine/ppl/world/initialize_fn.py
+++ b/src/beanmachine/ppl/world/initialize_fn.py
@@ -31,7 +31,7 @@ def init_to_uniform(distribution: dist.Distribution) -> torch.Tensor:
     if distribution.has_enumerate_support:
         support = distribution.enumerate_support(expand=False).flatten()
         return support[torch.randint_like(sample_val, support.numel()).long()]
-    elif not distribution.support.is_discrete:
+    elif isinstance(distribution.support, constraints.interval):
         transform = dist.biject_to(distribution.support)
         return transform(torch.rand_like(transform.inv(sample_val)) * 4 - 2)
     else:

--- a/src/beanmachine/ppl/world/initialize_fn.py
+++ b/src/beanmachine/ppl/world/initialize_fn.py
@@ -8,6 +8,7 @@ from typing import Callable
 
 import torch
 import torch.distributions as dist
+import torch.distributions.constraints as constraints
 
 
 InitializeFn = Callable[[dist.Distribution], torch.Tensor]


### PR DESCRIPTION
### Motivation

`init_to_uniform` only makes sense for bounded support reals i.e. `constraints.interval`. However, right now even unconstrained reals pass `not distribution.support.is_discrete` and as a result we get initialization over the unit interval (NOT uniform over the reals... whatever that means).

### Changes proposed

Changes `init_to_uniform` to fall back to ancestral for unbounded supports

### Test Plan
Please provide clear instructions on how the changes were verified. Attach screenshots if applicable.

Sampling neal's funnel using `initialize_world`
```py
nu = 4.1

z_dist = dist.StudentT(loc=0.0, scale=10.0, df=nu)
@bm.random_variable
def z():
    return z_dist

@bm.random_variable
def x():
    return dist.Normal(0.0, (z() / 2.0).exp())


class GroundTruthProposer(BaseProposer):
    def propose(
        self,
        _world: World,
    ):
        return BaseInference._initialize_world([z(), x()], {}, init_to_uniform), torch.zeros(1)


class GroundTruthSampling(BaseInference):
    def __init__(self):
        self._proposer = None

    def get_proposers(
        self,
        world: World,
        target_rvs,
        num_adaptive_sample: int,
    ):
        if self._proposer is None:
            self._proposer = GroundTruthProposer()
        return [self._proposer]
```
 
before
![image](https://user-images.githubusercontent.com/990069/149428397-e0e4afdb-72d3-47fe-a57d-0ce174398e68.png)


after
![image](https://user-images.githubusercontent.com/990069/149427453-a4340b45-65ae-4ee5-8011-d31a7a8d2204.png)



### Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](https://github.com/facebookresearch/beanmachine/blob/main/CONTRIBUTING.md)** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] The title of my pull request is a short description of the requested changes.
