### PR TITLE
Simplify performance tests

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/binary_vs_multiary_addition_perf_test.py
+++ b/src/beanmachine/ppl/compiler/tests/binary_vs_multiary_addition_perf_test.py
@@ -5,12 +5,9 @@
 
 """Test performance of multiary addition optimization """
 import platform
-import random
-import re
 import unittest
 
 import beanmachine.ppl as bm
-import torch
 from beanmachine.ppl.inference import BMGInference
 from torch.distributions import Normal
 
@@ -45,28 +42,17 @@ def get_report(skip_optimizations):
     return perf_report
 
 
-def tidy(s):
-    s = re.sub(r"generated_at:.*\n", "generated_at: --\n", s)
-    s = re.sub(r"\d+ ms", "-- ms", s)
-    s = re.sub(r"\(\d+\)", "(--)", s)
-    return s
-
-
 class BinaryVsMultiaryAdditionPerformanceTest(unittest.TestCase):
     def test_perf_num_nodes_edges(self) -> None:
         """
         Test to check if Multiary addition optimization reduces the
         number of nodes and number of edges using the performance
         report returned by BMGInference.
-        We initialize the seed to ensure the test is deterministic.
         """
         if platform.system() == "Windows":
             self.skipTest("Disabling *_perf_test.py until flakiness is resolved")
 
         self.maxDiff = None
-        seed = 0
-        torch.manual_seed(seed)
-        random.seed(seed)
 
         skip_optimizations = {
             "BetaBernoulliConjugateFixer",
@@ -75,67 +61,8 @@ class BinaryVsMultiaryAdditionPerformanceTest(unittest.TestCase):
         }
         report_w_optimization = get_report(skip_optimizations)
 
-        observed_report_w_optimization = str(report_w_optimization)
-        expected_report_w_optimization = """
-title: Bean Machine Graph performance report
-generated_at: --
-num_samples: 1000
-algorithm: 3
-seed: 5123401
-node_count: 105
-edge_count: 204
-factor_count: 0
-dist_count: 1
-const_count: 2
-op_count: 102
-add_count: 2
-det_supp_count: [2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]
-bmg_profiler_report: nmc_infer:(1) -- ms
-  initialize:(1) -- ms
-  collect_samples:(1) -- ms
-    step:(100000) -- ms
-      create_prop:(200000) -- ms
-        compute_grads:(200000) -- ms
-        unattributed: -- ms
-      sample:(100000) -- ms
-      save_old:(100000) -- ms
-      eval:(100000) -- ms
-      clear_grads:(100000) -- ms
-      restore_old:(8136) -- ms
-      unattributed: -- ms
-    collect_sample:(1000) -- ms
-    unattributed: -- ms
-  unattributed: -- ms
-unattributed: -- ms
-
-profiler_report: accumulate:(1) -- ms
-infer:(1) -- ms
-  fix_problems:(1) -- ms
-    VectorizedModelFixer:(--) -- ms
-    BoolArithmeticFixer:(1) -- ms
-    AdditionFixer:(1) -- ms
-    BoolComparisonFixer:(1) -- ms
-    UnsupportedNodeFixer:(1) -- ms
-    MatrixScaleFixer:(--) -- ms
-    MultiaryAdditionFixer:(1) -- ms
-    LogSumExpFixer:(1) -- ms
-    MultiaryMultiplicationFixer:(1) -- ms
-    RequirementsFixer:(1) -- ms
-    ObservationsFixer:(1) -- ms
-    unattributed: -- ms
-  build_bmg_graph:(1) -- ms
-  graph_infer:(1) -- ms
-  deserialize_perf_report:(1) -- ms
-  transpose_samples:(1) -- ms
-  build_mcsamples:(1) -- ms
-  unattributed: -- ms
-unattributed: -- ms
-"""
-
-        self.assertEqual(
-            tidy(observed_report_w_optimization).strip(),
-            tidy(expected_report_w_optimization).strip(),
-        )
+        self.assertEqual(report_w_optimization.node_count, 105)
+        self.assertEqual(report_w_optimization.edge_count, 204)
 
         skip_optimizations = {
             "MultiaryAdditionFixer",
@@ -144,76 +71,5 @@ unattributed: -- ms
             "NormalNormalConjugateFixer",
         }
         report_wo_optimization = get_report(skip_optimizations)
