### PR TITLE
Finish initial graph fixer refactorings

### DIFF
--- a/src/beanmachine/ppl/compiler/fix_problem.py
+++ b/src/beanmachine/ppl/compiler/fix_problem.py
@@ -75,7 +75,8 @@ def type_guard(t: Type, fixer: Callable) -> NodeFixer:
 # error report is non-empty then further processing should stop and the error should
 # be reported to the user.
 
-GraphFixer = Callable[[], Tuple[bool, ErrorReport]]
+GraphFixerResult = Tuple[bool, ErrorReport]
+GraphFixer = Callable[[], GraphFixerResult]
 
 
 def ancestors_first_graph_fixer(  # noqa


### PR DESCRIPTION
Summary:
In this diff I complete the initial round of refactorings of the graph fixing passes, by refactoring the passes which turn an observe-true on a Bernoulli into a factor -- this fixer is turned off by default -- and I've split up the pass which devectorizes operators and devectorizes observations into two passes.

In the next diff I'm going to do some further refactorings on the devectorizer, but this diff gets us to the point where we have a consistent interface to the graph rewriters.

Now that every pass has the same form -- a function with the signature `() -> (made_progress, errors)` -- in the upcoming diffs I'll start making the initial passes repeat their work until we get either an error or we stop making progress. That is, until we reach a fixpoint.

Reviewed By: feynmanliang

Differential Revision: D34570499

