### PR TITLE
Fix bug in multiplication devectorizer

### DIFF
--- a/src/beanmachine/ppl/compiler/fix_vectorized_models.py
+++ b/src/beanmachine/ppl/compiler/fix_vectorized_models.py
@@ -211,11 +211,17 @@ def _vectorized_operator_node_fixer(bmg: BMGraphBuilder, sizer: Sizer) -> NodeFi
         if type(n) not in operator_factories:
             return Inapplicable
         # We do not rewrite multiplications of matrices by scalars; that's
-        # handled in a later rewriter.
+        # handled in a later rewriter. If both operands are "fixable" then
+        # both are vectors or matrices. If one or both operands are not
+        # "fixable" then either they are scalars or higher-dimensional tensors.
+        # Either way, we can skip fixing the multiplication.
         if (
             isinstance(n, bn.MultiplicationNode)
             and len(n.inputs) == 2
-            and (len(sizer[n.inputs[0]]) <= 1 or len(sizer[n.inputs[1]]) <= 1)
+            and (
+                not _is_fixable_size(sizer[n.inputs[0]])
+                or not _is_fixable_size(sizer[n.inputs[1]])
+            )
         ):
             return Inapplicable
         if not _is_fixable_size(sizer[n]):


### PR DESCRIPTION
Summary:
The multiplication devectorizer is intended to find models which contain element-by-element tensor-style multiplication of 1-d or 2-d tensors, and decompose them into individual multiplications. (Because BMG does not support tensor multiplications.)  However, we have an operator in BMG for matrix-scalar multiplication. The intention of the code here was "do not devectorize multiplication if either operand is a scalar" but I accidentally wrote "do not devectorize if either operand is a 1-d vector or scalar", which is plainly wrong.

I've fixed the bug and created a test case which demonstrates that we do the devectorization correctly.

Reviewed By: wtaha

Differential Revision: D35264508

