### PR TITLE
Include `py.typed` in PyPI package.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -148,6 +148,7 @@ setup(
     install_requires=INSTALL_REQUIRES,
     packages=find_packages("src"),
     package_dir={"": "src"},
+    package_data={"beanmachine/ppl": ["py.typed"]},
     ext_modules=[
         Pybind11Extension(
             name="beanmachine.graph",

--- a/src/beanmachine/ppl/testlib/abstract_conjugate.py
+++ b/src/beanmachine/ppl/testlib/abstract_conjugate.py
@@ -135,13 +135,10 @@ class AbstractConjugateTests(metaclass=ABCMeta):
         model = NormalNormalModel(mu, std, sigma)
         queries = [model.normal_p()]
         observations = {model.normal(): obs}
-        expected_mean = (1 / (1 / sigma.pow(2.0) + 1 / std.pow(2.0))) * (
-            mu / std.pow(2.0) + obs / sigma.pow(2.0)
+        expected_mean = (mu / std.pow(2.0) + obs / sigma.pow(2.0)) / (
+            1.0 / sigma.pow(2.0) + 1.0 / std.pow(2.0)
         )
         expected_std = (std.pow(-2.0) + sigma.pow(-2.0)).pow(-0.5)
-        # pyre-fixme[7]: Expected `Tuple[Tensor, Tensor, List[RVIdentifier],
-        #  Dict[RVIdentifier, Tensor]]` but got `Tuple[float, typing.Any,
-        #  List[typing.Any], Dict[typing.Any, typing.Any]]`.
         return (expected_mean, expected_std, queries, observations)
 
     def compute_dirichlet_categorical_moments(self):


### PR DESCRIPTION
Summary: I was also able to work around a mysterious Pyre issue by rewriting `a * (1 / b)` as `a / b` in [abstract_conjugate.py](https://www.internalfb.com/code/fbsource/[ef250e904fe5]/fbcode/beanmachine/beanmachine/ppl/testlib/abstract_conjugate.py?lines=141-144).

Reviewed By: horizon-blue

Differential Revision: D35600767

