### PR TITLE
Fix broken API doc generation

### DIFF
--- a/website/Makefile
+++ b/website/Makefile
@@ -1,10 +1,12 @@
+SHELL := /bin/bash
+
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?= 
+SPHINXOPTS    ?=
 SPHINXBUILD   ?= sphinx-build
-SOURCEDIR     = sphinx
+SOURCEDIR     = ./sphinx
 MODULEDIR     = ../src/beanmachine
-MODULEIGNOREDIRS     = ../src/beanmachine/{applications,graph,tutorials}* ../src/beanmachine/ppl/{compiler,diagnostic,examples,experimental,inference/utils,legacy,testlib,utils}
+MODULEIGNOREDIRS     = ../src/beanmachine/{applications,graph,tutorials}* ../src/beanmachine/ppl/{conftest.py,compiler,diagnostics,examples,experimental,inference/utils,legacy,testlib,utils}
 BUILDDIR      = ./static
 ALLSPHINXOPTS = -q -d $(BUILDDIR)/doctrees $(SPHINXOPTS) $(SOURCEDIR)
 
@@ -15,12 +17,13 @@ BASHHACK	  = 2>&1 >/dev/null | grep -v -E "(use :noindex:)|(more than one target
 
 apidocs:
 	sphinx-apidoc -e -o $(SOURCEDIR) $(MODULEDIR) $(MODULEIGNOREDIRS)
+	mv $(SOURCEDIR)/modules.rst $(SOURCEDIR)/index.rst
 
 apihtml: apidocs
-	-$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/api $(BASHHACK)
+	! $(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/api $(BASHHACK)
 
 clean:
-	rm -rf build/ $(SOURCEDIR)/beanmachine*.rst $(SOURCEDIR)/modules.rst
+	rm -rf build/ $(SOURCEDIR)/beanmachine*.rst $(SOURCEDIR)/index.rst
 
 all: clean apidocs apihtml
 	yarn build

--- a/website/sphinx/conf.py
+++ b/website/sphinx/conf.py
@@ -19,8 +19,8 @@
 # -- Project information -----------------------------------------------------
 
 project = "Bean Machine"
-copyright = "2022, Facebook"
-author = "Facebook"
+copyright = "2022, Meta Platforms, Inc."
+author = "Meta Platforms, Inc."
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
Summary:
Our API doc is down at the moment: https://beanmachine.org/api/index.html

{F724216290}

It turns out that `sphinx-build` cannot find an `index.rst` file to start generating the website, and at a closer look, it's caused by two issues introduced in D35412060 (https://github.com/facebookresearch/beanmachine/commit/0ba6819687e6f7844d52bc4c8b3f6365533c82b5):
- the Makefile that we have could generate the rst files in the wrong directory
- the error from `sphinx-build` was silent by the hyphen (`-`) prefix, so the CI didn't catch the error

This diff should fixed the issues and should be able to bring the API doc back online.

Differential Revision: D35771174

