### PR TITLE
Setup cibuildwheel for M1 and manylinux binaries

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       deploy:
-        description: 'Where to deploy the artifacts? Only build, deploy to test PyPI, deploy to PyPI.'
+        description: 'Where to deploy the artifacts? Only build (build), deploy to test PyPI (test), or deploy to PyPI (prod).'
         required: true
         type: choice
         default: 'test'
@@ -19,14 +19,17 @@ env:
   PYTEST_ADDOPTS: "--color=yes"
 
 jobs:
-  build-wheel:
+  build-windows-wheel-and-sdist:
     # do not run on forked repo
     if: github.repository == 'facebookresearch/beanmachine'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, windows-latest]
+        os: [windows-latest]
         python-version: ['3.7', '3.8', '3.9']  # TODO: Add python 3.10 with next PyTorch version
+        include:
+          - python-version: '3.8'  # source distribution only needs to be build once
+            os: ubuntu-latest
     defaults:
       run:
         # https://github.com/conda-incubator/setup-miniconda/tree/v2#use-a-default-shell
@@ -50,20 +53,17 @@ jobs:
         python -m pip install --upgrade pip
         pip install -U build
 
-    - name: Building Bean Machine wheel for ${{ matrix.os }}
+    - name: Building Bean Machine wheel on ${{ matrix.os }} ${{ matrix.python-version }}
+      if: matrix.os == 'windows-latest'
       run: python -m build --wheel
 
-    - name: Build Bean Machine source distribution
-      # source distribution only needs to be built on one OS
-      if: matrix.os == 'macos-latest'
+    - name: Building source distribution on ${{ matrix.os }}
+      if: matrix.os == 'ubuntu-latest'
       run: python -m build --sdist
 
-    - name: Install from sdist
-      if: matrix.os == 'macos-latest'
-      run: pip install dist/*.tar.gz
-
-    - name: Install built Bean Machine dist
-      run: pip install dist/*.whl
+    - name: Install built Bean Machine
+      # this will install prebuilt wheels on Windows or sdist on Ubuntu
+      run: pip install dist/*
 
     - name: Install pytest
       run: pip install -U pytest
@@ -75,69 +75,68 @@ jobs:
       run: pytest
 
     - name: Sending wheels to the deployment workflow
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
-        name: beanmachine-${{ matrix.os }}
+        name: beanmachine-wheels
         path: dist/*
 
-  build-linux-wheel:
+  cibuildwheel:
     if: github.repository == 'facebookresearch/beanmachine'
-    runs-on: ubuntu-latest
-    container: quay.io/pypa/manylinux2014_x86_64
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ['cp37-cp37m', 'cp38-cp38', 'cp39-cp39']  # TODO: Add python 3.10 with next PyTorch version
+        os: [ubuntu-latest, macos-latest]
+        cibw_build: ['cp37-*', 'cp38-*', 'cp39-*']
 
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Install dependencies
-      run: |
-        yum install -y boost169-devel eigen3-devel
-        /opt/python/${{ matrix.python-version }}/bin/python -m pip install --upgrade pip
-        /opt/python/${{ matrix.python-version }}/bin/pip install -U build
+    - name: Install Boost and Eigen dependencies (MacOS only)
+      if: matrix.os == 'macos-latest'
+      run: brew install boost eigen
 
-    - name: Building Bean Machine wheel for Linux
-      run: /opt/python/${{ matrix.python-version }}/bin/python -m build --wheel
+    - name: Build wheels
+      uses: pypa/cibuildwheel@v2.4.0
+      env:
+        CIBW_BUILD: ${{ matrix.cibw_build }}
+        CIBW_SKIP: "*-manylinux_i686 *-musllinux_*"
+        CIBW_ARCHS_MACOS: x86_64 universal2 arm64
+        CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+        CIBW_BEFORE_ALL_LINUX: > # Manually install Eigen3.4 since yum is not up to date
+          yum install -y wget boost169-devel &&
+          wget https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz &&
+          tar -xvf eigen-3.4.0.tar.gz &&
+          mv eigen-3.4.0 /usr/include/eigen3
+        CIBW_TEST_REQUIRES: pytest
+        CIBW_TEST_COMMAND: pytest {package}
+        MACOSX_DEPLOYMENT_TARGET: "10.13"
 
-    - name: Repair wheel to support manylinux
-      run: auditwheel -v repair dist/*
-
-    - name: Install built Bean Machine dist
-      run: /opt/python/${{ matrix.python-version }}/bin/pip install wheelhouse/*.whl
-
-    - name: Install pytest
-      run: /opt/python/${{ matrix.python-version }}/bin/pip install -U pytest
-
-    - name: Print out package info to help with debug
-      run: /opt/python/${{ matrix.python-version }}/bin/pip list
-
-    - name: Run unit tests with pytest
-      run: /opt/python/${{ matrix.python-version }}/bin/pytest
 
     - name: Sending wheels to the deployment workflow
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
-        name: beanmachine-manylinux
+        name: beanmachine-wheels
         path: wheelhouse/*
+
 
   publish-to-pypi:
     runs-on: ubuntu-latest
     needs:
-      - build-wheel
-      - build-linux-wheel
+      - build-windows-wheel-and-sdist
+      - cibuildwheel
     steps:
     - name: Download wheels from previous jobs
       # by default this will download all artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
+      with:
+        name: beanmachine-wheels
+        # PyPI publish action uploads everything under dist/* by default
+        path: dist
 
-    - name: Reorganize file structure
-      # PyPI publish action uploads everything under dist/*
-      run: |
-        ls -R
-        mkdir dist
-        mv beanmachine-*/* dist/
+    - name: Display the list of artifacts
+      run: ls -R dist
 
     - name: Publish to Test PyPI
       if: github.event.inputs.deploy == 'test'

--- a/setup.py
+++ b/setup.py
@@ -115,6 +115,12 @@ if sys.platform.startswith("linux"):
             "/usr/include/x86_64-linux-gnu",
         ]
     )
+elif sys.platform.startswith("darwin"):
+    # MacOS dependencies installed through HomeBrew
+    INCLUDE_DIRS.extend(
+        glob("/usr/local/Cellar/eigen/*/include/eigen3")
+        + glob("/usr/local/Cellar/boost/*/include")
+    )
 
 setup(
     name="beanmachine",


### PR DESCRIPTION
Summary: [cibuildwheel](https://cibuildwheel.readthedocs.io/en/stable/) is a tool released by PyPA (Python Packaging Authorization) that simplify the process of building Python binary wheels across multiple platform. It supports cross build of MacOS M1 wheels on a x86 runner. It also support manylinux build (i.e. a "universal" binary that works for all Linux distribution).

Summary of changes:
- Move MacOS and manylinux wheel-building workflows to `cibuildwheel`
- Because `cibuildwheel` does not work with Conda, we can no longer use `conda-forge` to get our Boost and Eigen dependencies
  - On MacOS, we will download Boost and Eigen from Homebrew instead
  - On manylinux2014 (CentOS 7?), we will download Boost from `yum`, and will download and extract Eigen manually, because `yum` only has Eigen 3.3.4, whereas BMG uses features that are only available in Eigen 3.4.
  - I have no idea what to do with Windows, so the workflow remained as-is (i.e. Windows wheels are still built manually in a Conda environment at the moment).

`cibuildwheel` should also allow us to build wheels for ARM Linux or `musllinux` with a few configuration change if we ever need them in the future, though they have not been enabled in the current workflow.

Differential Revision: D35943329

