### PR TITLE
Remove handler methods from compiler runtime module

### DIFF
--- a/src/beanmachine/ppl/compiler/bm_graph_builder.py
+++ b/src/beanmachine/ppl/compiler/bm_graph_builder.py
@@ -90,24 +90,8 @@ class BMGraphBuilder:
     # By memoizing almost all the "add" methods we ensure that
     # the graph is deduplicated automatically.
     #
-    # The "handle" methods, in contrast, conditionally create new
-    # graph nodes only when required because an operation on a
-    # stochastic value must be accumulated into the graph.
-    #
-    # For example, if we have a call to handle_addition where all
-    # operands are ordinary floats (or constant graph nodes)
-    # then there is no need to add a new node to the graph. But
-    # if we have an addition of 1.0 to a stochastic node -- perhaps
-    # a sample node, or perhaps some other graph node that eventually
-    # involves a sample node -- then we need to construct a new
-    # addition node, which is then returned and becomes the value
-    # manipulated by the executing lifted program.
-    #
-    # TODO: The code in the "handle" methods which folds operations
-    # on constant nodes and regular values is a holdover from an
-    # earlier prototyping stage in which all values were lifted to
-    # graph nodes. These scenarios should now be impossible, and we
-    # should take a work item to remove this now-unnecessary code.
+    # TODO: This code does constant folding as well as deduplication,
+    # but that could be moved to a later optimization pass.
 
     def add_node(self, node: BMGNode) -> BMGNode:
         # TODO: This should be private