-
-        observed_report_wo_optimization = str(report_wo_optimization)
-        expected_report_wo_optimization = """
-title: Bean Machine Graph performance report
-generated_at: --
-num_samples: 1000
-algorithm: 3
-seed: 5123401
-node_count: 203
-edge_count: 302
-factor_count: 0
-dist_count: 1
-const_count: 2
-op_count: 200
-add_count: 100
-det_supp_count: [100,100,99,98,97,96,95,94,93,92,91,90,89,88,87,86,85,84,83,82,81,80,79,78,77,76,75,74,73,72,71,70,69,68,67,66,65,64,63,62,61,60,59,58,57,56,55,54,53,52,51,50,49,48,47,46,45,44,43,42,41,40,39,38,37,36,35,34,33,32,31,30,29,28,27,26,25,24,23,22,21,20,19,18,17,16,15,14,13,12,11,10,9,8,7,6,5,4,3,2]
-bmg_profiler_report: nmc_infer:(1) -- ms
-  initialize:(1) -- ms
-  collect_samples:(1) -- ms
-    step:(100000) -- ms
-      create_prop:(200000) -- ms
-        compute_grads:(200000) -- ms
-        unattributed: -- ms
-      sample:(100000) -- ms
-      save_old:(100000) -- ms
-      eval:(100000) -- ms
-      clear_grads:(100000) -- ms
-      restore_old:(8136) -- ms
-      unattributed: -- ms
-    collect_sample:(1000) -- ms
-    unattributed: -- ms
-  unattributed: -- ms
-unattributed: -- ms
-
-profiler_report: accumulate:(1) -- ms
-infer:(1) -- ms
-  fix_problems:(1) -- ms
-    VectorizedModelFixer:(--) -- ms
-    BoolArithmeticFixer:(1) -- ms
-    AdditionFixer:(1) -- ms
-    BoolComparisonFixer:(1) -- ms
-    UnsupportedNodeFixer:(1) -- ms
-    MatrixScaleFixer:(--) -- ms
-    LogSumExpFixer:(1) -- ms
-    MultiaryMultiplicationFixer:(1) -- ms
-    RequirementsFixer:(1) -- ms
-    ObservationsFixer:(1) -- ms
-    unattributed: -- ms
-  build_bmg_graph:(1) -- ms
-  graph_infer:(1) -- ms
-  deserialize_perf_report:(1) -- ms
-  transpose_samples:(1) -- ms
-  build_mcsamples:(1) -- ms
-  unattributed: -- ms
-unattributed: -- ms
-"""
-
-        self.assertEqual(
-            tidy(observed_report_wo_optimization).strip(),
-            tidy(expected_report_wo_optimization).strip(),
-        )
-
-        expected_nodes_reduction = 98
-        observed_nodes_reduction = (
-            report_wo_optimization.node_count - report_w_optimization.node_count
-        )
-        self.assertEqual(expected_nodes_reduction, observed_nodes_reduction)
-
-        expected_edges_reduction = 98
-        observed_edges_reduction = (
-            report_wo_optimization.edge_count - report_w_optimization.edge_count
-        )
-        self.assertEqual(expected_edges_reduction, observed_edges_reduction)
+        self.assertEqual(report_wo_optimization.node_count, 203)
+        self.assertEqual(report_wo_optimization.edge_count, 302)

--- a/src/beanmachine/ppl/compiler/tests/binary_vs_multiary_multiplication_perf_test.py
+++ b/src/beanmachine/ppl/compiler/tests/binary_vs_multiary_multiplication_perf_test.py
@@ -5,12 +5,9 @@
 
 """Test performance of multiary multiplication optimization """
 import platform
-import random
-import re
 import unittest
 
 import beanmachine.ppl as bm
-import torch
 from beanmachine.ppl.inference import BMGInference
 from torch.distributions import Normal
 
@@ -45,28 +42,17 @@ def get_report(skip_optimizations):
     return perf_report
 
 
