### PR TITLE
Adds two warnings to allow list to unblock the next release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,22 +8,22 @@ addopts = "-ra --import-mode=importlib --ignore-glob=tutorials/*.py"
 filterwarnings = [
     # By default, all warnings are treated as errors
     "error",
-    # patsy is a statsmodels dependency which currently triggers a DeprecationWarning
-    "default::DeprecationWarning:patsy.constraint",
     # pytorch warns about vmap usage since it's experimental
     "ignore:torch.vmap is an experimental prototype.*:UserWarning",
     # pandas sometimes complains about binary compatibility with numpy
     "default:numpy.ufunc size changed, may indicate binary incompatibility.*:RuntimeWarning",
     # flowtorch warnings
     "ignore:DenseAutoregressive input_dim = 1. Consider using an affine transformation instead.*:UserWarning",
-    # statsmodels's deprecation warning
-    "default:the 'unbiased'' keyword is deprecated, use 'adjusted' instead.*:FutureWarning",
     # nbval fspath deprecation not supported in sphinx
     "ignore::DeprecationWarning:nbval",
     # PyTorch 1.10 warns against creating a tensor from a list of numpy arrays
-    """default:Creating a tensor from a list of numpy.ndarrays is extremely slow. Please
-    consider converting the list to a single numpy.ndarray with numpy.array() before
-    converting to a tensor.*:UserWarning""",
+    "default:Creating a tensor from a list of numpy.ndarrays is extremely slow.*:UserWarning",
+    # xarray uses a module that's deprecated since setuptools 60.0.0. This has been
+    # fixed in xarray/pull/6096, so we can remove this filter with the next xarray
+    # release
+    "default:distutils Version classes are deprecated.*:DeprecationWarning",
+    # statsmodels imports a module that's deprecated since pandas 1.14.0
+    "default:pandas.Int64Index is deprecated *:FutureWarning",
 ]
 
 [tool.usort]


### PR DESCRIPTION
Summary:
In a [test run of the deployment workflow](https://github.com/facebookresearch/beanmachine/actions/runs/1748339829), we found that there're two warnings (that are treated as errors) that blocks the release:
- [`DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.`](https://github.com/facebookresearch/beanmachine/runs/4945075054?check_suite_focus=true)
  - This is being raised from newer versions of `setuptools`. It's triggered from ~~one~~ two of our dependencies, xarray and statsmodels. Both packages has since updated their code to use `packaging.version`, but haven't make a PyPI release yet.
- [`FutureWarning: pandas.Int64Index is deprecated and will be removed from pandas in a future version. Use pandas.Index with the appropriate dtype instead.`](https://github.com/facebookresearch/beanmachine/runs/4945075612?check_suite_focus=true)
  - This one is introduced by  [`pandas` 1.4.0 release](https://github.com/pandas-dev/pandas/releases/tag/v1.4.0) that was made 4 days ago. This one also comes from `statsmodels`.

Since neither of the warnings are directly triggered by us, there isn't much we can do to silence them other than waiting for our dependencies to make a new release :). Hence, I'm going to add both warnings to our allow list temporarily (and removes two warnings that are no longer relevant from the list).

Some thoughts on future improvements: Perhaps we should only treat warnings that are directly triggered by us as errors (if possible). The original motivation for treating warnings as errors was to improve the quality of our own codebase, but for warnings that are directly raised by our dependencies (such as the two in this diff), there isn't much we can do here.

Differential Revision: D33797991

