### PR TITLE
Bump version to v0.1.1

### DIFF
--- a/src/beanmachine/__init__.py
+++ b/src/beanmachine/__init__.py
@@ -3,4 +3,4 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-__version__ = "0.1.0.post1"
+__version__ = "0.1.1"


### PR DESCRIPTION
Summary: Bumping the version number in preparation for 0.1.1 release (with Python 3.9 support)

Differential Revision: D33830741

