### PR TITLE
Start adding location information to error messages

### DIFF
--- a/src/beanmachine/ppl/compiler/bm_graph_builder.py
+++ b/src/beanmachine/ppl/compiler/bm_graph_builder.py
@@ -13,6 +13,7 @@ import numpy as np
 import torch
 import torch.distributions as dist
 from beanmachine.ppl.compiler.bmg_nodes import BMGNode, ConstantNode
+from beanmachine.ppl.compiler.execution_context import ExecutionContext
 from beanmachine.ppl.compiler.hint import log1mexp, math_log1mexp
 from beanmachine.ppl.utils.memoize import memoize
 
@@ -28,6 +29,8 @@ supported_bool_types = {bool, np.bool_}
 supported_float_types = {np.longdouble, np.float16, np.float32, np.float64, float}
 supported_int_types = {np.int16, np.int32, np.int64, np.int8, np.longlong}
 supported_int_types |= {np.uint16, np.uint32, np.uint64, np.uint8, np.ulonglong, int}
+
+_empty_context = ExecutionContext()
 
 
 class BMGraphBuilder:
@@ -64,10 +67,13 @@ class BMGraphBuilder:
 
     _pd: Optional[prof.ProfilerData]
 
-    def __init__(self) -> None:
+    execution_context: ExecutionContext
+
+    def __init__(self, execution_context: ExecutionContext = _empty_context) -> None:
         self._nodes = {}
         self._node_counter = 0
         self._pd = None
+        self.execution_context = execution_context
 
     def _begin(self, s: str) -> None:
         pd = self._pd

--- a/src/beanmachine/ppl/compiler/execution_context.py
+++ b/src/beanmachine/ppl/compiler/execution_context.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Callable, List, Dict, Optional
+from typing import Any, Callable, List, Dict, Optional, Set
 
 from beanmachine.ppl.compiler.bmg_nodes import BMGNode
 from beanmachine.ppl.utils.multidictionary import MultiDictionary
@@ -82,6 +82,9 @@ class ExecutionContext:
             site = self.current_site()
         if site is not None:
             self._node_locations.add(node, site)
