### PR TITLE
Reword some awkward compiler error messages

### DIFF
--- a/src/beanmachine/ppl/compiler/error_report.py
+++ b/src/beanmachine/ppl/compiler/error_report.py
@@ -15,12 +15,8 @@ from beanmachine.ppl.compiler.bmg_types import (
     Requirement,
     requirement_to_type,
 )
-from beanmachine.ppl.compiler.graph_labels import get_node_label
-
-
-# TODO: We use the DOT label of the node in the error messages here,
-# but we can probably do a better job. These labels are designed for
-# displaying a graph, not an error message.
+from beanmachine.ppl.compiler.graph_labels import get_node_error_label
+from beanmachine.ppl.utils.a_or_an import a_or_an, A_or_An
 
 
 class BMGError(ABC):
@@ -55,9 +51,9 @@ class Violation(BMGError):
         # TODO: Fix this error message for the case where we require
         # a matrix but we can only get a scalar value
         msg = (
-            f"The {self.edge} of a {get_node_label(self.consumer)} "
-            + f"is required to be a {t.long_name} "
-            + f"but is a {self.node_type.long_name}."
+            f"The {self.edge} of {a_or_an(get_node_error_label(self.consumer))} "
+            + f"is required to be {a_or_an(t.long_name)} "
+            + f"but is {a_or_an(self.node_type.long_name)}."
         )
         return msg
 
@@ -74,10 +70,10 @@ class ImpossibleObservation(BMGError):
         v = self.node.value
         s = self.node.observed
         assert isinstance(s, SampleNode)
-        d = get_node_label(s.operand)
+        d = get_node_error_label(s.operand)
         t = self.distribution_type.long_name
         msg = (
-            f"A {d} distribution is observed to have value {v} "
+            f"{A_or_An(d)} distribution is observed to have value {v} "
             + f"but only produces samples of type {t}."
         )
         return msg
@@ -96,9 +92,9 @@ class UnsupportedNode(BMGError):
     def __str__(self) -> str:
         msg = (
             # TODO: Improve wording and diagnosis.
-            f"The model uses a {get_node_label(self.node)} operation unsupported by "
+            f"The model uses {a_or_an(get_node_error_label(self.node))} operation unsupported by "
             + f"Bean Machine Graph.\nThe unsupported node is the {self.edge} "
-            + f"of a {get_node_label(self.consumer)}."
+            + f"of {a_or_an(get_node_error_label(self.consumer))}."
         )
         return msg
 

--- a/src/beanmachine/ppl/compiler/graph_labels.py
+++ b/src/beanmachine/ppl/compiler/graph_labels.py
@@ -27,6 +27,7 @@ def _val(node: bn.ConstantNode) -> str:
     return str(node.value)
 
 
