### PR TITLE
Move `black` to `INSTALL_REQUIRES`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install linters
       run: |
         python -m pip install --upgrade pip
-        pip install black==20.8b1 usort==0.6.4 flake8
+        python -m pip install black==21.4b2 flake8==4.0.1 libcst==0.4.1 ufmt==1.3.2 usort==0.6.4
 
     - name: Print out package info to help with debug
       run: pip list
@@ -34,8 +34,5 @@ jobs:
     - name: Lint with flake8
       run: flake8 .
 
-    - name: Lint with usort
-      run: usort check .
-
-    - name: Lint with black
-      run: black --check .
+    - name: Lint with ufmt (black + usort)
+      run: ufmt check .

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Bean Machine supports Python 3.7-3.9 and PyTorch 1.10.
 ### Install the Latest Release with Pip
 
 ```bash
-pip install beanmachine
+python -m pip install beanmachine
 ```
 
 ### Install from Source
@@ -40,7 +40,7 @@ We recommend using [conda](https://docs.conda.io/en/latest/) to manage the virtu
 ```bash
 conda create -n {env name} python=3.7; conda activate {env name}
 conda install boost eigen
-pip install .
+python -m pip install .
 ```
 
 #### Docker
@@ -55,8 +55,8 @@ docker run -it beanmachine:latest bash
 If you would like to run the builtin unit tests:
 
 ```bash
-pip install -U 'pytest>=7.0.0'
-pytest .
+python -m pip install "beanmachine[test]"
+pytest src
 ```
 
 ## License

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ REQUIRED_MINOR = 7
 INSTALL_REQUIRES = [
     "arviz>=0.11.0",
     "astor>=0.7.1",
+    "black==21.4b2",
     "botorch>=0.5.1",
     "flowtorch>=0.3",
     "gpytorch>=1.3.0",
@@ -49,15 +50,17 @@ DEV_REQUIRES = (
     TEST_REQUIRES
     + TUTORIALS_REQUIRES
     + [
-        "black==20.8b1",
-        "flake8",
+        "flake8==4.0.1",
         "flake8-bugbear",
+        "libcst==0.4.1",
         "nbval",
         "sphinx==4.2.0",
         "sphinx-autodoc-typehints",
         "sphinx_rtd_theme",
         "toml>=0.10.2",
-        "usort",
+        # `black` is included in `INSTALL_REQUIRES` above.
+        "ufmt==1.3.2",
+        "usort==0.6.4",
     ]
 )
 

--- a/src/beanmachine/ppl/conftest.py
+++ b/src/beanmachine/ppl/conftest.py
@@ -10,11 +10,11 @@ import torch.distributions as dist
 
 @pytest.fixture(autouse=True)
 def fix_random_seed():
-    """Fix the random state for every test in the test suite"""
+    """Fix the random state for every test in the test suite."""
     bm.seed(0)
 
 
 @pytest.fixture(autouse=True)
 def disable_torch_distribution_validation():
-    """ """
+    """Disables validation of Torch distribution arguments."""
     dist.Distribution.set_default_validate_args(False)


### PR DESCRIPTION
Summary: We import `black` in `beanmachine.ppl.compiler.ast_tools.py`, but `black` is not included in `INSTALL_REQUIRES`.

Differential Revision: D35219729

