### PR TITLE
Added some NNC improvements

### DIFF
--- a/src/beanmachine/ppl/inference/proposer/hmc_proposer.py
+++ b/src/beanmachine/ppl/inference/proposer/hmc_proposer.py
@@ -67,8 +67,6 @@ class HMCProposer(BaseProposer):
         self._positions = self._to_unconstrained(
             {node: initial_world[node] for node in self._target_rvs}
         )
-        # cache pe and pe_grad to prevent re-computation
-
         self._pe, self._pe_grad = self._potential_grads(self._positions)
         # initialize parameters
         self.trajectory_length = trajectory_length

--- a/src/beanmachine/ppl/inference/proposer/hmc_proposer.py
+++ b/src/beanmachine/ppl/inference/proposer/hmc_proposer.py
@@ -68,10 +68,6 @@ class HMCProposer(BaseProposer):
             {node: initial_world[node] for node in self._target_rvs}
         )
         # cache pe and pe_grad to prevent re-computation
-        if nnc_compile and False:
-            from .nnc_utils import nnc_jit
-
-            self._potential_grads = nnc_jit(self._potential_grads)
 
         self._pe, self._pe_grad = self._potential_grads(self._positions)
         # initialize parameters

--- a/src/beanmachine/ppl/inference/proposer/hmc_proposer.py
+++ b/src/beanmachine/ppl/inference/proposer/hmc_proposer.py
@@ -68,7 +68,7 @@ class HMCProposer(BaseProposer):
             {node: initial_world[node] for node in self._target_rvs}
         )
         # cache pe and pe_grad to prevent re-computation
-        if nnc_compile:
+        if nnc_compile and False:
             from .nnc_utils import nnc_jit
 
             self._potential_grads = nnc_jit(self._potential_grads)

--- a/src/beanmachine/ppl/inference/proposer/nnc_utils.py
+++ b/src/beanmachine/ppl/inference/proposer/nnc_utils.py
@@ -7,7 +7,7 @@ import functorch
 import torch
 import torch.jit
 import torch.utils._pytree as pytree
-from functorch.compile import nop, aot_function
+from functorch.compile import nop, aot_function, decomposition_table, register_decomposition
 
 # override the usage of torch.jit.script, which has a bit of issue handling
 # empty lists (functorch#440)
@@ -20,6 +20,16 @@ def simple_ts_compile(fx_g, example_inps):
 def nnc_jit(f, static_argnums=None):
     return aot_function(f, simple_ts_compile, nop, static_argnums=static_argnums)
 
+aten = torch.ops.aten
+decompositions = [aten.detach]
+bm_decompositions = {k: v for k,v in decomposition_table.items() if k in decompositions}
+
+@register_decomposition(aten.mv, bm_decompositions)
+def mv(a, b):
+    return (a * b).sum(dim=-1)
+
+def nnc_jit(f, static_argnums=None):
+    return aot_function(f, simple_ts_compile, nop, static_argnums=static_argnums, decompositions=bm_decompositions)
 
 functorch._src.compilers.simple_ts_compile = simple_ts_compile
 

--- a/src/beanmachine/ppl/inference/proposer/nnc_utils.py
+++ b/src/beanmachine/ppl/inference/proposer/nnc_utils.py
@@ -9,24 +9,44 @@ import torch.jit
 import torch.utils._pytree as pytree
 from functorch.compile import nop, aot_function, decomposition_table, register_decomposition
 
+torch._C._jit_set_texpr_reductions_enabled(True)
+
 # override the usage of torch.jit.script, which has a bit of issue handling
 # empty lists (functorch#440)
 def simple_ts_compile(fx_g, example_inps):
     f = torch.jit.trace(fx_g, example_inps, strict=False)
     f = torch.jit.freeze(f.eval())
+    torch._C._jit_pass_remove_mutation(f.graph)
+
+    for _ in range(5):
+        f(*example_inps)
+    print(f.graph_for(*example_inps))
     return f
 
 
-def nnc_jit(f, static_argnums=None):
-    return aot_function(f, simple_ts_compile, nop, static_argnums=static_argnums)
-
 aten = torch.ops.aten
-decompositions = [aten.detach]
+decompositions = [aten.detach.default]
 bm_decompositions = {k: v for k,v in decomposition_table.items() if k in decompositions}
 
 @register_decomposition(aten.mv, bm_decompositions)
 def mv(a, b):
     return (a * b).sum(dim=-1)
