### PR TITLE
Implemented MALA proposer in bean machine

### DIFF
--- a/src/beanmachine/ppl/inference/proposer/mala_proposer.py
+++ b/src/beanmachine/ppl/inference/proposer/mala_proposer.py
@@ -1,0 +1,88 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Set, Tuple
+
+import torch
+from beanmachine.ppl.inference.proposer.hmc_proposer import HMCProposer
+from beanmachine.ppl.model.rv_identifier import RVIdentifier
+from beanmachine.ppl.world import World
+
+
+class MALAProposer(HMCProposer):
+    """
+        The Metropolis Adapted Langevin Algorithm sampler [1] implemented as a special
+        case of Hamiltonian Monte Carlo (HMC) algorithm with a single step as described in [2]
+
+        Reference:
+            [1] Gareth O. Roberts and Richard L. Tweedie, "Exponential Convergence of Langevin Distributions and Their Discrete
+    Approximations" (1996). https://www2.stat.duke.edu/~scs/Courses/Stat376/Papers/Langevin/RobertsTweedieBernoulli1996.pdf
+            [2] Radford Neal. "MCMC Using Hamiltonian Dynamics" (2011).
+                https://arxiv.org/abs/1206.1901
+
+        Args:
+            initial_world: Initial world to propose from.
+            target_rvs: Set of RVIdentifiers to indicate which variables to propose.
+            num_adaptive_samples: Number of adaptive samples to run.
+            initial_step_size: Initial step size.
+            adapt_step_size: Flag whether to adapt step size, defaults to True.
+            adapt_mass_matrix: Flat whether to adapt mass matrix, defaults to True.
+            target_accept_prob: Target accept prob, defaults to 0.8.
+            nnc_compile: (Experimental) If True, NNC compiler will be used to accelerate the
+                inference (defaults to False).
+    """
+
+    def __init__(
+        self,
+        initial_world: World,
+        target_rvs: Set[RVIdentifier],
+        num_adaptive_samples: int,
+        initial_step_size: float = 1.0,
+        adapt_step_size: bool = True,
+        adapt_mass_matrix: bool = True,
+        target_accept_prob: float = 0.8,
+        nnc_compile: bool = False,
+    ):
+        arbitrary_trajectory_value = 0.0
+        super().__init__(
+            initial_world,
+            target_rvs,
+            num_adaptive_samples,
+            trajectory_length=arbitrary_trajectory_value,
+            initial_step_size=initial_step_size,
+            adapt_step_size=adapt_step_size,
+            adapt_mass_matrix=adapt_mass_matrix,
+            target_accept_prob=target_accept_prob,
+            nnc_compile=nnc_compile,
+        )
+
+    def propose(self, world: World) -> Tuple[World, torch.Tensor]:
+        if world is not self.world:
+            # re-compute cached values since world was modified by other sources
+            self.world = world
+            self._positions = self._to_unconstrained(
+                {node: world[node] for node in self._target_rvs}
+            )
+            self._pe, self._pe_grad = self._potential_grads(self._positions)
+        momentums = self._initialize_momentums(self._positions)
+        current_energy = self._hamiltonian(
+            self._positions, momentums, self._mass_inv, self._pe
+        )
+        # only one leapfrog step is used.
+        positions, momentums, pe, pe_grad = self._leapfrog_step(
+            self._positions, momentums, self.step_size, self._mass_inv, self._pe_grad
+        )
+        new_energy = torch.nan_to_num(
+            self._hamiltonian(positions, momentums, self._mass_inv, pe),
+            float("inf"),
+        )
+        delta_energy = new_energy - current_energy
+        self._alpha = torch.clamp(torch.exp(-delta_energy), max=1.0)
+        # accept/reject new world
+        if torch.bernoulli(self._alpha):
+            self.world = self.world.replace(self._to_unconstrained.inv(positions))
+            # update cache
+            self._positions, self._pe, self._pe_grad = positions, pe, pe_grad
+        return self.world, torch.zeros_like(self._alpha)

--- a/src/beanmachine/ppl/inference/proposer/tests/mala_proposer_test.py
+++ b/src/beanmachine/ppl/inference/proposer/tests/mala_proposer_test.py
@@ -1,0 +1,58 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import beanmachine.ppl as bm
+import pytest
+import torch
+import torch.distributions as dist
+from beanmachine.ppl.inference.proposer.mala_proposer import MALAProposer
+from beanmachine.ppl.world import World
+
+
+@bm.random_variable
+def foo():
+    return dist.Uniform(0.0, 1.0)
+
+
+@bm.random_variable
+def bar():
+    return dist.Normal(foo(), 1.0)
+
+
+@pytest.fixture
+def world():
+    w = World()
+    w.call(bar())
+    return w
+
+
+@pytest.fixture
+def mala(world):
+    mala_proposer = MALAProposer(world, world.latent_nodes, 5)
+    return mala_proposer
+
+
+def test_aller_retour(mala):
+    """
+    Test that the sampler comes back to the initial phase space point after reversing momentum.
+    """
+    step_size = 0.1
+    tolerance = 1e-6
+    momentums = mala._initialize_momentums(mala._positions)
+    intermediate_positions, intermediate_momentums, pe, pe_grad = mala._leapfrog_step(
+        mala._positions, momentums, step_size, mala._mass_inv
+    )
+    new_positions, new_momentums, pe, pe_grad = mala._leapfrog_step(
+        intermediate_positions, intermediate_momentums, -step_size, mala._mass_inv
+    )
+    for (_init_node, init_z), (_final_node, final_z) in zip(
+        mala._positions.items(), new_positions.items()
+    ):
+        assert torch.isclose(init_z, final_z, atol=tolerance)
+
+    for (_init_node, init_r), (_final_node, final_r) in zip(
+        momentums.items(), new_momentums.items()
+    ):
+        assert torch.isclose(init_r, final_r, atol=tolerance)


### PR DESCRIPTION
Summary:
Implemented MALAProposer by subclassing the HMCProposer and limiting it to 1 leapfrog step. The HMCPRoposer has a required attribute called trajectory_length which is not required in MALA because it takes only 1 leapfrog step. Three design alternatives were considered in the overridden method: .__init__() .propose():
1. Make trajectory_length an optional parameter for the methods in HMCProposer.
2. Re-use the base constructor with a hardcoded arbitrary value for trajectory_length and handle it internally in the MALAProposer class.
3. Reuse code and reimplement methods to not require trajectory_length in MAlAProposer.
Option 3 was chosen to not break future changes and / or explicit design choices in HMCProposer.

Differential Revision: D37008050

