### PR TITLE
Fix for mangled URLs in MDX

### DIFF
--- a/scripts/convert_ipynb_to_mdx.py
+++ b/scripts/convert_ipynb_to_mdx.py
@@ -8,9 +8,9 @@ import shutil
 import uuid
 from os import PathLike
 from pathlib import Path
-from textwrap import wrap
 from typing import Dict, Tuple, Union
 
+import mdformat
 import nbformat
 from nbformat.notebooknode import NotebookNode
 
@@ -95,22 +95,12 @@ def transform_markdown_cell(
         new_img_path = str(img_folder.joinpath(name))
         shutil.copy(str(old_img_path), new_img_path)
 
-    # Wrap lines using black's default of 88 characters. Used to help debug issues from
-    # the tutorials. Note that all tables (lines that start with |) are not wrapped as
-    # well as any LaTeX formulas that start new block math sections ($$).
-    cell_source = cell_source.splitlines()
-    math_lines = [i for i, line in enumerate(cell_source) if line.startswith("$$")]
-    math_lines = [(i, j) for i, j in zip(math_lines, math_lines[1:])]
-    math_line_check = [False] * len(cell_source)
-    for start, stop in math_lines:
-        math_line_check[start : stop + 1] = [True] * (stop + 1 - start)
-    new_cell_source = ""
-    for i, line in enumerate(cell_source):
-        if math_line_check[i] or line.startswith("|"):
-            new_cell_source += f"{line}\n"
-        elif not math_line_check[i]:
-            md = "\n".join(wrap(line, width=88, replace_whitespace=False))
-            new_cell_source += f"{md}\n"
+    # Wrap lines using black's default of 88 characters.
+    new_cell_source = mdformat.text(
+        cell_source,
+        options={"wrap": 88},
+        extensions={"myst"},
+    )
 
     return f"{new_cell_source}\n\n"
 

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,8 @@ TUTORIALS_REQUIRES = [
     "ipywidgets",
     "jupyter",
     "matplotlib",
+    "mdformat",
+    "mdformat-myst",
     "scikit-learn>=1.0.0",
     "seaborn",
     "torchvision",


### PR DESCRIPTION
### Changes proposed
- Updates the `convert_ipynb_to_mdx` script to use `mdformat` for
  formatting markdown cells.
- Includes `mdformat` and `mdformat-myst` as required dev packages in
  `setup.py`.
- Resolves #1465 

### Types of changes
- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](https://github.com/facebookresearch/beanmachine/blob/main/CONTRIBUTING.md)** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] The title of my pull request is a short description of the requested changes.