### PR TITLE
Compiler runtime now tracks call stack for node context

### DIFF
--- a/src/beanmachine/ppl/compiler/execution_context.py
+++ b/src/beanmachine/ppl/compiler/execution_context.py
@@ -1,0 +1,93 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, Callable, List, Dict, Optional
+
+from beanmachine.ppl.compiler.bmg_nodes import BMGNode
+from beanmachine.ppl.utils.multidictionary import MultiDictionary
+
+# We wish to associate the program state at the time of node creation
+# with that node, so that we can produce better diagnostics, error messages,
+# and so on.
+
+
+class FunctionCall:
+    # A record of a particular function call.
+    func: Callable
+    args: Any
+    kwargs: Dict[str, Any]
+
+    def __init__(self, func: Callable, args: Any, kwargs: Dict[str, Any]) -> None:
+        self.func = func
+        self.args = args
+        self.kwargs = kwargs
+
+    def __str__(self) -> str:
+        func = self.func.__name__
+        args = ",".join(str(arg) for arg in self.args)
+        kwargs = ",".join(
+            sorted(
+                (str(kwarg) + "=" + str(self.kwargs[kwarg])) for kwarg in self.kwargs
+            )
+        )
+        comma = "," if len(args) > 0 and len(kwargs) > 0 else ""
+        return f"{func}({args}{comma}{kwargs})"
+
+
+class CallStack:
+    _stack: List[FunctionCall]
+
+    def __init__(self) -> None:
+        self._stack = []
+
+    def push(self, FunctionCall: FunctionCall) -> None:
+        self._stack.append(FunctionCall)
+
+    def pop(self) -> FunctionCall:
+        return self._stack.pop()
+
+    def peek(self) -> Optional[FunctionCall]:
+        return self._stack[-1] if len(self._stack) > 0 else None
+
+
+_empty_kwargs = {}
+
+
+class ExecutionContext:
+    # An execution context does two jobs right now:
+    # * Tracks the current call stack
+    # * Maintains a map from nodes to the function call that
+    #   created them.
+    #
+    # NOTE: Because most nodes are deduplicated, it is possible that
+    # one node is associated with multiple calls. We therefore have
+    # a multidictionary that maps from nodes to a set of function calls.
+
+    _stack: CallStack
+    _node_locations: MultiDictionary  # BMGNode -> {FunctionCall}
+
+    def __init__(self) -> None:
+        self._stack = CallStack()
+        self._node_locations = MultiDictionary()
+
+    def current_site(self) -> Optional[FunctionCall]:
+        return self._stack.peek()
+
+    def record_node_call(
+        self, node: BMGNode, site: Optional[FunctionCall] = None
+    ) -> None:
+        if site is None:
+            site = self.current_site()
+        if site is not None:
+            self._node_locations.add(node, site)
+
+    def call(
+        self, func: Callable, args: Any, kwargs: Dict[str, Any] = _empty_kwargs
+    ) -> Any:
+        self._stack.push(FunctionCall(func, args, kwargs))
+        try:
+            return func(*args, **kwargs)
+        finally:
+            self._stack.pop()

--- a/src/beanmachine/ppl/compiler/tests/node_context_test.py
+++ b/src/beanmachine/ppl/compiler/tests/node_context_test.py
@@ -1,0 +1,70 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import beanmachine.ppl as bm
+from beanmachine.ppl.compiler.runtime import BMGRuntime
+from torch.distributions import Bernoulli, Beta
+
+
+@bm.random_variable
+def beta():
+    return Beta(2.0, 2.0)
+
+
+@bm.random_variable
+def flip1(n):
+    return Bernoulli(beta())
+
+
+@bm.functional
+def sum1():
+    return flip1(0) + 1.0
+
+
+def sum2(n, m):
+    # Note that sum2 is NOT a functional.
+    # The returned addition node should deduplicate with
+    # the one returned by sum1().
+    return flip1(0) + (n * m)
+
+
+@bm.functional
+def prod1(n):
+    # Try a named argument.
+    return sum1() * sum2(1.0, m=1.0)
+
+
+@bm.functional
+def log1(n):
+    return prod1(n).log()
+
+
+def _dict_to_str(d) -> str:
+    return "\n".join(
+        sorted(
+            type(key).__name__ + ":{" + ",".join(sorted(str(v) for v in d[key])) + "}"
+            for key in d
+        )
+    )
+
+
+class NodeContextTest(unittest.TestCase):
+    def test_node_context(self) -> None:
+        self.maxDiff = None
+        rt = BMGRuntime()
+        rt.accumulate_graph([log1(123)], {})
+        expected = """
+AdditionNode:{sum1(),sum2(1.0,m=1.0)}
+BernoulliNode:{flip1(0)}
+BetaNode:{beta()}
+LogNode:{log1(123)}
+MultiplicationNode:{prod1(123)}
+SampleNode:{beta()}
+SampleNode:{flip1(0)}
+"""
+        observed = _dict_to_str(rt._context._node_locations)
+        self.assertEqual(expected.strip(), observed.strip())

--- a/src/beanmachine/ppl/utils/multidictionary.py
+++ b/src/beanmachine/ppl/utils/multidictionary.py
@@ -3,7 +3,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-
 from typing import Any, Dict, Set
 
 


### PR DESCRIPTION
Summary:
We wish to know facts about the provenance of a graph node for purposes of diagnostics, error messages, debugging, and so on. Now that function calling is refactored in the runtime module so that there are a very small number of locations where a node can be created, we can more easily do so.

In this diff we just create a map from graph nodes to the function call which created them; we do not use this information for any purpose yet. That will come in a later diff.

Similarly, we will also build a mechanism for more fine-grained tracking (such as: what line of code in the original model should be associated with this node?) in a later diff.

Reviewed By: yucenli

Differential Revision: D33696305

