### PR TITLE
Add simple multidictionary

### DIFF
--- a/src/beanmachine/ppl/utils/multidictionary.py
+++ b/src/beanmachine/ppl/utils/multidictionary.py
@@ -1,0 +1,51 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+from typing import Any, Dict, Set
+
+
+class MultiDictionary:
+    """A simple append-only multidictionary; values are deduplicated
+    and must be hashable."""
+
+    _d: Dict[Any, Set[Any]]
+
+    def __init__(self) -> None:
+        self._d = {}
+
+    def add(self, key: Any, value: Any) -> None:
+        if key not in self._d:
+            self._d[key] = {value}
+        else:
+            self._d[key].add(value)
+
+    def __getitem__(self, key: Any) -> Set[Any]:
+        return self._d[key] if key in self else set()
+
+    def __iter__(self):
+        return iter(self._d)
+
+    def __len__(self):
+        return len(self._d)
+
+    def __contains__(self, key: Any):
+        return key in self._d
+
+    def keys(self):
+        return self._d.keys()
+
+    def items(self):
+        return self._d.items()
+
+    def __repr__(self) -> str:
+        return (
+            "{"
+            + "\n".join(
+                str(key) + ":{" + ",\n".join(sorted(str(v) for v in self[key])) + "}"
+                for key in self
+            )
+            + "}"
+        )

--- a/src/beanmachine/ppl/utils/tests/multidictionary_test.py
+++ b/src/beanmachine/ppl/utils/tests/multidictionary_test.py
@@ -1,0 +1,29 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+from beanmachine.ppl.utils.multidictionary import MultiDictionary
+
+
+class MultiDictionaryTest(unittest.TestCase):
+    def test_multidictionary(self) -> None:
+        d = MultiDictionary()
+        d.add(1, "alpha")
+        d.add(1, "bravo")
+        d.add(2, "charlie")
+        d.add(2, "delta")
+        self.assertEqual(2, len(d))
+        self.assertEqual(2, len(d[1]))
+        self.assertEqual(2, len(d[2]))
+        self.assertEqual(0, len(d[3]))
+        self.assertTrue("alpha" in d[1])
+        self.assertTrue("alpha" not in d[2])
+        expected = """
+{1:{alpha,
+bravo}
+2:{charlie,
+delta}}"""
+        self.assertEqual(expected.strip(), str(d).strip())


### PR DESCRIPTION
Summary: I'm going to need a simple append-only multidictionary for building a map that tracks nodes -> [associated call sites]. I've knocked together this quick class for testing and experimentation; we can replace it later with a suitable standard multidictionary class.

Reviewed By: feynmanliang

Differential Revision: D33720265

