### PR TITLE
Adding experimental `nnc_compile` option to NUTS and HMC

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,24 @@ from setuptools import find_packages, setup
 REQUIRED_MAJOR = 3
 REQUIRED_MINOR = 7
 
-
+INSTALL_REQUIRES = [
+    "arviz>=0.11.0",
+    "astor>=0.7.1",
+    "botorch>=0.5.1",
+    "flowtorch>=0.3",
+    "gpytorch>=1.3.0",
+    "graphviz>=0.17",
+    "numpy>=1.18.1",
+    "pandas>=0.24.2",
+    "parameterized>=0.8.1",
+    "plotly>=2.2.1",
+    "scipy>=0.16",
+    "statsmodels>=0.12.0",
+    "torch>=1.9.0",
+    "tqdm>=4.46.0",
+    "typing-extensions>=3.10",
+    "xarray>=0.16.0",
+]
 TEST_REQUIRES = ["pytest>=7.0.0", "pytest-cov"]
 TUTORIALS_REQUIRES = [
     "bokeh",
@@ -48,6 +65,7 @@ if platform.system() == "Windows":
     CPP_COMPILE_ARGS = ["/WX", "/permissive-", "-DEIGEN_HAS_C99_MATH"]
 else:
     CPP_COMPILE_ARGS = ["-std=c++17", "-Werror"]
+    INSTALL_REQUIRES.append("functorch>=0.1.0")
 
 
 # Check for python version
@@ -125,24 +143,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     python_requires=">={}.{}".format(REQUIRED_MAJOR, REQUIRED_MINOR),
-    install_requires=[
-        "arviz>=0.11.0",
-        "astor>=0.7.1",
-        "botorch>=0.5.1",
-        "flowtorch>=0.3",
-        "gpytorch>=1.3.0",
-        "graphviz>=0.17",
-        "numpy>=1.18.1",
-        "pandas>=0.24.2",
-        "parameterized>=0.8.1",
-        "plotly>=2.2.1",
-        "scipy>=0.16",
-        "statsmodels>=0.12.0",
-        "torch>=1.9.0",
-        "tqdm>=4.46.0",
-        "typing-extensions>=3.10",
-        "xarray>=0.16.0",
-    ],
+    install_requires=INSTALL_REQUIRES,
     packages=find_packages("src"),
     package_dir={"": "src"},
     ext_modules=[

--- a/sphinx/Makefile
+++ b/sphinx/Makefile
@@ -12,7 +12,7 @@ ALLSPHINXOPTS = -q -d $(BUILDDIR)/doctrees $(SPHINXOPTS) ./source
 # NOTE: Since we cannot ignore the no-duplicates warning specifically
 # we use a Bash hack for the same purpose. Note, ! is to invert error
 # status of grep
-BASHHACK	  = 2>&1 >/dev/null | grep -v -E "(use :noindex:)|(more than one target found)"
+BASHHACK	  = 2>&1 >/dev/null | grep -v -E "(use :noindex:)|(more than one target found)|(warnings.warn)|(experimental)"
 
 
 # Put it first so that "make" without argument is like "make help".

--- a/src/beanmachine/ppl/experimental/nnc/__init__.py
+++ b/src/beanmachine/ppl/experimental/nnc/__init__.py
@@ -1,0 +1,40 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import sys
+from typing import Callable, TypeVar, Optional, Tuple
+
+from typing_extensions import ParamSpec
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+def nnc_jit(
+    f: Callable[P, R], static_argnums: Optional[Tuple[int]] = None
+) -> Callable[P, R]:
+    """
+    A helper function that lazily imports the NNC utils, which initialize the compiler
+    and displaying a experimental warning, then invoke the underlying nnc_jit on
+    the function f.
+    """
+    try:
+        # The setup code in `nnc.utils` will only be executed once in a Python session
+        from beanmachine.ppl.experimental.nnc.utils import nnc_jit as raw_nnc_jit
+    except ImportError as e:
+        if sys.platform.startswith("win"):
+            message = "functorch is not available on Windows."
+        else:
+            message = (
+                "Fails to initialize NNC. This is likely caused by version mismatch "
+                "between PyTorch and functorch. Please checkout the functorch project "
+                "for installation guide (https://github.com/pytorch/functorch)."
+            )
+        raise RuntimeError(message) from e
+
+    return raw_nnc_jit(f, static_argnums)
+
+
+__all__ = ["nnc_jit"]

--- a/src/beanmachine/ppl/experimental/nnc/utils.py
+++ b/src/beanmachine/ppl/experimental/nnc/utils.py
@@ -1,0 +1,93 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import warnings
+
+import functorch
+import torch
+import torch.jit
+import torch.utils._pytree as pytree
+from functorch.compile import (
+    nop,
+    aot_function,
+    decomposition_table,
+    register_decomposition,
+)
+
+# the warning will only be shown to user once when this module is imported
+warnings.warn(
+    "The support of NNC compiler is experimental and the API is subject to"
+    "change in the future releases of Bean Machine. For questions regarding NNC, please"
+    "checkout the functorch project (https://github.com/pytorch/functorch)."
+)
+
+# allows reductions to be compiled by NNC
+torch._C._jit_set_texpr_reductions_enabled(True)
+
+# override the usage of torch.jit.script, which has a bit of issue handling
+# empty lists (functorch#440)
+def simple_ts_compile(fx_g, example_inps):
+    f = torch.jit.trace(fx_g, example_inps, strict=False)
+    f = torch.jit.freeze(f.eval())
+    torch._C._jit_pass_remove_mutation(f.graph)
+
+    return f
+
+
+# Overrides decomposition rules for some operators
+aten = torch.ops.aten
+decompositions = [aten.detach]
+bm_decompositions = {
+    k: v for k, v in decomposition_table.items() if k in decompositions
+}
+
+
+@register_decomposition(aten.mv, bm_decompositions)
+def mv(a, b):
+    return (a * b).sum(dim=-1)
+
+
+@register_decomposition(aten.dot, bm_decompositions)
+def dot(a, b):
+    return (a * b).sum(dim=-1)
+
+
+@register_decomposition(aten.zeros_like, bm_decompositions)
+def zeros_like(a, **kwargs):
+    return a * 0
+
+
+@register_decomposition(aten.ones_like, bm_decompositions)
+def ones_like(a, **kwargs):
+    return a * 0 + 1
+
+
+def nnc_jit(f, static_argnums=None):
+    return aot_function(
+        f,
+        simple_ts_compile,
+        nop,
+        static_argnums=static_argnums,
+        decompositions=bm_decompositions,
+    )
+
+
+functorch._src.compilers.simple_ts_compile = simple_ts_compile
+
+
+# override default dict flatten (which requires keys to be sortable)
+def _dict_flatten(d):
+    keys = list(d.keys())
+    values = [d[key] for key in keys]
+    return values, keys
+
+
+def _dict_unflatten(values, context):
+    return {key: value for key, value in zip(context, values)}
+
+
+pytree._register_pytree_node(dict, _dict_flatten, _dict_unflatten)
+
+__all__ = ["nnc_jit"]

--- a/src/beanmachine/ppl/experimental/tests/nnc_test.py
+++ b/src/beanmachine/ppl/experimental/tests/nnc_test.py
@@ -1,0 +1,52 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import sys
+import warnings
+
+import beanmachine.ppl as bm
+import pytest
+import torch
+import torch.distributions as dist
+
+if sys.platform.startswith("win"):
+    pytest.skip("functorch is not available on Windows", allow_module_level=True)
+
+
+class SampleModel:
+    @bm.random_variable
+    def foo(self):
+        return dist.Normal(0.0, 1.0)
+
+    @bm.random_variable
+    def bar(self):
+        return dist.Normal(self.foo(), 1.0)
+
+
+@pytest.mark.parametrize(
+    "algorithm",
+    [
+        bm.GlobalNoUTurnSampler(nnc_compile=True),
+        bm.GlobalHamiltonianMonteCarlo(trajectory_length=1.0, nnc_compile=True),
+    ],
+)
+def test_nnc_compile(algorithm):
+    model = SampleModel()
+    queries = [model.foo()]
+    observations = {model.bar(): torch.tensor(0.5)}
+    num_samples = 30
+    num_chains = 2
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        # verify that NNC can run through
+        samples = algorithm.infer(
+            queries,
+            observations,
+            num_samples,
+            num_adaptive_samples=num_samples,
+            num_chains=num_chains,
+        )
+    # sanity check: make sure that the samples are valid
+    assert not torch.isnan(samples[model.foo()]).any()

--- a/src/beanmachine/ppl/inference/hmc_inference.py
+++ b/src/beanmachine/ppl/inference/hmc_inference.py
@@ -30,6 +30,8 @@ class GlobalHamiltonianMonteCarlo(BaseInference):
         adapt_mass_matrix (bool): Whether to adapt the mass matrix. Defaults to True,
         target_accept_prob (float): Target accept prob. Increasing this value would lead
             to smaller step size. Defaults to 0.8.
+        nnc_compile: (Experimental) If True, NNC compiler will be used to accelerate the
+            inference (defaults to False).
     """
 
     def __init__(
@@ -39,12 +41,14 @@ class GlobalHamiltonianMonteCarlo(BaseInference):
         adapt_step_size: bool = True,
         adapt_mass_matrix: bool = True,
         target_accept_prob: float = 0.8,
+        nnc_compile: bool = False,
     ):
         self.trajectory_length = trajectory_length
         self.initial_step_size = initial_step_size
         self.adapt_step_size = adapt_step_size
         self.adapt_mass_matrix = adapt_mass_matrix
         self.target_accept_prob = target_accept_prob
+        self.nnc_compile = nnc_compile
         self._proposer = None
 
     def _get_default_num_adaptive_samples(self, num_samples: int) -> int:
@@ -66,6 +70,7 @@ class GlobalHamiltonianMonteCarlo(BaseInference):
                 self.adapt_step_size,
                 self.adapt_mass_matrix,
                 self.target_accept_prob,
+                self.nnc_compile,
             )
         return [self._proposer]
 
@@ -94,12 +99,14 @@ class SingleSiteHamiltonianMonteCarlo(BaseInference):
         adapt_step_size: bool = True,
         adapt_mass_matrix: bool = True,
         target_accept_prob: float = 0.8,
+        nnc_compile: bool = False,
     ):
         self.trajectory_length = trajectory_length
         self.initial_step_size = initial_step_size
         self.adapt_step_size = adapt_step_size
         self.adapt_mass_matrix = adapt_mass_matrix
         self.target_accept_prob = target_accept_prob
+        self.nnc_compile = nnc_compile
         self._proposers = {}
 
     def _get_default_num_adaptive_samples(self, num_samples: int) -> int:
@@ -123,6 +130,7 @@ class SingleSiteHamiltonianMonteCarlo(BaseInference):
                     self.adapt_step_size,
                     self.adapt_mass_matrix,
                     self.target_accept_prob,
+                    self.nnc_compile,
                 )
             proposers.append(self._proposers[node])
         return proposers

--- a/src/beanmachine/ppl/inference/nuts_inference.py
+++ b/src/beanmachine/ppl/inference/nuts_inference.py
@@ -38,6 +38,8 @@ class GlobalNoUTurnSampler(BaseInference):
             defaults to True.
         target_accept_prob (float): Target accept probability. Increasing this would
             lead to smaller step size. Defaults to 0.8.
+        nnc_compile: (Experimental) If True, NNC compiler will be used to accelerate the
+            inference (defaults to False).
     """
 
     def __init__(
@@ -49,6 +51,7 @@ class GlobalNoUTurnSampler(BaseInference):
         adapt_mass_matrix: bool = True,
         multinomial_sampling: bool = True,
         target_accept_prob: float = 0.8,
+        nnc_compile: bool = False,
     ):
         self.max_tree_depth = max_tree_depth
         self.max_delta_energy = max_delta_energy
@@ -57,6 +60,7 @@ class GlobalNoUTurnSampler(BaseInference):
         self.adapt_mass_matrix = adapt_mass_matrix
         self.multinomial_sampling = multinomial_sampling
         self.target_accept_prob = target_accept_prob
+        self.nnc_compile = nnc_compile
         self._proposer = None
 
     def _get_default_num_adaptive_samples(self, num_samples: int) -> int:
@@ -80,6 +84,7 @@ class GlobalNoUTurnSampler(BaseInference):
                 self.adapt_mass_matrix,
                 self.multinomial_sampling,
                 self.target_accept_prob,
+                self.nnc_compile,
             )
         return [self._proposer]
 
@@ -106,6 +111,8 @@ class SingleSiteNoUTurnSampler(BaseInference):
             defaults to True.
         target_accept_prob (float): Target accept probability. Increasing this would
             lead to smaller step size. Defaults to 0.8.
+        nnc_compile: (Experimental) If True, NNC compiler will be used to accelerate the
+            inference (defaults to False).
     """
 
     def __init__(
@@ -117,6 +124,7 @@ class SingleSiteNoUTurnSampler(BaseInference):
         adapt_mass_matrix: bool = True,
         multinomial_sampling: bool = True,
         target_accept_prob: float = 0.8,
+        nnc_compile: bool = False,
     ):
         self.max_tree_depth = max_tree_depth
         self.max_delta_energy = max_delta_energy
@@ -125,6 +133,7 @@ class SingleSiteNoUTurnSampler(BaseInference):
         self.adapt_mass_matrix = adapt_mass_matrix
         self.multinomial_sampling = multinomial_sampling
         self.target_accept_prob = target_accept_prob
+        self.nnc_compile = nnc_compile
         self._proposers = {}
 
     def _get_default_num_adaptive_samples(self, num_samples: int) -> int:
@@ -150,6 +159,7 @@ class SingleSiteNoUTurnSampler(BaseInference):
                     self.adapt_mass_matrix,
                     self.multinomial_sampling,
                     self.target_accept_prob,
+                    self.nnc_compile,
                 )
             proposers.append(self._proposers[node])
         return proposers

--- a/src/beanmachine/ppl/inference/proposer/tests/hmc_utils_test.py
+++ b/src/beanmachine/ppl/inference/proposer/tests/hmc_utils_test.py
@@ -31,15 +31,15 @@ class SampleModel:
 
 
 def test_dual_average_adapter():
-    adapter = DualAverageAdapter(0.1)
+    adapter = DualAverageAdapter(torch.tensor(0.1))
     epsilon1 = adapter.step(torch.tensor(1.0))
     epsilon2 = adapter.step(torch.tensor(0.0))
     assert epsilon2 < adapter.finalize() < epsilon1
 
 
 def test_dual_average_with_different_delta():
-    adapter1 = DualAverageAdapter(1.0, delta=0.8)
-    adapter2 = DualAverageAdapter(1.0, delta=0.2)
+    adapter1 = DualAverageAdapter(torch.tensor(1.0), delta=0.8)
+    adapter2 = DualAverageAdapter(torch.tensor(1.0), delta=0.2)
     prob = torch.tensor(0.5)
     # prob > delta means we can increase the step size, wherease prob < delta means
     # we need to decrease the step size

--- a/src/beanmachine/ppl/world/world.py
+++ b/src/beanmachine/ppl/world/world.py
@@ -194,7 +194,7 @@ class World(BaseWorld, Mapping[RVIdentifier, torch.Tensor]):
 
         log_prob = torch.tensor(0.0)
         for node in set(nodes):
-            log_prob += torch.sum(self._variables[node].log_prob)
+            log_prob = log_prob + torch.sum(self._variables[node].log_prob)
         return log_prob
 
     def enumerate_node(self, node: RVIdentifier) -> torch.Tensor:


### PR DESCRIPTION
**This PR is not ready for review yet**: I'm creating the PR just so that the changes can be imported and run against the internal tests. I'll update the summary of the PR after polishing the files.

### Motivation
With the first Beta release of [functorch](https://github.com/pytorch/functorch), we can begin to merge in our BM-NNC integration prototype, which uses NNC to JIT compile part of the algorithm to accelerate inferences. 

### Changes proposed
- `functorch>=0.1.0` is added to out list of dependencies
- Because NNC is yet to support control flow primitives, in NUTS, NNC is applied on the base case of recursive tree building algorithm. In HMC, NNC is applied on a single leapfrog step.
- We use `torch.Tensor` instead of raw scalars for some variables because TorchScript tracer requires inputs/outputs to be of the same type (?) (i.e., we can't return a tuple of a mixture of `Tensor`s and `float`s)
- All of the NNC utils are put into `beanmachine.ppl.experimental.nnc.utils`, which will throw a warning when it's being imported for the first time.
- The docstring of HMC & NUTS classes are updated as well

To try NNC out, simply set `nnc_compile` to `True` when initializing the inference class, e.g.

```python
nuts = bm.GlobalNoUTurnSampler(nnc_compile=True)
nuts.infer(...)  # same arguments as usual
```

### Test Plan
I've added a simple sanity check to cover the NNC compile option on NUTS and HMC, which can be run with
```bash
pytest src/beanmachine/ppl/experimental/tests/nnc_test.py
```


### Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](https://github.com/facebookresearch/beanmachine/blob/main/CONTRIBUTING.md)** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] The title of my pull request is a short description of the requested changes.
