### PR TITLE
Adding .gitattribute to mark Jupyter notebook as documentation

### DIFF
--- a/.gitattribute
+++ b/.gitattribute
@@ -1,0 +1,2 @@
+# Mark Jupyter notebooks as documentation instead of source code
+*.ipynb linguist-documentation


### PR DESCRIPTION
Summary:
GitHub considers BM as a Jupyter notebook project because the number of lines in `*.ipynb` files exceeds the number of lines in either Python or C++. The  `.gitattribute` should be able to teach GitHub that Jupyter notebooks should be considered as tutorials instead of source code

{F713553322}

Differential Revision: D34901051

