### PR TITLE
Compiler now requires matmul operands to be real matrices

### DIFF
--- a/src/beanmachine/ppl/compiler/bmg_requirements.py
+++ b/src/beanmachine/ppl/compiler/bmg_requirements.py
@@ -50,11 +50,7 @@ _known_requirements: Dict[type, List[bt.Requirement]] = {
     # Operators
     bn.LogisticNode: [bt.Real],
     bn.Log1mexpNode: [bt.NegativeReal],
-    # TODO: We haven't implemented restrictions on matmul yet.
-    # We'll need a special requirement with the semantics "input must be a matrix
-    # with real, +real, -real or prob elements". To meet the requirement if unmet we
-    # can simply insert a ToRealMatrix node.
-    bn.MatrixMultiplicationNode: [bt.any_requirement, bt.any_requirement],
+    bn.MatrixMultiplicationNode: [bt.any_real_matrix, bt.any_real_matrix],
     bn.PhiNode: [bt.Real],
     bn.ToIntNode: [bt.upper_bound(bt.Real)],
     bn.ToNegativeRealNode: [bt.Real],

--- a/src/beanmachine/ppl/compiler/bmg_types.py
+++ b/src/beanmachine/ppl/compiler/bmg_types.py
@@ -745,6 +745,17 @@ class AnyRequirement(BaseRequirement):
 any_requirement = AnyRequirement()
 
 
+class AnyRealMatrix(BaseRequirement):
+    # BMG's matrix multiplication node requires that both inputs be
+    # a real, positive real, negative real or probability matrix.
+    # This singleton represents that requirement.
+    def __init__(self) -> None:
+        BaseRequirement.__init__(self, "ARM", "any real matrix")
+
+
+any_real_matrix = AnyRealMatrix()
+
+
 # TODO: Memoize these, remove memoization of construction functions below.
 class UpperBound(BaseRequirement):
     bound: BMGLatticeType
@@ -803,6 +814,8 @@ def must_be_matrix(r: Requirement) -> bool:
     """Does the requirement indicate that the edge must be a matrix?"""
     if r is any_requirement:
         return False
+    if r is any_real_matrix:
+        return True
     if isinstance(r, AlwaysMatrix):
         return True
     t = requirement_to_type(r)


### PR DESCRIPTION
Summary:
This diff completes my efforts to finish the implementation of matrix multiplication in the compiler. We now ensure that the inputs to any matrix multiplication are double-valued matrices, as required by BMG.

BMG requires that the inputs to a matrix multiplication be a matrix of doubles; whether reals, negative reals, positive reals or probabilities, it does not care so long as they are not naturals or bools. To ensure this:

* Constant matrices that are inputs are automatically emitted as double-valued matrices even if their elements are naturals.

* stochastic inputs that are not real, negative real, positive real or probability matrices have a to-real-matrix operator inserted on the edge.

Reviewed By: yucenli

Differential Revision: D34865292

