### PR TITLE
Add optional dict posterior arguement to bm.simulate

### DIFF
--- a/src/beanmachine/ppl/inference/tests/predictive_test.py
+++ b/src/beanmachine/ppl/inference/tests/predictive_test.py
@@ -190,3 +190,30 @@ class PredictiveTest(unittest.TestCase):
             1,
             2,
         )
+
+    def test_posterior_dict(self):
+        obs = {
+            self.likelihood_i(0): torch.tensor(1.0),
+            self.likelihood_i(1): torch.tensor(0.0),
+        }
+
+        posterior = {self.prior(): torch.tensor([0.5, 0.5])}
+
+        predictives_dict = bm.simulate(list(obs.keys()), posterior)
+        assert predictives_dict[self.likelihood_i(0)].shape == (1, 2)
+        assert predictives_dict[self.likelihood_i(1)].shape == (1, 2)
+
+    def test_posterior_dict_predictive(self):
+        obs = {
+            self.likelihood_i(0): torch.tensor(1.0),
+            self.likelihood_i(1): torch.tensor(0.0),
+        }
+        post_samples = bm.SingleSiteAncestralMetropolisHastings().infer(
+            [self.prior()], obs, num_samples=10, num_chains=1
+        )
+        assert post_samples[self.prior()].shape == (1, 10)
+
+        post_samples_dict = dict(post_samples)
+        predictives_dict = bm.simulate(list(obs.keys()), post_samples_dict)
+        assert predictives_dict[self.likelihood_i(0)].shape == (1, 10)
+        assert predictives_dict[self.likelihood_i(1)].shape == (1, 10)


### PR DESCRIPTION
Summary:
I added an optional dictionary posterior argument to `bm.simulate`.
- I renamed the posterior `MonteCarloSamples` to `monte_carlo_posterior`
- I named the dictionary posterior argument `dict_posterior`
- I decided to add an optional `num_adaptive_samples` that defaults to 0. I added this because I noticed that we drop the warm-up samples, which are the `num_adaptive_samples` variable in  `MonteCarloSamples`.

Differential Revision: D36857476

