### PR TITLE
Ensures that inference runs successfully with float64/double

### DIFF
--- a/src/beanmachine/ppl/experimental/tests/nnc_test.py
+++ b/src/beanmachine/ppl/experimental/tests/nnc_test.py
@@ -3,6 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import os
 import sys
 import warnings
 
@@ -13,6 +14,9 @@ import torch.distributions as dist
 
 if sys.platform.startswith("win"):
     pytest.skip("functorch is not available on Windows", allow_module_level=True)
+
+if os.environ.get("SANDCASTLE") is not None:
+    pytest.skip("NNC does not work with Buck yet", allow_module_level=True)
 
 
 class SampleModel:

--- a/src/beanmachine/ppl/inference/proposer/hmc_utils.py
+++ b/src/beanmachine/ppl/inference/proposer/hmc_utils.py
@@ -87,7 +87,9 @@ class DualAverageAdapter:
 
     def step(self, alpha: torch.Tensor) -> torch.Tensor:
         H_frac = 1.0 / (self._m + self._t0)
-        self._H = ((1 - H_frac) * self._H) + H_frac * (self._delta - alpha)
+        self._H = ((1 - H_frac) * self._H) + H_frac * (
+            self._delta - alpha.to(self._log_avg_epsilon)
+        )
 
         log_epsilon = self._mu - (math.sqrt(self._m) / self._gamma) * self._H
         step_frac = self._m ** (-self._kappa)


### PR DESCRIPTION
Summary:
In an earlier diff that introduces `nnc_compile` option to NUTS and HMC, a few of the parameters were promoted from float to Tensor type to make them NNC compilable. However, in doing so, I also accidentally made it incompatible with double. I noticed this issue when rerunning one of the tutorials where the observations are converted from pandas DataFrame (which uses float64 by default).

This diff fixes the issue on running NUTS when the inputs are `double` Tensors and add a test to cover it (as well as a few other algorithms).

Reviewed By: jpchen

Differential Revision: D35338363

