### PR TITLE
Update installation instruction with pytest 7.0 release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,8 +65,8 @@ jobs:
     - name: Install built Bean Machine dist
       run: pip install dist/*.whl
 
-    - name: Install pytest 7.0 (with a importlib patch in pytest-dev/pytest#7870)
-      run: pip install git+https://github.com/pytest-dev/pytest.git@7.0.0.dev0
+    - name: Install pytest
+      run: pip install -U pytest
 
     - name: Print out package info to help with debug
       run: pip list
@@ -107,8 +107,8 @@ jobs:
     - name: Install built Bean Machine dist
       run: /opt/python/${{ matrix.python-version }}/bin/pip install wheelhouse/*.whl
 
-    - name: Install pytest 7.0 (with a importlib patch in pytest-dev/pytest#7870)
-      run: /opt/python/${{ matrix.python-version }}/bin/pip install git+https://github.com/pytest-dev/pytest.git@7.0.0.dev0
+    - name: Install pytest
+      run: /opt/python/${{ matrix.python-version }}/bin/pip install -U pytest
 
     - name: Print out package info to help with debug
       run: /opt/python/${{ matrix.python-version }}/bin/pip list

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -37,10 +37,7 @@ jobs:
         python -m pip install --upgrade pip
 
     - name: Install Bean Machine
-      run: pip install -v .
-
-    - name: Install pytest 7.0 (with a importlib patch in pytest-dev/pytest#7870)
-      run: pip install git+https://github.com/pytest-dev/pytest.git@7.0.0.dev0
+      run: pip install -v .[test]
 
     - name: Print out package info to help with debug
       run: pip list

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,9 +43,6 @@ jobs:
     - name: Install Bean Machine in editable mode
       run: pip install -v -e .[dev]
 
-    - name: Install pytest 7.0 (with a importlib patch in pytest-dev/pytest#7870)
-      run: pip install git+https://github.com/pytest-dev/pytest.git@7.0.0.dev0
-
     - name: Print out package info to help with debug
       run: pip list
 

--- a/README.md
+++ b/README.md
@@ -55,8 +55,7 @@ docker run -it beanmachine:latest bash
 If you would like to run the builtin unit tests:
 
 ```bash
-# install pytest 7.0 from GitHub
-pip install git+https://github.com/pytest-dev/pytest.git@7.0.0.dev0
+pip install -U 'pytest>=7.0.0'
 pytest .
 ```
 

--- a/docs/overview/installation/installation.md
+++ b/docs/overview/installation/installation.md
@@ -23,8 +23,16 @@ To install from source, the first step is to clone the git repository:
 ```
 git clone https://github.com/facebookresearch/beanmachine.git
 cd beanmachine
-pip install -e .
 ```
+
+We recommend using [conda](https://docs.conda.io/en/latest/) to manage the virtual environment and install the necessary build dependencies.
+
+```
+conda create -n {env name} python=3.7; conda activate {env name}
+conda install boost eigen  # C++ dependencies
+pip install .
+```
+
 If you are a developer and plan to experiment with modifying the code, we recommend replacing the last step above with:
 ```
 pip install -e ".[dev]"

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ REQUIRED_MAJOR = 3
 REQUIRED_MINOR = 7
 
 
-TEST_REQUIRES = ["pytest", "pytest-cov"]
+TEST_REQUIRES = ["pytest>=7.0.0", "pytest-cov"]
 TUTORIALS_REQUIRES = [
     "bokeh",
     "cma",


### PR DESCRIPTION
Summary: pytest 7.0 fixes an issue where the test files are loaded without a module metadata, which used to break our compiler. Prior to the official release of pytest 7, we had to manually install the pre release version from GitHub. Now that [pytest 7.0](https://pypi.org/project/pytest/7.0.1/) is officially released, we can update our dependency and remove the manually installation from our CIs.

Differential Revision: D34595351

