### PR TITLE
Temporarily pin flowtorch version to unblock CI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ INSTALL_REQUIRES = [
     "astor>=0.7.1",
     "black==21.4b2",
     "botorch>=0.5.1",
-    "flowtorch>=0.3",
+    "flowtorch>=0.3,<0.7",
     "gpytorch>=1.3.0",
     "graphviz>=0.17",
     "numpy>=1.18.1",


### PR DESCRIPTION
Summary:
flowtorch 0.7 release seems to cause VI in Bean Machine to pass duplicate parameters to torch optimizer, so let's pin to 0.6 for now until we either fix the regression or remove the flowtorch dependency

See failing workflow: https://github.com/facebookresearch/beanmachine/runs/6181605588?check_suite_focus=true

Differential Revision: D35946790

