### PR TITLE
Compiler now detects invalid matrix multiplications

### DIFF
--- a/src/beanmachine/ppl/compiler/bmg_requirements.py
+++ b/src/beanmachine/ppl/compiler/bmg_requirements.py
@@ -50,14 +50,8 @@ _known_requirements: Dict[type, List[bt.Requirement]] = {
     # Operators
     bn.LogisticNode: [bt.Real],
     bn.Log1mexpNode: [bt.NegativeReal],
-    # TODO: We haven't implemented restrictions on matmul yet. What we need to do is:
-    #
-    # (1) create an error handling pass that looks for violations of the size rules.
-    # That is, we need both operands to be matrices, and their sizes must be (a, b) and
-    # (b, c).  Do not attempt to express this rule as a requirement on edges because
-    # it's unclear which edge is the bad one and there's no obvious way to fix it.
-    #
-    # (2) We'll need a special requirement with the semantics "input must be a matrix
+    # TODO: We haven't implemented restrictions on matmul yet.
+    # We'll need a special requirement with the semantics "input must be a matrix
     # with real, +real, -real or prob elements". To meet the requirement if unmet we
     # can simply insert a ToRealMatrix node.
     bn.MatrixMultiplicationNode: [bt.AnyRequirement(), bt.AnyRequirement()],

--- a/src/beanmachine/ppl/compiler/fix_problem.py
+++ b/src/beanmachine/ppl/compiler/fix_problem.py
@@ -198,6 +198,25 @@ def edge_error_pass(
     return error_pass
 
 
+def node_error_pass(
+    bmg: BMGraphBuilder, get_error: Callable[[bn.BMGNode], Optional[BMGError]]
+) -> GraphFixer:
+    """Given a function that takes an node in the graph and returns an optional error,
+    build a pass which checks for errors every node in the graph that is an ancestor
+    of a query, observation, or sample."""
+
+    def error_pass() -> Tuple[bool, ErrorReport]:
+        errors = ErrorReport()
+        nodes = bmg.all_ancestor_nodes()
+        for node in nodes:
+            error = get_error(node)
+            if error is not None:
+                errors.add_error(error)
+        return False, errors
+
+    return error_pass
+
+
 def sequential_graph_fixer(fixers: List[GraphFixer]) -> GraphFixer:
     """Takes a list of graph fixers and applies each in turn once unless one fails."""
 

--- a/src/beanmachine/ppl/compiler/fix_problems.py
+++ b/src/beanmachine/ppl/compiler/fix_problems.py
@@ -40,8 +40,10 @@ from beanmachine.ppl.compiler.fix_problem import (
 )
 from beanmachine.ppl.compiler.fix_requirements import requirements_fixer
 from beanmachine.ppl.compiler.fix_unsupported import (
+    bad_matmul_reporter,
     unsupported_node_fixer,
     unsupported_node_reporter,
+    untypable_node_reporter,
 )
 from beanmachine.ppl.compiler.fix_vectorized_models import (
     vectorized_observation_fixer,
@@ -109,6 +111,8 @@ def fix_problems(
         [
             arithmetic_graph_fixer(skip_optimizations, bmg),
             unsupported_node_reporter(bmg),
+            bad_matmul_reporter(bmg),
+            untypable_node_reporter(bmg),
             conjugacy_graph_fixer(skip_optimizations, bmg),
             requirements_fixer(bmg),
             observations_fixer(bmg),

--- a/src/beanmachine/ppl/compiler/tests/matrix_multiplication_test.py
+++ b/src/beanmachine/ppl/compiler/tests/matrix_multiplication_test.py
@@ -59,6 +59,13 @@ def trivial():
     return trivial_norm_matrix() @ trivial_norm_matrix()
 
 
+@bm.functional
+def matmul_bad_dimensions():
+    n = norm()  # 2x2
+    m = torch.eye(3)  # 3x3
+    return n @ m
+
+
 class MatMulTest(unittest.TestCase):
     def test_matrix_multiplication(self) -> None:
 
@@ -122,3 +129,11 @@ digraph "graph" {
 }"""
         observed = BMGInference().to_dot([trivial()], {})
         self.assertEqual(expected_trivial.strip(), observed.strip())
+
+        with self.assertRaises(ValueError) as ex:
+            BMGInference().to_dot([matmul_bad_dimensions()], {})
+        expected = """
+The model uses a matrix multiplication (@) operation unsupported by Bean Machine Graph.
+The dimensions of the operands are 2x2 and 3x3.
+The unsupported node was created in function call matmul_bad_dimensions()."""
+        self.assertEqual(expected.strip(), str(ex.exception).strip())


### PR DESCRIPTION
Summary:
BMG requires that a matrix multiplication have the left operand's column count exactly equal the right operand's row count; here we enforce that rule in the compiler by adding a new error checking pass that runs after the unsupported node checking pass.

We do not yet enforce the BMG requirement that the operands be real, negative real, positive real or probability matrices; I'll add that code in an upcoming diff.

While I was adding a new error pass I took this opportunity to add a pass which should help me or other future developers detect mistakes early. By the time we get past the unsupported node checking pass, every node remaining in the graph (except constants, which are type checked during edge requirements checking) should have a type assigned to it by the BMG lattice typer.

If that invariant is not met then the upcoming passes can crash. Rather than allowing that crash and debugging the problem then, it will be easier for all involved if we detect the problem early and do not run passes which require an invariant that we know to be violated.

Reviewed By: yucenli

Differential Revision: D34775673