+
+    def node_locations(self, node: BMGNode) -> Set[FunctionCall]:
+        return self._node_locations[node]
 
     def call(
         self, func: Callable, args: Any, kwargs: Dict[str, Any] = _empty_kwargs

--- a/src/beanmachine/ppl/compiler/fix_unsupported.py
+++ b/src/beanmachine/ppl/compiler/fix_unsupported.py
@@ -394,4 +394,10 @@ class UnsupportedNodeFixer(ProblemFixerBase):
         # TODO: The edge labels used to visualize the graph in DOT
         # are not necessarily the best ones for displaying errors.
         # Consider fixing this.
-        return UnsupportedNode(n.inputs[index], n, get_edge_label(n, index))
+        unsupported_node = n.inputs[index]
+        return UnsupportedNode(
+            unsupported_node,
+            n,
+            get_edge_label(n, index),
+            self._bmg.execution_context.node_locations(unsupported_node),
+        )

--- a/src/beanmachine/ppl/compiler/runtime.py
+++ b/src/beanmachine/ppl/compiler/runtime.py
@@ -141,13 +141,13 @@ class BMGRuntime:
     _context: ExecutionContext
 
     def __init__(self) -> None:
-        self._bmg = BMGraphBuilder()
+        self._context = ExecutionContext()
+        self._bmg = BMGraphBuilder(self._context)
         self._pd = None
         self.rv_map = {}
         self.lifted_map = {}
         self.in_flight = set()
         self._rv_to_query = {}
-        self._context = ExecutionContext()
         self._special_function_caller = SpecialFunctionCaller(self._bmg)
 
     def _begin(self, s: str) -> None:

--- a/src/beanmachine/ppl/compiler/tests/bmg_arithmetic_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_arithmetic_test.py
@@ -1549,13 +1549,13 @@ class BMGArithmeticTest(unittest.TestCase):
             BMGInference().infer(queries, {}, 1)
         expected = """
 The model uses a 'not' operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call not_5().
 The model uses a 'not' operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call not_6().
 The model uses a 'not' operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call not_7().
 The model uses a 'not' operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call not_9().
         """
         observed = str(ex.exception)
         self.assertEqual(observed.strip(), expected.strip())
@@ -1892,13 +1892,13 @@ digraph "graph" {
             BMGInference().infer(queries, {}, 1)
         expected = """
 The model uses a 'bitwise and' (&) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call and_5().
 The model uses a 'bitwise and' (&) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call and_6().
 The model uses a 'bitwise and' (&) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call and_7().
 The model uses a 'bitwise and' (&) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call and_9().
         """
         observed = str(ex.exception)
         self.assertEqual(observed.strip(), expected.strip())
@@ -1992,13 +1992,13 @@ digraph "graph" {
             BMGInference().infer(queries, {}, 1)
         expected = """
 The model uses an equality (==) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call eq_5().
 The model uses an equality (==) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call eq_6().
 The model uses an equality (==) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call eq_7().
 The model uses an equality (==) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call eq_9().
         """
         observed = str(ex.exception)
         self.assertEqual(observed.strip(), expected.strip())
@@ -2029,13 +2029,13 @@ The unsupported node is the operator of a query.
             BMGInference().infer(queries, {}, 1)
         expected = """
 The model uses a // operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call floordiv_5().
 The model uses a // operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call floordiv_6().
 The model uses a // operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call floordiv_7().
 The model uses a // operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call floordiv_9().
         """
         observed = str(ex.exception)
         self.assertEqual(observed.strip(), expected.strip())
@@ -2061,13 +2061,13 @@ The unsupported node is the operator of a query.
             BMGInference().infer(queries, {}, 1)
         expected = """
 The model uses a 'greater than or equal' (>=) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call ge_5().
 The model uses a 'greater than or equal' (>=) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call ge_6().
 The model uses a 'greater than or equal' (>=) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call ge_7().
 The model uses a 'greater than or equal' (>=) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call ge_9().
         """
         observed = str(ex.exception)
         self.assertEqual(observed.strip(), expected.strip())
@@ -2093,13 +2093,13 @@ The unsupported node is the operator of a query.
             BMGInference().infer(queries, {}, 1)
         expected = """
 The model uses a 'greater than' (>) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call gt_5().
 The model uses a 'greater than' (>) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call gt_6().
 The model uses a 'greater than' (>) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call gt_7().
 The model uses a 'greater than' (>) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call gt_9().
         """
         observed = str(ex.exception)
         self.assertEqual(observed.strip(), expected.strip())
@@ -2124,11 +2124,11 @@ The unsupported node is the operator of a query.
             BMGInference().infer(queries, {}, 1)
         expected = """
 The model uses a 'not in' operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call not_in_3().
 The model uses an 'in' operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call in_3().
 The model uses an 'in' operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call in_5().
 """
         observed = str(ex.exception)
         self.assertEqual(observed.strip(), expected.strip())
@@ -2153,13 +2153,13 @@ The unsupported node is the operator of a query.
             BMGInference().infer(queries, {}, 1)
         expected = """
 The model uses an 'is not' operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call is_not_2().
 The model uses an 'is not' operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call is_not_4().
 The model uses an 'is' operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call is_2().
 The model uses an 'is' operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query."""
+The unsupported node was created in function call is_4()."""
         observed = str(ex.exception)
         self.assertEqual(observed.strip(), expected.strip())
 
@@ -2182,16 +2182,15 @@ The unsupported node is the operator of a query."""
         ]
         with self.assertRaises(ValueError) as ex:
             BMGInference().infer(queries, {}, 1)
-        # TODO: This is weirdly capitalized and ungrammatical. Fix the error message.
         expected = """
 The model uses a 'bitwise invert' (~) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call inv_5().
 The model uses a 'bitwise invert' (~) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call inv_6().
 The model uses a 'bitwise invert' (~) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call inv_7().
 The model uses a 'bitwise invert' (~) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call inv_9().
         """
         observed = str(ex.exception)
         self.assertEqual(observed.strip(), expected.strip())
@@ -2217,13 +2216,13 @@ The unsupported node is the operator of a query.
             BMGInference().infer(queries, {}, 1)
         expected = """
 The model uses a 'less than or equal' (<=) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call le_5().
 The model uses a 'less than or equal' (<=) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call le_6().
 The model uses a 'less than or equal' (<=) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call le_7().
 The model uses a 'less than or equal' (<=) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call le_9().
         """
         observed = str(ex.exception)
         self.assertEqual(observed.strip(), expected.strip())
@@ -2249,13 +2248,13 @@ The unsupported node is the operator of a query.
             BMGInference().infer(queries, {}, 1)
         expected = """
 The model uses a 'left shift' (<<) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call lshift_5().
 The model uses a 'left shift' (<<) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call lshift_6().
 The model uses a 'left shift' (<<) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call lshift_7().
 The model uses a 'left shift' (<<) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call lshift_9().
         """
         observed = str(ex.exception)
         self.assertEqual(observed.strip(), expected.strip())
@@ -2281,13 +2280,13 @@ The unsupported node is the operator of a query.
             BMGInference().infer(queries, {}, 1)
         expected = """
 The model uses a 'less than' (<) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call lt_5().
 The model uses a 'less than' (<) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call lt_6().
 The model uses a 'less than' (<) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call lt_7().
 The model uses a 'less than' (<) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call lt_9().
         """
         observed = str(ex.exception)
         self.assertEqual(observed.strip(), expected.strip())
@@ -2313,13 +2312,13 @@ The unsupported node is the operator of a query.
             BMGInference().infer(queries, {}, 1)
         expected = """
 The model uses a modulus (%) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call mod_5().
 The model uses a modulus (%) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call mod_6().
 The model uses a modulus (%) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call mod_7().
 The model uses a modulus (%) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call mod_9().
         """
         observed = str(ex.exception)
         self.assertEqual(observed.strip(), expected.strip())
@@ -2415,13 +2414,13 @@ digraph "graph" {
             BMGInference().infer(queries, {}, 1)
         expected = """
 The model uses an inequality (!=) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call ne_5().
 The model uses an inequality (!=) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call ne_6().
 The model uses an inequality (!=) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call ne_7().
 The model uses an inequality (!=) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call ne_9().
         """
         observed = str(ex.exception)
         self.assertEqual(observed.strip(), expected.strip())
@@ -2447,13 +2446,13 @@ The unsupported node is the operator of a query.
             BMGInference().infer(queries, {}, 1)
         expected = """
 The model uses a 'bitwise or' (|) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call or_5().
 The model uses a 'bitwise or' (|) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call or_6().
 The model uses a 'bitwise or' (|) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call or_7().
 The model uses a 'bitwise or' (|) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call or_9().
         """
         observed = str(ex.exception)
         self.assertEqual(observed.strip(), expected.strip())
@@ -2479,13 +2478,13 @@ The unsupported node is the operator of a query.
             BMGInference().infer(queries, {}, 1)
         expected = """
 The model uses a 'right shift' (>>) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call rshift_5().
 The model uses a 'right shift' (>>) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call rshift_6().
 The model uses a 'right shift' (>>) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call rshift_7().
 The model uses a 'right shift' (>>) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call rshift_9().
 """
         observed = str(ex.exception)
         self.assertEqual(observed.strip(), expected.strip())
@@ -2626,13 +2625,13 @@ digraph "graph" {
             BMGInference().infer(queries, {}, 1)
         expected = """
 The model uses a 'bitwise xor' (^) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call xor_5().
 The model uses a 'bitwise xor' (^) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call xor_6().
 The model uses a 'bitwise xor' (^) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call xor_7().
 The model uses a 'bitwise xor' (^) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call xor_9().
         """
         observed = str(ex.exception)
         self.assertEqual(observed.strip(), expected.strip())

--- a/src/beanmachine/ppl/compiler/tests/categorical_test.py
+++ b/src/beanmachine/ppl/compiler/tests/categorical_test.py
@@ -204,7 +204,7 @@ q2 = g.query(n4)
         observed = str(ex.exception)
         expected = """
 The model uses a categorical operation unsupported by Bean Machine Graph.
-The unsupported node is the operand of a sample.
+The unsupported node was created in function call c_random_logit().
         """
         self.assertEqual(expected.strip(), observed.strip())
 

--- a/src/beanmachine/ppl/compiler/tests/lse_vector_test.py
+++ b/src/beanmachine/ppl/compiler/tests/lse_vector_test.py
@@ -274,7 +274,7 @@ digraph "graph" {
         bmg = BMGRuntime().accumulate_graph([f2by1()], {})
         expected = """
 The model uses a logsumexp operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call f2by1().
 """
         with self.assertRaises(ValueError) as ex:
             to_dot(bmg, after_transform=True)

--- a/src/beanmachine/ppl/compiler/tests/matrix_multiplication_test.py
+++ b/src/beanmachine/ppl/compiler/tests/matrix_multiplication_test.py
@@ -72,9 +72,9 @@ digraph "graph" {
 }"""
         expected_error = """
 The model uses a matrix multiplication (@) operation unsupported by Bean Machine Graph.
-The unsupported node is the left of a matrix multiplication (@).
+The unsupported node was created in function call mm().
 The model uses a matrix multiplication (@) operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call mm().
         """
 
         observed = BMGInference().to_dot([mm()], {}, after_transform=False)
@@ -83,11 +83,25 @@ The unsupported node is the operator of a query.
             BMGInference().to_dot([mm()], {}, after_transform=True)
         self.assertEqual(expected_error.strip(), str(ex.exception))
 
+        expected_error = """
+The model uses a matrix multiplication (@) operation unsupported by Bean Machine Graph.
+The unsupported node was created in function call matmul().
+The model uses a matrix multiplication (@) operation unsupported by Bean Machine Graph.
+The unsupported node was created in function call matmul().
+        """
+
         observed = BMGInference().to_dot([matmul()], {}, after_transform=False)
         self.assertEqual(expected_accumulation.strip(), observed.strip())
         with self.assertRaises(ValueError) as ex:
             BMGInference().to_dot([matmul()], {}, after_transform=True)
         self.assertEqual(expected_error.strip(), str(ex.exception))
+
+        expected_error = """
+The model uses a matrix multiplication (@) operation unsupported by Bean Machine Graph.
+The unsupported node was created in function call infix().
+The model uses a matrix multiplication (@) operation unsupported by Bean Machine Graph.
+The unsupported node was created in function call infix().
+        """
 
         observed = BMGInference().to_dot([infix()], {}, after_transform=False)
         self.assertEqual(expected_accumulation.strip(), observed.strip())
@@ -95,8 +109,15 @@ The unsupported node is the operator of a query.
             BMGInference().to_dot([infix()], {}, after_transform=True)
         self.assertEqual(expected_error.strip(), str(ex.exception))
 
+        expected_error = """
+The model uses a matrix multiplication (@) operation unsupported by Bean Machine Graph.
+The unsupported node was created in function call op_matmul().
+The model uses a matrix multiplication (@) operation unsupported by Bean Machine Graph.
+The unsupported node was created in function call op_matmul().
+        """
+
         observed = BMGInference().to_dot([op_matmul()], {}, after_transform=False)
         self.assertEqual(expected_accumulation.strip(), observed.strip())
         with self.assertRaises(ValueError) as ex:
-            BMGInference().to_dot([infix()], {}, after_transform=True)
+            BMGInference().to_dot([op_matmul()], {}, after_transform=True)
         self.assertEqual(expected_error.strip(), str(ex.exception))

--- a/src/beanmachine/ppl/compiler/tests/tensor_operations_test.py
+++ b/src/beanmachine/ppl/compiler/tests/tensor_operations_test.py
@@ -128,9 +128,14 @@ digraph "graph" {
         # TODO: Do a better job here. Say why the operation is unsupported.
         expected = """
 The model uses a logsumexp operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query.
+The unsupported node was created in function call lse_bad_1().
         """
         self.assertEqual(expected.strip(), str(ex.exception).strip())
+
+        expected = """
+The model uses a logsumexp operation unsupported by Bean Machine Graph.
+The unsupported node was created in function call lse_bad_2().
+        """
 
         with self.assertRaises(ValueError) as ex:
             BMGInference().infer([lse_bad_2()], {}, 1)

--- a/src/beanmachine/ppl/compiler/tests/to_matrix_test.py
+++ b/src/beanmachine/ppl/compiler/tests/to_matrix_test.py
@@ -495,7 +495,7 @@ digraph "graph" {
 
         expected = """
 The model uses a tensor operation unsupported by Bean Machine Graph.
-The unsupported node is the operator of a query."""
+The unsupported node was created in function call f1by2by3()."""
         with self.assertRaises(ValueError) as ex:
             to_dot(
                 bmg,


### PR DESCRIPTION
Summary:
When we have an operation or distribution in a model that we cannot support in BMG we produced an error message of the form:

`The model uses a 'bitwise and' (&) operation unsupported by Bean Machine Graph.
The unsupported node is the operator of a query.`

The first sentence describes the problem; the second sentence is intended to help the developer locate the problem in the original code, but this is not very helpful.  The message is phrased in the jargon of Bayesian graph topology, not in terms of the source code; it describes an outgoing edge from the unsupported node.

I've updated the error generation code so that if we know what function created the offending node, we say that *instead* of describing the edge:

`The model uses a 'bitwise and' (&) operation unsupported by Bean Machine Graph.
The unsupported node was created in function call and_5().`

I would like to have even more granular error reporting locations; ideally we'd say not just what function created the node but also what line of code it was. That will require quite a bit more work though.

In this diff I just do the "unsupported node" error message; I'll make similar changes to other error messages in upcoming diffs.

Reviewed By: yucenli

Differential Revision: D34260996

