### PR TITLE
Create a fixpoint combinator for graph fixers

### DIFF
--- a/src/beanmachine/ppl/compiler/fix_bool_arithmetic.py
+++ b/src/beanmachine/ppl/compiler/fix_bool_arithmetic.py
@@ -26,7 +26,10 @@ class BoolArithmeticFixer:
     def _fix_multiplication(self, n: bn.MultiplicationNode) -> NodeFixerResult:
         # We can simplify 1*anything, 0*anything or bool*anything
         # to anything, 0, or an if-then-else respectively.
-        assert len(n.inputs) == 2
+
+        # TODO: We could extend this to multiary multiplication.
+        if len(n.inputs) != 2:
+            return Inapplicable
         if bn.is_zero(n.inputs[0]):
             return n.inputs[0]
         if bn.is_one(n.inputs[0]):
@@ -45,7 +48,9 @@ class BoolArithmeticFixer:
 
     def _fix_addition(self, n: bn.AdditionNode) -> NodeFixerResult:
         # We can simplify 0+anything.
-        assert len(n.inputs) == 2
+        # TODO: We could extend this to multiary addition.
+        if len(n.inputs) != 2:
+            return Inapplicable
         if bn.is_zero(n.inputs[0]):
             return n.inputs[1]
         if bn.is_zero(n.inputs[1]):

--- a/src/beanmachine/ppl/compiler/fix_problem.py
+++ b/src/beanmachine/ppl/compiler/fix_problem.py
@@ -186,4 +186,17 @@ def sequential_graph_fixer(fixers: List[GraphFixer]) -> GraphFixer:
     return sequential
 
 
+def fixpoint_graph_fixer(fixer: GraphFixer) -> GraphFixer:
+    """Executes a graph fixer repeatedly until it stops making progress
+    or produces an error."""
+
+    def fixpoint() -> GraphFixerResult:
+        while True:
+            made_progress, errors = fixer()
+            if not made_progress or errors.any():
+                return made_progress, errors
+
+    return fixpoint
+
+
 # TODO: Create a fixpoint combinator on GraphFixers.

--- a/src/beanmachine/ppl/compiler/fix_problems.py
+++ b/src/beanmachine/ppl/compiler/fix_problems.py
@@ -31,6 +31,7 @@ from beanmachine.ppl.compiler.fix_problem import (
     NodeFixer,
     ancestors_first_graph_fixer,
     conditional_graph_fixer,
+    fixpoint_graph_fixer,
     node_fixer_first_match,
     sequential_graph_fixer,
 )
@@ -61,13 +62,10 @@ _arithmetic_fixer_factories: List[
     addition_fixer,
     bool_arithmetic_fixer,
     bool_comparison_fixer,
+    logsumexp_fixer,
     matrix_scale_fixer,
     multiary_addition_fixer,
     multiary_multiplication_fixer,
-    # TODO: logsumexp_fixer needs to come after multiary_addition_fixer right now;
-    # when we make the arithmetic_graph_fixer attain a fixpoint then we can do
-    # these fixers in any order.
-    logsumexp_fixer,
     unsupported_node_fixer,
 ]
 
@@ -81,8 +79,7 @@ def arithmetic_graph_fixer(skip: Set[str], bmg: BMGraphBuilder) -> GraphFixer:
     ]
     node_fixer = node_fixer_first_match(node_fixers)
     arith = ancestors_first_graph_fixer(bmg, typer, node_fixer)
-    # TODO: this should be a fixpoint combinator, not a sequence combinator
-    return sequential_graph_fixer([vector_ops, vector_obs, arith])
+    return fixpoint_graph_fixer(sequential_graph_fixer([vector_ops, vector_obs, arith]))
 
 
 _conjugacy_fixer_factories: List[Callable[[BMGraphBuilder], NodeFixer]] = [


### PR DESCRIPTION
Summary:
A graph fixer is a function which mutates a graph and produces a `(bool, errors)` pair; the bool indicates whether the fixer did any mutation, and the errors indicate whether there was a fatal error detected.

I've added a fixpoint combinator that takes a graph fixer and produces the graph fixer that keeps running the input fixer until either it stops making changes or produces any error.

With this combinator we now run the initial arithmetic rewriting pass over and over again until it either errors or stops finding things to fix.  This then means that we can do the rewrites in *any order*. This then eliminates the "chicken and egg" issues in the graph fixing step, where we had fixers that must run both before and after other fixers.

To demonstrate that we've achieved this desirable property I've reordered the logsumexp node fixer and the multiary addition node fixer. Previously we required that the logsumexp fixer run after the multiary addition fixer, but now it does not matter which order they run in because we will keep re-running the pass until we stop making progress.

Reviewed By: yucenli

Differential Revision: D34700882

