### PR TITLE
Use C++ 20 standard and upgrade Boost and Eigen dependency

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        conda install -y eigen boost
+        conda install -c conda-forge -y eigen boost-cpp
         python -m pip install --upgrade pip
         pip install -U build
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get install -y yarn
-        conda install -y eigen boost
+        conda install -c conda-forge -y eigen boost-cpp
         python -m pip install --upgrade pip
         python -m pip install setuptools
         python -m pip install notebook

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,7 +33,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        conda install -y eigen boost
+        conda install -c conda-forge -y eigen boost-cpp
         python -m pip install --upgrade pip
 
     - name: Install Bean Machine

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        conda install -y eigen boost
+        conda install -c conda-forge -y eigen boost-cpp
         python -m pip install --upgrade pip
 
     - name: Install Bean Machine in editable mode

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Then, you can choose from any of the following installation options.
 We recommend using [conda](https://docs.conda.io/en/latest/) to manage the virtual environment and install the necessary build dependencies.
 
 ```bash
-conda create -n {env name} python=3.7; conda activate {env name}
-conda install boost eigen
+conda create -n {env name} python=3.8; conda activate {env name}
+conda install -c conda-forge boost eigen
 python -m pip install .
 ```
 

--- a/docs/overview/installation/installation.md
+++ b/docs/overview/installation/installation.md
@@ -28,8 +28,8 @@ cd beanmachine
 We recommend using [conda](https://docs.conda.io/en/latest/) to manage the virtual environment and install the necessary build dependencies.
 
 ```
-conda create -n {env name} python=3.7; conda activate {env name}
-conda install boost eigen  # C++ dependencies
+conda create -n {env name} python=3.8; conda activate {env name}
+conda install -c conda-forge boost eigen  # C++ dependencies
 pip install .
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ INSTALL_REQUIRES = [
     "graphviz>=0.17",
     "numpy>=1.18.1",
     "pandas>=0.24.2",
-    "parameterized>=0.8.1",
     "plotly>=2.2.1",
     "scipy>=0.16",
     "statsmodels>=0.12.0",
@@ -65,9 +64,9 @@ DEV_REQUIRES = (
 )
 
 if platform.system() == "Windows":
-    CPP_COMPILE_ARGS = ["/WX", "/permissive-", "-DEIGEN_HAS_C99_MATH"]
+    CPP_COMPILE_ARGS = ["/WX", "/permissive-", "/std:c++20"]
 else:
-    CPP_COMPILE_ARGS = ["-std=c++17", "-Werror"]
+    CPP_COMPILE_ARGS = ["-std=c++2a", "-Werror"]
     INSTALL_REQUIRES.append("functorch>=0.1.0")
 
 


### PR DESCRIPTION
Summary: As part of our internal platform010 migration, fbcode bumps the C++ standard from C++17 to C++20. The internal Eigen and Boost libraries have also been upgraded accordingly. To keep the workflow consistent, in this diff we update the compiler flag to use `std=c++20` for external installation as well and install Boost and Eigen from `conda-forge` (which contains the more up-to-date versions of both libraries).

Differential Revision: D35407156

