### PR TITLE
docs: adding ELI5 video to the home page

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -60,6 +60,29 @@ function Feature({imageUrl, title, description}) {
   );
 }
 
+function VideoContainer() {
+  return (
+    <div align="center" className="container margin-top--xl margin-bottom--xl">
+      <div className="row">
+        <div className="col">
+          <h2>Watch Introductory Video</h2>
+          <div>
+            <iframe
+              width="560"
+              height="315"
+              src="https://www.youtube.com/embed/XvrtH8xVXU0"
+              title="Explain Like I'm 5: Bean Machine"
+              frameBorder="0"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowFullScreen
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function Home() {
   const context = useDocusaurusContext();
   const {siteConfig = {}} = context;
@@ -105,6 +128,7 @@ function Home() {
         </div>
       </header>
       <main>
+        <VideoContainer />
         {features && features.length > 0 && (
           <section className={styles.features}>
             <div className="container">


### PR DESCRIPTION
## Summary
Here at Meta Open Source, we've been creating short-form videos to explain Meta OSS projects in the simplest terms possible. We started embedding these videos into project pages as you can see in [Docusaurus home page](https://docusaurus.io/), [Recoil](https://recoiljs.org/), [Litho](https://fblitho.com/), [Hydra](https://hydra.cc/), etc.

## Test plan
![image](https://user-images.githubusercontent.com/12485205/155429937-44283218-4c42-4743-b716-5c21aa9a254c.png)