### PR TITLE
Separate unsupported node rewriting from error reporting

### DIFF
--- a/src/beanmachine/ppl/compiler/fix_problems.py
+++ b/src/beanmachine/ppl/compiler/fix_problems.py
@@ -27,7 +27,10 @@ from beanmachine.ppl.compiler.fix_normal_conjugate_prior import (
 from beanmachine.ppl.compiler.fix_observations import ObservationsFixer
 from beanmachine.ppl.compiler.fix_observe_true import ObserveTrueFixer
 from beanmachine.ppl.compiler.fix_requirements import RequirementsFixer
-from beanmachine.ppl.compiler.fix_unsupported import UnsupportedNodeFixer
+from beanmachine.ppl.compiler.fix_unsupported import (
+    UnsupportedNodeFixer,
+    UnsupportedNodeReporter,
+)
 from beanmachine.ppl.compiler.fix_vectorized_models import VectorizedModelFixer
 from beanmachine.ppl.compiler.lattice_typer import LatticeTyper
 
@@ -53,6 +56,7 @@ _standard_fixer_types: List[Type] = [
     AdditionFixer,
     BoolComparisonFixer,
     UnsupportedNodeFixer,
+    UnsupportedNodeReporter,
     MatrixScaleFixer,
     MultiaryAdditionFixer,
     LogSumExpFixer,

--- a/src/beanmachine/ppl/compiler/fix_unsupported.py
+++ b/src/beanmachine/ppl/compiler/fix_unsupported.py
@@ -390,6 +390,20 @@ class UnsupportedNodeFixer(ProblemFixerBase):
         # It's not a constant. If the node is not supported then try to fix it.
         return not is_supported_by_bmg(n)
 
+
+class UnsupportedNodeReporter(ProblemFixerBase):
+    def __init__(self, bmg: BMGraphBuilder, typer: LatticeTyper) -> None:
+        ProblemFixerBase.__init__(self, bmg, typer)
+
+    def _get_replacement(self, n: bn.BMGNode) -> Optional[bn.BMGNode]:
+        return None
+
+    def _needs_fixing(self, n: bn.BMGNode) -> bool:
+        if isinstance(n, bn.ConstantNode):
+            t = bt.type_of_value(n.value)
+            return t == bt.Tensor or t == bt.Untypable
+        return not is_supported_by_bmg(n)
+
     def _get_error(self, n: bn.BMGNode, index: int) -> Optional[BMGError]:
         # TODO: The edge labels used to visualize the graph in DOT
         # are not necessarily the best ones for displaying errors.


### PR DESCRIPTION
Summary:
We have a chicken-and-egg problem in the graph rewriter.  In the early days of implementing the graph rewriting "problem fixing" passes there was a clear order in which the passes could run, but that's no longer the case; see the comment in method `_needs_fixing` in this diff for the details.  We will eventually need to have an infrastructure which supports iterating on rewriters until we achieve a fixpoint (as we do with AST rewriting.)

I'm beginning to implement the plan described in that comment: step one is to separate the "I know how to replace an unsupported node with an equivalent supported node" pass and the "I report errors when an unsupported node is still in the graph" pass.

Reviewed By: yucenli

Differential Revision: D34322999

