### PR TITLE
Make AnyRequirement a singleton

### DIFF
--- a/src/beanmachine/ppl/compiler/bmg_requirements.py
+++ b/src/beanmachine/ppl/compiler/bmg_requirements.py
@@ -35,8 +35,8 @@ from beanmachine.ppl.compiler.lattice_typer import LatticeTyper
 # what their inputs are.
 
 _known_requirements: Dict[type, List[bt.Requirement]] = {
-    bn.Observation: [bt.AnyRequirement()],
-    bn.Query: [bt.AnyRequirement()],
+    bn.Observation: [bt.any_requirement],
+    bn.Query: [bt.any_requirement],
     # Distributions
     bn.BernoulliLogitNode: [bt.Real],
     bn.BernoulliNode: [bt.Probability],
@@ -54,7 +54,7 @@ _known_requirements: Dict[type, List[bt.Requirement]] = {
     # We'll need a special requirement with the semantics "input must be a matrix
     # with real, +real, -real or prob elements". To meet the requirement if unmet we
     # can simply insert a ToRealMatrix node.
-    bn.MatrixMultiplicationNode: [bt.AnyRequirement(), bt.AnyRequirement()],
+    bn.MatrixMultiplicationNode: [bt.any_requirement, bt.any_requirement],
     bn.PhiNode: [bt.Real],
     bn.ToIntNode: [bt.upper_bound(bt.Real)],
     bn.ToNegativeRealNode: [bt.Real],
@@ -436,7 +436,7 @@ class EdgeRequirements:
         if input_count == 0:
             result = []
         elif self.typer[node] == bt.Untypable:
-            result = [bt.AnyRequirement()] * input_count
+            result = [bt.any_requirement] * input_count
         else:
             t = type(node)
             if t in _known_requirements:
@@ -444,7 +444,7 @@ class EdgeRequirements:
             elif t in self._dispatch:
                 result = self._dispatch[t](node)
             else:
-                result = [bt.AnyRequirement()] * input_count
+                result = [bt.any_requirement] * input_count
 
         assert _requirements_valid(node, result)
         return result

--- a/src/beanmachine/ppl/compiler/bmg_types.py
+++ b/src/beanmachine/ppl/compiler/bmg_types.py
@@ -737,12 +737,15 @@ class BaseRequirement:
         self.long_name = long_name
 
 
-# TODO: Memoize these, remove memoization of construction functions below.
 class AnyRequirement(BaseRequirement):
     def __init__(self) -> None:
         BaseRequirement.__init__(self, "any", "any")
 
 
+any_requirement = AnyRequirement()
+
+
+# TODO: Memoize these, remove memoization of construction functions below.
 class UpperBound(BaseRequirement):
     bound: BMGLatticeType
 
@@ -774,7 +777,7 @@ def upper_bound(bound: Requirement) -> BaseRequirement:
         return upper_bound(bound.bound)
     if isinstance(bound, BMGLatticeType):
         return UpperBound(bound)
-    assert isinstance(bound, AnyRequirement)
+    assert bound is any_requirement
     return bound
 
 
@@ -798,7 +801,7 @@ def requirement_to_type(r: Requirement) -> BMGLatticeType:
 
 def must_be_matrix(r: Requirement) -> bool:
     """Does the requirement indicate that the edge must be a matrix?"""
-    if isinstance(r, AnyRequirement):
+    if r is any_requirement:
         return False
     if isinstance(r, AlwaysMatrix):
         return True

--- a/src/beanmachine/ppl/compiler/fix_requirements.py
+++ b/src/beanmachine/ppl/compiler/fix_requirements.py
@@ -47,7 +47,7 @@ class RequirementsFixer:
 
     def _type_meets_requirement(self, t: bt.BMGLatticeType, r: bt.Requirement) -> bool:
         assert t != bt.Untypable
-        if isinstance(r, bt.AnyRequirement):
+        if r is bt.any_requirement:
             return True
         if isinstance(r, bt.UpperBound):
             return bt.supremum(t, r.bound) == r.bound
@@ -86,7 +86,7 @@ class RequirementsFixer:
         # regarding UntypedConstantNode support.
 
         if self._type_meets_requirement(it, bt.upper_bound(requirement)):
-            if isinstance(requirement, bt.AnyRequirement):
+            if requirement is bt.any_requirement:
                 # The lattice type of the constant might be Zero or One; in that case,
                 # generate a bool constant node.
                 required_type = bt.lattice_to_bmg(it)


### PR DESCRIPTION
Summary: We represent edge requirements imposed by BMG by a requirement object; there is no reason why we ever need two or more instances of the object representing "there is no requirement imposed, anything will do".  I've made this object a singleton.

Reviewed By: ToddSmall

Differential Revision: D34827079

