### PR TITLE
Replace `df.append` with `pd.concat` to address FutureWarning in pandas 1.14.0

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,7 @@ on:
 
 env:
   PYTHONUNBUFFERED: 1
+  PYTEST_ADDOPTS: "--color=yes"
 
 jobs:
   build-wheel:

--- a/src/beanmachine/applications/hme/null_mixture_model.py
+++ b/src/beanmachine/applications/hme/null_mixture_model.py
@@ -240,10 +240,11 @@ class NullMixtureMixedEffectModel(AbstractLinearModel):
             :, lambda df: np.logical_not(df.columns.duplicated())
         ]
 
-        pred_df = pd.DataFrame()
+        pred_rows = []
         for _, row in new_preprocessed_data.iterrows():
             pred_row = self._predict_fere_byrow(row, post_samples)
             if self.model_config.mean_mixture.use_bimodal_alternative:
                 pred_row = np.exp(pred_row)
-            pred_df = pred_df.append(pred_row, ignore_index=True)
+            pred_rows.append(pred_row)
+        pred_df = pd.concat(pred_rows, axis=1, ignore_index=True).T
         return pred_df


### PR DESCRIPTION
Summary:
Pandas 1.14.0 deprecates `df.append` because the data in the `DataFrame` has to be copied every time the method is invoked. This `FutureWarning` appears on our [Python 3.8 and Python 3.9 test workflow](https://github.com/facebookresearch/beanmachine/runs/4959301275?check_suite_focus=true) (Python 3.7 don't have the issue because Pandas 1.14.0 no longer supports it) and it's blocking our next BM release 😅

Since calling `df.append` in a loop is particularly slow (requires `O(n^2)` to copy the data), in addressing the `FutureWarning`, this diff also updates the code so that the series are accumulated in a temporarily list and calling `pd.concat` only once (which should be `O(n)`).

Differential Revision: D33825096

