### PR TITLE
Continue refactoring graph fixing passes to use combinators

### DIFF
--- a/src/beanmachine/ppl/compiler/fix_additions.py
+++ b/src/beanmachine/ppl/compiler/fix_additions.py
@@ -3,50 +3,38 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Optional
-
 import beanmachine.ppl.compiler.bmg_nodes as bn
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
-from beanmachine.ppl.compiler.fix_problem import ProblemFixerBase
+from beanmachine.ppl.compiler.fix_problem import (
+    NodeFixer,
+    NodeFixerResult,
+    Inapplicable,
+)
 from beanmachine.ppl.compiler.lattice_typer import LatticeTyper
 
 
-class AdditionFixer(ProblemFixerBase):
-    """This class takes a Bean Machine Graph builder and attempts to
-    rewrite reachable additions of the form:
-
+def addition_fixer(bmg: BMGraphBuilder, typer: LatticeTyper) -> NodeFixer:
+    """This fixer rewrites additions into complements:
     * add(1, negate(prob)) or add(negate(prob), 1) -> complement(prob)
     * add(1, negate(bool)) or add(negate(bool), 1) -> complement(bool)"""
 
-    def __init__(self, bmg: BMGraphBuilder, typer: LatticeTyper) -> None:
-        ProblemFixerBase.__init__(self, bmg, typer)
+    def fixer(node: bn.BMGNode) -> NodeFixerResult:
+        if not isinstance(node, bn.AdditionNode) or len(node.inputs) != 2:
+            return Inapplicable
+        left = node.inputs[0]
+        right = node.inputs[1]
+        if (
+            bn.is_one(left)
+            and isinstance(right, bn.NegateNode)
+            and typer.is_prob_or_bool(right.operand)
+        ):
+            return bmg.add_complement(right.operand)
+        if (
+            bn.is_one(right)
+            and isinstance(left, bn.NegateNode)
+            and typer.is_prob_or_bool(left.operand)
+        ):
+            return bmg.add_complement(left.operand)
+        return Inapplicable
 
-    def _is_one_minus_prob(self, x: bn.BMGNode, y: bn.BMGNode) -> bool:
-        return (
-            bn.is_one(x)
-            and isinstance(y, bn.NegateNode)
-            and self._typer.is_prob_or_bool(y.operand)  # pyre-ignore
-        )
-
-    def _can_be_complement(self, n: bn.AdditionNode) -> bool:
-        assert len(n.inputs) == 2
-        return self._is_one_minus_prob(
-            n.inputs[0], n.inputs[1]
-        ) or self._is_one_minus_prob(n.inputs[1], n.inputs[0])
-
-    def _needs_fixing(self, n: bn.BMGNode) -> bool:
-        return isinstance(n, bn.AdditionNode) and self._can_be_complement(n)
-
-    def _get_replacement(self, n: bn.BMGNode) -> Optional[bn.BMGNode]:
-        assert isinstance(n, bn.AdditionNode)
-        assert len(n.inputs) == 2
-        assert self._can_be_complement(n)
-        # We have 1+(-x) or (-x)+1 where x is either P or B, and require
-        # a P or B. Complement(x) is of the same type as x if x is P or B.
-        if bn.is_one(n.inputs[0]):
-            other = n.inputs[1]
-        else:
-            assert bn.is_one(n.inputs[1])
-            other = n.inputs[0]
-        assert isinstance(other, bn.NegateNode)
-        return self._bmg.add_complement(other.operand)
+    return fixer

--- a/src/beanmachine/ppl/compiler/fix_bool_arithmetic.py
+++ b/src/beanmachine/ppl/compiler/fix_bool_arithmetic.py
@@ -3,57 +3,29 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Optional
-
 import beanmachine.ppl.compiler.bmg_nodes as bn
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
-from beanmachine.ppl.compiler.fix_problem import ProblemFixerBase
+from beanmachine.ppl.compiler.fix_problem import (
+    node_fixer_first_match,
+    NodeFixer,
+    Inapplicable,
+    NodeFixerResult,
+    type_guard,
+)
 from beanmachine.ppl.compiler.lattice_typer import LatticeTyper
 
 
-class BoolArithmeticFixer(ProblemFixerBase):
-    def __init__(self, bmg: BMGraphBuilder, typer: LatticeTyper) -> None:
-        ProblemFixerBase.__init__(self, bmg, typer)
+class BoolArithmeticFixer:
+    _bmg: BMGraphBuilder
+    _typer: LatticeTyper
 
-    def _needs_fixing(self, n: bn.BMGNode) -> bool:
-        assert isinstance(self._typer, LatticeTyper)
+    def __init__(self, bmg: BMGraphBuilder, typer: LatticeTyper) -> None:
+        self._bmg = bmg
+        self._typer = typer
+
+    def _fix_multiplication(self, n: bn.MultiplicationNode) -> NodeFixerResult:
         # We can simplify 1*anything, 0*anything or bool*anything
         # to anything, 0, or an if-then-else respectively.
-        if isinstance(n, bn.MultiplicationNode):
-            assert len(n.inputs) == 2
-            return self._typer.is_bool(  # pyre-ignore
-                n.inputs[0]
-            ) or self._typer.is_bool(n.inputs[1])
-        # We can simplify 0+anything.
-        if isinstance(n, bn.AdditionNode):
-            assert len(n.inputs) == 2
-            return bn.is_zero(n.inputs[0]) or bn.is_zero(n.inputs[1])
-
-        # We can simplify anything**bool.
-        if isinstance(n, bn.PowerNode):
-            return self._typer.is_bool(n.right)
-
-        # TODO: We could support b ** n where b is bool and n is a natural
-        # constant. If n is the constant zero then the result is just
-        # the Boolean constant true; if n is a non-zero constant then
-        # b ** n is simply b.
-        #
-        # NOTE: We CANNOT support b ** n where b is bool and n is a
-        # non-constant natural and the result is bool. That would
-        # have the semantics of "if b then true else n == 0" but we do
-        # not have an equality operator on naturals in BMG.
-
-        return False
-
-    def _get_replacement(self, n: bn.BMGNode) -> Optional[bn.BMGNode]:
-        if isinstance(n, bn.MultiplicationNode):
-            return self._fix_multiplication(n)
-        if isinstance(n, bn.AdditionNode):
-            return self._fix_addition(n)
-        assert isinstance(n, bn.PowerNode)
-        return self._fix_power(n)
-
-    def _fix_multiplication(self, n: bn.MultiplicationNode) -> bn.BMGNode:
         assert len(n.inputs) == 2
         if bn.is_zero(n.inputs[0]):
             return n.inputs[0]
@@ -63,21 +35,37 @@ class BoolArithmeticFixer(ProblemFixerBase):
             return n.inputs[1]
         if bn.is_one(n.inputs[1]):
             return n.inputs[0]
-        zero = self._bmg.add_constant(0.0)
-        if self._typer.is_bool(n.inputs[0]):  # pyre-ignore
+        if self._typer.is_bool(n.inputs[0]):
+            zero = self._bmg.add_constant(0.0)
             return self._bmg.add_if_then_else(n.inputs[0], n.inputs[1], zero)
-        assert self._typer.is_bool(n.inputs[1])
-        return self._bmg.add_if_then_else(n.inputs[1], n.inputs[0], zero)
+        if self._typer.is_bool(n.inputs[1]):
+            zero = self._bmg.add_constant(0.0)
+            return self._bmg.add_if_then_else(n.inputs[1], n.inputs[0], zero)
+        return Inapplicable
 
-    def _fix_addition(self, n: bn.AdditionNode) -> bn.BMGNode:
+    def _fix_addition(self, n: bn.AdditionNode) -> NodeFixerResult:
+        # We can simplify 0+anything.
         assert len(n.inputs) == 2
         if bn.is_zero(n.inputs[0]):
             return n.inputs[1]
-        assert bn.is_zero(n.inputs[1])
-        return n.inputs[0]
+        if bn.is_zero(n.inputs[1]):
+            return n.inputs[0]
+        return Inapplicable
 
-    def _fix_power(self, n: bn.PowerNode) -> bn.BMGNode:
+    def _fix_power(self, n: bn.PowerNode) -> NodeFixerResult:
         # x ** b  -->   if b then x else 1
-        assert self._typer.is_bool(n.right)  # pyre-ignore
-        one = self._bmg.add_constant(1.0)
-        return self._bmg.add_if_then_else(n.right, n.left, one)
+        if self._typer.is_bool(n.right):
+            one = self._bmg.add_constant(1.0)
+            return self._bmg.add_if_then_else(n.right, n.left, one)
+        return Inapplicable
+
+
+def bool_arithmetic_fixer(bmg: BMGraphBuilder, typer: LatticeTyper) -> NodeFixer:
+    baf = BoolArithmeticFixer(bmg, typer)
+    return node_fixer_first_match(
+        [
+            type_guard(bn.AdditionNode, baf._fix_addition),
+            type_guard(bn.MultiplicationNode, baf._fix_multiplication),
+            type_guard(bn.PowerNode, baf._fix_power),
+        ]
+    )

--- a/src/beanmachine/ppl/compiler/fix_bool_comparisons.py
+++ b/src/beanmachine/ppl/compiler/fix_bool_comparisons.py
@@ -3,35 +3,43 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Optional
-
 import beanmachine.ppl.compiler.bmg_nodes as bn
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
 from beanmachine.ppl.compiler.bmg_types import Boolean
-from beanmachine.ppl.compiler.fix_problem import ProblemFixerBase
+from beanmachine.ppl.compiler.fix_problem import (
+    Inapplicable,
+    NodeFixer,
+    NodeFixerResult,
+    node_fixer_first_match,
+    type_guard,
+)
 from beanmachine.ppl.compiler.lattice_typer import LatticeTyper
 
 
-class BoolComparisonFixer(ProblemFixerBase):
+class BoolComparisonFixer:
     """This class takes a Bean Machine Graph builder and replaces all comparison
     operators whose operands are bool with semantically equivalent IF nodes."""
 
-    def __init__(self, bmg: BMGraphBuilder, typer: LatticeTyper) -> None:
-        ProblemFixerBase.__init__(self, bmg, typer)
+    _bmg: BMGraphBuilder
+    _typer: LatticeTyper
 
-    def _needs_fixing(self, n: bn.BMGNode) -> bool:
-        return (
-            isinstance(n, bn.ComparisonNode)
-            and self._typer.is_bool(n.left)  # pyre-ignore
-            and self._typer.is_bool(n.right)
+    def __init__(self, bmg: BMGraphBuilder, typer: LatticeTyper) -> None:
+        self._bmg = bmg
+        self._typer = typer
+
+    def _both_bool(self, n: bn.BMGNode) -> bool:
+        return self._typer.is_bool(n.left) and self._typer.is_bool(  # pyre-ignore
+            n.right  # pyre-ignore
         )
 
-    def _replace_bool_equals(self, node: bn.EqualNode) -> bn.BMGNode:
+    def _replace_bool_equals(self, node: bn.EqualNode) -> NodeFixerResult:
         # 1 == y        -->  y
         # x == 1        -->  x
         # 0 == y        -->  not y
         # x == 0        -->  not x
         # x == y        -->  if x then y else not y
+        if not self._both_bool(node):
+            return Inapplicable
         if bn.is_one(node.left):
             return node.right
         if bn.is_one(node.right):
@@ -43,12 +51,14 @@ class BoolComparisonFixer(ProblemFixerBase):
         alt = self._bmg.add_complement(node.right)
         return self._bmg.add_if_then_else(node.left, node.right, alt)
 
-    def _replace_bool_not_equals(self, node: bn.NotEqualNode) -> bn.BMGNode:
+    def _replace_bool_not_equals(self, node: bn.NotEqualNode) -> NodeFixerResult:
         # 1 != y        -->  not y
         # x != 1        -->  not x
         # 0 != y        -->  y
         # x != 0        -->  x
         # x != y        -->  if x then not y else y
+        if not self._both_bool(node):
+            return Inapplicable
         if bn.is_one(node.left):
             return self._bmg.add_complement(node.right)
         if bn.is_one(node.right):
@@ -60,12 +70,14 @@ class BoolComparisonFixer(ProblemFixerBase):
         cons = self._bmg.add_complement(node.right)
         return self._bmg.add_if_then_else(node.left, cons, node.right)
 
-    def _replace_bool_gte(self, node: bn.GreaterThanEqualNode) -> bn.BMGNode:
+    def _replace_bool_gte(self, node: bn.GreaterThanEqualNode) -> NodeFixerResult:
         # 1 >= y        -->  true
         # x >= 1        -->  x
         # 0 >= y        -->  not y
         # x >= 0        -->  true
         # x >= y        -->  if x then true else not y
+        if not self._both_bool(node):
+            return Inapplicable
         if bn.is_one(node.left):
             return self._bmg.add_constant_of_type(True, Boolean)
         if bn.is_one(node.right):
@@ -78,12 +90,14 @@ class BoolComparisonFixer(ProblemFixerBase):
         alt = self._bmg.add_complement(node.right)
         return self._bmg.add_if_then_else(node.left, cons, alt)
 
-    def _replace_bool_gt(self, node: bn.GreaterThanNode) -> bn.BMGNode:
+    def _replace_bool_gt(self, node: bn.GreaterThanNode) -> NodeFixerResult:
         # 1 > y        -->  not y
         # x > 1        -->  false
         # 0 > y        -->  false
         # x > 0        -->  x
         # x > y        -->  if x then not y else false
+        if not self._both_bool(node):
+            return Inapplicable
         if bn.is_one(node.left):
             return self._bmg.add_complement(node.right)
         if bn.is_one(node.right):
@@ -96,12 +110,14 @@ class BoolComparisonFixer(ProblemFixerBase):
         alt = self._bmg.add_constant_of_type(False, Boolean)
         return self._bmg.add_if_then_else(node.left, cons, alt)
 
-    def _replace_bool_lte(self, node: bn.LessThanEqualNode) -> bn.BMGNode:
+    def _replace_bool_lte(self, node: bn.LessThanEqualNode) -> NodeFixerResult:
         # 1 <= y        -->  y
         # x <= 1        -->  true
         # 0 <= y        -->  true
         # x <= 0        -->  not x
         # x <= y        -->  if x then y else true
+        if not self._both_bool(node):
+            return Inapplicable
         if bn.is_one(node.left):
             return node.right
         if bn.is_one(node.right):
@@ -113,12 +129,14 @@ class BoolComparisonFixer(ProblemFixerBase):
         alt = self._bmg.add_constant_of_type(True, Boolean)
         return self._bmg.add_if_then_else(node.left, node.right, alt)
 
-    def _replace_bool_lt(self, node: bn.LessThanNode) -> bn.BMGNode:
+    def _replace_bool_lt(self, node: bn.LessThanNode) -> NodeFixerResult:
         # 1 < y        -->  false
         # x < 1        -->  not x
         # 0 < y        -->  y
         # x < 0        -->  false
         # x < y        -->  if x then false else y
+        if not self._both_bool(node):
+            return Inapplicable
         if bn.is_one(node.left):
             return self._bmg.add_constant_of_type(False, Boolean)
         if bn.is_one(node.right):
@@ -130,20 +148,19 @@ class BoolComparisonFixer(ProblemFixerBase):
         cons = self._bmg.add_constant_of_type(False, Boolean)
         return self._bmg.add_if_then_else(node.left, cons, node.right)
 
-    def _get_replacement(self, n: bn.BMGNode) -> Optional[bn.BMGNode]:
-        # TODO: Should we treat "x is y" the same as "x == y" when they are
-        # bools, or should that be an error?
-        if isinstance(n, bn.EqualNode):
-            return self._replace_bool_equals(n)
-        if isinstance(n, bn.NotEqualNode):
-            return self._replace_bool_not_equals(n)
-        if isinstance(n, bn.GreaterThanEqualNode):
-            return self._replace_bool_gte(n)
-        if isinstance(n, bn.GreaterThanNode):
-            return self._replace_bool_gt(n)
-        if isinstance(n, bn.LessThanEqualNode):
-            return self._replace_bool_lte(n)
-        if isinstance(n, bn.LessThanNode):
-            return self._replace_bool_lt(n)
 
-        return None
+def bool_comparison_fixer(bmg: BMGraphBuilder, typer: LatticeTyper) -> NodeFixer:
+    bcf = BoolComparisonFixer(bmg, typer)
+    # TODO: Should we treat "x is y" the same as "x == y" when they are
+    # bools, or should that be an error?
+
+    return node_fixer_first_match(
+        [
+            type_guard(bn.EqualNode, bcf._replace_bool_equals),
+            type_guard(bn.GreaterThanEqualNode, bcf._replace_bool_gte),
+            type_guard(bn.GreaterThanNode, bcf._replace_bool_gt),
+            type_guard(bn.LessThanEqualNode, bcf._replace_bool_lte),
+            type_guard(bn.LessThanNode, bcf._replace_bool_lt),
+            type_guard(bn.NotEqualNode, bcf._replace_bool_not_equals),
+        ]
+    )

--- a/src/beanmachine/ppl/compiler/fix_matrix_scale.py
+++ b/src/beanmachine/ppl/compiler/fix_matrix_scale.py
@@ -3,55 +3,45 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Optional
 
 import beanmachine.ppl.compiler.bmg_nodes as bn
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
-from beanmachine.ppl.compiler.fix_problem import ProblemFixerBase
+from beanmachine.ppl.compiler.fix_problem import (
+    NodeFixer,
+    NodeFixerResult,
+    Inapplicable,
+)
 from beanmachine.ppl.compiler.lattice_typer import LatticeTyper
 
+"""This node fixer takes a Bean Machine Graph builder and attempts to
+rewrite binary multiplications that involve a matrix and a scalar into
+a matrix_scale node.
+"""
 
-class MatrixScaleFixer(ProblemFixerBase):
-    """This class takes a Bean Machine Graph builder and attempts to
-    rewrite binary multiplications that involve a matrix and a scalar into
-    a matrix_scale node.
-    """
 
-    def __init__(self, bmg: BMGraphBuilder, typer: LatticeTyper) -> None:
-        ProblemFixerBase.__init__(self, bmg, typer)
-
-    def _needs_fixing(self, n: bn.BMGNode) -> bool:
-        # See note in fix_unsupported.py for why this is temporarily disabled.
-        return False
-        """
+def matrix_scale_fixer(bmg: BMGraphBuilder, typer: LatticeTyper) -> NodeFixer:
+    def fixer(n: bn.BMGNode) -> NodeFixerResult:
         # A matrix multiplication is fixable (to matrix_scale) if it is
