### PR TITLE
Bump black to 22.3.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install linters
       run: |
         python -m pip install --upgrade pip
-        python -m pip install black==21.4b2 flake8==4.0.1 libcst==0.4.1 ufmt==1.3.2 usort==0.6.4
+        python -m pip install black==22.3.0 flake8==4.0.1 libcst==0.4.1 ufmt==1.3.2 usort==0.6.4
 
     - name: Print out package info to help with debug
       run: pip list

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ REQUIRED_MINOR = 7
 INSTALL_REQUIRES = [
     "arviz>=0.11.0",
     "astor>=0.7.1",
-    "black==21.4b2",
+    "black==22.3.0",
     "botorch>=0.5.1",
     "gpytorch>=1.3.0",
     "graphviz>=0.17",


### PR DESCRIPTION
Summary: Update the formatter following D36324783 (https://github.com/facebookresearch/beanmachine/commit/dd76e0eef5da73d41218b8cf0f2a071924e4a76f) to clear the lint exceptions

Differential Revision: D36337516