+# These are the labels used when rendering a graph as a DOT.
 _node_labels = {
     bn.AdditionNode: "+",
     bn.BernoulliLogitNode: "Bernoulli(logits)",
@@ -116,6 +117,98 @@ _node_labels = {
     bn.UntypedConstantNode: _val,
     bn.VectorIndexNode: "index",
 }
+
+# These are the labels used when describing a node in an error message.
+_node_error_labels = {
+    bn.AdditionNode: "addition (+)",
+    bn.BernoulliLogitNode: "Bernoulli",
+    bn.BernoulliNode: "Bernoulli",
+    bn.BetaNode: "beta",
+    bn.BinomialNode: "binomial",
+    bn.BinomialLogitNode: "binomial",
+    bn.BitAndNode: "'bitwise and' (&)",
+    bn.BitOrNode: "'bitwise or' (|)",
+    bn.BitXorNode: "'bitwise xor' (^)",
+    bn.BooleanNode: "Boolean value",
+    bn.CategoricalLogitNode: "categorical",
+    bn.CategoricalNode: "categorical",
+    bn.Chi2Node: "chi-squared",
+    bn.ChoiceNode: "choice",
+    bn.ColumnIndexNode: "column index",
+    bn.ComplementNode: "complement",
+    bn.ConstantBooleanMatrixNode: "Boolean matrix",
+    bn.ConstantNaturalMatrixNode: "natural matrix",
+    bn.ConstantNegativeRealMatrixNode: "negative real matrix",
+    bn.ConstantPositiveRealMatrixNode: "positive real matrix",
+    bn.ConstantProbabilityMatrixNode: "probability matrix",
+    bn.ConstantRealMatrixNode: "real matrix",
+    bn.ConstantSimplexMatrixNode: "simplex",
+    bn.ConstantTensorNode: "tensor",
+    bn.DirichletNode: "Dirichlet",
+    bn.DivisionNode: "division (/)",
+    bn.EqualNode: "equality (==)",
+    bn.ExpM1Node: "expm1",
+    bn.ExpNode: "exp",
+    bn.ExpProductFactorNode: "exp product factor",
+    bn.FlatNode: "flat",
+    bn.FloorDivNode: "floor division (//)",
+    bn.GammaNode: "gamma",
+    bn.GreaterThanEqualNode: "'greater than or equal' (>=)",
+    bn.GreaterThanNode: "'greater than' (>)",
+    bn.HalfCauchyNode: "half Cauchy",
+    bn.IfThenElseNode: "'if'",
+    bn.InNode: "'in'",
+    bn.IndexNode: "index",
+    bn.InvertNode: "'bitwise invert' (~)",
+    bn.IsNode: "'is'",
+    bn.IsNotNode: "'is not'",
+    bn.ItemNode: "item",
+    bn.LessThanEqualNode: "'less than or equal' (<=)",
+    bn.LessThanNode: "'less than' (<)",
+    bn.Log1mexpNode: "log1mexp",
+    bn.LogisticNode: "logistic",
+    bn.LogNode: "log",
+    bn.LogSumExpNode: "logsumexp",
+    bn.LogSumExpTorchNode: "logsumexp",
+    bn.LogSumExpVectorNode: "logsumexp",
+    bn.LShiftNode: "'left shift' (<<)",
+    bn.MatrixMultiplicationNode: "matrix multiplication (@)",
+    bn.MatrixScaleNode: "matrix scale",
+    bn.ModNode: "modulus (%)",
+    bn.MultiplicationNode: "multiplication (*)",
+    bn.NaturalNode: "natural value",
+    bn.NegateNode: "negation (-)",
+    bn.NegativeRealNode: "negative real value",
+    bn.NormalNode: "normal",
+    bn.HalfNormalNode: "half normal",
+    bn.NotEqualNode: "inequality (!=)",
+    bn.NotInNode: "'not in'",
+    bn.NotNode: "'not'",
+    bn.Observation: "observation",
+    bn.PhiNode: "phi",
+    bn.PositiveRealNode: "positive real value",
+    bn.PowerNode: "power (**)",
+    bn.ProbabilityNode: "probability value",
+    bn.Query: "query",
+    bn.RealNode: "real value",
+    bn.RShiftNode: "'right shift' (>>)",
+    bn.SampleNode: "sample",
+    bn.StudentTNode: "student T",
+    bn.SwitchNode: "switch",
+    bn.TensorNode: "tensor",
+    bn.ToIntNode: "'to int'",
+    bn.ToMatrixNode: "'to matrix'",
+    bn.ToNegativeRealNode: "'to negative real'",
+    bn.ToPositiveRealMatrixNode: "'to positive real matrix'",
+    bn.ToPositiveRealNode: "'to positive real'",
+    bn.ToProbabilityNode: "'to probability'",
+    bn.ToRealMatrixNode: "'to real matrix'",
+    bn.ToRealNode: "'to real'",
+    bn.UniformNode: "uniform",
+    bn.UntypedConstantNode: "constant value",
+    bn.VectorIndexNode: "index",
+}
+
 
 _none = []
 _left_right = ["left", "right"]
@@ -214,14 +307,15 @@ _edge_labels = {
 
 
 def get_node_label(node: bn.BMGNode) -> str:
-    t = type(node)
-    if t not in _node_labels:
-        return "UNKNOWN"
-    label = _node_labels[t]
+    label = _node_labels.get(type(node), "UNKNOWN")  # pyre-ignore
     if isinstance(label, str):
         return label
     assert isinstance(label, Callable)
     return label(node)
+
+
+def get_node_error_label(node: bn.BMGNode) -> str:
+    return _node_error_labels.get(type(node), "UNKNOWN")  # pyre-ignore
 
 
 def get_edge_labels(node: bn.BMGNode) -> List[str]:

--- a/src/beanmachine/ppl/compiler/tests/bmg_arithmetic_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_arithmetic_test.py
@@ -131,16 +131,6 @@ def bino():
 
 
 @bm.functional
-def unsupported_invert():
-    return ~bino()
-
-
-@bm.functional
-def unsupported_bitxor():
-    return bino() ^ bino()
-
-
-@bm.functional
 def unsupported_add():
     # What happens if we use a stochastic quantity in an operation with
     # a non-tensor, non-number?
@@ -1542,6 +1532,8 @@ class BMGArithmeticTest(unittest.TestCase):
         # "not" operators are not yet properly supported by the compiler/BMG;
         # update this test when we get them working.
 
+        # TODO: Add test cases for not operators on Bernoulli samples.
+
         queries = [
             not_1(),
             not_2(),
@@ -1556,14 +1548,14 @@ class BMGArithmeticTest(unittest.TestCase):
         with self.assertRaises(ValueError) as ex:
             BMGInference().infer(queries, {}, 1)
         expected = """
-The model uses a not operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-The model uses a not operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-The model uses a not operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-The model uses a not operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
+The model uses a 'not' operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+The model uses a 'not' operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+The model uses a 'not' operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+The model uses a 'not' operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
         """
         observed = str(ex.exception)
         self.assertEqual(observed.strip(), expected.strip())
@@ -1899,14 +1891,14 @@ digraph "graph" {
         with self.assertRaises(ValueError) as ex:
             BMGInference().infer(queries, {}, 1)
         expected = """
-The model uses a & operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-The model uses a & operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-The model uses a & operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-The model uses a & operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
+The model uses a 'bitwise and' (&) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+The model uses a 'bitwise and' (&) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+The model uses a 'bitwise and' (&) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+The model uses a 'bitwise and' (&) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
         """
         observed = str(ex.exception)
         self.assertEqual(observed.strip(), expected.strip())
@@ -1999,14 +1991,14 @@ digraph "graph" {
         with self.assertRaises(ValueError) as ex:
             BMGInference().infer(queries, {}, 1)
         expected = """
-The model uses a == operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-The model uses a == operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-The model uses a == operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-The model uses a == operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
+The model uses an equality (==) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+The model uses an equality (==) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+The model uses an equality (==) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+The model uses an equality (==) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
         """
         observed = str(ex.exception)
         self.assertEqual(observed.strip(), expected.strip())
@@ -2037,13 +2029,13 @@ The unsupported node is the operator of a Query.
             BMGInference().infer(queries, {}, 1)
         expected = """
 The model uses a // operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
+The unsupported node is the operator of a query.
 The model uses a // operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
+The unsupported node is the operator of a query.
 The model uses a // operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
+The unsupported node is the operator of a query.
 The model uses a // operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
+The unsupported node is the operator of a query.
         """
         observed = str(ex.exception)
         self.assertEqual(observed.strip(), expected.strip())
@@ -2068,14 +2060,14 @@ The unsupported node is the operator of a Query.
         with self.assertRaises(ValueError) as ex:
             BMGInference().infer(queries, {}, 1)
         expected = """
-The model uses a >= operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-The model uses a >= operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-The model uses a >= operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-The model uses a >= operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
+The model uses a 'greater than or equal' (>=) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+The model uses a 'greater than or equal' (>=) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+The model uses a 'greater than or equal' (>=) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+The model uses a 'greater than or equal' (>=) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
         """
         observed = str(ex.exception)
         self.assertEqual(observed.strip(), expected.strip())
@@ -2100,14 +2092,14 @@ The unsupported node is the operator of a Query.
         with self.assertRaises(ValueError) as ex:
             BMGInference().infer(queries, {}, 1)
         expected = """
-The model uses a > operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-The model uses a > operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-The model uses a > operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-The model uses a > operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
+The model uses a 'greater than' (>) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+The model uses a 'greater than' (>) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+The model uses a 'greater than' (>) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+The model uses a 'greater than' (>) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
         """
         observed = str(ex.exception)
         self.assertEqual(observed.strip(), expected.strip())
@@ -2131,13 +2123,13 @@ The unsupported node is the operator of a Query.
         with self.assertRaises(ValueError) as ex:
             BMGInference().infer(queries, {}, 1)
         expected = """
-The model uses a In operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-The model uses a In operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-The model uses a NotIn operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-        """
+The model uses a 'not in' operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+The model uses an 'in' operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+The model uses an 'in' operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+"""
         observed = str(ex.exception)
         self.assertEqual(observed.strip(), expected.strip())
 
@@ -2160,15 +2152,14 @@ The unsupported node is the operator of a Query.
         with self.assertRaises(ValueError) as ex:
             BMGInference().infer(queries, {}, 1)
         expected = """
-The model uses a Is operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-The model uses a Is operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-The model uses a IsNot operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-The model uses a IsNot operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-        """
+The model uses an 'is not' operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+The model uses an 'is not' operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+The model uses an 'is' operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+The model uses an 'is' operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query."""
         observed = str(ex.exception)
         self.assertEqual(observed.strip(), expected.strip())
 
@@ -2193,14 +2184,14 @@ The unsupported node is the operator of a Query.
             BMGInference().infer(queries, {}, 1)
         # TODO: This is weirdly capitalized and ungrammatical. Fix the error message.
         expected = """
-The model uses a Invert operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-The model uses a Invert operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-The model uses a Invert operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-The model uses a Invert operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
+The model uses a 'bitwise invert' (~) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+The model uses a 'bitwise invert' (~) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+The model uses a 'bitwise invert' (~) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+The model uses a 'bitwise invert' (~) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
         """
         observed = str(ex.exception)
         self.assertEqual(observed.strip(), expected.strip())
@@ -2225,14 +2216,14 @@ The unsupported node is the operator of a Query.
         with self.assertRaises(ValueError) as ex:
             BMGInference().infer(queries, {}, 1)
         expected = """
-The model uses a <= operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-The model uses a <= operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-The model uses a <= operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-The model uses a <= operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
+The model uses a 'less than or equal' (<=) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+The model uses a 'less than or equal' (<=) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+The model uses a 'less than or equal' (<=) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+The model uses a 'less than or equal' (<=) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
         """
         observed = str(ex.exception)
         self.assertEqual(observed.strip(), expected.strip())
@@ -2257,14 +2248,14 @@ The unsupported node is the operator of a Query.
         with self.assertRaises(ValueError) as ex:
             BMGInference().infer(queries, {}, 1)
         expected = """
-The model uses a << operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-The model uses a << operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-The model uses a << operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-The model uses a << operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
+The model uses a 'left shift' (<<) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+The model uses a 'left shift' (<<) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+The model uses a 'left shift' (<<) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+The model uses a 'left shift' (<<) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
         """
         observed = str(ex.exception)
         self.assertEqual(observed.strip(), expected.strip())
@@ -2289,14 +2280,14 @@ The unsupported node is the operator of a Query.
         with self.assertRaises(ValueError) as ex:
             BMGInference().infer(queries, {}, 1)
         expected = """
-The model uses a < operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-The model uses a < operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-The model uses a < operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-The model uses a < operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
+The model uses a 'less than' (<) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+The model uses a 'less than' (<) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+The model uses a 'less than' (<) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+The model uses a 'less than' (<) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
         """
         observed = str(ex.exception)
         self.assertEqual(observed.strip(), expected.strip())
@@ -2321,14 +2312,14 @@ The unsupported node is the operator of a Query.
         with self.assertRaises(ValueError) as ex:
             BMGInference().infer(queries, {}, 1)
         expected = """
-The model uses a % operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-The model uses a % operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-The model uses a % operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-The model uses a % operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
+The model uses a modulus (%) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+The model uses a modulus (%) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+The model uses a modulus (%) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+The model uses a modulus (%) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
         """
         observed = str(ex.exception)
         self.assertEqual(observed.strip(), expected.strip())
@@ -2423,14 +2414,14 @@ digraph "graph" {
         with self.assertRaises(ValueError) as ex:
             BMGInference().infer(queries, {}, 1)
         expected = """
-The model uses a != operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-The model uses a != operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-The model uses a != operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-The model uses a != operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
+The model uses an inequality (!=) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+The model uses an inequality (!=) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+The model uses an inequality (!=) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+The model uses an inequality (!=) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
         """
         observed = str(ex.exception)
         self.assertEqual(observed.strip(), expected.strip())
@@ -2455,14 +2446,14 @@ The unsupported node is the operator of a Query.
         with self.assertRaises(ValueError) as ex:
             BMGInference().infer(queries, {}, 1)
         expected = """
-The model uses a | operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-The model uses a | operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-The model uses a | operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-The model uses a | operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
+The model uses a 'bitwise or' (|) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+The model uses a 'bitwise or' (|) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+The model uses a 'bitwise or' (|) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+The model uses a 'bitwise or' (|) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
         """
         observed = str(ex.exception)
         self.assertEqual(observed.strip(), expected.strip())
@@ -2487,15 +2478,15 @@ The unsupported node is the operator of a Query.
         with self.assertRaises(ValueError) as ex:
             BMGInference().infer(queries, {}, 1)
         expected = """
-The model uses a >> operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-The model uses a >> operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-The model uses a >> operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-The model uses a >> operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-        """
+The model uses a 'right shift' (>>) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+The model uses a 'right shift' (>>) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+The model uses a 'right shift' (>>) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+The model uses a 'right shift' (>>) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+"""
         observed = str(ex.exception)
         self.assertEqual(observed.strip(), expected.strip())
 
@@ -2634,14 +2625,14 @@ digraph "graph" {
         with self.assertRaises(ValueError) as ex:
             BMGInference().infer(queries, {}, 1)
         expected = """
-The model uses a ^ operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-The model uses a ^ operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-The model uses a ^ operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-The model uses a ^ operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
+The model uses a 'bitwise xor' (^) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+The model uses a 'bitwise xor' (^) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+The model uses a 'bitwise xor' (^) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
+The model uses a 'bitwise xor' (^) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
         """
         observed = str(ex.exception)
         self.assertEqual(observed.strip(), expected.strip())
@@ -2959,26 +2950,14 @@ digraph "graph" {
 """
         self.assertEqual(expected.strip(), observed.strip())
 
-    def test_unsupported_arithmetic(self) -> None:
-        self.maxDiff = None
-
-        with self.assertRaises(ValueError) as ex:
-            BMGInference().infer([unsupported_bitxor()], {}, 1)
-        expected = """
-The model uses a ^ operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
-        """
-        observed = str(ex.exception)
-        self.assertEqual(expected.strip(), observed.strip())
-
     def test_unsupported_operands(self) -> None:
         self.maxDiff = None
         with self.assertRaises(ValueError) as ex:
             BMGInference().infer([unsupported_add()], {}, 1)
         # TODO: This error message is terrible; fix it.
         expected = """
-The model uses a foo operation unsupported by Bean Machine Graph.
-The unsupported node is the right of a +.
+The model uses a constant value operation unsupported by Bean Machine Graph.
+The unsupported node is the right of an addition (+).
         """
         observed = str(ex.exception)
         self.assertEqual(expected.strip(), observed.strip())

--- a/src/beanmachine/ppl/compiler/tests/bmg_query_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_query_test.py
@@ -232,10 +232,10 @@ digraph "graph" {
             BMGInference().to_dot([invalid_tensor_1(), invalid_tensor_2()], {})
         # TODO: This error message is horrid. Fix it.
         expected = (
-            "The model uses a [[[1.0,2.0],\\n[3.0,4.0]],\\n[[5.0,6.0],\\n[7.0,8.0]]] "
+            "The model uses a tensor "
             + "operation unsupported by Bean Machine Graph.\n"
-            + "The unsupported node is the operator of a Query.\n"
-            + "The model uses a [] operation unsupported by Bean Machine Graph.\n"
-            + "The unsupported node is the operator of a Query."
+            + "The unsupported node is the operator of a query.\n"
+            + "The model uses a tensor operation unsupported by Bean Machine Graph.\n"
+            + "The unsupported node is the operator of a query."
         )
         self.assertEqual(expected, str(ex.exception))

--- a/src/beanmachine/ppl/compiler/tests/categorical_test.py
+++ b/src/beanmachine/ppl/compiler/tests/categorical_test.py
@@ -203,8 +203,8 @@ q2 = g.query(n4)
             BMGInference().infer(queries, observations, 10)
         observed = str(ex.exception)
         expected = """
-The model uses a Categorical(logits) operation unsupported by Bean Machine Graph.
-The unsupported node is the operand of a Sample.
+The model uses a categorical operation unsupported by Bean Machine Graph.
+The unsupported node is the operand of a sample.
         """
         self.assertEqual(expected.strip(), observed.strip())
 
@@ -224,6 +224,6 @@ The unsupported node is the operand of a Sample.
             BMGInference().infer(queries, observations, 10)
         observed = str(ex.exception)
         expected = """
-The probability of a Categorical is required to be a 2 x 1 simplex matrix but is a 2 x 2 simplex matrix.
+The probability of a categorical is required to be a 2 x 1 simplex matrix but is a 2 x 2 simplex matrix.
         """
         self.assertEqual(expected.strip(), observed.strip())

--- a/src/beanmachine/ppl/compiler/tests/fix_problems_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_problems_test.py
@@ -254,10 +254,10 @@ digraph "graph" {
         error_report = fix_problems(bmg)
         observed = str(error_report)
         expected = """
-The count of a Binomial is required to be a natural but is a positive real.
+The count of a binomial is required to be a natural but is a positive real.
 The probability of a Bernoulli is required to be a probability but is a 2 x 1 simplex matrix.
-The probability of a Binomial is required to be a probability but is a positive real.
-The sigma of a Normal is required to be a positive real but is a negative real.
+The probability of a binomial is required to be a probability but is a positive real.
+The sigma of a normal is required to be a positive real but is a negative real.
         """
         self.assertEqual(observed.strip(), expected.strip())
 
@@ -553,10 +553,10 @@ digraph "graph" {
         error_report = fix_problems(bmg)
         observed = str(error_report)
         expected = """
-The model uses a Uniform operation unsupported by Bean Machine Graph.
-The unsupported node is the operand of a Sample.
-The model uses a Uniform operation unsupported by Bean Machine Graph.
-The unsupported node is the operand of a Sample.
+The model uses a uniform operation unsupported by Bean Machine Graph.
+The unsupported node is the operand of a sample.
+The model uses a uniform operation unsupported by Bean Machine Graph.
+The unsupported node is the operand of a sample.
 """
         self.assertEqual(observed.strip(), expected.strip())
 
@@ -942,7 +942,7 @@ digraph "graph" {
         observed = str(error_report)
         expected = """
 A Bernoulli distribution is observed to have value -1.5 but only produces samples of type bool.
-A Binomial distribution is observed to have value 5.25 but only produces samples of type natural.
+A binomial distribution is observed to have value 5.25 but only produces samples of type natural.
 """
         self.assertEqual(observed.strip(), expected.strip())
 

--- a/src/beanmachine/ppl/compiler/tests/index_test.py
+++ b/src/beanmachine/ppl/compiler/tests/index_test.py
@@ -419,7 +419,7 @@ digraph "graph" {
         with self.assertRaises(ValueError) as ex:
             BMGInference().to_dot([negative_constant_index()], {})
         self.assertEqual(
-            "The right of a index is required to be a natural but is a negative real.",
+            "The right of an index is required to be a natural but is a negative real.",
             str(ex.exception),
         )
 

--- a/src/beanmachine/ppl/compiler/tests/log1mexp_test.py
+++ b/src/beanmachine/ppl/compiler/tests/log1mexp_test.py
@@ -101,7 +101,7 @@ digraph "graph" {
         observations = {}
         with self.assertRaises(ValueError) as ex:
             observed = BMGInference().to_dot(queries, observations)
-        expected = """The operand of a Log1mexp is required to be a negative real but is a positive real."""
+        expected = """The operand of a log1mexp is required to be a negative real but is a positive real."""
         self.assertEqual(expected.strip(), str(ex.exception))
 
         with self.assertRaises(ValueError) as ex:
@@ -151,7 +151,7 @@ digraph "graph" {
         observations = {}
         with self.assertRaises(ValueError) as ex:
             observed = BMGInference().to_dot(queries, observations)
-        expected = """The operand of a Log1mexp is required to be a negative real but is a positive real."""
+        expected = """The operand of a log1mexp is required to be a negative real but is a positive real."""
         self.assertEqual(expected.strip(), str(ex.exception))
 
         with self.assertRaises(ValueError) as ex:

--- a/src/beanmachine/ppl/compiler/tests/lse_vector_test.py
+++ b/src/beanmachine/ppl/compiler/tests/lse_vector_test.py
@@ -273,8 +273,8 @@ digraph "graph" {
         self.maxDiff = None
         bmg = BMGRuntime().accumulate_graph([f2by1()], {})
         expected = """
-The model uses a LogSumExp operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
+The model uses a logsumexp operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
 """
         with self.assertRaises(ValueError) as ex:
             to_dot(bmg, after_transform=True)

--- a/src/beanmachine/ppl/compiler/tests/matrix_multiplication_test.py
+++ b/src/beanmachine/ppl/compiler/tests/matrix_multiplication_test.py
@@ -71,10 +71,10 @@ digraph "graph" {
   N7 -> N8;
 }"""
         expected_error = """
-The model uses a @ operation unsupported by Bean Machine Graph.
-The unsupported node is the left of a @.
-The model uses a @ operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
+The model uses a matrix multiplication (@) operation unsupported by Bean Machine Graph.
+The unsupported node is the left of a matrix multiplication (@).
+The model uses a matrix multiplication (@) operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
         """
 
         observed = BMGInference().to_dot([mm()], {}, after_transform=False)

--- a/src/beanmachine/ppl/compiler/tests/tensor_operations_test.py
+++ b/src/beanmachine/ppl/compiler/tests/tensor_operations_test.py
@@ -127,8 +127,8 @@ digraph "graph" {
             BMGInference().infer([lse_bad_1()], {}, 1)
         # TODO: Do a better job here. Say why the operation is unsupported.
         expected = """
-The model uses a LogSumExp operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query.
+The model uses a logsumexp operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query.
         """
         self.assertEqual(expected.strip(), str(ex.exception).strip())
 

--- a/src/beanmachine/ppl/compiler/tests/to_matrix_test.py
+++ b/src/beanmachine/ppl/compiler/tests/to_matrix_test.py
@@ -494,8 +494,8 @@ digraph "graph" {
         # We could say what is wrong: its size.
 
         expected = """
-The model uses a Tensor operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a Query."""
+The model uses a tensor operation unsupported by Bean Machine Graph.
+The unsupported node is the operator of a query."""
         with self.assertRaises(ValueError) as ex:
             to_dot(
                 bmg,

--- a/src/beanmachine/ppl/utils/a_or_an.py
+++ b/src/beanmachine/ppl/utils/a_or_an.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import re
+
+
+def _first_word(s: str) -> str:
+    r = re.search("\\w+", s)
+    return r.group(0) if r else ""
+
+
+_always_a = {"uniform"}
+_always_an = {"18"}
+
+_vowel_sounds = "aeiouxAEIOUX8"
+
+
+def use_an(s: str) -> bool:
+    w = _first_word(s)
+    if len(w) == 0:
+        return False
+    if any(w.startswith(prefix) for prefix in _always_a):
+        return False
+    if any(w.startswith(prefix) for prefix in _always_an):
+        return True
+    return w[0] in _vowel_sounds
+
+
+def a_or_an(s: str) -> str:
+    return "an " + s if use_an(s) else "a " + s
+
+
+def A_or_An(s: str) -> str:
+    return "An " + s if use_an(s) else "A " + s


### PR DESCRIPTION
Summary:
The compiler error messages were a little bit awkward:

`The model uses a & operation unsupported by Bean Machine Graph.`

Not wrong but hard to read. We always said `a` instead of `an` when necessary, we capitalized inconsistently, we used symbols instead of words inconsistently, and so on.

Not every error message is perfect now, but as a result of these changes (1) we use articles mostly correctly, (2) capitalization is mostly correct, (3) operators are described using both words and symbols as appropriate.

We still do not do error messages involving illegal values very well but I will rewrite those in a later diff.

Reviewed By: yucenli

Differential Revision: D34191131