-        # a binary multiplication with non-singlton result type
+        # a binary multiplication with non-singleton result type
         # and the type of one argument is matrix and the other is scalar
-        if not isinstance(n, bn.MultiplicationNode) or not (len(n.inputs) == 2):
-            return False
+        if not isinstance(n, bn.MultiplicationNode) or len(n.inputs) != 2:
+            return Inapplicable
         # The return type of the node should be matrix
-        if not (self._typer[n]).is_singleton():
-            return False
+        if not typer[n].is_singleton():
+            return Inapplicable
         # Now let's check the types of the inputs
-        input_types = [self._typer[i] for i in n.inputs]
+        input_types = [typer[i] for i in n.inputs]
         # If both are scalar, then there is nothing to do
         if all(t.is_singleton() for t in input_types):
-            return False  # Both are scalar
+            return Inapplicable  # Both are scalar
         # If both are matrices, then there is nothing to do
         if all(not (t.is_singleton()) for t in input_types):
-            return False  # Both are matrices
-        return True"""
-
-    def _get_replacement(self, n: bn.BMGNode) -> Optional[bn.BMGNode]:
-        # Double check we can proceed, and that exactly one is scalar
-        assert self._needs_fixing(n)
-        # We'll need to name the inputs and their types
+            return Inapplicable  # Both are matrices
         left, right = n.inputs
-        left_type, right_type = [self._typer[i] for i in n.inputs]
-        # Let's assume the first is the scalr one
-        scalar, matrix = left, right
-        # Fix it if necessary
-        if right_type.is_singleton():
-            scalar = right
-            matrix = left
-        return self._bmg.add_matrix_scale(scalar, matrix)
+        if input_types[1].is_singleton():
+            scalar, matrix = right, left
+        else:
+            scalar, matrix = left, right
+        return bmg.add_matrix_scale(scalar, matrix)
+
+    return fixer

--- a/src/beanmachine/ppl/compiler/fix_problem.py
+++ b/src/beanmachine/ppl/compiler/fix_problem.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from abc import ABC, abstractmethod
-from typing import Optional, Callable, List, Tuple, Union
+from typing import Optional, Callable, List, Tuple, Type, Union
 
 import beanmachine.ppl.compiler.bmg_nodes as bn
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
@@ -61,6 +61,13 @@ def node_fixer_first_match(fixers: List[NodeFixer]) -> NodeFixer:
         return Inapplicable
 
     return first_match
+
+
+def type_guard(t: Type, fixer: Callable) -> NodeFixer:
+    def guarded(node: bn.BMGNode) -> Optional[bn.BMGNode]:
+        return fixer(node) if isinstance(node, t) else None
+
+    return guarded
 
 
 # A GraphFixer is a function that takes no arguments and returns (1) a bool indicating
@@ -158,6 +165,10 @@ def ancestors_first_graph_fixer(  # noqa
 
 # TODO: Create a match-first combinator on GraphFixers.
 # TODO: Create a fixpoint combinator on GraphFixers.
+
+
+# TODO: Eventually this base class will be refactored away and
+# only GraphFixer / NodeFixer will remain.
 
 
 class ProblemFixerBase(ABC):

--- a/src/beanmachine/ppl/compiler/fix_problems.py
+++ b/src/beanmachine/ppl/compiler/fix_problems.py
@@ -3,20 +3,20 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import List, Set, Type
+from typing import Callable, List, Set
 
 import beanmachine.ppl.compiler.profiler as prof
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
 from beanmachine.ppl.compiler.error_report import ErrorReport
-from beanmachine.ppl.compiler.fix_additions import AdditionFixer
+from beanmachine.ppl.compiler.fix_additions import addition_fixer
 from beanmachine.ppl.compiler.fix_beta_conjugate_prior import (
     BetaBernoulliConjugateFixer,
     BetaBinomialConjugateFixer,
 )
-from beanmachine.ppl.compiler.fix_bool_arithmetic import BoolArithmeticFixer
-from beanmachine.ppl.compiler.fix_bool_comparisons import BoolComparisonFixer
+from beanmachine.ppl.compiler.fix_bool_arithmetic import bool_arithmetic_fixer
+from beanmachine.ppl.compiler.fix_bool_comparisons import bool_comparison_fixer
 from beanmachine.ppl.compiler.fix_logsumexp import LogSumExpFixer
-from beanmachine.ppl.compiler.fix_matrix_scale import MatrixScaleFixer
+from beanmachine.ppl.compiler.fix_matrix_scale import matrix_scale_fixer
 from beanmachine.ppl.compiler.fix_multiary_ops import (
     MultiaryAdditionFixer,
     MultiaryMultiplicationFixer,
@@ -26,38 +26,41 @@ from beanmachine.ppl.compiler.fix_normal_conjugate_prior import (
 )
 from beanmachine.ppl.compiler.fix_observations import ObservationsFixer
 from beanmachine.ppl.compiler.fix_observe_true import ObserveTrueFixer
+from beanmachine.ppl.compiler.fix_problem import (
+    GraphFixer,
+    node_fixer_first_match,
+    ancestors_first_graph_fixer,
+)
 from beanmachine.ppl.compiler.fix_requirements import RequirementsFixer
 from beanmachine.ppl.compiler.fix_unsupported import (
-    UnsupportedNodeFixer,
+    unsupported_node_fixer,
     UnsupportedNodeReporter,
 )
 from beanmachine.ppl.compiler.fix_vectorized_models import VectorizedModelFixer
 from beanmachine.ppl.compiler.lattice_typer import LatticeTyper
 
 
-# Some notes on ordering:
-#
-# AdditionFixer needs to run before RequirementsFixer. Why?
-# The requirement fixing pass runs from leaves to roots, inserting
-# conversions as it goes. If we have add(1, negate(p)) then we need
-# to turn that into complement(p), but if we process the add *after*
-# we process the negate(p) then we will already have generated
-# add(1, negate(to_real(p)).  Better to turn it into complement(p)
-# and orphan the negate(p) early.
-#
-# TODO: Add other notes on ordering constraints here.
-
 # TODO[Walid]: Investigate ways to generalize transformations such as MatrixScale to
 # work with multiary multiplications.
 
-_standard_fixer_types: List[Type] = [
+
+def arithmetic_graph_fixer(bmg: BMGraphBuilder, typer: LatticeTyper) -> GraphFixer:
+    node_fixer = node_fixer_first_match(
+        [
+            addition_fixer(bmg, typer),
+            bool_arithmetic_fixer(bmg, typer),
+            bool_comparison_fixer(bmg, typer),
+            matrix_scale_fixer(bmg, typer),
+            unsupported_node_fixer(bmg, typer),
+        ]
+    )
+    return ancestors_first_graph_fixer(bmg, typer, node_fixer)
+
+
+_standard_fixer_types: List[Callable] = [
     VectorizedModelFixer,
-    BoolArithmeticFixer,
-    AdditionFixer,
-    BoolComparisonFixer,
-    UnsupportedNodeFixer,
+    arithmetic_graph_fixer,
     UnsupportedNodeReporter,
-    MatrixScaleFixer,
     MultiaryAdditionFixer,
     LogSumExpFixer,
     MultiaryMultiplicationFixer,
@@ -79,8 +82,9 @@ def fix_problems(
     bmg: BMGraphBuilder, skip_optimizations: Set[str] = default_skip_optimizations
 ) -> ErrorReport:
     bmg._begin(prof.fix_problems)
+
     typer = LatticeTyper()
-    fixer_types: List[Type] = []
+    fixer_types: List[Callable] = []
     for fixer_type in _standard_fixer_types:
         if fixer_type.__name__ not in skip_optimizations:
             fixer_types.append(fixer_type)
@@ -91,9 +95,13 @@ def fix_problems(
     for fixer_type in fixer_types:
         bmg._begin(fixer_type.__name__)
         fixer = fixer_type(bmg, typer)
-        fixer.fix_problems()
+        if hasattr(fixer, "fix_problems"):
+            fixer.fix_problems()
+            errors = fixer.errors
+        else:
+            _, errors = fixer()
         bmg._finish(fixer_type.__name__)
-        errors = fixer.errors
+
         if errors.any():
             break
     bmg._finish(prof.fix_problems)

--- a/src/beanmachine/ppl/compiler/tests/bug_regression_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bug_regression_test.py
@@ -33,28 +33,23 @@ class BugRegressionTest(unittest.TestCase):
     def test_regress_1312(self) -> None:
         self.maxDiff = None
 
-        # TODO: There are two problems exposed by this user-supplied repro.
-        # The first, which is fixed, is that a typo in the code which propagated
-        # type mutations through the graph during the problem-fixing phase was
-        # causing some types to not be updated correctly, which was then causing
-        # internal compiler errors down the line.
+        # There were two problems exposed by this user-supplied repro. Both are
+        # now fixed.
         #
-        # The second, which is not yet fixed, is that this repro demonstrates that
-        # the problem fixers need to run repeatedly until a fixpoint is reached.
-        # Notice the very strange graph generation here: the operation 1-beta should
-        # be generated as Complement(Sample(Beta(...))) but instead is generated as
-        # ToProb(Add(ToReal(Negate(ToPosReal(Sample(Beta(...)))), 1.0))! The generated
-        # code will work but is way more nodes than it needs to be.
+        # The first was that a typo in the code which propagated type mutations
+        # through the graph during the problem-fixing phase was causing some types
+        # to not be updated correctly, which was then causing internal compiler
+        # errors down the line.
         #
-        # What is happening here is: the AdditionFixer is running first but skipping
-        # the rewrite of 1-beta into a complement because beta has an untypable
-        # Uniform(0, 1) node in its ancestors. We rewrite that into a Flat node in
-        # the UnsupportedNodeFixer, but we do not then re-run the AdditionFixer.
+        # The second was that due to the order in which the problem fixers ran,
+        # the 1-beta operation was generated as:
         #
-        # What we should do is have each fixer behave like the parse tree rewriters.
-        # That is, we should have them report on whether they made progress. We can
-        # then write combinators that keep running rewriters until they stop making
-        # progress and we've either reported errors or attained a fixpoint.
+        # ToProb(Add(1.0, ToReal(Negate(ToPosReal(Sample(Beta(...))))))
+        #
+        # Which is not wrong but is quite inefficient. It is now generated as
+        # you would expect:
+        #
+        # Complement(Sample(Beta(...)))
 
         queries = [unif()]
         observations = {flip(): torch.tensor(1)}
@@ -69,33 +64,23 @@ digraph "graph" {
   N04[label="+"];
   N05[label=Beta];
   N06[label=Sample];
-  N07[label=1.0];
-  N08[label=ToPosReal];
-  N09[label="-"];
-  N10[label=ToReal];
-  N11[label="+"];
-  N12[label=ToProb];
-  N13[label=Bernoulli];
-  N14[label=Sample];
-  N15[label="Observation True"];
-  N16[label=Query];
+  N07[label=complement];
+  N08[label=Bernoulli];
+  N09[label=Sample];
+  N10[label="Observation True"];
+  N11[label=Query];
   N00 -> N01;
   N01 -> N02;
-  N01 -> N16;
+  N01 -> N11;
   N02 -> N04;
   N03 -> N04;
   N04 -> N05;
   N04 -> N05;
   N05 -> N06;
-  N06 -> N08;
-  N07 -> N11;
+  N06 -> N07;
+  N07 -> N08;
   N08 -> N09;
   N09 -> N10;
-  N10 -> N11;
-  N11 -> N12;
-  N12 -> N13;
-  N13 -> N14;
-  N14 -> N15;
 }
         """
         self.assertEqual(expected.strip(), observed.strip())


### PR DESCRIPTION
Summary:
I'm continuing the work I began in the previous diff. We have numerous difficulties in the "problem fixing" phase where the graph is gradually rewritten from its accumulated form into a valid BMG graph; these difficulties are the result of an inflexible approach to coordinating mutations. We can be both more flexible and more efficient by using a combinator-based approach.

In the previous diff I started by refactoring the unsupported node fixer and unsupported node error reporter. In this diff:

* continue refactoring the unsupported node fixer
* the implementation of matrix scale fixing can now go back to its own module
* refactor the Boolean comparison, add, multiply and power rewriters to use combinators
* refactor the `(1+(-p)) --> complement(p)` rewriter

These refactorings not only get us farther along the road of the ultimate goal to use a combinator-based approach, they fix a known issue; due to the way we chose to order mutations we were not correctly rewriting a complement if one of its operands was rewritten by the unsupported node rewriter. With the combinator-based approach of combining all the node rewriters together into one graph fixer, this issue goes away.  (However, issues involving failure to reach a fixpoint by repeated applications of fixers still exist; I'll address those in a later diff.)

Reviewed By: feynmanliang

Differential Revision: D34400702