+
+@register_decomposition(aten.dot, bm_decompositions)
+def dot(a, b):
+    return (a * b).sum(dim=-1)
+
+@register_decomposition(aten.nan_to_num, bm_decompositions)
+def nan_to_num(a, val):
+    return aten.where(a != a, val, a)
+
+@register_decomposition(aten.zeros_like, bm_decompositions)
+def zeros_like(a, **kwargs):
+    return a * 0
+
+@register_decomposition(aten.ones_like, bm_decompositions)
+def ones_like(a, **kwargs):
+    return a * 0 + 1
 
 def nnc_jit(f, static_argnums=None):
     return aot_function(f, simple_ts_compile, nop, static_argnums=static_argnums, decompositions=bm_decompositions)

--- a/src/beanmachine/ppl/inference/proposer/nuts_proposer.py
+++ b/src/beanmachine/ppl/inference/proposer/nuts_proposer.py
@@ -162,8 +162,10 @@ class NUTSProposer(HMCProposer):
         if tree_depth == 0:
             return self._build_tree_base_case(root, args)
             import time
+            for _ in range(5):
+                self._build_tree_base_case(root, args)
             begin = time.perf_counter()
-            iters = 100
+            iters = 10000
             for _ in range(iters):
                 out = self._build_tree_base_case(root, args)
             print((time.perf_counter()-begin)*1e6/iters, flush=True)

--- a/src/beanmachine/ppl/inference/proposer/nuts_proposer.py
+++ b/src/beanmachine/ppl/inference/proposer/nuts_proposer.py
@@ -100,7 +100,7 @@ class NUTSProposer(HMCProposer):
         self._max_tree_depth = max_tree_depth
         self._max_delta_energy = max_delta_energy
         self._multinomial_sampling = multinomial_sampling
-        if nnc_compile and True:
+        if nnc_compile:
             from .nnc_utils import nnc_jit
 
             self._build_tree_base_case = nnc_jit(self._build_tree_base_case)
@@ -160,6 +160,7 @@ class NUTSProposer(HMCProposer):
         """Build the binary tree by recursively build the left and right subtrees and
         combine the two."""
         if tree_depth == 0:
+            return self._build_tree_base_case(root, args)
             import time
             begin = time.perf_counter()
             iters = 100

--- a/src/beanmachine/ppl/model/rv_identifier.py
+++ b/src/beanmachine/ppl/model/rv_identifier.py
@@ -20,6 +20,9 @@ class RVIdentifier:
     def __str__(self):
         return str(self.function.__name__) + str(self.arguments)
 
+    def __lt__(self, other):
+        return len(self.arguments) < len(other.arguments)
+
     @property
     def function(self):
         return self.wrapper.__wrapped__


### PR DESCRIPTION
Benchmarking it by modifying the `self._build_tree` call like so

```
    def _build_tree(self, root: _TreeNode, tree_depth: int, args: _TreeArgs) -> _Tree:
        """Build the binary tree by recursively build the left and right subtrees and
        combine the two."""
        if tree_depth == 0:
            import time
            begin = time.perf_counter()
            iters = 10000
            for _ in range(iters):
                out = self._build_tree_base_case(root, args)
            print((time.perf_counter()-begin)*1e6/iters, flush=True)
            return out
```

```
Logistic regression:
NNC new (this PR): 197 us
NNC old (previous PR): 677 us
No NNC: 1020 us

Robust regression:
NNC new: 313 us
NNC old: 886 us
No NNC: 1815 us

N-schools:
NNC new: 371 us
NNC old: 681 us
No NNC: 2203 us
```

As a summary, main modifications I made to make it run faster.

1. JIT the entire `_build_tree_base_case` function instead of just `_potential_grads`.
2. Decompose `aten::mv` into a multiplication and summation. `aten::mv` likely calls into specialized kernels, which are very good for larger tensors, but get beaten out by simpler codegen in this overhead-dominated regime.
3. Enable reduction fusion support for NNC.

Main things missing to make it run faster is operator support. In particular, including `aten::view` and `aten::expand` into the fusion group are 2 big ones.

Currently the modification to the compiler makes it dump out the graph, we should probably provide a better way of introspecting that (we probably have one, I just don't know it).