### PR TITLE
More compiler error message improvements

### DIFF
--- a/src/beanmachine/ppl/compiler/error_report.py
+++ b/src/beanmachine/ppl/compiler/error_report.py
@@ -30,6 +30,7 @@ class Violation(BMGError):
     requirement: Requirement
     consumer: BMGNode
     edge: str
+    node_locations: Set[FunctionCall]
 
     def __init__(
         self,
@@ -38,12 +39,14 @@ class Violation(BMGError):
         requirement: Requirement,
         consumer: BMGNode,
         edge: str,
+        node_locations: Set[FunctionCall],
     ) -> None:
         self.node = node
         self.node_type = node_type
         self.requirement = requirement
         self.consumer = consumer
         self.edge = edge
+        self.node_locations = node_locations
 
     def __str__(self) -> str:
         r = self.requirement
@@ -51,11 +54,16 @@ class Violation(BMGError):
         assert isinstance(t, BMGLatticeType)
         # TODO: Fix this error message for the case where we require
         # a matrix but we can only get a scalar value
+        consumer_label = get_node_error_label(self.consumer)
         msg = (
-            f"The {self.edge} of {a_or_an(get_node_error_label(self.consumer))} "
+            f"The {self.edge} of {a_or_an(consumer_label)} "
             + f"is required to be {a_or_an(t.long_name)} "
             + f"but is {a_or_an(self.node_type.long_name)}."
         )
+        if len(self.node_locations) > 0:
+            msg += f"\nThe {consumer_label} was created in function call "
+            msg += ", ".join(sorted(str(loc) for loc in self.node_locations))
+            msg += "."
         return msg
 
 

--- a/src/beanmachine/ppl/compiler/fix_requirements.py
+++ b/src/beanmachine/ppl/compiler/fix_requirements.py
@@ -103,7 +103,16 @@ class RequirementsFixer:
 
         # We cannot convert this node to any type that meets the requirement.
         # Add an error.
-        self.errors.add_error(Violation(node, it, requirement, consumer, edge))
+        self.errors.add_error(
+            Violation(
+                node,
+                it,
+                requirement,
+                consumer,
+                edge,
+                self.bmg.execution_context.node_locations(consumer),
+            )
+        )
         return node
 
     def _convert_operator_to_atomic_type(
@@ -291,7 +300,14 @@ class RequirementsFixer:
         else:
             # We have no way to make the conversion we need, so add an error.
             self.errors.add_error(
-                Violation(node, node_type, requirement, consumer, edge)
+                Violation(
+                    node,
+                    node_type,
+                    requirement,
+                    consumer,
+                    edge,
+                    self.bmg.execution_context.node_locations(consumer),
+                )
             )
             return node
 

--- a/src/beanmachine/ppl/compiler/tests/categorical_test.py
+++ b/src/beanmachine/ppl/compiler/tests/categorical_test.py
@@ -225,5 +225,6 @@ The unsupported node was created in function call c_random_logit().
         observed = str(ex.exception)
         expected = """
 The probability of a categorical is required to be a 2 x 1 simplex matrix but is a 2 x 2 simplex matrix.
+The categorical was created in function call c_multi().
         """
         self.assertEqual(expected.strip(), observed.strip())

--- a/src/beanmachine/ppl/compiler/tests/dirichlet_test.py
+++ b/src/beanmachine/ppl/compiler/tests/dirichlet_test.py
@@ -349,12 +349,13 @@ digraph "graph" {
         expected = (
             "The concentration of a Dirichlet is required to be"
             + " a 3 x 1 positive real matrix but is"
-            + " a 3 x 2 positive real matrix."
+            + " a 3 x 2 positive real matrix.\n"
+            + "The Dirichlet was created in function call d23()."
         )
 
         with self.assertRaises(ValueError) as ex:
             BMGInference().infer([d23()], {}, 1)
-        self.assertEqual(expected, str(ex.exception))
+        self.assertEqual(expected.strip(), str(ex.exception).strip())
 
     def test_dirichlet_fix_problems(self) -> None:
 

--- a/src/beanmachine/ppl/compiler/tests/error_report_test.py
+++ b/src/beanmachine/ppl/compiler/tests/error_report_test.py
@@ -17,7 +17,7 @@ class ErrorReportTest(unittest.TestCase):
         bmg = BMGraphBuilder()
         r = bmg.add_real(-2.5)
         b = bmg.add_bernoulli(r)
-        v = Violation(r, NegativeReal, Probability, b, "probability")
+        v = Violation(r, NegativeReal, Probability, b, "probability", {})
         e = ErrorReport()
         e.add_error(v)
         expected = """

--- a/src/beanmachine/ppl/compiler/tests/log1mexp_test.py
+++ b/src/beanmachine/ppl/compiler/tests/log1mexp_test.py
@@ -101,8 +101,10 @@ digraph "graph" {
         observations = {}
         with self.assertRaises(ValueError) as ex:
             observed = BMGInference().to_dot(queries, observations)
-        expected = """The operand of a log1mexp is required to be a negative real but is a positive real."""
-        self.assertEqual(expected.strip(), str(ex.exception))
+        expected = """
+The operand of a log1mexp is required to be a negative real but is a positive real.
+The log1mexp was created in function call wrong()."""
+        self.assertEqual(expected.strip(), str(ex.exception).strip())
 
         with self.assertRaises(ValueError) as ex:
             BMGInference().infer(queries, observations, 1, 1)
@@ -151,8 +153,10 @@ digraph "graph" {
         observations = {}
         with self.assertRaises(ValueError) as ex:
             observed = BMGInference().to_dot(queries, observations)
-        expected = """The operand of a log1mexp is required to be a negative real but is a positive real."""
-        self.assertEqual(expected.strip(), str(ex.exception))
+        expected = """
+The operand of a log1mexp is required to be a negative real but is a positive real.
+The log1mexp was created in function call math_wrong()."""
+        self.assertEqual(expected.strip(), str(ex.exception).strip())
 
         with self.assertRaises(ValueError) as ex:
             BMGInference().infer(queries, observations, 1, 1)

--- a/src/beanmachine/ppl/compiler/tests/to_probability_test.py
+++ b/src/beanmachine/ppl/compiler/tests/to_probability_test.py
@@ -101,11 +101,10 @@ digraph "graph" {
         # TODO: Raise a better error than a generic ValueError
         with self.assertRaises(ValueError) as ex:
             bmg.infer([bad_flip()], {}, 10)
-        self.assertEqual(
-            str(ex.exception),
-            "The probability of a Bernoulli is required to be a"
-            + " probability but is a positive real.",
-        )
+        expected = """
+The probability of a Bernoulli is required to be a probability but is a positive real.
+The Bernoulli was created in function call bad_flip()."""
+        self.assertEqual(expected.strip(), str(ex.exception).strip())
 
     def test_to_neg_real_1(self) -> None:
         self.maxDiff = None


### PR DESCRIPTION
Summary:
This diff continues the work begun in the previous; I am adding location information to error messages when known.  In this diff, violations of BMG type system rules are now reported with a location:

`The operand of a log1mexp is required to be a negative real but is a positive real.
The log1mexp was created in function call wrong().`

Reviewed By: yucenli

Differential Revision: D34284012

