### PR TITLE
Disable torch distribution validation in conftest.py to unblock CI

### DIFF
--- a/src/beanmachine/ppl/conftest.py
+++ b/src/beanmachine/ppl/conftest.py
@@ -5,9 +5,16 @@
 
 import beanmachine.ppl as bm
 import pytest
+import torch.distributions as dist
 
 
 @pytest.fixture(autouse=True)
 def fix_random_seed():
     """Fix the random state for every test in the test suite"""
     bm.seed(0)
+
+
+@pytest.fixture(autouse=True)
+def disable_torch_distribution_validation():
+    """ """
+    dist.Distribution.set_default_validate_args(False)


### PR DESCRIPTION
Summary:
A recent release of [BoTorch adds Pyro as its dependency](https://github.com/pytorch/botorch/blob/v0.6.3.1/setup.py#L98), which in turns enables torch distribution validation globally when being imported. In doing so, many of our test fails because they use toy models with invalid args.

The distribution validation can be really helpful in debugging misspecified models, so we should make sure that BM can run successfully even when the validation is turned on. Doing so is going to take a bit of time, so just to unblock other works in the mean time, this diff swallows the error by turning the validation off before running each test.

#fileatask Re-enable torch distribution validation after addressing the errors in Bean Machine

Related task: T81756389

Differential Revision: D35273336

