### PR TITLE
Refactor conjugacy rewriters

### DIFF
--- a/src/beanmachine/ppl/compiler/fix_beta_conjugate_prior.py
+++ b/src/beanmachine/ppl/compiler/fix_beta_conjugate_prior.py
@@ -3,76 +3,54 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from abc import abstractmethod
-from typing import List, Optional, Tuple
+from typing import List, Tuple
 
 import beanmachine.ppl.compiler.bmg_nodes as bn
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
-from beanmachine.ppl.compiler.fix_problem import ProblemFixerBase
-from beanmachine.ppl.compiler.typer_base import TyperBase
+from beanmachine.ppl.compiler.fix_problem import (
+    NodeFixer,
+    NodeFixerResult,
+    Inapplicable,
+)
 
 
-class BetaPriorFixer(ProblemFixerBase):
-    """Beta distribution is a conjugate prior to Bernoulli, Binomial, Negative
-    Binomial and Geometric distributions. Graph pattern check for the Beta prior
-    is same for all the conjugate pairs. This fixer checks if the prior satisfies
-    required transformation conditions.
-    """
-
-    def __init__(self, bmg: BMGraphBuilder, typer: TyperBase) -> None:
-        ProblemFixerBase.__init__(self, bmg, typer)
-
-    def _theta_is_beta_with_real_params(self, n: bn.SampleNode) -> bool:
-        # TODO: For now we support conjugate prior transformation on
-        # priors with constant parameter values.
-        beta_node = n.inputs[0]
-        if not isinstance(beta_node, bn.BetaNode):
-            return False
-        alpha = beta_node.inputs[0]
-        beta = beta_node.inputs[1]
-        return isinstance(alpha, bn.ConstantNode) and isinstance(beta, bn.ConstantNode)
-
-    def _theta_is_queried(self, n: bn.SampleNode) -> bool:
-        # TODO: This check can be removed if it is not a necessary condition.
-        return any(isinstance(i, bn.Query) for i in n.outputs.items)
-
-    def _sample_contains_obs(self, n: bn.SampleNode) -> bool:
-        return any(isinstance(o, bn.Observation) for o in n.outputs.items)
-
-    def _liklihood_is_observed(self, n: bn.BMGNode) -> bool:
-        return any(self._sample_contains_obs(i) for i in n.outputs.items)
-
-    def _get_likelihood_obs_samples(
-        self, n: bn.BMGNode
-    ) -> Tuple[List[bn.Observation], List[bn.SampleNode]]:
-        obs = []
-        samples = []
-        for o in n.outputs.items:
-            if isinstance(o, bn.SampleNode) and self._sample_contains_obs(o):
-                obs.append(next(iter(o.outputs.items.keys())))
-                samples.append(o)
-        return obs, samples
-
-    def _needs_fixing(self, n: bn.BMGNode) -> bool:
-        if not isinstance(n, bn.SampleNode):
-            return False
-        return self._theta_is_beta_with_real_params(n) and self._theta_is_queried(n)
-
-    def _transform_alpha(
-        self, alpha: bn.ConstantNode, obs: List[bn.Observation]
-    ) -> bn.BMGNode:
-        # Update: alpha' = alpha + obs_sum
-        obs_sum = sum(o.value for o in obs)
-        return self._bmg.add_pos_real(alpha.value + obs_sum)
-
-    @abstractmethod
-    def _transform_beta(
-        self, beta: bn.ConstantNode, obs: List[bn.Observation]
-    ) -> bn.BMGNode:
-        pass
+def _theta_is_beta_with_real_params(n: bn.SampleNode) -> bool:
+    # TODO: For now we support conjugate prior transformation on
+    # priors with constant parameter values.
+    beta_node = n.inputs[0]
+    if not isinstance(beta_node, bn.BetaNode):
+        return False
+    alpha = beta_node.inputs[0]
+    beta = beta_node.inputs[1]
+    return isinstance(alpha, bn.ConstantNode) and isinstance(beta, bn.ConstantNode)
 
 
-class BetaBernoulliConjugateFixer(BetaPriorFixer):
+def _theta_is_queried(n: bn.SampleNode) -> bool:
+    # TODO: This check can be removed if it is not a necessary condition.
+    return any(isinstance(i, bn.Query) for i in n.outputs.items)
+
+
+def _sample_contains_obs(n: bn.SampleNode) -> bool:
+    return any(isinstance(o, bn.Observation) for o in n.outputs.items)
+
+
+def _get_likelihood_obs_samples(
+    n: bn.BMGNode,
+) -> Tuple[List[bn.Observation], List[bn.SampleNode]]:
+    obs = []
+    samples = []
+    for o in n.outputs.items:
+        if isinstance(o, bn.SampleNode) and _sample_contains_obs(o):
+            obs.append(next(iter(o.outputs.items.keys())))
+            samples.append(o)
+    return obs, samples
+
+
+def _liklihood_is_observed(n: bn.BMGNode) -> bool:
+    return any(_sample_contains_obs(i) for i in n.outputs.items)
+
+
+def beta_bernoulli_conjugate_fixer(bmg: BMGraphBuilder) -> NodeFixer:
     """This fixer transforms graphs with Bernoulli likelihood and Beta prior.
     Since this is a conjugate pair, we analytically update the prior
     parameters Beta(alpha, beta) using observations to get the posterior
@@ -82,18 +60,8 @@ class BetaBernoulliConjugateFixer(BetaPriorFixer):
     update is reduced to parameter update which can lead to performance
     wins during inference."""
 
