### PR TITLE
Fix random walk adaptation for scalar latent random variable

### DIFF
--- a/src/beanmachine/ppl/inference/proposer/single_site_random_walk_proposer.py
+++ b/src/beanmachine/ppl/inference/proposer/single_site_random_walk_proposer.py
@@ -27,7 +27,8 @@ class SingleSiteRandomWalkProposer(SingleSiteAncestralProposer):
         if torch.isnan(accept_log_prob):
             return
         accept_prob = accept_log_prob.exp()
-        if world[self.node].shape[0] == 1:
+        val_shape = world[self.node].shape
+        if len(val_shape) == 0 or val_shape[0] == 1:
             target_acc_rate = self.target_acc_rate[False]
             c = torch.reciprocal(target_acc_rate)
         else:

--- a/src/beanmachine/ppl/inference/sampler.py
+++ b/src/beanmachine/ppl/inference/sampler.py
@@ -81,6 +81,7 @@ class Sampler(Generator[World, Optional[World], None]):
         for proposer in proposers:
             try:
                 new_world, accept_log_prob = proposer.propose(world)
+                accept_log_prob = accept_log_prob.clamp(max=0.0)
                 accepted = torch.rand_like(accept_log_prob).log() < accept_log_prob
                 if accepted:
                     world = new_world

--- a/src/beanmachine/ppl/inference/tests/single_site_random_walk_test.py
+++ b/src/beanmachine/ppl/inference/tests/single_site_random_walk_test.py
@@ -204,13 +204,13 @@ class SingleSiteRandomWalkTest(unittest.TestCase):
 
     def test_single_site_adaptive_random_walk(self):
         model = NormalNormalModel(
-            mu=torch.zeros(1), std=torch.ones(1), sigma=torch.ones(1)
+            mu=torch.tensor(0.0), std=torch.tensor(1.0), sigma=torch.ones(1)
         )
         mh = bm.SingleSiteRandomWalk(step_size=4)
         p_key = model.normal_p()
         queries = [p_key]
         observations = {model.normal(): torch.tensor(100.0)}
-        predictions = mh.infer(queries, observations, 100, 30)
+        predictions = mh.infer(queries, observations, 100, num_adaptive_samples=30)
         predictions = predictions.get_chain()[p_key]
         self.assertIn(True, [45 < pred < 55 for pred in predictions])
 


### PR DESCRIPTION
Summary:
Fix https://github.com/facebookresearch/beanmachine/issues/1414

The main change here is to make sure that the scalar is not 0-dimensional before attempting to check the size of its first dimension, so that we won't run into index out of range error during adaptation. I also updated one of the test to use a model with scalar latent variable to make sure that the fix is working as expected.

One interesting I notice while fixing the adaptation is that the "adaptive random walk" test wasn't testing the adaptation at all. Instead of running 30 adaptive iterations, it was set to sample 30 chains (but still manage to pass the test). And then, after fixing the inference args, the inference began to fail 😂. It turned out that it was because we didn't cap the acceptance probability, which, as in the case of the failing test, can result in the step size being scaled up to infinity.

{F728916681}

Differential Revision: D36121999

