### PR TITLE
Inject custom build script into internal static doc

### DIFF
--- a/scripts/convert_ipynb_to_mdx.py
+++ b/scripts/convert_ipynb_to_mdx.py
@@ -14,9 +14,14 @@ from typing import Dict, Tuple, Union
 import nbformat
 from nbformat.notebooknode import NotebookNode
 
+try:
+    from libfb.py.fbcode_root import get_fbcode_dir
+except ImportError:
+    SCRIPTS_DIR = Path(__file__).parent.resolve()
+    LIB_DIR = SCRIPTS_DIR.joinpath("..").resolve()
+else:
+    LIB_DIR = (Path(get_fbcode_dir()) / "beanmachine").resolve()
 
-SCRIPTS_DIR = Path(__file__).parent.resolve()
-LIB_DIR = SCRIPTS_DIR.joinpath("..").resolve()
 WEBSITE_DIR = LIB_DIR.joinpath("website")
 DOCS_DIR = LIB_DIR.joinpath("docs")
 OVERVIEW_DIR = DOCS_DIR.joinpath("overview")
@@ -82,7 +87,7 @@ def transform_markdown_cell(
         # Change the path to always be `assets/img/...`
         start = cell_source.find("(") + 1
         stop = cell_source.find(")")
-        old_img_path = ("tutorials" / Path(cell_source[start:stop])).resolve()
+        old_img_path = (LIB_DIR / "tutorials" / Path(cell_source[start:stop])).resolve()
         name = old_img_path.name
         img_path_str = f"assets/img/{name}"
         cell_source = cell_source[:start] + img_path_str + cell_source[stop:]
@@ -522,7 +527,7 @@ if __name__ == "__main__":
     print("Converting tutorial notebooks into mdx files")
     print("--------------------------------------------")
     for _, value in tutorials_metadata.items():
-        path = Path(value["nb_path"]).resolve()
+        path = (LIB_DIR / value["nb_path"]).resolve()
         print(f"{path.stem}")
         mdx, jsx = transform_notebook(path)
     print("")

--- a/website/Makefile
+++ b/website/Makefile
@@ -25,4 +25,10 @@ clean:
 all: clean apidocs apihtml
 	yarn build
 
+prebuild:
+	# Only run prebuild script with Buck internally
+	if [ -f "../TARGETS" ]; then \
+		buck run //beanmachine/scripts:ipynb-to-mdx; \
+	fi
+
 FORCE:

--- a/website/package.json
+++ b/website/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "start": "docusaurus start",
-    "build": "NODE_OPTIONS=--max-old-space-size=8192 docusaurus build",
+    "build": "make prebuild && NODE_OPTIONS=--max-old-space-size=8192 docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -58,10 +58,7 @@ module.exports = {
         },
       ],
       Advanced: ['overview/beanstalk/beanstalk'],
-      Tutorials: fbContent({
-        internal: ['overview/tutorials/tutorials'],
-        external: tutorials(),
-      }),
+      Tutorials: tutorials(),
     },
     // TODO(sepehrakhavan): Re-display this once we have at least one package present.
     // {


### PR DESCRIPTION
Summary: Our internal static site rendering job only knows how to run `yarn build`, but it wasn't aware of the custom scripts we have for sphinx API doc and the tutorials conversion. To fix the tutorial rendering, this diff modifies the `yarn build` command slightly so that, when being run internally, it trigger the tutorial conversion script with Buck prior to calling docusaurus. The changes here should be sufficient to unblock https://github.com/facebookresearch/beanmachine/pull/1399 where the website is modified to contain links to the tutorials page

Differential Revision: D33250776