-    def __init__(self, bmg: BMGraphBuilder, typer: TyperBase) -> None:
-        BetaPriorFixer.__init__(self, bmg, typer)
+    def fixer(n: bn.BMGNode) -> NodeFixerResult:
 
-    def _transform_beta(
-        self, beta: bn.ConstantNode, obs: List[bn.Observation]
-    ) -> bn.BMGNode:
-        # Update: beta' = beta + n - obs_sum
-        obs_sum = sum(o.value for o in obs)
-        n = len(obs)
-        return self._bmg.add_pos_real(beta.value + n - obs_sum)
-
-    def _needs_fixing(self, n: bn.BMGNode) -> bool:
         # A graph is beta-bernoulli conjugate fixable if:
         #
         # There is a bernoulli node with theta that is sampled
@@ -125,42 +93,49 @@ class BetaBernoulliConjugateFixer(BetaPriorFixer):
         #       Query
 
         if not isinstance(n, bn.BernoulliNode):
-            return False
-        sample = n.inputs[0]
-        return super()._needs_fixing(sample) and self._liklihood_is_observed(n)
-
-    def _get_replacement(self, n: bn.BMGNode) -> Optional[bn.BMGNode]:
-        assert isinstance(n, bn.BernoulliNode)
+            return Inapplicable
         beta_sample = n.inputs[0]
-        assert isinstance(beta_sample, bn.SampleNode)
+        if not (
+            isinstance(beta_sample, bn.SampleNode)
+            and _theta_is_beta_with_real_params(beta_sample)
+            and _theta_is_queried(beta_sample)
+            and _liklihood_is_observed(n)
+        ):
+            return Inapplicable
+
         beta_node = beta_sample.inputs[0]
         assert isinstance(beta_node, bn.BetaNode)
 
-        obs, samples_to_remove = self._get_likelihood_obs_samples(n)
+        obs, samples_to_remove = _get_likelihood_obs_samples(n)
 
         alpha = beta_node.inputs[0]
         assert isinstance(alpha, bn.ConstantNode)
-        transformed_alpha = self._transform_alpha(alpha, obs)
+        obs_sum = sum(o.value for o in obs)
+        transformed_alpha = bmg.add_pos_real(alpha.value + obs_sum)
 
         beta = beta_node.inputs[1]
         assert isinstance(beta, bn.ConstantNode)
-        transformed_beta = self._transform_beta(beta, obs)
+
+        # Update: beta' = beta + n - obs_sum
+        transformed_beta = bmg.add_pos_real(beta.value + len(obs) - obs_sum)
 
         beta_node.inputs[0] = transformed_alpha
         beta_node.inputs[1] = transformed_beta
 
         # We need to remove both the sample and the observation node.
         for o in obs:
-            self._bmg.remove_leaf(o)
+            bmg.remove_leaf(o)
 
         for s in samples_to_remove:
             if len(s.outputs.items) == 0:
-                self._bmg.remove_node(s)
+                bmg.remove_node(s)
 
         return n
 
+    return fixer
 
-class BetaBinomialConjugateFixer(BetaPriorFixer):
+
+def beta_binomial_conjugate_fixer(bmg: BMGraphBuilder) -> NodeFixer:
     """This fixer transforms graphs with Binomial likelihood and Beta prior.
     Since this is a conjugate pair, we analytically update the prior
     parameters Beta(alpha, beta) using observations to get the posterior
@@ -170,19 +145,7 @@ class BetaBinomialConjugateFixer(BetaPriorFixer):
     update is reduced to parameter update which can lead to performance
     wins during inference."""
 
