### PR TITLE
Update installation instruction in README

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        conda install -c conda-forge -y eigen boost-cpp
+        conda install -c conda-forge -y boost-cpp eigen
         python -m pip install --upgrade pip
         pip install -U build
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get install -y yarn
-        conda install -c conda-forge -y eigen boost-cpp
+        conda install -c conda-forge -y boost-cpp eigen
         python -m pip install --upgrade pip
         python -m pip install setuptools
         python -m pip install notebook

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,7 +33,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        conda install -c conda-forge -y eigen boost-cpp
+        conda install -c conda-forge -y boost-cpp eigen
         python -m pip install --upgrade pip
 
     - name: Install Bean Machine

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        conda install -c conda-forge -y eigen boost-cpp
+        conda install -c conda-forge -y boost-cpp eigen
         python -m pip install --upgrade pip
 
     - name: Install Bean Machine in editable mode

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ We recommend using [conda](https://docs.conda.io/en/latest/) to manage the virtu
 
 ```bash
 conda create -n {env name} python=3.8; conda activate {env name}
-conda install -c conda-forge boost eigen
+conda install -c conda-forge boost-cpp eigen
 python -m pip install .
 ```
 

--- a/docs/overview/installation/installation.md
+++ b/docs/overview/installation/installation.md
@@ -29,7 +29,7 @@ We recommend using [conda](https://docs.conda.io/en/latest/) to manage the virtu
 
 ```
 conda create -n {env name} python=3.8; conda activate {env name}
-conda install -c conda-forge boost eigen  # C++ dependencies
+conda install -c conda-forge boost-cpp eigen # C++ dependencies
 pip install .
 ```
 


### PR DESCRIPTION
Summary: `boost` package includes way too many things and conflicts with our build ([e.g. see this failing workflow](https://github.com/facebookresearch/beanmachine/runs/5841279900?check_suite_focus=true)), whereas `boost-cpp` contains just the library that we need. I've updated the CI in D35407156 (https://github.com/facebookresearch/beanmachine/commit/242897934a0df97d176bbb6336918bff2b8eafb8) to use `boost-cpp`, but I forgot to modify the README to reflect the change

Differential Revision: D35630401

