### PR TITLE
Enabling algorithm-specific default num_adaptive_samples

### DIFF
--- a/src/beanmachine/ppl/inference/hmc_inference.py
+++ b/src/beanmachine/ppl/inference/hmc_inference.py
@@ -47,6 +47,9 @@ class GlobalHamiltonianMonteCarlo(BaseInference):
         self.target_accept_prob = target_accept_prob
         self._proposer = None
 
+    def _get_default_num_adaptive_samples(self, num_samples: int) -> int:
+        return num_samples // 2
+
     def get_proposers(
         self,
         world: World,
@@ -98,6 +101,9 @@ class SingleSiteHamiltonianMonteCarlo(BaseInference):
         self.adapt_mass_matrix = adapt_mass_matrix
         self.target_accept_prob = target_accept_prob
         self._proposers = {}
+
+    def _get_default_num_adaptive_samples(self, num_samples: int) -> int:
+        return num_samples // 2
 
     def get_proposers(
         self,

--- a/src/beanmachine/ppl/inference/nuts_inference.py
+++ b/src/beanmachine/ppl/inference/nuts_inference.py
@@ -59,6 +59,9 @@ class GlobalNoUTurnSampler(BaseInference):
         self.target_accept_prob = target_accept_prob
         self._proposer = None
 
+    def _get_default_num_adaptive_samples(self, num_samples: int) -> int:
+        return num_samples // 2
+
     def get_proposers(
         self,
         world: World,
@@ -123,6 +126,9 @@ class SingleSiteNoUTurnSampler(BaseInference):
         self.multinomial_sampling = multinomial_sampling
         self.target_accept_prob = target_accept_prob
         self._proposers = {}
+
+    def _get_default_num_adaptive_samples(self, num_samples: int) -> int:
+        return num_samples // 2
 
     def get_proposers(
         self,

--- a/src/beanmachine/ppl/inference/tests/compositional_infer_test.py
+++ b/src/beanmachine/ppl/inference/tests/compositional_infer_test.py
@@ -231,3 +231,26 @@ def test_block_inference_changing_shape():
     # however, K is going to be stuck at its initial value because changing it will
     # invalidate alpha
     assert torch.all(samples[model.K()] == samples[model.K()][0])
+
+
+def test_default_num_adaptive_samples():
+    model = SampleModel()
+    num_samples = 100
+    compositional = bm.CompositionalInference(
+        {
+            model.bar: bm.SingleSiteAncestralMetropolisHastings(),
+            ...: bm.SingleSiteRandomWalk(),
+        }
+    )
+    # none of the method in compositional requires adaptation, so default to 0
+    assert compositional._get_default_num_adaptive_samples(num_samples) == 0
+    compositional = bm.CompositionalInference(
+        {
+            model.foo: bm.GlobalNoUTurnSampler(),
+            model.bar: bm.SingleSiteAncestralMetropolisHastings(),
+        }
+    )
+    # default to num_samples // 2 due to NUTS' default
+    assert (
+        compositional._get_default_num_adaptive_samples(num_samples) == num_samples // 2
+    )

--- a/src/beanmachine/ppl/inference/tests/sampler_test.py
+++ b/src/beanmachine/ppl/inference/tests/sampler_test.py
@@ -24,7 +24,7 @@ def test_sampler():
     queries = [model.foo()]
     observations = {model.bar(): torch.tensor(0.5)}
     num_samples = 10
-    sampler = nuts.sampler(queries, observations, num_samples)
+    sampler = nuts.sampler(queries, observations, num_samples, num_adaptive_samples=0)
     worlds = list(sampler)
     assert len(worlds) == num_samples
     for world in worlds:


### PR DESCRIPTION
Summary:
The number of adaptive samples for all algorithm is set to 0 by default, which is okay for algorithms like ancestral MH or NMC, but not for HMC and NUTS. Per our previous discussion, instead of using the same default value for all algorithms, a better solution is to let each algorithm determine how many adaptive iterations are necessary. For compositional inference, it will look up the number of adaptive samples required by each inference method in the config and default to the maximum among them (see [Option 3 in Warmup Design](https://fb.quip.com/jzFvAai8ogWV#temp:C:WMIc97e2ffd843b4ab19bbe40c7c) for details).

This diff implement this idea by introducing a `_get_default_num_adaptive_samples` private method on `BaseInference`, which is default to 0. Algorithms can override the default behavior by overloading the method.

Differential Revision: D34404061

