### PR TITLE
Remove StatisticalModel class and add typeguards

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -149,6 +149,7 @@ setup(
     install_requires=INSTALL_REQUIRES,
     packages=find_packages("src"),
     package_dir={"": "src"},
+    package_data={"beanmachine/ppl": ["py.typed"]},
     ext_modules=[
         Pybind11Extension(
             name="beanmachine.graph",

--- a/src/beanmachine/ppl/inference/tests/utils_test.py
+++ b/src/beanmachine/ppl/inference/tests/utils_test.py
@@ -3,9 +3,12 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import unittest
+
 import beanmachine.ppl as bm
 import torch
 import torch.distributions as dist
+import torch.testing
 
 
 @bm.random_variable
@@ -23,3 +26,43 @@ def test_set_random_seed():
     samples1 = sample_with_seed(123)
     samples2 = sample_with_seed(123)
     assert torch.allclose(samples1[foo()], samples2[foo()])
+
+
+class TestMakeQueriesAndObservations(unittest.TestCase):
+    def setUp(self) -> None:
+        def a_variable() -> dist.Distribution:
+            return dist.Normal(0, 1)
+
+        self.alpha = bm.random_variable(a_variable)
+
+        def b_variable() -> dist.Distribution:
+            return dist.Beta(1, 1)
+
+        self.beta = bm.random_variable(b_variable)
+
+    def test_make_queries(self) -> None:
+        with self.assertRaises(TypeError):
+            bm.inference.utils.make_queries([self.alpha(), self.beta(), torch.ones(2)])
+
+        self.assertEqual(
+            bm.inference.utils.make_queries([self.alpha(), self.beta()]),
+            [self.alpha(), self.beta()],
+        )
+
+    def test_make_observations(self) -> None:
+        with self.assertRaises(TypeError):
+            bm.inference.utils.make_observations(
+                {
+                    self.alpha(): torch.ones(2),
+                    self.beta(): torch.zeros(2),
+                    "c": torch.ones(2),
+                }
+            )
+
+        expected = {self.alpha(): torch.ones(2), self.beta(): torch.zeros(2)}
+        actual = bm.inference.utils.make_observations(
+            {self.alpha(): torch.ones(2), self.beta(): torch.zeros(2)}
+        )
+        self.assertEqual(actual.keys(), expected.keys())
+        for k in actual:
+            torch.testing.assert_allclose(actual[k], expected[k])

--- a/src/beanmachine/ppl/inference/utils.py
+++ b/src/beanmachine/ppl/inference/utils.py
@@ -6,11 +6,12 @@
 import random
 from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
-from typing import Dict, List, Callable, Any
+from typing import Any, Callable, Dict, List, Union
 
 import numpy.random
 import torch
 from beanmachine.ppl.model.rv_identifier import RVIdentifier
+from beanmachine.ppl.utils.typeguards import is_rvidentifier_dict, is_rvidentifier_list
 
 
 RVDict = Dict[RVIdentifier, torch.Tensor]
@@ -95,6 +96,20 @@ def safe_log_prob_sum(distrib, value: torch.Tensor) -> torch.Tensor:
             return torch.tensor(float("-Inf")).to(value.device)
         else:
             raise e
+
+
+def make_queries(rvs: List[Union[RVIdentifier, torch.Tensor]]) -> List[RVIdentifier]:
+    if not is_rvidentifier_list(rvs):
+        raise TypeError("`rvs` must be of type List[RVIdentifier]")
+    return rvs
+
+
+def make_observations(
+    obs_dict: Dict[Union[RVIdentifier, torch.Tensor], torch.Tensor]
+) -> Dict[RVIdentifier, torch.Tensor]:
+    if not is_rvidentifier_dict(obs_dict):
+        raise TypeError("`obs_dict` must be of type Dict[RVIdentifier, torch.Tensor].")
+    return obs_dict
 
 
 def merge_dicts(

--- a/src/beanmachine/ppl/model/__init__.py
+++ b/src/beanmachine/ppl/model/__init__.py
@@ -4,23 +4,17 @@
 # LICENSE file in the root directory of this source tree.
 
 from beanmachine.ppl.model.rv_identifier import RVIdentifier
-from beanmachine.ppl.model.statistical_model import (
-    StatisticalModel,
-    functional,
-    param,
-    random_variable,
-)
+from beanmachine.ppl.model.statistical_model import functional, param, random_variable
 from beanmachine.ppl.model.utils import get_beanmachine_logger
 
 
 __all__ = [
     "Mode",
     "RVIdentifier",
-    "StatisticalModel",
     "functional",
+    "get_beanmachine_logger",
     "param",
     "query",
     "random_variable",
     "sample",
-    "get_beanmachine_logger",
 ]

--- a/src/beanmachine/ppl/model/statistical_model.py
+++ b/src/beanmachine/ppl/model/statistical_model.py
@@ -17,126 +17,102 @@ from typing_extensions import ParamSpec
 P = ParamSpec("P")
 
 
-class StatisticalModel:
+def get_func_key(wrapper, arguments) -> RVIdentifier:
     """
-    Parent class to all statistical models implemented in Bean Machine.
+    Creates a key to uniquely identify the Random Variable.
 
-    Every random variable in the model needs to be defined with function
-    declaration wrapped the ``bm.random_variable`` .
+    Args:
+      wrapper: reference to the wrapper function
+      arguments: function arguments
 
-    Every deterministic functional that a user would like to query during
-    inference should be wrapped in a ``bm.functional`` .
+    Returns:
+      Tuple of function and arguments which is to be used to identify
+      a particular function call.
+    """
+    return RVIdentifier(wrapper=wrapper, arguments=arguments)
 
-    [EXPERIMENTAL]: Every parameter of the guide distribution that is to be learned
-    via variational inference should be wrapped in a ``bm.param`` .
+
+def random_variable(
+    f: Callable[P, dist.Distribution]
+) -> Callable[P, Union[RVIdentifier, torch.Tensor]]:
+    """
+    Decorator to be used for every stochastic random variable defined in
+    all statistical models. E.g.::
+
+      @bm.random_variable
+      def foo():
+        return Normal(0., 1.)
+
+      def foo():
+        return Normal(0., 1.)
+      foo = bm.random_variable(foo)
     """
 
-    @staticmethod
-    def get_func_key(wrapper, arguments) -> RVIdentifier:
-        """
-        Creates a key to uniquely identify the Random Variable.
+    @wraps(f)
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> Union[RVIdentifier, torch.Tensor]:
+        func_key = get_func_key(wrapper, args, **kwargs)
+        world = get_world_context()
+        if world is None:
+            return func_key
+        else:
+            return world.update_graph(func_key)
 
-        Args:
-          wrapper: reference to the wrapper function
-          arguments: function arguments
-
-        Returns:
-          Tuple of function and arguments which is to be used to identify
-          a particular function call.
-        """
-        return RVIdentifier(wrapper=wrapper, arguments=arguments)
-
-    @staticmethod
-    def random_variable(
-        f: Callable[P, dist.Distribution]
-    ) -> Callable[P, Union[RVIdentifier, torch.Tensor]]:
-        """
-        Decorator to be used for every stochastic random variable defined in
-        all statistical models. E.g.::
-
-          @bm.random_variable
-          def foo():
-            return Normal(0., 1.)
-
-          def foo():
-            return Normal(0., 1.)
-          foo = bm.random_variable(foo)
-        """
-
-        @wraps(f)
-        def wrapper(
-            *args: P.args, **kwargs: P.kwargs
-        ) -> Union[RVIdentifier, torch.Tensor]:
-            func_key = StatisticalModel.get_func_key(wrapper, args, **kwargs)
-            world = get_world_context()
-            if world is None:
-                return func_key
-            else:
-                return world.update_graph(func_key)
-
-        wrapper.is_functional = False
-        wrapper.is_random_variable = True
-        return wrapper
-
-    @staticmethod
-    def functional(
-        f: Callable[P, torch.Tensor]
-    ) -> Callable[P, Union[RVIdentifier, torch.Tensor]]:
-        """
-        Decorator to be used for every query defined in statistical model, which are
-        functions of ``bm.random_variable`` ::
-
-          @bm.random_variable
-          def foo():
-            return Normal(0., 1.)
-
-          @bm.functional():
-          def bar():
-            return foo() * 2.0
-        """
-
-        @wraps(f)
-        def wrapper(
-            *args: P.args, **kwargs: P.kwargs
-        ) -> Union[RVIdentifier, torch.Tensor]:
-            world = get_world_context()
-            if world is None:
-                return StatisticalModel.get_func_key(wrapper, args, **kwargs)
-            elif isinstance(world, World) and world.get_cache_functionals():
-                return world.update_cached_functionals(f, *args, **kwargs)
-            else:
-                return f(*args, **kwargs)
-
-        wrapper.is_functional = True
-        wrapper.is_random_variable = False
-        return wrapper
-
-    @staticmethod
-    def param(init_fn):
-        """
-        Decorator to be used for params (variable to be optimized with VI).::
-
-          @bm.param
-          def mu():
-            return Normal(0., 1.)
-
-          @bm.random_variable
-          def foo():
-            return Normal(mu(), 1.)
-        """
-
-        @wraps(init_fn)
-        def wrapper(*args):
-            func_key = StatisticalModel.get_func_key(wrapper, args)
-            world = get_world_context()
-            if isinstance(world, World):
-                return world.get_param(func_key)
-            else:
-                return func_key
-
-        return wrapper
+    wrapper.is_functional = False
+    wrapper.is_random_variable = True
+    return wrapper
 
 
-random_variable = StatisticalModel.random_variable
-functional = StatisticalModel.functional
-param = StatisticalModel.param
+def functional(
+    f: Callable[P, torch.Tensor]
+) -> Callable[P, Union[RVIdentifier, torch.Tensor]]:
+    """
+    Decorator to be used for every query defined in statistical model, which are
+    functions of ``bm.random_variable`` ::
+
+      @bm.random_variable
+      def foo():
+        return Normal(0., 1.)
+
+      @bm.functional():
+      def bar():
+        return foo() * 2.0
+    """
+
+    @wraps(f)
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> Union[RVIdentifier, torch.Tensor]:
+        world = get_world_context()
+        if world is None:
+            return get_func_key(wrapper, args, **kwargs)
+        elif isinstance(world, World) and world.get_cache_functionals():
+            return world.update_cached_functionals(f, *args, **kwargs)
+        else:
+            return f(*args, **kwargs)
+
+    wrapper.is_functional = True
+    wrapper.is_random_variable = False
+    return wrapper
+
+
+def param(init_fn):
+    """
+    Decorator to be used for params (variable to be optimized with VI).::
+
+      @bm.param
+      def mu():
+        return Normal(0., 1.)
+
+      @bm.random_variable
+      def foo():
+        return Normal(mu(), 1.)
+    """
+
+    @wraps(init_fn)
+    def wrapper(*args):
+        func_key = get_func_key(wrapper, args)
+        world = get_world_context()
+        if isinstance(world, World):
+            return world.get_param(func_key)
+        else:
+            return func_key
+
+    return wrapper

--- a/src/beanmachine/ppl/model/tests/statistical_model_test.py
+++ b/src/beanmachine/ppl/model/tests/statistical_model_test.py
@@ -13,7 +13,7 @@ from beanmachine.ppl.model.statistical_model import RVIdentifier
 
 
 class StatisticalModelTest(unittest.TestCase):
-    class SampleModel(object):
+    class SampleModel:
         @bm.random_variable
         def foo(self):
             return dist.Normal(torch.tensor(0.0), torch.tensor(1.0))
@@ -26,7 +26,7 @@ class StatisticalModelTest(unittest.TestCase):
         def baz(self):
             return dist.Normal(self.foo(), self.bar().abs())
 
-    class SampleLargeModel(object):
+    class SampleLargeModel:
         @bm.random_variable
         def foo(self):
             return dist.Normal(torch.tensor(0.0), torch.tensor(1.0))

--- a/src/beanmachine/ppl/utils/tests/typeguards_test.py
+++ b/src/beanmachine/ppl/utils/tests/typeguards_test.py
@@ -1,0 +1,38 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+import torch.distributions as dist
+from beanmachine.ppl import random_variable
+from beanmachine.ppl.utils.typeguards import is_rvidentifier_dict, is_rvidentifier_list
+
+
+class TypeGuardsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        @random_variable
+        def alpha() -> dist.Distribution:
+            return dist.Normal(0, 1)
+
+        @random_variable
+        def beta() -> dist.Distribution:
+            return dist.Beta(1, 1)
+
+        self.true_list = [alpha(), beta()]
+        self.true_dict = {alpha(): torch.ones(2), beta(): torch.zeros(3)}
+
+    def test_is_rvidentifier_list(self) -> None:
+        self.assertTrue(is_rvidentifier_list(self.true_list))
+        self.assertFalse(is_rvidentifier_list(self.true_list + [None]))
+        self.assertFalse(is_rvidentifier_list(self.true_list + [torch.ones(2)]))
+        self.assertFalse(is_rvidentifier_list([]))
+
+    def test_is_rvidentifier_dict(self) -> None:
+        self.assertTrue(is_rvidentifier_dict(self.true_dict))
+        self.assertFalse(
+            is_rvidentifier_dict({**self.true_dict, **{"a": torch.ones(5)}})
+        )
+        self.assertFalse(is_rvidentifier_dict({}))

--- a/src/beanmachine/ppl/utils/typeguards.py
+++ b/src/beanmachine/ppl/utils/typeguards.py
@@ -1,0 +1,36 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from typing import Union
+
+import torch
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
+from typing_extensions import TypeGuard
+
+
+def is_rvidentifier_list(
+    val: list[Union[RVIdentifier, torch.Tensor]]
+) -> TypeGuard[list[RVIdentifier]]:
+    """Checks whether all elements of `val` are of type RVIdentifier.
+
+    Returns False if val is an empty list.
+    """
+    if val:
+        return all(isinstance(x, RVIdentifier) for x in val)
+    return False
+
+
+def is_rvidentifier_dict(
+    val: dict[Union[RVIdentifier, torch.Tensor], torch.Tensor]
+) -> TypeGuard[dict[RVIdentifier, torch.Tensor]]:
+    """Check whether all keys of `val` are of type RVIdentifier.
+
+    Returns False if val is an empty dictionary.
+    """
+    if val:
+        return all(isinstance(k, RVIdentifier) for k in val)
+    return False


### PR DESCRIPTION
Summary:
The StatisticalModel class was a class with only static methods. I've removed the class and made the static methods module-level functions.

I've also add two "typeguards" to help prove to the type checker that we've narrowed `Union[RVIdentifier, torch.Tensor]` to `RVIdentifier` appropriately.

I also was able to work around a mysterious Pyre issue by rewriting `a * (1 / b)` as `a / b` in [abstract_conjugate.py](https://www.internalfb.com/code/fbsource/[ef250e904fe5]/fbcode/beanmachine/beanmachine/ppl/testlib/abstract_conjugate.py?lines=141-144).

Differential Revision: D34979861