-    def __init__(self, bmg: BMGraphBuilder, typer: TyperBase) -> None:
-        BetaPriorFixer.__init__(self, bmg, typer)
-
-    def _transform_beta(
-        self, beta: bn.ConstantNode, obs: List[bn.Observation], count: float
-    ) -> bn.BMGNode:
-        # Update: beta' = beta + sum count - obs_sum
-        obs_sum = sum(o.value for o in obs)
-        n = len(obs)
-        updated_count = n * count
-        return self._bmg.add_pos_real(beta.value + updated_count - obs_sum)
-
-    def _needs_fixing(self, n: bn.BMGNode) -> bool:
+    def fixer(n: bn.BMGNode) -> NodeFixerResult:
         # A graph is beta-binomial conjugate fixable if:
         #
         # There is a binomial node with theta that is sampled
@@ -214,38 +177,46 @@ class BetaBinomialConjugateFixer(BetaPriorFixer):
         #       Query
 
         if not isinstance(n, bn.BinomialNode):
-            return False
-        sample = n.inputs[1]
-        return super()._needs_fixing(sample) and self._liklihood_is_observed(n)
+            return Inapplicable
+        beta_sample = n.inputs[1]
 
-    def _get_replacement(self, n: bn.BMGNode) -> Optional[bn.BMGNode]:
-        assert isinstance(n, bn.BinomialNode)
+        if not (
+            isinstance(beta_sample, bn.SampleNode)
+            and _theta_is_beta_with_real_params(beta_sample)
+            and _theta_is_queried(beta_sample)
+            and _liklihood_is_observed(n)
+        ):
+            return Inapplicable
+
         count = n.inputs[0]
         assert isinstance(count, bn.UntypedConstantNode)
-        beta_sample = n.inputs[1]
-        assert isinstance(beta_sample, bn.SampleNode)
         beta_node = beta_sample.inputs[0]
         assert isinstance(beta_node, bn.BetaNode)
 
-        obs, samples_to_remove = self._get_likelihood_obs_samples(n)
+        obs, samples_to_remove = _get_likelihood_obs_samples(n)
 
         alpha = beta_node.inputs[0]
         assert isinstance(alpha, bn.ConstantNode)
-        transformed_alpha = self._transform_alpha(alpha, obs)
+        obs_sum = sum(o.value for o in obs)
+        transformed_alpha = bmg.add_pos_real(alpha.value + obs_sum)
 
+        # Update: beta' = beta + sum count - obs_sum
         beta = beta_node.inputs[1]
         assert isinstance(beta, bn.ConstantNode)
-        transformed_beta = self._transform_beta(beta, obs, count.value)
+        updated_count = len(obs) * count.value
+        transformed_beta = bmg.add_pos_real(beta.value + updated_count - obs_sum)
 
         beta_node.inputs[0] = transformed_alpha
         beta_node.inputs[1] = transformed_beta
 
         # We need to remove both the sample and the observation node.
         for o in obs:
-            self._bmg.remove_leaf(o)
+            bmg.remove_leaf(o)
 
         for s in samples_to_remove:
             if len(s.outputs.items) == 0:
-                self._bmg.remove_node(s)
+                bmg.remove_node(s)
 
         return n
+
+    return fixer

--- a/src/beanmachine/ppl/compiler/fix_normal_conjugate_prior.py
+++ b/src/beanmachine/ppl/compiler/fix_normal_conjugate_prior.py
@@ -4,15 +4,43 @@
 # LICENSE file in the root directory of this source tree.
 
 import math
