### PR TITLE
Fix beanmachine issue 1312

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/bug_regression_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bug_regression_test.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import beanmachine.ppl as bm
+import torch
+import torch.distributions as dist
+from beanmachine.ppl.inference import BMGInference
+
+# https://github.com/facebookresearch/beanmachine/issues/1312
+
+
+@bm.random_variable
+def unif():
+    return dist.Uniform(0, 1)
+
+
+@bm.random_variable
+def beta():
+    return dist.Beta(unif() + 0.1, unif() + 0.1)
+
+
+@bm.random_variable
+def flip():
+    return dist.Bernoulli(1 - beta())
+
+
+class BugRegressionTest(unittest.TestCase):
+    def test_regress_1312(self) -> None:
+        self.maxDiff = None
+
+        # TODO: There are two problems exposed by this user-supplied repro.
+        # The first, which is fixed, is that a typo in the code which propagated
+        # type mutations through the graph during the problem-fixing phase was
+        # causing some types to not be updated correctly, which was then causing
+        # internal compiler errors down the line.
+        #
+        # The second, which is not yet fixed, is that this repro demonstrates that
+        # the problem fixers need to run repeatedly until a fixpoint is reached.
+        # Notice the very strange graph generation here: the operation 1-beta should
+        # be generated as Complement(Sample(Beta(...))) but instead is generated as
+        # ToProb(Add(ToReal(Negate(ToPosReal(Sample(Beta(...)))), 1.0))! The generated
+        # code will work but is way more nodes than it needs to be.
+        #
+        # What is happening here is: the AdditionFixer is running first but skipping
+        # the rewrite of 1-beta into a complement because beta has an untypable
+        # Uniform(0, 1) node in its ancestors. We rewrite that into a Flat node in
+        # the UnsupportedNodeFixer, but we do not then re-run the AdditionFixer.
+        #
+        # What we should do is have each fixer behave like the parse tree rewriters.
+        # That is, we should have them report on whether they made progress. We can
+        # then write combinators that keep running rewriters until they stop making
+        # progress and we've either reported errors or attained a fixpoint.
+
+        queries = [unif()]
+        observations = {flip(): torch.tensor(1)}
+
+        observed = BMGInference().to_dot(queries, observations)
+        expected = """
+digraph "graph" {
+  N00[label=Flat];
+  N01[label=Sample];
+  N02[label=ToPosReal];
+  N03[label=0.1];
+  N04[label="+"];
+  N05[label=Beta];
+  N06[label=Sample];
+  N07[label=1.0];
+  N08[label=ToPosReal];
+  N09[label="-"];
+  N10[label=ToReal];
+  N11[label="+"];
+  N12[label=ToProb];
+  N13[label=Bernoulli];
+  N14[label=Sample];
+  N15[label="Observation True"];
+  N16[label=Query];
+  N00 -> N01;
+  N01 -> N02;
+  N01 -> N16;
+  N02 -> N04;
+  N03 -> N04;
+  N04 -> N05;
+  N04 -> N05;
+  N05 -> N06;
+  N06 -> N08;
+  N07 -> N11;
+  N08 -> N09;
+  N09 -> N10;
+  N10 -> N11;
+  N11 -> N12;
+  N12 -> N13;
+  N13 -> N14;
+  N14 -> N15;
+}
+        """
+        self.assertEqual(expected.strip(), observed.strip())

--- a/src/beanmachine/ppl/compiler/typer_base.py
+++ b/src/beanmachine/ppl/compiler/typer_base.py
@@ -158,7 +158,7 @@ class TyperBase(ABC, Generic[T]):
             self._nodes[cur] = new_type
             if current_type == new_type:
                 continue
-            for o in node.outputs.items:
+            for o in cur.outputs.items:
                 if o in self._nodes:
                     work.put(o)
 


### PR DESCRIPTION
Summary:
See

https://github.com/facebookresearch/beanmachine/issues/1312

This user-supplied repro with a simple model produces an internal compiler error.

What's happening here is: the graph is mutable, and large graphs may be expensive to type, but we also may need to know the type of each node before a possible mutation. What we do is: when a graph node mutates, we check to see if its type changed. If no, then we're done. If yes, then we check to see if any of its outputs need to have *their* types updated.

This algorithm is supposed to be transitive; if an output changes its type, then *its* outputs are also checked, and so on, until we run out of descendents whose types changed.  Due to a typo in the algorithm, we did not propagate changes more than one level down the graph.

The requirements checking pass assumes that all nodes in the graph that are ancestors of a query or observation have already either produced an error, stopping the rewrite before it gets to requirements checking, or that we have only well-typed nodes in the graph. Since some of those nodes were being incorrectly typed if an ancestor was mutated, this was then causing an internal compiler error.

This repro also is a concise reproducer of a known issue that I've been putting off addressing; see the large comment in the regression test for details.

Reviewed By: yucenli

Differential Revision: D34230362

