### PR TITLE
Refactor the devectorizer

### DIFF
--- a/src/beanmachine/ppl/compiler/fix_problem.py
+++ b/src/beanmachine/ppl/compiler/fix_problem.py
@@ -3,7 +3,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from abc import ABC, abstractmethod
 from typing import Optional, Callable, List, Tuple, Type, Union
 
 import beanmachine.ppl.compiler.bmg_nodes as bn
@@ -166,69 +165,3 @@ def ancestors_first_graph_fixer(  # noqa
 
 # TODO: Create a match-first combinator on GraphFixers.
 # TODO: Create a fixpoint combinator on GraphFixers.
-
-
-# TODO: Eventually this base class will be refactored away and
-# only GraphFixer / NodeFixer will remain.
-
-
-class ProblemFixerBase(ABC):
-    _bmg: BMGraphBuilder
-    _typer: TyperBase
-    errors: ErrorReport
-
-    def __init__(self, bmg: BMGraphBuilder, typer: TyperBase) -> None:
-        self._bmg = bmg
-        self._typer = typer
-        self.errors = ErrorReport()
-
-    @abstractmethod
-    def _needs_fixing(self, n: bn.BMGNode) -> bool:
-        pass
-
-    def _get_replacement(self, n: bn.BMGNode) -> Optional[bn.BMGNode]:
-        pass
-
-    def _get_error(self, n: bn.BMGNode, index: int) -> Optional[BMGError]:
-        # n.inputs[i] needed fixing but was unfixable. If that needs to
-        # produce an error, do by overriding this method
-        return None
-
-    def fix_problems(self) -> None:
-        replacements = {}
-        reported = set()
-        nodes = self._bmg.all_ancestor_nodes()
-        for node in nodes:
-            node_was_updated = False
-            for i in range(len(node.inputs)):
-                c = node.inputs[i]
-                # Have we already replaced this input with something?
-                # If so, no need to compute the replacement again.
-                if c in replacements:
-                    if node.inputs[i] is not replacements[c]:
-                        node.inputs[i] = replacements[c]
-                        node_was_updated = True
-                    continue
-                # Does the input need fixing at all?
-                if not self._needs_fixing(c):
-                    continue
-                # The input needs fixing. Get the replacement.
-                replacement = self._get_replacement(c)
-                if replacement is not None:
-                    replacements[c] = replacement
-                    if node.inputs[i] is not replacement:
-                        node.inputs[i] = replacement
-                        node_was_updated = True
-                    continue
-                # It needed fixing but we did not succeed. Have we already
-                # reported this error?  If so, no need to compute the error.
-                if c in reported:
-                    continue
-                # Mark the node as having been error-reported, and emit
-                # an error into the error report.
-                reported.add(c)
-                error = self._get_error(node, i)
-                if error is not None:
-                    self.errors.add_error(error)
-            if node_was_updated:
-                self._typer.update_type(node)

--- a/src/beanmachine/ppl/compiler/fix_vectorized_models.py
+++ b/src/beanmachine/ppl/compiler/fix_vectorized_models.py
@@ -3,25 +3,28 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Optional, List, Dict, Type, Callable
+from typing import List, Dict, Type, Callable
 
 import beanmachine.ppl.compiler.bmg_nodes as bn
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
 from beanmachine.ppl.compiler.error_report import ErrorReport
 from beanmachine.ppl.compiler.fix_problem import (
-    ProblemFixerBase,
+    ancestors_first_graph_fixer,
+    node_fixer_first_match,
     GraphFixer,
     GraphFixerResult,
+    Inapplicable,
+    NodeFixer,
+    NodeFixerResult,
 )
 from beanmachine.ppl.compiler.sizer import Sizer
 
 # TODO Move this to a utils module
 from beanmachine.ppl.compiler.support import _prod
-from beanmachine.ppl.compiler.typer_base import TyperBase
 from torch import Size, tensor
 
 
-# This class turns vectorized models into unvectorized models.
+# These graph fixers turn vectorized models into unvectorized models.
 # For example, the model
 #
 # @rv def flip():
@@ -54,191 +57,207 @@ def _is_fixable_size(s: Size) -> bool:
     return False
 
 
-class VectorizedOperatorFixer(ProblemFixerBase):
+def _node_to_index_list(
+    bmg: BMGraphBuilder, sizer: Sizer, n: bn.BMGNode
+) -> List[bn.BMGNode]:
+    size = sizer[n]
+    dim = len(size)
+    index_list = []
+    if dim == 0:
+        # If we have just a single value then there's no indexing required.
+        index_list.append(n)
+    elif dim == 1:
+        for i in range(0, size[0]):
+            ci = bmg.add_constant(i)
+            ni = bmg.add_index(n, ci)
+            index_list.append(ni)
+    else:
+        assert dim == 2
+        for i in range(0, size[0]):
+            for j in range(0, size[1]):
+                ci = bmg.add_constant(i)
+                cj = bmg.add_constant(j)
+                ni = bmg.add_index(n, ci)
+                nij = bmg.add_index(ni, cj)
+                index_list.append(nij)
+    return index_list
 
-    fixed_one: bool
-    _distribution_factories: Dict[Type, Callable]
-    _operator_factories: Dict[Type, Callable]
 
-    def __init__(self, bmg: BMGraphBuilder, sizer: Sizer) -> None:
-        ProblemFixerBase.__init__(self, bmg, sizer)
-        self.fixed_one = False
-        # TODO: categorical
-        # TODO: categorical logit
-        # TODO: dirichlet
-        self._distribution_factories = {
-            bn.BernoulliLogitNode: bmg.add_bernoulli_logit,
-            bn.BernoulliNode: bmg.add_bernoulli,
-            bn.BetaNode: bmg.add_beta,
-            bn.BinomialNode: bmg.add_binomial,
-            bn.BinomialLogitNode: bmg.add_binomial_logit,
-            bn.Chi2Node: bmg.add_chi2,
-            bn.GammaNode: bmg.add_gamma,
-            bn.HalfCauchyNode: bmg.add_halfcauchy,
-            bn.HalfNormalNode: bmg.add_halfnormal,
-            bn.NormalNode: bmg.add_normal,
-            bn.PoissonNode: bmg.add_poisson,
-            bn.StudentTNode: bmg.add_studentt,
-            bn.UniformNode: bmg.add_uniform,
-        }
-        self._operator_factories = {
-            # TODO: Do addition and multiply need to be the multi- versions?
-            bn.AdditionNode: bmg.add_addition,
-            bn.DivisionNode: bmg.add_division,
-            bn.ExpNode: bmg.add_exp,
-            bn.LogisticNode: bmg.add_logistic,
-            bn.LogNode: bmg.add_log,
-            bn.MultiplicationNode: bmg.add_multiplication,
-            bn.NegateNode: bmg.add_negate,
-            bn.PhiNode: bmg.add_phi,
-            bn.PowerNode: bmg.add_power,
-        }
-        # TODO soon: LogSumExp, ExpM1, Logm1exp
-        # TODO later: all comparisons, all bitwise, floordiv,
-        # shifts, mod, not, invert,
+def _generate_arglists(bmg: BMGraphBuilder, sizer: Sizer, node: bn.BMGNode):
+    # This code is a bit tricky to understand so lets work an example.
+    # Suppose node has two inputs, call them X and Y. X has size [3], Y has
+    # size [2, 3], and node has size [2, 3].
+    final_size = sizer[node]  # Size([2, 3])
+    final_length = _prod(final_size)  # 2 x 3 = 6
+    input_nodes = [_node_to_index_list(bmg, sizer, n) for n in node.inputs]
+    # input_nodes is [
+    #   [ Index(X, 0), Index(X, 1), Index(X, 2)],
+    #   [ Index(Index(Y, 0), 0), Index(Index(Y, 0), 1), ...]
+    # ]
+    index_lists = []
+    # Let's now look at what happens on the FIRST loop iteration:
+    for i in range(len(input_nodes)):
+        input_node = input_nodes[i]
+        # First time through the loop input_node is [Index(X, 0), Index(X, 1), Index(X, 2)]
+        input_length = len(input_node)  # 3
+        input_size = sizer[node.inputs[i]]  # Size([3])
+        t = (
+            tensor(range(input_length))  # tensor([0, 1, 2])
+            .reshape(input_size)  # tensor([0, 1, 2])
+            .broadcast_to(final_size)  # tensor([[0, 1, 2], [0, 1, 2]])
+            .reshape(final_length)  # tensor([0, 1, 2, 0, 1, 2])
+            .tolist()  # [0, 1, 2, 0, 1, 2]
+        )
+        index_lists.append(t)
 
-    def _node_to_index_list(self, n: bn.BMGNode) -> List[bn.BMGNode]:
-        size = self._typer[n]
-        dim = len(size)
-        index_list = []
-        if dim == 0:
-            # If we have just a single value then there's no indexing required.
-            index_list.append(n)
-        elif dim == 1:
-            for i in range(0, size[0]):
-                ci = self._bmg.add_constant(i)
-                ni = self._bmg.add_index(n, ci)
-                index_list.append(ni)
-        else:
-            assert dim == 2
-            for i in range(0, size[0]):
-                for j in range(0, size[1]):
-                    ci = self._bmg.add_constant(i)
-                    cj = self._bmg.add_constant(j)
-                    ni = self._bmg.add_index(n, ci)
-                    nij = self._bmg.add_index(ni, cj)
-                    index_list.append(nij)
-        return index_list
+    # When we're done both iterations we have two lists of the same length:
+    # [0, 1, 2, 0, 1, 2]
+    # [0, 1, 2, 3, 4, 5]
+    #
+    # Now make tuples out of each column.
+    #
+    # [(0, 0), (1, 1), (2, 2), (0, 3), (1, 4), (2, 5)]
+    index_tuples = list(zip(*index_lists))
+    # These pairs give the elements of X and Y needed to build devectorized nodes.
 
-    def _generate_arglists(self, node: bn.BMGNode):
-        # This code is a bit tricky to understand so lets work an example.
-        # Suppose node has two inputs, call them X and Y. X has size [3], Y has
-        # size [2, 3], and node has size [2, 3].
-        final_size = self._typer[node]  # Size([2, 3])
-        final_length = _prod(final_size)  # 2 x 3 = 6
-        input_nodes = [self._node_to_index_list(n) for n in node.inputs]
-        # input_nodes is [
-        #   [ Index(X, 0), Index(X, 1), Index(X, 2)],
-        #   [ Index(Index(Y, 0), 0), Index(Index(Y, 0), 1), ...]
-        # ]
-        index_lists = []
-        # Let's now look at what happens on the FIRST loop iteration:
-        for i in range(len(input_nodes)):
-            input_node = input_nodes[i]
-            # First time through the loop input_node is [Index(X, 0), Index(X, 1), Index(X, 2)]
-            input_length = len(input_node)  # 3
-            input_size = self._typer[node.inputs[i]]  # Size([3])
-            t = (
-                tensor(range(input_length))  # tensor([0, 1, 2])
-                .reshape(input_size)  # tensor([0, 1, 2])
-                .broadcast_to(final_size)  # tensor([[0, 1, 2], [0, 1, 2]])
-                .reshape(final_length)  # tensor([0, 1, 2, 0, 1, 2])
-                .tolist()  # [0, 1, 2, 0, 1, 2]
-            )
-            index_lists.append(t)
+    # Now make actual argument lists for each tuple.
+    return [
+        [input_nodes[i][index_tuple[i]] for i in range(len(index_tuple))]
+        for index_tuple in index_tuples
+    ]
 
-        # When we're done both iterations we have two lists of the same length:
-        # [0, 1, 2, 0, 1, 2]
-        # [0, 1, 2, 3, 4, 5]
-        #
-        # Now make tuples out of each column.
-        #
-        # [(0, 0), (1, 1), (2, 2), (0, 3), (1, 4), (2, 5)]
-        index_tuples = list(zip(*index_lists))
-        # These pairs give the elements of X and Y needed to build devectorized nodes.
 
-        # Now make actual argument lists for each tuple.
-        return [
-            [input_nodes[i][index_tuple[i]] for i in range(len(index_tuple))]
-            for index_tuple in index_tuples
-        ]
+def _distribution_factories(bmg: BMGraphBuilder) -> Dict[Type, Callable]:
+    # These are all the distributions that we know how to devectorize,
+    # and the factory methods we need to use to generate a new node
+    # of the appropriate type.
 
-    def _replace_sample(self, node: bn.SampleNode) -> bn.BMGNode:
+    # TODO: categorical
+    # TODO: categorical logit
+    # TODO: dirichlet
+    return {
+        bn.BernoulliLogitNode: bmg.add_bernoulli_logit,
+        bn.BernoulliNode: bmg.add_bernoulli,
+        bn.BetaNode: bmg.add_beta,
+        bn.BinomialNode: bmg.add_binomial,
+        bn.BinomialLogitNode: bmg.add_binomial_logit,
+        bn.Chi2Node: bmg.add_chi2,
+        bn.GammaNode: bmg.add_gamma,
+        bn.HalfCauchyNode: bmg.add_halfcauchy,
+        bn.HalfNormalNode: bmg.add_halfnormal,
+        bn.NormalNode: bmg.add_normal,
+        bn.PoissonNode: bmg.add_poisson,
+        bn.StudentTNode: bmg.add_studentt,
+        bn.UniformNode: bmg.add_uniform,
+    }
+
+
+_distribution_types = list(_distribution_factories(BMGraphBuilder()).keys())
+
+
+def _is_fixable_sample(sizer: Sizer, n: bn.BMGNode) -> bool:
+    if not isinstance(n, bn.SampleNode):
+        return False
+    dist = n.operand
+    if type(dist) not in _distribution_types:
+        return False
+    return _is_fixable_size(sizer[dist])
+
+
+def _vectorized_distribution_node_fixer(bmg: BMGraphBuilder, sizer: Sizer) -> NodeFixer:
+    distribution_factories = _distribution_factories(bmg)
+
+    def fixer(node: bn.BMGNode) -> NodeFixerResult:
+        if not _is_fixable_sample(sizer, node):
+            return Inapplicable
+        assert isinstance(node, bn.SampleNode)
         dist = node.operand
-        arglists = self._generate_arglists(dist)
+        arglists = _generate_arglists(bmg, sizer, dist)
         samples = []
         for arglist in arglists:
-            b = self._distribution_factories[type(dist)](*arglist)
-            s = self._bmg.add_sample(b)
+            b = distribution_factories[type(dist)](*arglist)
+            s = bmg.add_sample(b)
             samples.append(s)
-        size = self._typer[dist]
-        t = self._bmg.add_tensor(size, *samples)
+        size = sizer[dist]
+        t = bmg.add_tensor(size, *samples)
         return t
 
-    def _replace_operator(self, node: bn.OperatorNode) -> bn.BMGNode:
-        arglists = self._generate_arglists(node)
-        results = []
-        for arglist in arglists:
-            r = self._operator_factories[type(node)](*arglist)
-            results.append(r)
-        size = self._typer[node]
-        t = self._bmg.add_tensor(size, *results)
-        return t
+    return fixer
 
-    def _is_fixable_sample(self, n: bn.BMGNode) -> bool:
-        if not isinstance(n, bn.SampleNode):
-            return False
-        dist = n.operand
-        if type(dist) not in self._distribution_factories:
-            return False
-        return _is_fixable_size(self._typer[dist])
 
-    def _is_fixable_operator(self, n: bn.BMGNode) -> bool:
-        if type(n) not in self._operator_factories:
-            return False
+def _operator_factories(bmg: BMGraphBuilder) -> Dict[Type, Callable]:
+    return {
+        # TODO: Do addition and multiply need to be the multi- versions?
+        bn.AdditionNode: bmg.add_addition,
+        bn.DivisionNode: bmg.add_division,
+        bn.ExpNode: bmg.add_exp,
+        bn.LogisticNode: bmg.add_logistic,
+        bn.LogNode: bmg.add_log,
+        bn.MultiplicationNode: bmg.add_multiplication,
+        bn.NegateNode: bmg.add_negate,
+        bn.PhiNode: bmg.add_phi,
+        bn.PowerNode: bmg.add_power,
+    }
+    # TODO soon: LogSumExp, ExpM1, Logm1exp
+    # TODO later: all comparisons, all bitwise, floordiv,
+    # shifts, mod, not, invert,
+
+
+def _vectorized_operator_node_fixer(bmg: BMGraphBuilder, sizer: Sizer) -> NodeFixer:
+
+    operator_factories = _operator_factories(bmg)
+
+    def node_fixer(n: bn.BMGNode) -> NodeFixerResult:
+        if type(n) not in operator_factories:
+            return Inapplicable
         # We do not rewrite multiplications of matrices by scalars; that's
         # handled in a later rewriter.
         if (
             isinstance(n, bn.MultiplicationNode)
             and len(n.inputs) == 2
-            and (
-                len(self._typer[n.inputs[0]]) <= 1 or len(self._typer[n.inputs[1]]) <= 1
-            )
+            and (len(sizer[n.inputs[0]]) <= 1 or len(sizer[n.inputs[1]]) <= 1)
         ):
-            return False
-        return _is_fixable_size(self._typer[n])
-
-    def _needs_fixing(self, n: bn.BMGNode) -> bool:
-        return self._is_fixable_sample(n) or self._is_fixable_operator(n)
-
-    def _get_replacement(self, n: bn.BMGNode) -> Optional[bn.BMGNode]:
-        self.fixed_one = True
-        if isinstance(n, bn.SampleNode):
-            return self._replace_sample(n)
+            return Inapplicable
+        if not _is_fixable_size(sizer[n]):
+            return Inapplicable
         assert isinstance(n, bn.OperatorNode)
-        return self._replace_operator(n)
+        arglists = _generate_arglists(bmg, sizer, n)
+        results = []
+        for arglist in arglists:
+            r = operator_factories[type(n)](*arglist)
+            results.append(r)
+        size = sizer[n]
+        t = bmg.add_tensor(size, *results)
+        return t
+
+    return node_fixer
 
 
-# TODO: We don't use the typer.
-def vectorized_operator_fixer(bmg: BMGraphBuilder, typer: TyperBase) -> GraphFixer:
+# TODO: Typer is unused
+def vectorized_operator_fixer(bmg: BMGraphBuilder, typer) -> GraphFixer:
     def fixer() -> GraphFixerResult:
-        vof = VectorizedOperatorFixer(bmg, Sizer())
-        vof.fix_problems()
+        sizer = Sizer()
+
+        dist_fixer = _vectorized_distribution_node_fixer(bmg, sizer)
+        oper_fixer = _vectorized_operator_node_fixer(bmg, sizer)
+        node_fixer = node_fixer_first_match([dist_fixer, oper_fixer])
+        vof = ancestors_first_graph_fixer(bmg, sizer, node_fixer)
+        made_progress, errors = vof()
 
         # If we changed something then we might have a leaf sample node;
         # we can remove it.
-        if vof.fixed_one:
+        if made_progress:
             for n in bmg.all_nodes():
-                if vof._is_fixable_sample(n):
+                if _is_fixable_sample(sizer, n):
                     assert n.is_leaf
                     bmg.remove_leaf(n)
-        return vof.fixed_one, vof.errors
+        return made_progress, errors
 
     return fixer
 
 
-# TODO: We don't use the typer
-def vectorized_observation_fixer(bmg: BMGraphBuilder, typer: TyperBase) -> GraphFixer:
+# TODO: Typer is unused
+def vectorized_observation_fixer(bmg: BMGraphBuilder, typer) -> GraphFixer:
     def fixer() -> GraphFixerResult:
         made_change = False
         # We might have an illegal observation. Fix it.


### PR DESCRIPTION
Summary:
In a previous diff I made the devectorizer follow my new convention for graph fixers -- the public interface is `()->(bool, errors)` indicating whether progress was made and whether an error was discovered. But the implementation was the same as previously.

In this diff I refactor the implementation to reduce the work of each part of the devectorizer to two NodeFixers. (It looks like a lot of lines changed but its mostly just extracting methods to the top level.)

Reviewed By: yucenli

Differential Revision: D34652986