-from typing import List, Optional
+from typing import List
 
 import beanmachine.ppl.compiler.bmg_nodes as bn
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
-from beanmachine.ppl.compiler.fix_problem import ProblemFixerBase
-from beanmachine.ppl.compiler.typer_base import TyperBase
+from beanmachine.ppl.compiler.fix_problem import (
+    NodeFixer,
+    NodeFixerResult,
+    Inapplicable,
+)
 
 
-class NormalNormalConjugateFixer(ProblemFixerBase):
+def _mu_is_normal_with_real_params(n: bn.SampleNode) -> bool:
+    # TODO: For now we support conjugate prior transformation on
+    # priors with constant parameter values. We need to modify this for
+    # cascading normals e.g. normal(normal(normal...))
+    normal_node = n.inputs[0]
+    if not isinstance(normal_node, bn.NormalNode):
+        return False
+    mu = normal_node.inputs[0]
+    sigma = normal_node.inputs[1]
+    return isinstance(mu, bn.ConstantNode) and isinstance(sigma, bn.ConstantNode)
+
+
+def _mu_is_queried(n: bn.SampleNode) -> bool:
+    # TODO: This check can be removed if it is not a necessary condition.
+    return any(isinstance(i, bn.Query) for i in n.outputs.items)
+
+
+def _sample_contains_obs(n: bn.SampleNode) -> bool:
+    return any(isinstance(o, bn.Observation) for o in n.outputs.items)
+
+
+def _normal_is_observed(n: bn.BMGNode) -> bool:
+    return any(_sample_contains_obs(i) for i in n.outputs.items)
+
+
+def normal_normal_conjugate_fixer(bmg: BMGraphBuilder) -> NodeFixer:
     """This fixer transforms graphs with Normal likelihood with fixed sigma
     and Normal prior for mu. Since this is a conjugate pair, we analytically
     update the prior parameters Normal(mu, sigma) using observations to get
@@ -22,31 +50,32 @@ class NormalNormalConjugateFixer(ProblemFixerBase):
     update is reduced to parameter update which can lead to performance
     wins during inference."""
 
-    def __init__(self, bmg: BMGraphBuilder, typer: TyperBase) -> None:
-        ProblemFixerBase.__init__(self, bmg, typer)
+    def _transform_mu(
+        mu: bn.ConstantNode,
+        std: bn.ConstantNode,
+        sigma: bn.ConstantNode,
+        obs: List[bn.Observation],
+    ) -> bn.BMGNode:
+        precision_prior = pow(std.value, -2.0)
+        precision_data = len(obs) * pow(sigma.value, -2.0)
+        precision_inv = pow((precision_prior + precision_data), -1.0)
+        data_sum = sum(o.value for o in obs)
+        transformed_mu = precision_inv * (
+            (mu.value * pow(std.value, -2.0)) + (data_sum * pow(sigma.value, -2.0))
+        )
+        return bmg.add_constant(transformed_mu)
 
-    def _mu_is_normal_with_real_params(self, n: bn.SampleNode) -> bool:
-        # TODO: For now we support conjugate prior transformation on
-        # priors with constant parameter values. We need to modify this for
-        # cascading normals e.g. normal(normal(normal...))
-        normal_node = n.inputs[0]
-        if not isinstance(normal_node, bn.NormalNode):
-            return False
-        mu = normal_node.inputs[0]
-        sigma = normal_node.inputs[1]
-        return isinstance(mu, bn.ConstantNode) and isinstance(sigma, bn.ConstantNode)
+    def _transform_std(
+        std: bn.ConstantNode,
+        sigma: bn.ConstantNode,
+        obs: List[bn.Observation],
+    ) -> bn.BMGNode:
+        precision_prior = 1 / pow(std.value, 2)
+        precision_data = len(obs) / pow(sigma.value, 2)
+        transformed_std = math.sqrt(1 / (precision_prior + precision_data))
+        return bmg.add_constant(transformed_std)
 
-    def _mu_is_queried(self, n: bn.SampleNode) -> bool:
-        # TODO: This check can be removed if it is not a necessary condition.
-        return any(isinstance(i, bn.Query) for i in n.outputs.items)
-
-    def _sample_contains_obs(self, n: bn.SampleNode) -> bool:
-        return any(isinstance(o, bn.Observation) for o in n.outputs.items)
-
-    def _normal_is_observed(self, n: bn.BMGNode) -> bool:
-        return any(self._sample_contains_obs(i) for i in n.outputs.items)
-
-    def _needs_fixing(self, n: bn.BMGNode) -> bool:
+    def fixer(n: bn.BMGNode) -> NodeFixerResult:
         # A graph is normal-normal conjugate fixable if:
         #
         # There is a Normal node with mu that is sampled
@@ -79,56 +108,25 @@ class NormalNormalConjugateFixer(ProblemFixerBase):
         #       Query
 
         if not isinstance(n, bn.NormalNode):
-            return False
-        sample = n.inputs[0]
-        if not isinstance(sample, bn.SampleNode):
-            return False
-        return (
-            self._mu_is_normal_with_real_params(sample)
-            and self._mu_is_queried(sample)
-            and self._normal_is_observed(n)
-        )
+            return Inapplicable
+        mu_normal_sample = n.inputs[0]
+        if not (
+            isinstance(mu_normal_sample, bn.SampleNode)
+            and _mu_is_normal_with_real_params(mu_normal_sample)
+            and _mu_is_queried(mu_normal_sample)
+            and _normal_is_observed(n)
+        ):
+            return Inapplicable
 
