### PR TITLE
Refactor to_real arithmetic compiler test

### DIFF
--- a/src/beanmachine/ppl/compiler/runtime.py
+++ b/src/beanmachine/ppl/compiler/runtime.py
@@ -287,6 +287,7 @@ class BMGRuntime:
             # Math functions
             math.exp: self.handle_exp,
             math.log: self.handle_log,
+            float: self.handle_to_real,
             # Tensor instance functions
             torch.Tensor.add: self.handle_addition,
             torch.Tensor.div: self.handle_division,


### PR DESCRIPTION
Summary:
As in the previous diff in this series, I'm removing an existing unit test which calls internal methods on the BMGRuntime object, and replacing it with a user-scenario test that verifies that a toy model compiles correctly.

I'm going to be refactoring away the handle_to_real method in an upcomding diff, so there's no need to test it.

Reviewed By: feynmanliang

Differential Revision: D33773137