-def tidy(s):
-    s = re.sub(r"generated_at:.*\n", "generated_at: --\n", s)
-    s = re.sub(r"\d+ ms", "-- ms", s)
-    s = re.sub(r"\(\d+\)", "(--)", s)
-    return s
-
-
 class BinaryVsMultiaryMultiplicationPerformanceTest(unittest.TestCase):
     def test_perf_num_nodes_edges(self) -> None:
         """
         Test to check if Multiary multiplication optimization reduces the
         number of nodes and number of edges using the performance
         report returned by BMGInference.
-        We initialize the seed to ensure the test is deterministic.
         """
         if platform.system() == "Windows":
             self.skipTest("Disabling *_perf_test.py until flakiness is resolved")
 
         self.maxDiff = None
-        seed = 0
-        torch.manual_seed(seed)
-        random.seed(seed)
 
         skip_optimizations = {
             "BetaBernoulliConjugateFixer",
@@ -74,68 +60,8 @@ class BinaryVsMultiaryMultiplicationPerformanceTest(unittest.TestCase):
             "NormalNormalConjugateFixer",
         }
         report_w_optimization = get_report(skip_optimizations)
-
-        observed_report_w_optimization = str(report_w_optimization)
-        expected_report_w_optimization = """
-title: Bean Machine Graph performance report
-generated_at: --
-num_samples: 1000
-algorithm: 3
-seed: 5123401
-node_count: 105
-edge_count: 204
-factor_count: 0
-dist_count: 1
-const_count: 2
-op_count: 102
-add_count: 0
-det_supp_count: [2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]
-bmg_profiler_report: nmc_infer:(1) -- ms
-  initialize:(1) -- ms
-  collect_samples:(1) -- ms
-    step:(100000) -- ms
-      create_prop:(200000) -- ms
-        compute_grads:(200000) -- ms
-        unattributed: -- ms
-      sample:(100000) -- ms
-      save_old:(100000) -- ms
-      eval:(100000) -- ms
-      clear_grads:(100000) -- ms
-      restore_old:(8136) -- ms
-      unattributed: -- ms
-    collect_sample:(1000) -- ms
-    unattributed: -- ms
-  unattributed: -- ms
-unattributed: -- ms
-
-profiler_report: accumulate:(1) -- ms
-infer:(1) -- ms
-  fix_problems:(1) -- ms
-    VectorizedModelFixer:(--) -- ms
-    BoolArithmeticFixer:(1) -- ms
-    AdditionFixer:(1) -- ms
-    BoolComparisonFixer:(1) -- ms
-    UnsupportedNodeFixer:(1) -- ms
-    MatrixScaleFixer:(--) -- ms
-    MultiaryAdditionFixer:(1) -- ms
-    LogSumExpFixer:(1) -- ms
-    MultiaryMultiplicationFixer:(1) -- ms
-    RequirementsFixer:(1) -- ms
-    ObservationsFixer:(1) -- ms
-    unattributed: -- ms
-  build_bmg_graph:(1) -- ms
-  graph_infer:(1) -- ms
-  deserialize_perf_report:(1) -- ms
-  transpose_samples:(1) -- ms
-  build_mcsamples:(1) -- ms
-  unattributed: -- ms
-unattributed: -- ms
-"""
-
-        self.assertEqual(
-            tidy(observed_report_w_optimization).strip(),
-            tidy(expected_report_w_optimization).strip(),
-        )
+        self.assertEqual(report_w_optimization.node_count, 105)
+        self.assertEqual(report_w_optimization.edge_count, 204)
 
         skip_optimizations = {
             "MultiaryMultiplicationFixer",
@@ -144,77 +70,5 @@ unattributed: -- ms
             "NormalNormalConjugateFixer",
         }
         report_wo_optimization = get_report(skip_optimizations)