--- a/src/beanmachine/ppl/compiler/runtime.py
+++ b/src/beanmachine/ppl/compiler/runtime.py
@@ -51,7 +51,6 @@ three, four and five.
 """
 
 import inspect
-import operator
 from types import MethodType
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
@@ -182,80 +181,12 @@ class BMGRuntime:
             )
         )
 
-    def handle_greater_than(self, input: Any, other: Any) -> Any:
-        return self.handle_function(operator.gt, [input, other], {})
-
-    def handle_greater_than_equal(self, input: Any, other: Any) -> Any:
-        return self.handle_function(operator.ge, [input, other], {})
-
-    def handle_less_than(self, input: Any, other: Any) -> Any:
-        return self.handle_function(operator.lt, [input, other], {})
-
-    def handle_less_than_equal(self, input: Any, other: Any) -> Any:
-        return self.handle_function(operator.le, [input, other], {})
-
-    def handle_equal(self, input: Any, other: Any) -> Any:
-        return self.handle_function(operator.eq, [input, other], {})
-
-    def handle_not_equal(self, input: Any, other: Any) -> Any:
-        return self.handle_function(operator.ne, [input, other], {})
-
-    def handle_is(self, input: Any, other: Any) -> Any:
-        return self.handle_function(operator.is_, [input, other], {})
-
-    def handle_is_not(self, input: Any, other: Any) -> Any:
-        return self.handle_function(operator.is_not, [input, other], {})
-
-    def handle_in(self, input: Any, other: Any) -> Any:
-        # Note that we reverse the operands here; "a in b" is the
-        # same as "contains(b, a)"
-        return self.handle_function(operator.contains, [other, input], {})
-
     def handle_not_in(self, input: Any, other: Any) -> Any:
         # Unfortunately there is no operator function equivalent of
         # "not in" so we can't leverage the special function caller here.
         return self._possibly_stochastic_op(
             lambda x, y: x not in y, self._bmg.add_not_in, [input, other]
         )
-
-    def handle_multiplication(self, input: Any, other: Any) -> Any:
-        return self.handle_function(operator.mul, [input, other], {})
-
-    def handle_matrix_multiplication(self, input: Any, mat2: Any) -> Any:
-        return self.handle_function(operator.matmul, [input, mat2], {})
-
-    def handle_addition(self, input: Any, other: Any) -> Any:
-        return self.handle_function(operator.add, [input, other], {})
-
-    def handle_bitand(self, input: Any, other: Any) -> Any:
-        return self.handle_function(operator.and_, [input, other], {})
-
-    def handle_bitor(self, input: Any, other: Any) -> Any:
-        return self.handle_function(operator.or_, [input, other], {})
-
-    def handle_bitxor(self, input: Any, other: Any) -> Any:
-        return self.handle_function(operator.xor, [input, other], {})
-
-    def handle_subtraction(self, input: Any, other: Any) -> Any:
-        return self.handle_function(operator.sub, [input, other], {})
-
-    def handle_division(self, input: Any, other: Any) -> Any:
-        return self.handle_function(operator.truediv, [input, other], {})
-
-    def handle_floordiv(self, input: Any, other: Any) -> Any:
-        return self.handle_function(operator.floordiv, [input, other], {})
-
-    def handle_lshift(self, input: Any, other: Any) -> Any:
-        return self.handle_function(operator.lshift, [input, other], {})
-
-    def handle_mod(self, input: Any, other: Any) -> Any:
-        return self.handle_function(operator.mod, [input, other], {})
-
-    def handle_power(self, input: Any, exponent: Any) -> Any:
-        return self.handle_function(operator.pow, [input, exponent], {})
-
-    def handle_rshift(self, input: Any, other: Any) -> Any:
-        return self.handle_function(operator.rshift, [input, other], {})
 
     def _is_stochastic_tuple(self, t: Any):
         # A stochastic tuple is any tuple where any element is either a graph node
@@ -333,61 +264,6 @@ class BMGRuntime:
         ):
             raise ValueError("Stochastic slices are not yet implemented.")
         return left[lower:upper:step]
-
-    def handle_invert(self, input: Any) -> Any:
-        return self.handle_function(operator.inv, [input], {})
-
-    def handle_negate(self, input: Any) -> Any:
-        return self.handle_function(operator.neg, [input], {})
-
-    def handle_uadd(self, input: Any) -> Any:
-        return self.handle_function(operator.pos, [input], {})
-
-    def handle_not(self, input: Any) -> Any:
-        return self.handle_function(operator.not_, [input], {})
-
-    #
-    # Augmented assignment operators
-    #
-
-    def handle_iadd(self, left: Any, right: Any) -> Any:
-        return self.handle_function(operator.iadd, [left, right])
-
-    def handle_isub(self, left: Any, right: Any) -> Any:
-        return self.handle_function(operator.isub, [left, right])
-
-    def handle_imul(self, left: Any, right: Any) -> Any:
-        return self.handle_function(operator.imul, [left, right])
-
-    def handle_idiv(self, left: Any, right: Any) -> Any:
-        return self.handle_function(operator.itruediv, [left, right])
-
-    def handle_ifloordiv(self, left: Any, right: Any) -> Any:
-        return self.handle_function(operator.ifloordiv, [left, right])
-
-    def handle_imod(self, left: Any, right: Any) -> Any:
-        return self.handle_function(operator.imod, [left, right])
-
-    def handle_ipow(self, left: Any, right: Any) -> Any:
-        return self.handle_function(operator.ipow, [left, right])
-
-    def handle_imatmul(self, left: Any, right: Any) -> Any:
-        return self.handle_function(operator.imatmul, [left, right])
-
-    def handle_ilshift(self, left: Any, right: Any) -> Any:
-        return self.handle_function(operator.ilshift, [left, right])
-
-    def handle_irshift(self, left: Any, right: Any) -> Any:
-        return self.handle_function(operator.irshift, [left, right])
-
-    def handle_iand(self, left: Any, right: Any) -> Any:
-        return self.handle_function(operator.iand, [left, right])
-
-    def handle_ixor(self, left: Any, right: Any) -> Any:
-        return self.handle_function(operator.ixor, [left, right])
-
-    def handle_ior(self, left: Any, right: Any) -> Any:
-        return self.handle_function(operator.ior, [left, right])
 
     #
     # Control flow

--- a/src/beanmachine/ppl/compiler/tests/bm_to_bmg_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bm_to_bmg_test.py
@@ -201,6 +201,7 @@ digraph "graph" {
         observed = astor.to_source(bmgast)
         expected = """
 def foo_helper(bmg, __class__):
