### PR TITLE
use plotting components in tutorials

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -98,7 +98,10 @@ module.exports = {
     },
   },
   stylesheets: ['https://cdn.jsdelivr.net/npm/katex@0.11.0/dist/katex.min.css'],
-  scripts: ['https://cdn.bokeh.org/bokeh/release/bokeh-2.4.2.min.js'],
+  scripts: [
+    'https://cdn.bokeh.org/bokeh/release/bokeh-2.4.2.min.js',
+    'https://cdn.bokeh.org/bokeh/release/bokeh-widgets-2.4.2.min.js',
+  ],
   presets: [
     [
       require.resolve('docusaurus-plugin-internaldocs-fb/docusaurus-preset'),

--- a/website/src/components/Plotting.jsx
+++ b/website/src/components/Plotting.jsx
@@ -33,15 +33,15 @@ const Plotly = Loadable({
     timedOut ? (
       <blockquote>Error: Loading Plotly timed out.</blockquote>
     ) : (
-      <div>phooey</div>
+      <div>loading...</div>
     ),
   timeout: 10000,
 });
 
-export const PlotlyFigure = React.memo(({data, layout}) => {
+export const PlotlyFigure = React.memo(({data}) => {
   return (
     <div className="plotly-figure">
-      <Plotly data={data} layout={layout} />
+      <Plotly data={data['data']} layout={data['layout']} />
     </div>
   );
 });


### PR DESCRIPTION
### Motivation
Use the React components directly in tutorials and do not generate an
extraneous `.jsx` file for those plots.

Resolves #1471 

### Changes proposed
- Update to `scripts/convert_ipynb_to_mdx.py` that adds Bokeh and Plotly
  figures directly to the MDX file generated by the converter.
  - Note that the `jsx` output from the convert is kept as it is going
    to be used for the Bokeh diagnostic tools when they become available.
- Update `website/src/components/Plotting.jsx` to handle data for Plotly
  component in the same way data is handled for the Bokeh component.
  Also, removed the poorly named loading div to something more
  appropriate.

### Test Plan
The website was built locally and tested against changes. Tutorials were
rebuilt with the component use and viewed to ensure they built
correctly.

### Types of changes
- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](https://github.com/facebookresearch/beanmachine/blob/main/CONTRIBUTING.md)** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] The title of my pull request is a short description of the requested changes.