-
-        observed_report_wo_optimization = str(report_wo_optimization)
-
-        expected_report_wo_optimization = """
-title: Bean Machine Graph performance report
-generated_at: --
-num_samples: 1000
-algorithm: 3
-seed: 5123401
-node_count: 203
-edge_count: 302
-factor_count: 0
-dist_count: 1
-const_count: 2
-op_count: 200
-add_count: 0
-det_supp_count: [100,100,99,98,97,96,95,94,93,92,91,90,89,88,87,86,85,84,83,82,81,80,79,78,77,76,75,74,73,72,71,70,69,68,67,66,65,64,63,62,61,60,59,58,57,56,55,54,53,52,51,50,49,48,47,46,45,44,43,42,41,40,39,38,37,36,35,34,33,32,31,30,29,28,27,26,25,24,23,22,21,20,19,18,17,16,15,14,13,12,11,10,9,8,7,6,5,4,3,2]
-bmg_profiler_report: nmc_infer:(1) -- ms
-  initialize:(1) -- ms
-  collect_samples:(1) -- ms
-    step:(100000) -- ms
-      create_prop:(200000) -- ms
-        compute_grads:(200000) -- ms
-        unattributed: -- ms
-      sample:(100000) -- ms
-      save_old:(100000) -- ms
-      eval:(100000) -- ms
-      clear_grads:(100000) -- ms
-      restore_old:(8136) -- ms
-      unattributed: -- ms
-    collect_sample:(1000) -- ms
-    unattributed: -- ms
-  unattributed: -- ms
-unattributed: -- ms
-
-profiler_report: accumulate:(1) -- ms
-infer:(1) -- ms
-  fix_problems:(1) -- ms
-    VectorizedModelFixer:(--) -- ms
-    BoolArithmeticFixer:(1) -- ms
-    AdditionFixer:(1) -- ms
-    BoolComparisonFixer:(1) -- ms
-    UnsupportedNodeFixer:(1) -- ms
-    MatrixScaleFixer:(--) -- ms
-    MultiaryAdditionFixer:(1) -- ms
-    LogSumExpFixer:(1) -- ms
-    RequirementsFixer:(1) -- ms
-    ObservationsFixer:(1) -- ms
-    unattributed: -- ms
-  build_bmg_graph:(1) -- ms
-  graph_infer:(1) -- ms
-  deserialize_perf_report:(1) -- ms
-  transpose_samples:(1) -- ms
-  build_mcsamples:(1) -- ms
-  unattributed: -- ms
-unattributed: -- ms
-"""
-
-        self.assertEqual(
-            tidy(observed_report_wo_optimization).strip(),
-            tidy(expected_report_wo_optimization).strip(),
-        )
-
-        expected_nodes_reduction = 98
-        observed_nodes_reduction = (
-            report_wo_optimization.node_count - report_w_optimization.node_count
-        )
-        self.assertEqual(expected_nodes_reduction, observed_nodes_reduction)
-
-        expected_edges_reduction = 98
-        observed_edges_reduction = (
-            report_wo_optimization.edge_count - report_w_optimization.edge_count
-        )
-        self.assertEqual(expected_edges_reduction, observed_edges_reduction)
+        self.assertEqual(report_wo_optimization.node_count, 203)
+        self.assertEqual(report_wo_optimization.edge_count, 302)

--- a/src/beanmachine/ppl/compiler/tests/fix_logsumexp_perf_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_logsumexp_perf_test.py
@@ -4,12 +4,9 @@
 # LICENSE file in the root directory of this source tree.
 
 import platform
-import random
-import re
 import unittest
 
 import beanmachine.ppl as bm
-import torch
 from beanmachine.ppl.inference import BMGInference
 from torch import exp, log
 from torch.distributions import Normal
@@ -45,28 +42,17 @@ def get_report(skip_optimizations):
     return perf_report
 
 
-def tidy(s):
-    s = re.sub(r"generated_at:.*\n", "generated_at: --\n", s)
-    s = re.sub(r"\d+ ms", "-- ms", s)
-    s = re.sub(r"\(\d+\)", "(--)", s)
-    return s
-
-
 class LogSumExpPerformanceTest(unittest.TestCase):
     def test_perf_num_nodes_edges(self) -> None:
         """
         Test to check if LogSumExp Transformation reduces the
         number of nodes and number of edges using the performance
         report returned by BMGInference.
-        We initialize the seed to ensure the test is deterministic.
         """
         if platform.system() == "Windows":
             self.skipTest("Disabling *_perf_test.py until flakiness is resolved")
 
         self.maxDiff = None
-        seed = 0
-        torch.manual_seed(seed)
-        random.seed(seed)
 
         skip_optimizations = {
             "BetaBernoulliConjugateFixer",
@@ -74,68 +60,8 @@ class LogSumExpPerformanceTest(unittest.TestCase):
             "NormalNormalConjugateFixer",
         }
         report_w_optimization = get_report(skip_optimizations)
