### PR TITLE
Finish implementing tensor sum operator in compiler

### DIFF
--- a/src/beanmachine/ppl/compiler/fix_problems.py
+++ b/src/beanmachine/ppl/compiler/fix_problems.py
@@ -8,7 +8,7 @@ from typing import Callable, List, Set
 import beanmachine.ppl.compiler.profiler as prof
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
 from beanmachine.ppl.compiler.error_report import ErrorReport
-from beanmachine.ppl.compiler.fix_additions import addition_fixer
+from beanmachine.ppl.compiler.fix_additions import addition_fixer, sum_fixer
 from beanmachine.ppl.compiler.fix_beta_conjugate_prior import (
     beta_bernoulli_conjugate_fixer,
     beta_binomial_conjugate_fixer,
@@ -71,6 +71,7 @@ _arithmetic_fixer_factories: List[
     matrix_scale_fixer,
     multiary_addition_fixer,
     multiary_multiplication_fixer,
+    sum_fixer,
     trivial_matmul_fixer,
     unsupported_node_fixer,
 ]

--- a/src/beanmachine/ppl/compiler/tests/bmg_arithmetic_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_arithmetic_test.py
@@ -2640,15 +2640,49 @@ digraph "graph" {
             sum_3(),
             sum_4(),
         ]
-        with self.assertRaises(ValueError) as ex:
-            BMGInference().infer(queries, {}, 1)
+
         expected = """
-The model uses a sum operation unsupported by Bean Machine Graph.
-The unsupported node was created in function call sum_3().
-The model uses a sum operation unsupported by Bean Machine Graph.
-The unsupported node was created in function call sum_4()."""
-        observed = str(ex.exception)
-        self.assertEqual(observed.strip(), expected.strip())
+digraph "graph" {
+  N00[label=3.0];
+  N01[label=Query];
+  N02[label=6.0];
+  N03[label=Query];
+  N04[label=2.0];
+  N05[label=Beta];
+  N06[label=Sample];
+  N07[label=0.0];
+  N08[label=1.0];
+  N09[label=Normal];
+  N10[label=Sample];
+  N11[label=ToReal];
+  N12[label=3.0];
+  N13[label="+"];
+  N14[label=Query];
+  N15[label=4.0];
+  N16[label="+"];
+  N17[label=Query];
+  N00 -> N01;
+  N02 -> N03;
+  N04 -> N05;
+  N04 -> N05;
+  N05 -> N06;
+  N06 -> N11;
+  N07 -> N09;
+  N08 -> N09;
+  N09 -> N10;
+  N10 -> N13;
+  N10 -> N16;
+  N11 -> N13;
+  N11 -> N16;
+  N12 -> N13;
+  N13 -> N14;
+  N15 -> N16;
+  N16 -> N17;
+}
+"""
+        observed = BMGInference().to_dot(queries, {})
+
+        self.assertEqual(expected.strip(), observed.strip())
 
     def test_bmg_arithmetic_xor(self) -> None:
         self.maxDiff = None


### PR DESCRIPTION
Summary:
We now rewrite a tensor sum node in the graph as (1) index into all the elements of the tensor, then (2) make those inputs the operands of a multiary addition node.

This will allow us to compile the sum operator used in the model we are investigating at present; however there are a number of shortcomings that we might wish to address in future diffs:

* Because we have no vector sum operator in BMG, we need to generate potentially O(n) index operations in order to sum a size-n vector, which is a potentially large increase in the number of nodes in the graph. If we had a vector sum operator in BMG we could skip this rewriter entirely.
* Torch allows sums of 2-d tensors; it does not sum each individual vector in the tensors, but rather simply sums every element. We could do the same in the compiler (or in BMG)

Reviewed By: yucenli

Differential Revision: D34909918