-    def _transform_mu(
-        self,
-        mu: bn.ConstantNode,
-        std: bn.ConstantNode,
-        sigma: bn.ConstantNode,
-        obs: List[bn.Observation],
-    ) -> bn.BMGNode:
-        precision_prior = pow(std.value, -2.0)
-        precision_data = len(obs) * pow(sigma.value, -2.0)
-        precision_inv = pow((precision_prior + precision_data), -1.0)
-        data_sum = sum(o.value for o in obs)
-        transformed_mu = precision_inv * (
-            (mu.value * pow(std.value, -2.0)) + (data_sum * pow(sigma.value, -2.0))
-        )
-        return self._bmg.add_constant(transformed_mu)
-
-    def _transform_std(
-        self,
-        std: bn.ConstantNode,
-        sigma: bn.ConstantNode,
-        obs: List[bn.Observation],
-    ) -> bn.BMGNode:
-        precision_prior = 1 / pow(std.value, 2)
-        precision_data = len(obs) / pow(sigma.value, 2)
-        transformed_std = math.sqrt(1 / (precision_prior + precision_data))
-        return self._bmg.add_constant(transformed_std)
-
-    def _get_replacement(self, n: bn.BMGNode) -> Optional[bn.BMGNode]:
-        assert isinstance(n, bn.NormalNode)
         sigma = n.inputs[1]
         assert isinstance(sigma, bn.UntypedConstantNode)
-        mu_normal_sample = n.inputs[0]
-        assert isinstance(mu_normal_sample, bn.SampleNode)
         mu_normal_node = mu_normal_sample.inputs[0]
         assert isinstance(mu_normal_node, bn.NormalNode)
 
         obs = []
         samples_to_remove = []
         for o in n.outputs.items:
-            if isinstance(o, bn.SampleNode) and self._sample_contains_obs(o):
+            if isinstance(o, bn.SampleNode) and _sample_contains_obs(o):
                 obs.append(next(iter(o.outputs.items.keys())))
                 samples_to_remove.append(o)
 
@@ -137,18 +135,20 @@ class NormalNormalConjugateFixer(ProblemFixerBase):
         assert isinstance(mu, bn.ConstantNode)
         assert isinstance(std, bn.ConstantNode)
 
-        transformed_mu = self._transform_mu(mu, std, sigma, obs)
-        transformed_std = self._transform_std(std, sigma, obs)
+        transformed_mu = _transform_mu(mu, std, sigma, obs)
+        transformed_std = _transform_std(std, sigma, obs)
 
         mu_normal_node.inputs[0] = transformed_mu
         mu_normal_node.inputs[1] = transformed_std
 
         # We need to remove both the sample and the observation node.
         for o in obs:
-            self._bmg.remove_leaf(o)
+            bmg.remove_leaf(o)
 
         for s in samples_to_remove:
             if len(s.outputs.items) == 0:
-                self._bmg.remove_node(s)
+                bmg.remove_node(s)
 
         return n
+
+    return fixer

--- a/src/beanmachine/ppl/compiler/testlib/tests/fix_beta_conjugacy_test.py
+++ b/src/beanmachine/ppl/compiler/testlib/tests/fix_beta_conjugacy_test.py
@@ -23,9 +23,9 @@ _alpha = 2.0
 _beta = 2.0
 
 test_models = [
-    (BetaBernoulliBasicModel, "BetaBernoulliConjugateFixer"),
-    (BetaBernoulliOpsModel, "BetaBernoulliConjugateFixer"),
-    (BetaBernoulliScaleHyperParameters, "BetaBernoulliConjugateFixer"),
+    (BetaBernoulliBasicModel, "beta_bernoulli_conjugate_fixer"),
+    (BetaBernoulliOpsModel, "beta_bernoulli_conjugate_fixer"),
+    (BetaBernoulliScaleHyperParameters, "beta_bernoulli_conjugate_fixer"),
 ]
 
 

--- a/src/beanmachine/ppl/compiler/tests/binary_vs_multiary_addition_perf_test.py
+++ b/src/beanmachine/ppl/compiler/tests/binary_vs_multiary_addition_perf_test.py
@@ -55,9 +55,9 @@ class BinaryVsMultiaryAdditionPerformanceTest(unittest.TestCase):
         self.maxDiff = None
 
         skip_optimizations = {
-            "BetaBernoulliConjugateFixer",
-            "BetaBinomialConjugateFixer",
-            "NormalNormalConjugateFixer",
+            "beta_bernoulli_conjugate_fixer",
+            "beta_binomial_conjugate_fixer",
+            "normal_normal_conjugate_fixer",
         }
         report_w_optimization = get_report(skip_optimizations)
 
