### PR TITLE
Refactor handle_sample method in beanstalk runtime

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/bm_graph_builder_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bm_graph_builder_test.py
@@ -281,23 +281,6 @@ Node 9 type 3 parents [ 8 ] children [ ] real 0"""
         b = bmg.handle_bernoulli(betas)
         self.assertTrue(isinstance(b, BernoulliNode))
 
-    def test_handle_sample(self) -> None:
-
-        bmg = BMGRuntime()
-
-        # Sample on a graph node.
-        h = bmg._bmg.add_constant_tensor(tensor(0.5))
-        b = bmg._bmg.add_bernoulli(h)
-        s1 = bmg.handle_sample(b)
-        self.assertTrue(isinstance(s1, SampleNode))
-
-        # Sample on a distribution object.
-        b = Bernoulli(0.5)
-        s2 = bmg.handle_sample(b)
-        self.assertTrue(isinstance(s2, SampleNode))
-
-        # Verify that they are not memoized; samples are always distinct.
-        self.assertFalse(s1 is s2)
 
     def test_addition(self) -> None:
         """Test addition"""


### PR DESCRIPTION
Summary:
Method `handle_sample` in the beanstalk runtime has some minor problems that I'm fixing now:

* It is logically a private method, so I've renamed it as `_handle_sample`
* Since its a private implementation detail I've removed its unit test
* An upcomding diff is going to need this method to be single-return; doing so simplifies the logic as well.
* I've alphebetized the cases

Reviewed By: feynmanliang

Differential Revision: D33718008

