### PR TITLE
Fix monte_carlo_samples to copy over observed data and likelihoods

### DIFF
--- a/src/beanmachine/ppl/inference/monte_carlo_samples.py
+++ b/src/beanmachine/ppl/inference/monte_carlo_samples.py
@@ -281,6 +281,11 @@ class MonteCarloSamples(Mapping[RVIdentifier, torch.Tensor]):
             posterior = None
             warmup_posterior = None
 
+        if self.num_adaptive_samples > 0:
+            warmup_log_likelihood = self.adaptive_log_likelihoods
+        else:
+            warmup_log_likelihood = None
+
         if "posterior_predictive" in self.namespaces:
             posterior_predictive = self.namespaces["posterior_predictive"].samples
             if self.num_adaptive_samples > 0:
@@ -305,7 +310,7 @@ class MonteCarloSamples(Mapping[RVIdentifier, torch.Tensor]):
             warmup_posterior_predictive=warmup_posterior_predictive,
             prior_predictive=prior_predictive,
             save_warmup=include_adapt_steps,
-            warmup_log_likelihood=self.adaptive_log_likelihoods,
+            warmup_log_likelihood=warmup_log_likelihood,
             log_likelihood=self.log_likelihoods,
             observed_data=self.observations,
         )

--- a/src/beanmachine/ppl/inference/monte_carlo_samples.py
+++ b/src/beanmachine/ppl/inference/monte_carlo_samples.py
@@ -253,6 +253,15 @@ class MonteCarloSamples(Mapping[RVIdentifier, torch.Tensor]):
             )
 
     def add_groups(self, mcs: "MonteCarloSamples"):
+        if self.observations is None:
+            self.observations = mcs.observations
+
+        if self.log_likelihoods is None:
+            self.log_likelihoods = mcs.log_likelihoods
+
+        if self.adaptive_log_likelihoods is None:
+            self.adaptive_log_likelihoods = mcs.adaptive_log_likelihoods
+
         for n in mcs.namespaces:
             if n not in self.namespaces:
                 self.namespaces[n] = mcs.namespaces[n]

--- a/src/beanmachine/ppl/inference/tests/monte_carlo_samples_test.py
+++ b/src/beanmachine/ppl/inference/tests/monte_carlo_samples_test.py
@@ -231,6 +231,16 @@ class MonteCarloSamplesTest(unittest.TestCase):
         self.assertEqual(samples.get(model.foo(), chain=0).shape, (20,))
         self.assertEqual(samples.get(model.foo(), chain=0, thinning=4).shape, (5,))
 
+    def test_add_group(self):
+        model = self.SampleModel()
+        mh = bm.SingleSiteAncestralMetropolisHastings()
+        samples = mh.infer([model.foo()], {}, num_samples=20, num_chains=1)
+        bar_samples = MonteCarloSamples(samples.samples, default_namespace="bar")
+        bar_samples.add_groups(samples)
+        self.assertEqual(samples.observations, bar_samples.observations)
+        self.assertEqual(samples.log_likelihoods, bar_samples.log_likelihoods)
+        self.assertIn("posterior", bar_samples.namespaces)
+
     def test_to_inference_data(self):
         model = self.SampleModel()
         mh = bm.SingleSiteAncestralMetropolisHastings()

--- a/src/beanmachine/ppl/inference/tests/predictive_test.py
+++ b/src/beanmachine/ppl/inference/tests/predictive_test.py
@@ -175,6 +175,8 @@ class PredictiveTest(unittest.TestCase):
             vectorized=True,
         ).to_inference_data()
         assert "posterior" in predictives
+        assert "observed_data" in predictives
+        assert "log_likelihood" in predictives
         assert "posterior_predictive" in predictives
         assert predictives.posterior_predictive[self.likelihood_2(0)].shape == (
             2,


### PR DESCRIPTION
This fixes an oversight when `MonteCarloSamples` was refactored to copy over `observed_data` and log-likelihoods.

### Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](https://github.com/facebookresearch/beanmachine/blob/main/CONTRIBUTING.md)** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] The title of my pull request is a short description of the requested changes.
