### PR TITLE
Rewrite multiplications of negative reals

### DIFF
--- a/src/beanmachine/ppl/compiler/fix_arithmetic.py
+++ b/src/beanmachine/ppl/compiler/fix_arithmetic.py
@@ -1,0 +1,75 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import beanmachine.ppl.compiler.bmg_nodes as bn
+import beanmachine.ppl.compiler.bmg_types as bt
+from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
+from beanmachine.ppl.compiler.fix_problem import (
+    Inapplicable,
+    NodeFixer,
+    NodeFixerResult,
+)
+from beanmachine.ppl.compiler.lattice_typer import LatticeTyper
+
+
+# TODO: Move this to a utilities module
+def _count(bs) -> int:
+    """Given a sequence of bools, count the Trues"""
+    return sum(1 for b in bs if b)
+
+
+def negative_real_multiplication_fixer(
+    bmg: BMGraphBuilder, typer: LatticeTyper
+) -> NodeFixer:
+    """This fixer rewrites multiplications involving negative reals into
+    multiplications using only positive reals."""
+
+    # The BMG type system requires that all inputs to a multiplication be of
+    # the same type and that the type is a floating point type. The output type
+    # is then the same as the input type. There are three possibilities:
+    #
+    # P  * P  --> P
+    # R  * R  --> R
+    # R+ * R+ --> R+
+    #
+    # This means that if we have MULT(R-, R+) then the requirements fixer will
+    # convert both inputs to R, and we will lose track of the fact that
+    # we could know in the type system that the result is a R-.
+    #
+    # This is particularly unfortunate when the negative real is a log probability.
+    # If we multiply a log probability by two, say, that is logically squaring
+    # the probability. We know that POW(P, 2) --> P, and MULT(P, P) --> P, but
+    # the BMG multiplication operator does not know that MULT(2, R-) is R-.
+    #
+    # We could solve this problem by modifying the BMG type system so that we
+    # allow mixed-type inputs to a multiplication; until we do so, we'll
+    # work around the problem here by rewriting multiplications that involve
+    # combinations of R-, R+ and P.
+
+    def _negative_real_multiplication_fixer(node: bn.BMGNode) -> NodeFixerResult:
+        if not isinstance(node, bn.MultiplicationNode):
+            return Inapplicable
+
+        # If no input is R- then we don't have a rewrite to do here.
+        count = _count(typer[inpt] == bt.NegativeReal for inpt in node.inputs)
+        if count == 0:
+            return Inapplicable
+
+        # If any input is R, we cannot prevent the output from being R.
+        if any(typer[inpt] == bt.Real for inpt in node.inputs):
+            return Inapplicable
+
+        new_mult = bmg.add_multi_multiplication(
+            *(
+                bmg.add_negate(inpt) if typer[inpt] == bt.NegativeReal else inpt
+                for inpt in node.inputs
+            )
+        )
+
+        if count % 2 != 0:
+            new_mult = bmg.add_negate(new_mult)
+        return new_mult
+
+    return _negative_real_multiplication_fixer

--- a/src/beanmachine/ppl/compiler/fix_problems.py
+++ b/src/beanmachine/ppl/compiler/fix_problems.py
@@ -9,6 +9,7 @@ import beanmachine.ppl.compiler.profiler as prof
 from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
 from beanmachine.ppl.compiler.error_report import ErrorReport
 from beanmachine.ppl.compiler.fix_additions import addition_fixer, sum_fixer