-
-        observed_report_w_optimization = str(report_w_optimization)
-        expected_report_w_optimization = """
-title: Bean Machine Graph performance report
-generated_at: --
-num_samples: 1000
-algorithm: 3
-seed: 5123401
-node_count: 104
-edge_count: 202
-factor_count: 0
-dist_count: 1
-const_count: 2
-op_count: 101
-add_count: 0
-det_supp_count: [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]
-bmg_profiler_report: nmc_infer:(1) -- ms
-  initialize:(1) -- ms
-  collect_samples:(1) -- ms
-    step:(100000) -- ms
-      create_prop:(200000) -- ms
-        compute_grads:(200000) -- ms
-        unattributed: -- ms
-      sample:(100000) -- ms
-      save_old:(100000) -- ms
-      eval:(100000) -- ms
-      clear_grads:(100000) -- ms
-      restore_old:(8136) -- ms
-      unattributed: -- ms
-    collect_sample:(1000) -- ms
-    unattributed: -- ms
-  unattributed: -- ms
-unattributed: -- ms
-
-profiler_report: accumulate:(1) -- ms
-infer:(1) -- ms
-  fix_problems:(1) -- ms
-    VectorizedModelFixer:(--) -- ms
-    BoolArithmeticFixer:(1) -- ms
-    AdditionFixer:(1) -- ms
-    BoolComparisonFixer:(1) -- ms
-    UnsupportedNodeFixer:(1) -- ms
-    MatrixScaleFixer:(--) -- ms
-    MultiaryAdditionFixer:(1) -- ms
-    LogSumExpFixer:(1) -- ms
-    MultiaryMultiplicationFixer:(1) -- ms
-    RequirementsFixer:(1) -- ms
-    ObservationsFixer:(1) -- ms
-    unattributed: -- ms
-  build_bmg_graph:(1) -- ms
-  graph_infer:(1) -- ms
-  deserialize_perf_report:(1) -- ms
-  transpose_samples:(1) -- ms
-  build_mcsamples:(1) -- ms
-  unattributed: -- ms
-unattributed: -- ms
-"""
-
-        self.assertEqual(
-            tidy(observed_report_w_optimization).strip(),
-            tidy(expected_report_w_optimization).strip(),
-        )
+        self.assertEqual(report_w_optimization.node_count, 104)
+        self.assertEqual(report_w_optimization.edge_count, 202)
 
         skip_optimizations = {
             "LogSumExpFixer",
@@ -144,76 +70,5 @@ unattributed: -- ms
             "NormalNormalConjugateFixer",
         }
         report_wo_optimization = get_report(skip_optimizations)
-
-        observed_report_wo_optimization = str(report_wo_optimization)
-        expected_report_wo_optimization = """
-title: Bean Machine Graph performance report
-generated_at: --
-num_samples: 1000
-algorithm: 3
-seed: 5123401
-node_count: 205
-edge_count: 303
-factor_count: 0
-dist_count: 1
-const_count: 2
-op_count: 202
-add_count: 1
-det_supp_count: [3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3]
-bmg_profiler_report: nmc_infer:(1) -- ms
-  initialize:(1) -- ms
-  collect_samples:(1) -- ms
-    step:(100000) -- ms
-      create_prop:(200000) -- ms
-        compute_grads:(200000) -- ms
-        unattributed: -- ms
-      sample:(100000) -- ms
-      save_old:(100000) -- ms
-      eval:(100000) -- ms
-      clear_grads:(100000) -- ms
-      restore_old:(8136) -- ms
-      unattributed: -- ms
-    collect_sample:(1000) -- ms
-    unattributed: -- ms
-  unattributed: -- ms
-unattributed: -- ms
-
-profiler_report: accumulate:(1) -- ms
-infer:(1) -- ms
-  fix_problems:(1) -- ms
-    VectorizedModelFixer:(--) -- ms
-    BoolArithmeticFixer:(1) -- ms
-    AdditionFixer:(1) -- ms
-    BoolComparisonFixer:(1) -- ms
-    UnsupportedNodeFixer:(1) -- ms
-    MatrixScaleFixer:(--) -- ms
-    MultiaryAdditionFixer:(1) -- ms
-    MultiaryMultiplicationFixer:(1) -- ms
-    RequirementsFixer:(1) -- ms
-    ObservationsFixer:(1) -- ms
-    unattributed: -- ms
-  build_bmg_graph:(1) -- ms
-  graph_infer:(1) -- ms
-  deserialize_perf_report:(1) -- ms
-  transpose_samples:(1) -- ms
-  build_mcsamples:(1) -- ms
-  unattributed: -- ms
-unattributed: -- ms
-"""
-
-        self.assertEqual(
-            tidy(observed_report_wo_optimization).strip(),
-            tidy(expected_report_wo_optimization).strip(),
-        )
-
-        expected_nodes_reduction = 101
-        observed_nodes_reduction = (
-            report_wo_optimization.node_count - report_w_optimization.node_count
-        )
-        self.assertEqual(expected_nodes_reduction, observed_nodes_reduction)
-
-        expected_edges_reduction = 101
-        observed_edges_reduction = (
-            report_wo_optimization.edge_count - report_w_optimization.edge_count
-        )
-        self.assertEqual(expected_edges_reduction, observed_edges_reduction)
+        self.assertEqual(report_wo_optimization.node_count, 205)
+        self.assertEqual(report_wo_optimization.edge_count, 303)

