### PR TITLE
Always use fork-mode when running multiprocessing in pytest

### DIFF
--- a/src/beanmachine/ppl/inference/base_inference.py
+++ b/src/beanmachine/ppl/inference/base_inference.py
@@ -25,6 +25,7 @@ from beanmachine.ppl.world import RVDict, World, InitializeFn, init_to_uniform
 from torch import multiprocessing as mp
 from tqdm.auto import tqdm
 from tqdm.notebook import tqdm as notebook_tqdm
+from typing_extensions import Literal
 
 
 class BaseInference(metaclass=ABCMeta):
@@ -177,7 +178,7 @@ class BaseInference(metaclass=ABCMeta):
         initialize_fn: InitializeFn = init_to_uniform,
         max_init_retries: int = 100,
         run_in_parallel: bool = False,
-        mp_context: Optional[str] = None,
+        mp_context: Optional[Literal["fork", "spawn", "forkserver"]] = None,
     ) -> MonteCarloSamples:
         """
         Performs inference and returns a ``MonteCarloSamples`` object with samples from the posterior.

--- a/src/beanmachine/ppl/inference/tests/inference_test.py
+++ b/src/beanmachine/ppl/inference/tests/inference_test.py
@@ -51,6 +51,7 @@ def test_inference(multiprocess):
         num_adaptive_samples=num_samples,
         num_chains=num_chains,
         run_in_parallel=multiprocess,
+        mp_context="fork",
     )
 
     assert model.foo() in samples


### PR DESCRIPTION
Summary:
Our parallel inference test currently times out on MacOS Python 3.8 because the default multiprocessing mode is changed from "fork" to "spawn," whereas the "fork" mode is the only one that works in pytest.

So instead of relying on the OS default, we can change the test so that it always uses "fork" mode.

Differential Revision: D35323003