+from beanmachine.ppl.compiler.fix_arithmetic import negative_real_multiplication_fixer
 from beanmachine.ppl.compiler.fix_beta_conjugate_prior import (
     beta_bernoulli_conjugate_fixer,
     beta_binomial_conjugate_fixer,
@@ -61,6 +62,7 @@ _arithmetic_fixer_factories: List[
     logsumexp_fixer,
     multiary_addition_fixer,
     multiary_multiplication_fixer,
+    negative_real_multiplication_fixer,
     sum_fixer,
     trivial_matmul_fixer,
     unsupported_node_fixer,

--- a/src/beanmachine/ppl/compiler/tests/fix_multiary_ops_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_multiary_ops_test.py
@@ -7,7 +7,7 @@ import unittest
 
 import beanmachine.ppl as bm
 from beanmachine.ppl.inference import BMGInference
-from torch.distributions import Normal
+from torch.distributions import Bernoulli, Normal
 
 
 @bm.random_variable
@@ -53,6 +53,21 @@ def mult_3():
 @bm.functional
 def mult_4():
     return mult_1() * mult_2()
+
+
+@bm.random_variable
+def mult_negs_1():
+    # Verify that product of three negative reals is a negative real.
+    phi = Normal(0.0, 1.0).cdf
+    p1 = phi(norm(1))  # P
+    p2 = phi(norm(2))  # P
+    p3 = phi(norm(3))  # P
+    lp1 = p1.log()  # R-
+    lp2 = p2.log()  # R-
+    lp3 = p3.log()  # R-
+    prod = lp1 * lp2 * lp3  # Should be R-
+    ex = prod.exp()  # Should be P
+    return Bernoulli(ex)  # Should be legal
 
 
 class FixMultiaryOperatorTest(unittest.TestCase):
@@ -247,6 +262,61 @@ digraph "graph" {
   N11 -> N13;
   N12 -> N13;
   N13 -> N14;
+}
+"""
+        self.assertEqual(expected.strip(), observed.strip())
+
+    def test_fix_multiply_neg_reals(self) -> None:
+        self.maxDiff = None
+        observations = {}
+        queries = [mult_negs_1()]
+
+        observed = BMGInference().to_dot(queries, observations)
+        expected = """
+digraph "graph" {
+  N00[label=0.0];
+  N01[label=1.0];
+  N02[label=Normal];
+  N03[label=Sample];
+  N04[label=Sample];
+  N05[label=Sample];
+  N06[label=Phi];
+  N07[label=Log];
+  N08[label="-"];
+  N09[label=Phi];
+  N10[label=Log];
+  N11[label="-"];
+  N12[label=Phi];
+  N13[label=Log];
+  N14[label="-"];
+  N15[label="*"];
+  N16[label="-"];
+  N17[label=Exp];
+  N18[label=Bernoulli];
+  N19[label=Sample];
+  N20[label=Query];
+  N00 -> N02;
+  N01 -> N02;
+  N02 -> N03;
+  N02 -> N04;
+  N02 -> N05;
+  N03 -> N06;
+  N04 -> N09;
+  N05 -> N12;
+  N06 -> N07;
+  N07 -> N08;
+  N08 -> N15;
+  N09 -> N10;
+  N10 -> N11;
+  N11 -> N15;
+  N12 -> N13;
+  N13 -> N14;
+  N14 -> N15;
+  N15 -> N16;
+  N16 -> N17;
+  N17 -> N18;
+  N18 -> N19;
+  N19 -> N20;
 }
 """
         self.assertEqual(expected.strip(), observed.strip())

--- a/src/beanmachine/ppl/compiler/tests/fix_vectorized_models_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_vectorized_models_test.py
@@ -1010,19 +1010,21 @@ digraph "graph" {
   N04[label=Sample];
   N05[label=complement];
   N06[label=Log];
-  N07[label=ToReal];
+  N07[label="-"];
   N08[label="*"];
-  N09[label=6.0];
-  N10[label=2.0];
-  N11[label=4.0];
-  N12[label=Beta];
-  N13[label=Sample];
-  N14[label=complement];
-  N15[label=Log];
-  N16[label=ToReal];
-  N17[label="*"];
-  N18[label="+"];
-  N19[label=Query];
+  N09[label="-"];
+  N10[label=6.0];
+  N11[label=2.0];
+  N12[label=4.0];
+  N13[label=Beta];
+  N14[label=Sample];
+  N15[label=complement];
+  N16[label=Log];
+  N17[label="-"];
+  N18[label="*"];
+  N19[label="-"];
+  N20[label="+"];
+  N21[label=Query];
   N00 -> N08;
   N01 -> N03;
   N02 -> N03;
@@ -1031,10 +1033,10 @@ digraph "graph" {
   N05 -> N06;
   N06 -> N07;
   N07 -> N08;
-  N08 -> N18;
-  N09 -> N17;
-  N10 -> N12;
-  N11 -> N12;
+  N08 -> N09;
+  N09 -> N20;
+  N10 -> N18;
+  N11 -> N13;
   N12 -> N13;
   N13 -> N14;
   N14 -> N15;
@@ -1042,6 +1044,8 @@ digraph "graph" {
   N16 -> N17;
   N17 -> N18;
   N18 -> N19;
+  N19 -> N20;
+  N20 -> N21;
 }
 """
         self.assertEqual(expected.strip(), observed.strip())


### PR DESCRIPTION
Summary:
While working on compiling the GEP model I noticed that the BMG type system loses track of the sign of negative reals when multiplied by a positive real.

This is because BMG's multiplication node requires that all inputs be the same type and that the type be real, positive real or probability. This means that the output type is always the same as the input type.

Unfortunately this means that `R- * R-` is of type `R`, not `R+`, and `R- * R+` is of type `R` and not `R-`, because in both cases the type requirements fixer concludes that `R * R --> R` is the only valid choice.

This is unfortunate when working with log probs. If we have probability p and we would like the log prob of p squared then `2 * log(p)` is sensible, but BMG then believes that the result is real, not negative real.

We can fix this problem by changing BMG to allow mixed negative real and positive real inputs to multiplications, but until then we can work around the problem by detecting affected multiplications and inserting negate nodes appropriately to ensure that all multiplications of mixed R- and R+ are done as R+ inputs to the multiplication, and then we optionally insert a negate at the end to ensure that the total number of negate nodes inserted is even.

Reviewed By: gafter

Differential Revision: D35767778

