### PR TITLE
Devectorizer is its own pass again

### DIFF
--- a/src/beanmachine/ppl/compiler/fix_matrix_scale.py
+++ b/src/beanmachine/ppl/compiler/fix_matrix_scale.py
@@ -12,31 +12,31 @@ from beanmachine.ppl.compiler.fix_problem import (
     NodeFixerResult,
 )
 from beanmachine.ppl.compiler.lattice_typer import LatticeTyper
+from beanmachine.ppl.compiler.sizer import Sizer, is_scalar
 
 
-def matrix_scale_fixer(bmg: BMGraphBuilder, typer: LatticeTyper) -> NodeFixer:
+def matrix_scale_fixer(bmg: BMGraphBuilder, sizer: Sizer) -> NodeFixer:
     """This node fixer attempts to rewrite binary multiplications that involve
     a matrix and a scalar into a matrix_scale node."""
 
     def fixer(n: bn.BMGNode) -> NodeFixerResult:
         # A matrix multiplication is fixable (to matrix_scale) if it is
-        # a binary multiplication with non-singleton result type
-        # and the type of one argument is matrix and the other is scalar
+        # a binary multiplication with non-singleton result size
+        # and the size of one argument is matrix and the other is scalar
         if not isinstance(n, bn.MultiplicationNode) or len(n.inputs) != 2:
             return Inapplicable
-        # The return type of the node should be matrix
-        if not typer[n].is_singleton():
-            return Inapplicable
-        # Now let's check the types of the inputs
-        input_types = [typer[i] for i in n.inputs]
+        # Now let's check the sizes of the inputs
+        input_scalars = [is_scalar(sizer[i]) for i in n.inputs]
         # If both are scalar, then there is nothing to do
-        if all(t.is_singleton() for t in input_types):
+        if all(input_scalars):
             return Inapplicable  # Both are scalar
         # If both are matrices, then there is nothing to do
-        if all(not (t.is_singleton()) for t in input_types):
+        if all(not t for t in input_scalars):
             return Inapplicable  # Both are matrices
+        # The return type of the node should be matrix
+        assert not is_scalar(sizer[n])
         left, right = n.inputs
-        if input_types[1].is_singleton():
+        if input_scalars[1]:
             scalar, matrix = right, left
         else:
             scalar, matrix = left, right

--- a/src/beanmachine/ppl/compiler/sizer.py
+++ b/src/beanmachine/ppl/compiler/sizer.py
@@ -192,6 +192,10 @@ def size_to_str(size: Size) -> str:
     return "[" + ",".join(str(i) for i in size) + "]"
 
 
+def is_scalar(s: Size) -> bool:
+    return all(d == 1 for d in s)
+
+
 class Sizer(TyperBase[Size]):
 
     _dispatch: Dict[type, Callable]


### PR DESCRIPTION
Summary:
In this stack I've been refactoring the graph rewriting passes to make them simpler and more composable, and fixing bugs in the devectorizer along the way.

As part of this set of change I made the devectorizer and arithmetic rewriter run as part of the same pass; that is, we run the devectorizer, then the arithmetic rewriter, then the devectorizer... and so on, until together they stop making progress and attain a fixpoint.

This turned out to be a bad idea due to an oddity in how we do type analysis of nodes. In this diff I undo that; the devectorizer is now the first pass, and it runs until it reaches a fixpoint. After that fixpoint is reached then we are DONE devectorizing; if there are still operators in the graph that are vectorized that BMG does not support, we will report that in the requirements checking pass.

The problem arises because we have two competing type systems making type judgments about nodes. The lattice typer answers the question "if this node were in a legal BMG graph, what type would the BMG type system give it?" The sizer answers the question "in the original BeanMachine model, what size tensor was the quantity corresponding to this node?"  Those can be different!

The problem can be illustrated with the model I've added as a test case, which contains this fragment:

    p = tensor([5.0, 6.0]) * (-beta1234()).log1p()

`beta1234` is a 2-element vector where the first element is from Beta(1, 2) and the second from Beta(3, 4).  If the devectorizer and arithmetic rewriter were working properly then this should be rewritten into the equivalent of:

    p1 = 5.0 * log(1-sample_from_beta_1_2)
    p2 = 6.0 * log(1-sample_from_beta_3_4)
    p = tensor([p1, p2])

which is has devectorized the multiplication, devectorized the samples, and rewritten the log1p(-p) into log(1-p).  (We would then go on to rewrite (1-p) into a complement node to attain a fixpoint.)

But that's not what happens when the devectorizer and arithmetic rewriter run sequentially until they jointly reach a fixpoint. What happens then is:

First the devectorizer deals with the samples and produces a graph equivalent to:

    b1 = -sample_from_beta_1_2
    b2 = -sample_from_beta_3_4
    b = tensor([b1, b2])
    p = tensor([5, 6]) * log1p(b)

Then the arithmetic optimizer says that log1p(x) is rewritten to log(1+x):

    b1 = -sample_from_beta_1_2
    b2 = -sample_from_beta_3_4
    b = tensor([b1, b2])
    p = tensor([5, 6]) * log(1+b)

Then the arithmetic optimizer gets it wrong. It detects that we have a constant vector multiplied by a stochastic log and asks the *lattice typer* for the types of both operands. The lattice typer says that *in BMG*, the tensor is a two-element vector and the log is a real number, because the devectorizer has not devectorized the log yet, and *in BMG* a log node is never a vector. The arithmetic rewriter then says fine, that's a matrix scale and generates a matrix scale operator with the log as the scalar and the constant vector as the matrix, but this is obviously wrong. The log is a vector, it just hasn't been rewritten yet.

The devectorizer then devectorizes the log and we end up with

    b1 = -sample_from_beta_1_2
    b2 = -sample_from_beta_3_4
    log1 = log(1-sample_from_beta_1_2)
    log2 = log(1-sample_from_beta_3_4)
    logs = tensor([log1, log2])
    p = MATRIX_SCALE(logs, tensor([5, 6]))

and now we have a matrix scale with two matrices and no scalars, and we've violated a BMG type invariant.

The solution I've arrived at is as described above. We must NOT run the devectorizer part way, and then the arithmetic rewriter part way, and then the devectorizer part way, and so on, because they use different type systems.

Rather, what we'll do is:

* Rewriting multiplications as matrix scale operators is a "devectorizing" operation, in that it is taking an operation that cannot handle vectors (BMG requires multiplicands to be all scalars) and turning it into one that *can* handle vectors.  The matrix scale rewriter has been updated to use the sizer rather than the lattice typer, and it runs as part of the devectorizing pass.

* The devectorizing pass no longer relies upon the arithmetic rewriter to eliminate log1p, log2, sqrt, and so on. Rather, it simply devectorizes them and then the arithmetic rewriter can rewrite the devectorized versions.

* Devectorizing is once again a pass that runs until it attains a fixpoint, and then we go on to run arithmetic rewriting until it attains a fixpoint.

With these changes we now start with:

    p = tensor([5.0, 6.0]) * (-beta1234()).log1p()

We then devectorize it fully, into:

    p1 = 5 * log1p(-sample_from_beta_1_2)
    p2 = 6 * log1p(-sample_from_beta_3_4)
    p = tensor([p1, p2])

and then the arithmetic rewriter runs until it attains a fixpoint, producing:

    p1 = 5 * log(complement(sample_from_beta_1_2))
    p2 = 6 * log(complement(sample_from_beta_3_4))
    p = tensor([p1, p2])

which is fully devectorized, has only operations supported by BMG, and meets the requirements of the BMG type system.

Reviewed By: yucenli

Differential Revision: D35664445

