### PR TITLE
Graph fixer factories no longer take a typer

### DIFF
--- a/src/beanmachine/ppl/compiler/fix_observations.py
+++ b/src/beanmachine/ppl/compiler/fix_observations.py
@@ -20,13 +20,14 @@ from beanmachine.ppl.compiler.fix_problem import GraphFixer
 from beanmachine.ppl.compiler.lattice_typer import LatticeTyper
 
 
-def observations_fixer(bmg: BMGraphBuilder, typer: LatticeTyper) -> GraphFixer:
+def observations_fixer(bmg: BMGraphBuilder) -> GraphFixer:
     """This fixer attempts to fix violations of BMG type system requirements
     in observation nodes.
     It also finds observations that are impossible -- say, an observation
     that a Boolean node is -3.14 -- and reports them as errors."""
 
     def fixer():
+        typer = LatticeTyper()
         errors = ErrorReport()
         made_progress = False
         for o in bmg.all_observations():

--- a/src/beanmachine/ppl/compiler/fix_observe_true.py
+++ b/src/beanmachine/ppl/compiler/fix_observe_true.py
@@ -18,7 +18,6 @@ from beanmachine.ppl.compiler.bmg_nodes import (
 from beanmachine.ppl.compiler.bmg_types import is_one
 from beanmachine.ppl.compiler.error_report import ErrorReport
 from beanmachine.ppl.compiler.fix_problem import GraphFixer, GraphFixerResult
-from beanmachine.ppl.compiler.typer_base import TyperBase
 
 
 def _is_conversion(n: BMGNode) -> bool:
@@ -37,8 +36,7 @@ def _skip_conversions(n: BMGNode) -> BMGNode:
     return n
 
 
-# TODO: typer is unused
-def observe_true_fixer(bmg: BMGraphBuilder, typer: TyperBase) -> GraphFixer:
+def observe_true_fixer(bmg: BMGraphBuilder) -> GraphFixer:
     # A common technique in model design is to boost the probability density
     # score of a particular quantity by converting it to a probability
     # and then observing that a coin flip of that probability comes up heads.

--- a/src/beanmachine/ppl/compiler/fix_requirements.py
+++ b/src/beanmachine/ppl/compiler/fix_requirements.py
@@ -437,9 +437,9 @@ class RequirementsFixer:
         return made_progress
 
 
-def requirements_fixer(bmg: BMGraphBuilder, typer: LatticeTyper) -> GraphFixer:
+def requirements_fixer(bmg: BMGraphBuilder) -> GraphFixer:
     def graph_fixer():
-        rf = RequirementsFixer(bmg, typer)
+        rf = RequirementsFixer(bmg, LatticeTyper())
         made_progress = rf.fix_problems()
         return made_progress, rf.errors
 

--- a/src/beanmachine/ppl/compiler/fix_unsupported.py
+++ b/src/beanmachine/ppl/compiler/fix_unsupported.py
@@ -327,8 +327,7 @@ def _check_supported(n: bn.BMGNode) -> NodeFixerResult:
     return Inapplicable if is_supported_by_bmg(n) else Fatal
 
 
-# TODO: Typer is unused
-def unsupported_node_reporter(bmg: BMGraphBuilder, typer: LatticeTyper) -> GraphFixer:
+def unsupported_node_reporter(bmg: BMGraphBuilder) -> GraphFixer:
     def _error_for_unsupported_node(n: bn.BMGNode, index: int) -> Optional[BMGError]:
         # TODO: The edge labels used to visualize the graph in DOT
         # are not necessarily the best ones for displaying errors.
@@ -341,6 +340,7 @@ def unsupported_node_reporter(bmg: BMGraphBuilder, typer: LatticeTyper) -> Graph
             bmg.execution_context.node_locations(unsupported_node),
         )
 
+    # TODO: Make the typer optional
     return ancestors_first_graph_fixer(
-        bmg, typer, _check_supported, _error_for_unsupported_node
+        bmg, LatticeTyper(), _check_supported, _error_for_unsupported_node
     )

--- a/src/beanmachine/ppl/compiler/fix_vectorized_models.py
+++ b/src/beanmachine/ppl/compiler/fix_vectorized_models.py
@@ -233,8 +233,7 @@ def _vectorized_operator_node_fixer(bmg: BMGraphBuilder, sizer: Sizer) -> NodeFi
     return node_fixer
 
 
-# TODO: Typer is unused
-def vectorized_operator_fixer(bmg: BMGraphBuilder, typer) -> GraphFixer:
+def vectorized_operator_fixer(bmg: BMGraphBuilder) -> GraphFixer:
     def fixer() -> GraphFixerResult:
         sizer = Sizer()
 
@@ -256,8 +255,7 @@ def vectorized_operator_fixer(bmg: BMGraphBuilder, typer) -> GraphFixer:
     return fixer
 
 
-# TODO: Typer is unused
-def vectorized_observation_fixer(bmg: BMGraphBuilder, typer) -> GraphFixer:
+def vectorized_observation_fixer(bmg: BMGraphBuilder) -> GraphFixer:
     def fixer() -> GraphFixerResult:
         made_change = False
         # We might have an illegal observation. Fix it.


### PR DESCRIPTION
Summary:
This diff fixes a long-standing design issue with the graph fixing passes. Here's the issue:

* Many (but not all) of the fixing passes require a type analysis of nodes to correctly mutate the graph.

* The type of any node depends on potentially all of its ancestor nodes' types.

* And therefore any mutation to a node can cause all of its descendant nodes to require updating their types.

This implies that determining the type of a node is potentially an O(n) operation if there are n ancestors of a node, and updating the graph is also potentially O(n) if there are n descendants.

We therefore wish to be careful about how we compute, cache and update type information. The solution we arrived at was:

* A typer is an object which knows how to assign types to nodes; when it does so it caches the results so that the second time you ask for the type of a node, it's already there.

* A typer must be informed whenever the graph changes; when the type of a node changes that triggers a recomputation of cached types of descendant nodes. If any of those change their types, their (cached) descendants are retyped and so on.

How then does this design decision relate to our multi-pass graph fixing strategy? When I first designed it, I made the choice to create a single typer at the start of the fixing pass, and then pass that same typer into every graph fixer. Each fixer is *required* to update the typer if it changes anything.

I now regret this decision because unfortunately we are in the position that there are two *different kinds of typers*. The devectorization pass needs to know the *sizes* of nodes in the *original* Python model (computed by the Sizer), and the various other passes need to know the *BMG types* of legal BMG nodes. (Computed by the LatticeTyper).  And still other passes need no type information at all.

I don't particularly want to be in the position of having to pass around multiple typers and keep them all updated on every change. The type information required by a graph fixing pass is logically an implementation detail of that graph fixer.

In this diff we no longer give a single lattice typer to every graph fixer. Rather, each fixer creates whatever kind of typer it needs and then discards it when we're done. This might mean that we spend a small amount of time recomputing types that we could have cached, but it also means that we *avoid* spending time updating type information when the graph changes that we're going to ignore later.

Reviewed By: yucenli

Differential Revision: D34603174