--- a/src/beanmachine/ppl/compiler/tests/perf_report_test.py
+++ b/src/beanmachine/ppl/compiler/tests/perf_report_test.py
@@ -69,43 +69,6 @@ det_supp_count: [0]
 bmg_profiler_report: nmc_infer:(1) -- ms
   initialize:(1) -- ms
   collect_samples:(1) -- ms
-    step:(1000) -- ms
-      create_prop:(2000) -- ms
-        compute_grads:(--) -- ms
-        unattributed: -- ms
-      sample:(1000) -- ms
-      save_old:(1000) -- ms
-      eval:(1000) -- ms
-      clear_grads:(1000) -- ms
-      restore_old:(7) -- ms
-      unattributed: -- ms
-    collect_sample:(1000) -- ms
-    unattributed: -- ms
-  unattributed: -- ms
-unattributed: -- ms
-
-profiler_report: accumulate:(1) -- ms
-infer:(1) -- ms
-  fix_problems:(1) -- ms
-    VectorizedModelFixer:(--) -- ms
-    BoolArithmeticFixer:(--) -- ms
-    AdditionFixer:(1) -- ms
-    BoolComparisonFixer:(1) -- ms
-    UnsupportedNodeFixer:(1) -- ms
-    MatrixScaleFixer:(--) -- ms
-    MultiaryAdditionFixer:(1) -- ms
-    LogSumExpFixer:(1) -- ms
-    MultiaryMultiplicationFixer:(1) -- ms
-    RequirementsFixer:(1) -- ms
-    ObservationsFixer:(1) -- ms
-    unattributed: -- ms
-  build_bmg_graph:(1) -- ms
-  graph_infer:(1) -- ms
-  deserialize_perf_report:(--) -- ms
-  transpose_samples:(1) -- ms
-  build_mcsamples:(1) -- ms
-  unattributed: -- ms
-unattributed: -- ms
 """
 
         # Note that there are two profiler reports: one for time spent
@@ -114,7 +77,7 @@ unattributed: -- ms
         # See next test for details of how to access the elements of the
         # perf report and the profile reports
 
-        self.assertEqual(tidy(expected).strip(), tidy(observed).strip())
+        self.assertTrue(tidy(observed).strip().startswith(tidy(expected).strip()))
 
     def test_bmg_performance_report_2(self) -> None:
         if platform.system() == "Windows":


### PR DESCRIPTION
Summary:
These three performance tests do only one thing: run inference with and without a certain optimization, and measure the change in the number of nodes and edges in the resulting graphs.  They are very complicated for what they do and testing far too much. I'm intending to make some changes to the problem fixing infrastructure in upcoming diffs; these tests among other things verify what problem fixers run, and that's out of their scope.

Also, there was code in these tests to ensure reproducibility of inference, but the inference results are discarded! Graph topology is deterministic and that's what these tests are intended to measure.

Reviewed By: yucenli

Differential Revision: D34323334