@@ -66,9 +66,9 @@ class BinaryVsMultiaryAdditionPerformanceTest(unittest.TestCase):
 
         skip_optimizations = {
             "multiary_addition_fixer",
-            "BetaBernoulliConjugateFixer",
-            "BetaBinomialConjugateFixer",
-            "NormalNormalConjugateFixer",
+            "beta_bernoulli_conjugate_fixer",
+            "beta_binomial_conjugate_fixer",
+            "normal_normal_conjugate_fixer",
         }
         report_wo_optimization = get_report(skip_optimizations)
         self.assertEqual(report_wo_optimization.node_count, 203)

--- a/src/beanmachine/ppl/compiler/tests/binary_vs_multiary_multiplication_perf_test.py
+++ b/src/beanmachine/ppl/compiler/tests/binary_vs_multiary_multiplication_perf_test.py
@@ -55,9 +55,9 @@ class BinaryVsMultiaryMultiplicationPerformanceTest(unittest.TestCase):
         self.maxDiff = None
 
         skip_optimizations = {
-            "BetaBernoulliConjugateFixer",
-            "BetaBinomialConjugateFixer",
-            "NormalNormalConjugateFixer",
+            "beta_bernoulli_conjugate_fixer",
+            "beta_binomial_conjugate_fixer",
+            "normal_normal_conjugate_fixer",
         }
         report_w_optimization = get_report(skip_optimizations)
         self.assertEqual(report_w_optimization.node_count, 105)
@@ -65,9 +65,9 @@ class BinaryVsMultiaryMultiplicationPerformanceTest(unittest.TestCase):
 
         skip_optimizations = {
             "multiary_multiplication_fixer",
-            "BetaBernoulliConjugateFixer",
-            "BetaBinomialConjugateFixer",
-            "NormalNormalConjugateFixer",
+            "beta_bernoulli_conjugate_fixer",
+            "beta_binomial_conjugate_fixer",
+            "normal_normal_conjugate_fixer",
         }
         report_wo_optimization = get_report(skip_optimizations)
         self.assertEqual(report_wo_optimization.node_count, 203)

--- a/src/beanmachine/ppl/compiler/tests/fix_logsumexp_perf_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_logsumexp_perf_test.py
@@ -55,9 +55,9 @@ class LogSumExpPerformanceTest(unittest.TestCase):
         self.maxDiff = None
 
         skip_optimizations = {
-            "BetaBernoulliConjugateFixer",
-            "BetaBinomialConjugateFixer",
-            "NormalNormalConjugateFixer",
+            "beta_bernoulli_conjugate_fixer",
+            "beta_binomial_conjugate_fixer",
+            "normal_normal_conjugate_fixer",
         }
         report_w_optimization = get_report(skip_optimizations)
         self.assertEqual(report_w_optimization.node_count, 104)
@@ -65,9 +65,9 @@ class LogSumExpPerformanceTest(unittest.TestCase):
 
         skip_optimizations = {
             "logsumexp_fixer",
-            "BetaBernoulliConjugateFixer",
-            "BetaBinomialConjugateFixer",
-            "NormalNormalConjugateFixer",
+            "beta_bernoulli_conjugate_fixer",
+            "beta_binomial_conjugate_fixer",
+            "normal_normal_conjugate_fixer",
         }
         report_wo_optimization = get_report(skip_optimizations)
         self.assertEqual(report_wo_optimization.node_count, 205)

--- a/src/beanmachine/ppl/compiler/tests/fix_normal_normal_basic_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_normal_normal_basic_test.py
@@ -59,7 +59,7 @@ digraph "graph" {
             model.normal(): true_y.sample(),
         }
 
-        skip_optimizations = {"NormalNormalConjugateFixer"}
+        skip_optimizations = {"normal_normal_conjugate_fixer"}
         original_posterior = bmg.infer(
             queries, observations, num_samples, 1, skip_optimizations=skip_optimizations
         )


### PR DESCRIPTION
Summary: In this diff I'm continuing the efforts made in the previous diffs in this stack to refactor the rewriting passes. Here I've simplified the experimental "conjugacy optimization" passes; note that they are turned off by default right now.

Differential Revision: D34484166

