### PR TITLE
Use half space proposer for great_than_eq constraints

### DIFF
--- a/src/beanmachine/ppl/inference/proposer/single_site_random_walk_proposer.py
+++ b/src/beanmachine/ppl/inference/proposer/single_site_random_walk_proposer.py
@@ -49,7 +49,12 @@ class SingleSiteRandomWalkProposer(SingleSiteAncestralProposer):
 
         if is_constraint_eq(node_support, dist.constraints.real):
             return dist.Normal(node.value, self.step_size)
-        elif is_constraint_eq(node_support, dist.constraints.greater_than):
+        elif any(
+            is_constraint_eq(
+                node_support,
+                (dist.constraints.greater_than, dist.constraints.greater_than_eq),
+            )
+        ):
             lower_bound = node_support.lower_bound
             proposal_distribution = self.gamma_dist_from_moments(
                 node.value - lower_bound, self.step_size ** 2

--- a/src/beanmachine/ppl/inference/single_site_nmc.py
+++ b/src/beanmachine/ppl/inference/single_site_nmc.py
@@ -73,7 +73,12 @@ class SingleSiteNewtonianMonteCarlo(BaseInference):
         support = distribution.support
         if is_constraint_eq(support, dist.constraints.real):
             return SingleSiteRealSpaceNMCProposer(node, self.alpha, self.beta)
-        elif is_constraint_eq(support, dist.constraints.greater_than):
+        elif any(
+            is_constraint_eq(
+                support,
+                (dist.constraints.greater_than, dist.constraints.greater_than_eq),
+            )
+        ):
             return SingleSiteHalfSpaceNMCProposer(node)
         elif is_constraint_eq(support, dist.constraints.simplex) or (
             isinstance(support, dist.constraints.independent)


### PR DESCRIPTION
Summary:
This is to address the change in D36271169 where the support distributions like Gamma are changed from positive to nonnegative.

Currently, we use half space proposer for distributions whose support is `constraints.greater_than`, which includes Gamma. However, once the change in D36271169 is made, Gamma distribution will fall back to ancestral proposer. This diff address the issue by using half space proposer for  `constraints.greater_than_eq` as well :).

Differential Revision: D36291168

