### PR TITLE
Fix linter by removing unused import in world.py

### DIFF
--- a/src/beanmachine/ppl/legacy/world/world.py
+++ b/src/beanmachine/ppl/legacy/world/world.py
@@ -9,7 +9,6 @@ from typing import Dict, List, Optional, Set, Tuple
 
 import torch
 import torch.distributions as dist
-import torch.nn as nn
 from beanmachine.ppl.legacy.world.diff import Diff
 from beanmachine.ppl.legacy.world.diff_stack import DiffStack
 from beanmachine.ppl.legacy.world.variable import TransformData, TransformType, Variable


### PR DESCRIPTION
### Motivation

https://github.com/facebookresearch/beanmachine/runs/6219379670?check_suite_focus=true

### Changes proposed

Fixes the linter.

### Test Plan

<img width="617" alt="image" src="https://user-images.githubusercontent.com/990069/165980804-483b3133-0b1b-41bc-8915-e3c9c51ca400.png">


### Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](https://github.com/facebookresearch/beanmachine/blob/main/CONTRIBUTING.md)** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] The title of my pull request is a short description of the requested changes.