+    import operator
 
     def foo(self):
         a5 = super()
@@ -210,13 +211,13 @@ def foo_helper(bmg, __class__):
         f = bmg.handle_function(a1, r7, r10)
         a14 = [DerivedModel]
         a15 = [self]
-        r13 = bmg.handle_addition(a14, a15)
+        r13 = bmg.handle_function(operator.add, [a14, a15])
         a6 = super(*r13)
         a2 = bmg.handle_dot_get(a6, 'bar')
         r8 = []
         r11 = {}
         b = bmg.handle_function(a2, r8, r11)
-        r3 = bmg.handle_multiplication(f, b)
+        r3 = bmg.handle_function(operator.mul, [f, b])
         return r3
     a4 = bmg.handle_dot_get(bm, 'functional')
     r9 = [foo]

--- a/src/beanmachine/ppl/compiler/tests/comparison_rewriting_test.py
+++ b/src/beanmachine/ppl/compiler/tests/comparison_rewriting_test.py
@@ -53,26 +53,27 @@ class ComparisonRewritingTest(unittest.TestCase):
         observed = astor.to_source(bmgast)
         expected = """
 def y_helper(bmg):
+    import operator
 
     def y():
         a1 = 0.0
         r6 = []
         r10 = {}
         a4 = bmg.handle_function(x, r6, r10)
-        a7 = bmg.handle_less_than(a1, a4)
+        a7 = bmg.handle_function(operator.lt, [a1, a4])
         bmg.handle_if(a7)
         if a7:
             a8 = 2.0
-            z = bmg.handle_less_than(a4, a8)
+            z = bmg.handle_function(operator.lt, [a4, a8])
         else:
             z = a7
         a16 = 3.0
         a13 = [a16]
         a17 = [z]
-        a12 = bmg.handle_addition(a13, a17)
+        a12 = bmg.handle_function(operator.add, [a13, a17])
         a18 = 4.0
         a14 = [a18]
-        r11 = bmg.handle_addition(a12, a14)
+        r11 = bmg.handle_function(operator.add, [a12, a14])
         r15 = {}
         r2 = bmg.handle_function(StudentT, r11, r15)
         return r2

--- a/src/beanmachine/ppl/compiler/tests/jit_test.py
+++ b/src/beanmachine/ppl/compiler/tests/jit_test.py
@@ -223,6 +223,7 @@ class JITTest(unittest.TestCase):
         observed = astor.to_source(bmgast)
         expected = """
 def f_helper(bmg):
+    import operator
 
     def f(x):
         a2 = bmg.handle_dot_get(math, 'exp')
@@ -237,11 +238,12 @@ def f_helper(bmg):
         observed = astor.to_source(bmgast)
         expected = """
 def norm_helper(bmg):
+    import operator
 
     def norm(n):
         global counter
         a1 = 1
-        counter = bmg.handle_addition(counter, a1)
+        counter = bmg.handle_function(operator.add, [counter, a1])
         r4 = []
         a9 = 0.0
         a8 = dict(loc=a9)


### PR DESCRIPTION
Summary:
After the preceding refactorings we now have 39 unnecessary `handle_foo` functions in the runtime module; all of them can be replaced with `handle_function(operator.foo, ...)`.

Unfortunately there is no operator form of `not in`, so I've kept that one around. We might consider having the single assignment rewriter do the transformation

    x = y not in z   -->   x = not (y in z)

and then we could eliminate this as well.

Reviewed By: yucenli

Differential Revision: D34097564

