### PR TITLE
Enable License Lint for Bean Machine

### DIFF
--- a/scripts/convert_ipynb_to_mdx.py
+++ b/scripts/convert_ipynb_to_mdx.py
@@ -1,3 +1,8 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import json
 import shutil
 import uuid

--- a/sphinx/make.bat
+++ b/sphinx/make.bat
@@ -1,3 +1,8 @@
+@REM Copyright (c) Meta Platforms, Inc. and affiliates.
+@REM
+@REM This source code is licensed under the MIT license found in the
+@REM LICENSE file in the root directory of this source tree.
+
 @ECHO OFF
 
 pushd %~dp0

--- a/website/src/components/CellOutput.jsx
+++ b/website/src/components/CellOutput.jsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import React from 'react';
 import {v4 as uuidv4} from 'uuid';
 

--- a/website/src/components/LinkButtons.jsx
+++ b/website/src/components/LinkButtons.jsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import React from 'react';
 import Link from '@docusaurus/Link';
 

--- a/website/src/components/Plotting.jsx
+++ b/website/src/components/Plotting.jsx
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import React from 'react';
 import Loadable from 'react-loadable';
 import BrowserOnly from '@docusaurus/BrowserOnly';


### PR DESCRIPTION
Summary:
This diff enable license lint for Bean Machine project, which will enforce a copyright statement on top of every file under Bean Machine codebase. This will also give us a diff-time warning so we can avoid accidentally committing codes without the license and failing OSS requirement (such as T110683359).

I was hoping to enable this linter for a while so we don't have to keeping track of the headers manually, but license lint was using the "Facebook" variant of the headers. Now that it's updated to use "Meta," we can safely enable it for our project without having to do a major codemod later on :).

In addition to enabling the linter, this diff also updates the few files that failed the license requirement. These have to be done in the same diff to make the linter happy.

Differential Revision: D33772236

