### PR TITLE
Continue refactoring rewriting passes to use combinators

### DIFF
--- a/src/beanmachine/ppl/compiler/fix_logsumexp.py
+++ b/src/beanmachine/ppl/compiler/fix_logsumexp.py
@@ -3,47 +3,29 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Optional
-
 import beanmachine.ppl.compiler.bmg_nodes as bn
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
-from beanmachine.ppl.compiler.fix_problem import ProblemFixerBase
+from beanmachine.ppl.compiler.fix_problem import (
+    Inapplicable,
+    NodeFixer,
+    NodeFixerResult,
+)
 from beanmachine.ppl.compiler.lattice_typer import LatticeTyper
 
 
-class LogSumExpFixer(ProblemFixerBase):
-    """This class takes a Bean Machine Graph builder and attempts to
-    rewrite log expressions of the form:
-
-    * log( exp(a) + exp(b) + exp(c) ...) -> logsumexp(a,b,c, ...)
-
-    Note that this transformation depends on MultiaryAdditionFixer.
+def logsumexp_fixer(bmg: BMGraphBuilder, typer: LatticeTyper) -> NodeFixer:
+    """This fixer attempts to rewrite log expressions of the form
+    log( exp(a) + exp(b) + exp(c) ...) -> logsumexp(a,b,c, ...)
     """
 
-    def __init__(self, bmg: BMGraphBuilder, typer: LatticeTyper) -> None:
-        ProblemFixerBase.__init__(self, bmg, typer)
+    def fixer(node: bn.BMGNode) -> NodeFixerResult:
+        if not isinstance(node, bn.LogNode):
+            return Inapplicable
+        addition = node.operand
+        if not isinstance(addition, bn.AdditionNode):
+            return Inapplicable
+        if not all(isinstance(i, bn.ExpNode) for i in addition.inputs):
+            return Inapplicable
+        return bmg.add_logsumexp(*[i.operand for i in addition.inputs])
 
-    def _is_exp_input(self, n: bn.AdditionNode) -> bool:
-        return all(isinstance(i, bn.ExpNode) for i in n.inputs)
-
-    def can_be_log_sum_exp(self, n: bn.LogNode) -> bool:
-        o = n.operand
-        return isinstance(o, bn.AdditionNode) and self._is_exp_input(o)
-
-    def _needs_fixing(self, n: bn.BMGNode) -> bool:
-        # A log expression is fixable if operand is a AdditionNode.
-        # Additionally, each input of this AdditionNode is an ExpNode
-
-        return isinstance(n, bn.LogNode) and self.can_be_log_sum_exp(n)
-
-    def _get_replacement(self, n: bn.BMGNode) -> Optional[bn.BMGNode]:
-        assert isinstance(n, bn.LogNode)
-        assert self.can_be_log_sum_exp(n)
-
-        acc = []
-        for c in n.operand.inputs:
-            assert isinstance(c, bn.ExpNode)
-            acc.append(c.operand)
-
-        assert len(acc) == len(n.operand.inputs)
-        return self._bmg.add_logsumexp(*acc)
+    return fixer

--- a/src/beanmachine/ppl/compiler/fix_problems.py
+++ b/src/beanmachine/ppl/compiler/fix_problems.py
@@ -15,11 +15,11 @@ from beanmachine.ppl.compiler.fix_beta_conjugate_prior import (
 )
 from beanmachine.ppl.compiler.fix_bool_arithmetic import bool_arithmetic_fixer
 from beanmachine.ppl.compiler.fix_bool_comparisons import bool_comparison_fixer
-from beanmachine.ppl.compiler.fix_logsumexp import LogSumExpFixer
+from beanmachine.ppl.compiler.fix_logsumexp import logsumexp_fixer
 from beanmachine.ppl.compiler.fix_matrix_scale import matrix_scale_fixer
 from beanmachine.ppl.compiler.fix_multiary_ops import (
-    MultiaryAdditionFixer,
-    MultiaryMultiplicationFixer,
+    multiary_addition_fixer,
+    multiary_multiplication_fixer,
 )
 from beanmachine.ppl.compiler.fix_normal_conjugate_prior import (
     NormalNormalConjugateFixer,
@@ -30,6 +30,7 @@ from beanmachine.ppl.compiler.fix_problem import (
     GraphFixer,
     node_fixer_first_match,
     ancestors_first_graph_fixer,
+    NodeFixer,
 )
 from beanmachine.ppl.compiler.fix_requirements import RequirementsFixer
 from beanmachine.ppl.compiler.fix_unsupported import (
@@ -43,39 +44,38 @@ from beanmachine.ppl.compiler.lattice_typer import LatticeTyper
 # TODO[Walid]: Investigate ways to generalize transformations such as MatrixScale to
 # work with multiary multiplications.
 
-
-def arithmetic_graph_fixer(bmg: BMGraphBuilder, typer: LatticeTyper) -> GraphFixer:
-    node_fixer = node_fixer_first_match(
-        [
-            addition_fixer(bmg, typer),
-            bool_arithmetic_fixer(bmg, typer),
-            bool_comparison_fixer(bmg, typer),
-            matrix_scale_fixer(bmg, typer),
-            unsupported_node_fixer(bmg, typer),
-        ]
-    )
-    return ancestors_first_graph_fixer(bmg, typer, node_fixer)
-
-
-_standard_fixer_types: List[Callable] = [
-    VectorizedModelFixer,
-    arithmetic_graph_fixer,
-    UnsupportedNodeReporter,
-    MultiaryAdditionFixer,
-    LogSumExpFixer,
-    MultiaryMultiplicationFixer,
-    BetaBernoulliConjugateFixer,
-    BetaBinomialConjugateFixer,
-    NormalNormalConjugateFixer,
-    RequirementsFixer,
-    ObservationsFixer,
-]
-
 default_skip_optimizations: Set[str] = {
     "BetaBernoulliConjugateFixer",
     "BetaBinomialConjugateFixer",
     "NormalNormalConjugateFixer",
 }
+
+_arithmetic_fixer_factories: List[
+    Callable[[BMGraphBuilder, LatticeTyper], NodeFixer]
+] = [
+    addition_fixer,
+    bool_arithmetic_fixer,
+    bool_comparison_fixer,
+    matrix_scale_fixer,
+    multiary_addition_fixer,
+    multiary_multiplication_fixer,
+    # TODO: logsumexp_fixer needs to come after multiary_addition_fixer right now;
+    # when we make the arithmetic_graph_fixer attain a fixpoint then we can do
+    # these fixers in any order.
+    logsumexp_fixer,
+    unsupported_node_fixer,
+]
+
+
+def arithmetic_graph_fixer(skip: Set[str]) -> Callable:
+    def graph_fixer(bmg: BMGraphBuilder, typer: LatticeTyper) -> GraphFixer:
+        node_fixers = [
+            f(bmg, typer) for f in _arithmetic_fixer_factories if f.__name__ not in skip
+        ]
+        node_fixer = node_fixer_first_match(node_fixers)
+        return ancestors_first_graph_fixer(bmg, typer, node_fixer)
+
+    return graph_fixer
 
 
 def fix_problems(
@@ -83,14 +83,26 @@ def fix_problems(
 ) -> ErrorReport:
     bmg._begin(prof.fix_problems)
 
+    # Functions with signature either
+    # (BMGraphBuilder, Typer) -> GraphFixer
+    # (BMGraphBuilder, Typer) -> ProblemFixer  # This will be refactored away
+    graph_fixer_factories: List[Callable] = [
+        VectorizedModelFixer,
+        arithmetic_graph_fixer(skip_optimizations),
+        UnsupportedNodeReporter,
+        BetaBernoulliConjugateFixer,
+        BetaBinomialConjugateFixer,
+        NormalNormalConjugateFixer,
+        RequirementsFixer,
+        ObservationsFixer,
+    ]
+
     typer = LatticeTyper()
-    fixer_types: List[Callable] = []
-    for fixer_type in _standard_fixer_types:
-        if fixer_type.__name__ not in skip_optimizations:
-            fixer_types.append(fixer_type)
+    fixer_types: List[Callable] = [
+        ft for ft in graph_fixer_factories if ft.__name__ not in skip_optimizations
+    ]
     errors = ErrorReport()
     if bmg._fix_observe_true:
-        # Note: must NOT be +=, which would mutate _standard_fixer_types.
         fixer_types = fixer_types + [ObserveTrueFixer]
     for fixer_type in fixer_types:
         bmg._begin(fixer_type.__name__)

--- a/src/beanmachine/ppl/compiler/tests/binary_vs_multiary_addition_perf_test.py
+++ b/src/beanmachine/ppl/compiler/tests/binary_vs_multiary_addition_perf_test.py
@@ -65,7 +65,7 @@ class BinaryVsMultiaryAdditionPerformanceTest(unittest.TestCase):
         self.assertEqual(report_w_optimization.edge_count, 204)
 
         skip_optimizations = {
-            "MultiaryAdditionFixer",
+            "multiary_addition_fixer",
             "BetaBernoulliConjugateFixer",
             "BetaBinomialConjugateFixer",
             "NormalNormalConjugateFixer",

--- a/src/beanmachine/ppl/compiler/tests/binary_vs_multiary_multiplication_perf_test.py
+++ b/src/beanmachine/ppl/compiler/tests/binary_vs_multiary_multiplication_perf_test.py
@@ -64,7 +64,7 @@ class BinaryVsMultiaryMultiplicationPerformanceTest(unittest.TestCase):
         self.assertEqual(report_w_optimization.edge_count, 204)
 
         skip_optimizations = {
-            "MultiaryMultiplicationFixer",
+            "multiary_multiplication_fixer",
             "BetaBernoulliConjugateFixer",
             "BetaBinomialConjugateFixer",
             "NormalNormalConjugateFixer",

--- a/src/beanmachine/ppl/compiler/tests/disable_transformations_test.py
+++ b/src/beanmachine/ppl/compiler/tests/disable_transformations_test.py
@@ -42,7 +42,7 @@ class DisableTransformationsTest(unittest.TestCase):
         observations = {}
         queries = [sum_3(), sum_4()]
 
-        skip_optimizations = {"MultiaryAdditionFixer"}
+        skip_optimizations = {"multiary_addition_fixer"}
         observed = BMGInference().to_dot(
             queries, observations, skip_optimizations=skip_optimizations
         )
@@ -143,7 +143,7 @@ digraph "graph" {
         queries = [sum_3(), sum_4()]
         num_samples = 1000
 
-        skip_optimizations = {"MultiaryAdditionFixer"}
+        skip_optimizations = {"multiary_addition_fixer"}
         posterior_wo_opt = BMGInference().infer(
             queries, observations, num_samples, 1, skip_optimizations=skip_optimizations
         )

--- a/src/beanmachine/ppl/compiler/tests/fix_logsumexp_perf_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_logsumexp_perf_test.py
@@ -64,7 +64,7 @@ class LogSumExpPerformanceTest(unittest.TestCase):
         self.assertEqual(report_w_optimization.edge_count, 202)
 
         skip_optimizations = {
-            "LogSumExpFixer",
+            "logsumexp_fixer",
             "BetaBernoulliConjugateFixer",
             "BetaBinomialConjugateFixer",
             "NormalNormalConjugateFixer",

--- a/src/beanmachine/ppl/compiler/tests/fix_logsumexp_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_logsumexp_test.py
@@ -59,6 +59,7 @@ def log_6():
 
 class FixLogSumExpTest(unittest.TestCase):
     def test_fix_log_sum_exp_1(self) -> None:
+        self.maxDiff = None
         observations = {}
         queries_observed = [log_2()]
 
@@ -71,6 +72,7 @@ class FixLogSumExpTest(unittest.TestCase):
         self.assertEqual(graph_observed.strip(), graph_expected.strip())
 
     def test_fix_log_sum_exp_2(self) -> None:
+        self.maxDiff = None
         observations = {}
         queries_observed = [log_5()]
 
@@ -106,6 +108,7 @@ digraph "graph" {
         self.assertEqual(graph_observed.strip(), graph_expected.strip())
 
     def test_fix_log_sum_exp_3(self) -> None:
+        self.maxDiff = None
         observations = {}
         queries_observed = [log_6()]
 


### PR DESCRIPTION
Summary:
My work in the last couple of diffs continues; in this diff I'm refactoring the multiary addition, multiary multiplication and logsumexp rewriters to use my new combinator-based rewriting system.

This necessitated updating the logic that we have for skipping certain optimization passes for performance testing.

Reviewed By: yucenli

Differential Revision: D34408647

