### PR TITLE
Validate initial world and resample if needed

### DIFF
--- a/src/beanmachine/ppl/inference/base_inference.py
+++ b/src/beanmachine/ppl/inference/base_inference.py
@@ -32,17 +32,41 @@ class BaseInference(metaclass=ABCMeta):
         queries: List[RVIdentifier],
         observations: RVDict,
         initialize_fn: InitializeFn = init_to_uniform,
+        max_retries: int = 100,
     ) -> World:
         """
         Initializes a world with all of the random variables (queries and observations).
+        In case of initializing values outside of support of the distributions, the
+        method will keep resampling until a valid initialization is found up to
+        ``max_retries`` times.
+
+        Args:
+            queries: A list of random variables that need to be inferred.
+            observations: A dictionary from random variables to their corresponding values.
+            initialize_fn: A callable that takes in a distribution and returns a Tensor.
+                The default behavior is to sample from Uniform(-2, 2) then biject to
+                the support of the distribution.
+            max_retries: The number of attempts this method will make before throwing an
+                error (default to 100).
         """
-        world = World(observations, initialize_fn)
-        # recursively add parent nodes to the graph
-        for node in queries:
-            world.call(node)
-        for node in observations:
-            world.call(node)
-        return world
+        for _ in range(max_retries):
+            world = World(observations, initialize_fn)
+            # recursively add parent nodes to the graph
+            for node in queries:
+                world.call(node)
+            for node in observations:
+                world.call(node)
+
+            # check if the initial state is valid
+            log_prob = world.log_prob()
+            if not torch.isinf(log_prob) and not torch.isnan(log_prob):
+                return world
+
+        # None of the world gives us a valid initial state
+        raise ValueError(
+            f"Cannot find a valid initialization after {max_retries} retries. The model"
+            " might be misspecified."
+        )
 
     @abstractmethod
     def get_proposers(
@@ -66,6 +90,7 @@ class BaseInference(metaclass=ABCMeta):
         num_adaptive_samples: int = 0,
         verbose: VerboseLevel = VerboseLevel.LOAD_BAR,
         initialize_fn: InitializeFn = init_to_uniform,
+        max_init_retries: int = 100,
     ) -> MonteCarloSamples:
         """
         Performs inference and returns a ``MonteCarloSamples`` object with samples from the posterior.
@@ -77,7 +102,11 @@ class BaseInference(metaclass=ABCMeta):
             num_chains: Number of chains to run, defaults to 4.
             num_adaptive_samples:  Number of adaptive samples, defaults to 0.
             verbose: Verbose level for logging.
-            initialize_fn: Callable that returns a tensor. Initializes to uniform as default.
+            initialize_fn: A callable that takes in a distribution and returns a Tensor.
+                The default behavior is to sample from Uniform(-2, 2) then biject to
+                the support of the distribution.
+            max_init_retries: The number of attempts to make to initialize values for an
+                inference before throwing an error (default to 100).
         """
         _verify_queries_and_observations(
             queries, observations, observations_must_be_rv=True
@@ -134,6 +163,7 @@ class BaseInference(metaclass=ABCMeta):
         num_samples: Optional[int] = None,
         num_adaptive_samples: int = 0,
         initialize_fn: InitializeFn = init_to_uniform,
+        max_init_retries: int = 100,
     ) -> Sampler:
         """
         Returns a generator that returns a new world (represents a new state of the
@@ -145,7 +175,11 @@ class BaseInference(metaclass=ABCMeta):
             observations: Observations as an RVDict keyed by RVIdentifier
             num_samples: Number of samples, defaults to None for an infinite sampler.
             num_adaptive_samples:  Number of adaptive samples, defaults to 0.
-            initialize_fn: Callable that returns a tensor. Initializes to uniform as default.
+            initialize_fn: A callable that takes in a distribution and returns a Tensor.
+                The default behavior is to sample from Uniform(-2, 2) then biject to
+                the support of the distribution.
+            max_init_retries: The number of attempts to make to initialize values for an
+                inference before throwing an error (default to 100).
         """
         _verify_queries_and_observations(
             queries, observations, observations_must_be_rv=True

--- a/src/beanmachine/ppl/inference/tests/inference_test.py
+++ b/src/beanmachine/ppl/inference/tests/inference_test.py
@@ -6,6 +6,7 @@
 import math
 
 import beanmachine.ppl as bm
+import pytest
 import torch
 import torch.distributions as dist
 from beanmachine.ppl.inference.proposer.base_proposer import (
@@ -79,3 +80,32 @@ def test_initialize_from_prior():
 
     assert samples_from_prior[0] != samples_from_prior[1]
     assert math.isclose(sum(samples_from_prior) / 10000.0, 0.0, abs_tol=1e-2)
+
+
+def test_initialization_resampling():
+    mh = bm.SingleSiteAncestralMetropolisHastings()
+
+    @bm.random_variable
+    def foo():
+        return dist.Uniform(3.0, 5.0)
+
+    # verify that the method re-sample as expected
+    retries = 0
+
+    def init_after_three_tries(d: dist.Distribution):
+        nonlocal retries
+        retries += 1
+        return torch.tensor(float("nan")) if retries < 3 else d.sample()
+
+    sampler = mh.sampler(
+        [foo()], {}, num_samples=10, initialize_fn=init_after_three_tries
+    )
+    for world in sampler:
+        assert not torch.isinf(world.log_prob()) and not torch.isnan(world.log_prob())
+
+    # an extreme case where the init value is always out of the support
+    def init_to_zero(d: dist.Distribution):
+        return torch.zeros_like(d.sample())
+
+    with pytest.raises(ValueError, match="Cannot find a valid initialization"):
+        mh.infer([foo()], {}, num_samples=10, initialize_fn=init_to_zero)


### PR DESCRIPTION
Summary: To avoid accidentally initializing random variables outside of the support of the distributions and getting stuck at the initial value through the entire inference, this diff adds a sanity check to `_initialize_world`, verify that the log prob of the initial world is valid, and resample (up to 100 times) if needed.

Differential Revision: D33757665

