### PR TITLE
Mini BMG output from compiler

### DIFF
--- a/minibmg/minibmg.h
+++ b/minibmg/minibmg.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace beanmachine::minibmg {
+
+class GraphFactory {
+ public:
+  uint add_constant(double value);
+  uint add_operator(OperatorType op, std::vector<uint> parents);
+  Node* get_node(uint node_id);
+  Graph build();
+
+ private:
+  std::vector<Node*> nodes;
+};
+
+class Graph {
+ public:
+  const std::vector<graph::Node*>& nodes;
+};
+
+class Node {
+ public:
+  const uint sequence;
+  const Operator operator;
+  const Type type;
+};
+
+class OperatorNode : Node {
+ public:
+  const std::vector<graph::Node*>& in_nodes;
+}
+
+class ConstantNode : Node {
+ public:
+  const double value;
+};
+
+class QueryNode : OperatorNode {
+ public:
+  const uint query_index;
+}
+
+enum Operator {
+  // A scalar constant, like 1.2
+  // Result: the given constant value (REAL)
+  CONSTANT,
+  // A normal distribution.
+  // Parameters:
+  // - mean (REAL)
+  // - standard deviation (REAL)
+  // Result: the distribution (DISTRIBUTION)
+  DISTRIBUTION_NORMAL,
+  // A beta distribution.
+  // Parameters:
+  // - ??? (REAL)
+  // - ??? (REAL)
+  // Result: the distribution.
+  DISTRIBUTION_BETA,
+  // A bernoulli distribution (DISTRIBUTION)
+  // Parameters:
+  // - probability of yeilding 1 (as opposed to 0) (REAL)
+  // Result: the distribution (DISTRIBUTION)
+  DISTRIBUTION_BERNOULLI,
+  // Draw a sample from the distribution parameter.
+  // Parameters:
+  // - ditribution
+  // Result: the distribution (DISTRIBUTION)
+  SAMPLE,
+  // Observe a sample from the distribution parameter.
+  // Parameters:
+  // - ditribution (DISTRIBUTION)
+  // - value (REAL)
+  // Result: The given value (NONE)
+  OBSERVE,
+  // Query an intermediate result in the graph.
+  // Parameters:
+  // - value (REAL)
+  // Result: NONE.
+  QUERY,
+};
+
+enum Type {
+  // No type.  For example, the result of an observation node.
+  NONE,
+  // A scalar real value.
+  REAL,
+  // A distribution of real values.
+  DISTRIBUTION,
+};
+
+} // namespace beanmachine::minibmg

--- a/minibmg/sample.json
+++ b/minibmg/sample.json
@@ -1,0 +1,72 @@
+{
+    "comment" : "everything other than nodes is optional",
+    "nodes" : [
+        {
+            "sequence" : 0,
+            "operator" : "CONSTANT",
+            "type" : "REAL",
+            "value" : 2
+        },
+        {
+            "sequence" : 1,
+            "operator" : "DISTRIBUTION_BETA",
+            "type" : "DISTRIBUTION",
+            "in_nodes" : [ 0, 0 ]
+        },
+        {
+            "sequence" : 2,
+            "operator" : "SAMPLE",
+            "type" : "REAL",
+            "in_nodes" : [ 1 ]
+        },
+        {
+            "sequence" : 3,
+            "operator" : "DISTRIBUTION_BERNOULLI",
+            "type" : "DISTRIBUTION",
+            "in_nodes" : [ 2 ]
+        },
+        {
+            "sequence" : 4,
+            "operator" : "CONSTANT",
+            "type" : "REAL",
+            "value" : 0
+        },
+        {
+            "sequence" : 5,
+            "operator" : "CONSTANT",
+            "type" : "REAL",
+            "value" : 1
+        },
+        {
+            "sequence" : 6,
+            "operator" : "OBSERVE",
+            "type" : "NONE",
+            "in_nodes" : [ 3, 5 ]
+        },
+        {
+            "sequence" : 7,
+            "operator" : "OBSERVE",
+            "type" : "NONE",
+            "in_nodes" : [ 3, 5 ]
+        },
+        {
+            "sequence" : 8,
+            "operator" : "OBSERVE",
+            "type" : "NONE",
+            "in_nodes" : [ 3, 5 ]
+        },
+        {
+            "sequence" : 8,
+            "operator" : "OBSERVE",
+            "type" : "NONE",
+            "in_nodes" : [ 3, 4 ]
+        },
+        {
+            "sequence" : 9,
+            "operator" : "QUERY",
+            "type" : "NONE",
+            "in_nodes" : [ 2 ],
+            "query_index" : 0
+        }
+    ]
+}

--- a/src/beanmachine/ppl/compiler/gen_mini.py
+++ b/src/beanmachine/ppl/compiler/gen_mini.py
@@ -1,0 +1,214 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import json
+from typing import Any, Dict, List, Optional
+
+import beanmachine.ppl.compiler.bmg_nodes as bn
+from beanmachine.ppl.compiler.bm_graph_builder import BMGraphBuilder
+
+_node_type_to_distribution = {
+    bn.BernoulliNode: "DISTRIBUTION_BERNOULLI",
+    bn.BetaNode: "DISTRIBUTION_BETA",
+    bn.NormalNode: "DISTRIBUTION_NORMAL",
+}
+
+_node_type_to_operator = {
+    bn.MultiplicationNode: "MULTIPLY",
+    bn.SampleNode: "SAMPLE",
+}
+
+MiniNode = Dict[str, Any]
+
+
+class ToMini:
+    _node_to_mini_node: Dict[bn.BMGNode, MiniNode]
+    _observed_constants: int
+    _queries: int
+    _mini_nodes: List[MiniNode]
+
+    def __init__(self) -> None:
+        self._node_to_mini_node = {}
+        self._observed_constants = 0
+        self._queries = 0
+        self._mini_nodes = []
+
+    def to_json(self, bmg: BMGraphBuilder, indent=None) -> str:
+        self._observed_constants = 0
+        self._queries = 0
+        self._mini_nodes = []
+        self._node_to_mini_node = {}
+        # all_ancestor_nodes enumerates all samples, queries,
+        # observations, and all of their ancestors, in topo-sorted
+        # order, parents before children.
+        for node in bmg.all_ancestor_nodes():
+            self._add_node_to_mini_nodes(node)
+        mini = {
+            "comment": "Mini BMG",
+            "nodes": self._mini_nodes,
+        }
+        return json.dumps(mini, indent=indent)
+
+    def _add_mini_node(self, mini: MiniNode) -> None:
+        mini["sequence"] = len(self._mini_nodes)
+        self._mini_nodes.append(mini)
+
+    def _node_to_mini_seq(self, node: bn.BMGNode) -> int:
+        return self._node_to_mini_node[node]["sequence"]
+
+    def _add_inputs(self, mini: MiniNode, node: bn.BMGNode) -> None:
+        in_nodes = [self._node_to_mini_seq(i) for i in node.inputs]
+        if len(in_nodes) > 0:
+            mini["in_nodes"] = in_nodes
+
+    def _make_query(self, node: bn.Query) -> MiniNode:
+        mini: MiniNode = {
+            "operator": "QUERY",
+            "type": "NONE",
+            "query_index": self._queries,
+        }
+        self._queries += 1
+        self._add_inputs(mini, node)
+        return mini
+
+    def _make_constant(self, value: Any) -> MiniNode:
+        return {
+            "operator": "CONSTANT",
+            "type": "REAL",
+            "value": float(value),  # TODO: Deal with tensors
+        }
+
+    def _make_distribution(self, node: bn.DistributionNode) -> MiniNode:
+        op = _node_type_to_distribution[type(node)]  # pyre-ignore
+        mini: MiniNode = {
+            "operator": op,
+            "type": "DISTRIBUTION",
+        }
+        self._add_inputs(mini, node)
+        return mini
+
+    def _make_operator(self, node: bn.OperatorNode) -> MiniNode:
+        op = _node_type_to_operator[type(node)]  # pyre-ignore
+        mini: Dict[str, Any] = {
+            "operator": op,
+            "type": "REAL",
+        }
+        self._add_inputs(mini, node)
+        return mini
+
+    def _is_observed_sample(self, node: bn.BMGNode) -> bool:
+        return isinstance(node, bn.SampleNode) and any(
+            isinstance(o, bn.Observation) for o in node.outputs.items
+        )
+
+    def _get_sample_observation(self, node: bn.SampleNode) -> Any:
+        for o in node.outputs.items:
+            if isinstance(o, bn.Observation):
+                return o.value
+        return None
+
+    def _make_observed_sample(self, node: bn.SampleNode) -> None:
+        # Various parts of our system handle observations slightly
+        # differently, which can be somewhat confusing. Here is how
+        # it works:
+        #
+        # * In the graph accumulator, an observation is a node whose
+        #   parent is a sample node, and which contains a constant.
+        #
+        # * In BMG, an observation is not a node. Rather, it is an
+        #   annotation associating a value with a sample node.
+        #
+        # * In MiniBMG, both the observation and the observed value
+        #   are nodes, and observations are parented by a distribution,
+        #   not by a sample. In this system, observations are essentially
+        #   a special kind of sample that has two parents: a distribution
+        #   and a value.
+        #
+        # How then will we transform the accumulated graph into MiniBMG?
+        #
+        # Suppose we have accumulated this graph, for arbitrary subgraphs
+        # X and Y:
+        #
+        #             2
+        #            / \
+        #            BETA
+        #              |   \
+        #          SAMPLE   QUERY
+        #              |
+        #         BERNOULLI
+        #         /        \
+        #       SAMPLE    SAMPLE
+        #      /       \      |
+        #   OBSERVE(0)  X     Y
+        #
+        # then we will emit this MiniBMG:
+        #
+        #             2
+        #            / \
+        #            BETA
+        #              |   \
+        #          SAMPLE   QUERY
+        #              |
+        #    0    BERNOULLI
+        #   / \   /      \
+        #  X   OBSERVE   SAMPLE
+        #                 |
+        #                 Y
+        #
+        # Note that subgraph X has been re-parented to the constant,
+        # and the OBSERVE is also a child of the constant.
+        #
+        # We return None here because this code already takes care
+        # of ensuring that the new nodes are added to the list,
+        # that a sequence id is generated, and that the observed
+        # sample is mapped to the mini const.
+
+        ob = self._get_sample_observation(node)
+        mini_const = self._make_constant(ob)
+        self._add_mini_node(mini_const)
+        const_seq = mini_const["sequence"]
+        dist_seq = self._node_to_mini_seq(node.operand)
+        in_nodes = [dist_seq, const_seq]
+        mini_obs = {
+            "operator": "OBSERVE",
+            "type": "NONE",
+            "in_nodes": in_nodes,
+        }
+        self._add_mini_node(mini_obs)
+        self._node_to_mini_node[node] = mini_const
+
+    def _add_node_to_mini_nodes(self, node: bn.BMGNode) -> None:
+        mini: Optional[MiniNode] = None
+        if self._is_observed_sample(node):
+            # We have special handling for observed queries.
+            # mini stays None because the special handler ensures
+            # that the maps are set up correctly.
+            assert isinstance(node, bn.SampleNode)
+            self._make_observed_sample(node)
+        elif isinstance(node, bn.Observation):
+            # We do nothing when we encounter an observation node.
+            # Rather, the observation is added to MiniBMG state
+            # when the observed sample is handled.
+            pass
+        elif isinstance(node, bn.Query):
+            mini = self._make_query(node)
+        elif isinstance(node, bn.ConstantNode):
+            mini = self._make_constant(node.value)
+        elif isinstance(node, bn.DistributionNode):
+            mini = self._make_distribution(node)
+        elif isinstance(node, bn.OperatorNode):
+            mini = self._make_operator(node)
+        else:
+            raise ValueError(f"{type(node)} is not supported by miniBMG")
+
+        if mini is not None:
+            self._add_mini_node(mini)
+            self._node_to_mini_node[node] = mini
+
+
+def to_mini(bmg: BMGraphBuilder, indent=None) -> str:
+    # TODO: Run an error checking pass that rejects nodes
+    # we cannot map to Mini BMG
+    return ToMini().to_json(bmg, indent=indent)

--- a/src/beanmachine/ppl/compiler/tests/gen_mini_test.py
+++ b/src/beanmachine/ppl/compiler/tests/gen_mini_test.py
@@ -1,0 +1,183 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import beanmachine.ppl as bm
+from beanmachine.ppl.inference.bmg_inference import BMGInference
+from torch import tensor
+from torch.distributions import Bernoulli, Beta, Normal
+
+
+@bm.random_variable
+def beta():
+    return Beta(2.0, 2.0)
+
+
+@bm.random_variable
+def flip(n):
+    return Bernoulli(beta() * 0.5)
+
+
+@bm.random_variable
+def normal(n):
+    return Normal(flip(n), 1.0)
+
+
+class CoinFlipTest(unittest.TestCase):
+    def test_gen_mini(self) -> None:
+        self.maxDiff = None
+        # In the MiniBMG graph, the fact that we've observed
+        # the flip(0) input to Normal(flip(0), 1.0) should ensure
+        # that it is emitted into the graph as Normal(0.0, 1.0)
+        queries = [beta(), normal(0), normal(1)]
+        observations = {
+            flip(0): tensor(0.0),
+        }
+        observed = BMGInference()._to_mini(queries, observations, indent=2)
+        expected = """
+{
+  "comment": "Mini BMG",
+  "nodes": [
+    {
+      "operator": "CONSTANT",
+      "type": "REAL",
+      "value": 2.0,
+      "sequence": 0
+    },
+    {
+      "operator": "DISTRIBUTION_BETA",
+      "type": "DISTRIBUTION",
+      "in_nodes": [
+        0,
+        0
+      ],
+      "sequence": 1
+    },
+    {
+      "operator": "SAMPLE",
+      "type": "REAL",
+      "in_nodes": [
+        1
+      ],
+      "sequence": 2
+    },
+    {
+      "operator": "CONSTANT",
+      "type": "REAL",
+      "value": 0.5,
+      "sequence": 3
+    },
+    {
+      "operator": "MULTIPLY",
+      "type": "REAL",
+      "in_nodes": [
+        2,
+        3
+      ],
+      "sequence": 4
+    },
+    {
+      "operator": "DISTRIBUTION_BERNOULLI",
+      "type": "DISTRIBUTION",
+      "in_nodes": [
+        4
+      ],
+      "sequence": 5
+    },
+    {
+      "operator": "CONSTANT",
+      "type": "REAL",
+      "value": 0.0,
+      "sequence": 6
+    },
+    {
+      "operator": "OBSERVE",
+      "type": "NONE",
+      "in_nodes": [
+        5,
+        6
+      ],
+      "sequence": 7
+    },
+    {
+      "operator": "QUERY",
+      "type": "NONE",
+      "query_index": 0,
+      "in_nodes": [
+        2
+      ],
+      "sequence": 8
+    },
+    {
+      "operator": "CONSTANT",
+      "type": "REAL",
+      "value": 1.0,
+      "sequence": 9
+    },
+    {
+      "operator": "DISTRIBUTION_NORMAL",
+      "type": "DISTRIBUTION",
+      "in_nodes": [
+        6,
+        9
+      ],
+      "sequence": 10
+    },
+    {
+      "operator": "SAMPLE",
+      "type": "REAL",
+      "in_nodes": [
+        10
+      ],
+      "sequence": 11
+    },
+    {
+      "operator": "QUERY",
+      "type": "NONE",
+      "query_index": 1,
+      "in_nodes": [
+        11
+      ],
+      "sequence": 12
+    },
+    {
+      "operator": "SAMPLE",
+      "type": "REAL",
+      "in_nodes": [
+        5
+      ],
+      "sequence": 13
+    },
+    {
+      "operator": "DISTRIBUTION_NORMAL",
+      "type": "DISTRIBUTION",
+      "in_nodes": [
+        13,
+        9
+      ],
+      "sequence": 14
+    },
+    {
+      "operator": "SAMPLE",
+      "type": "REAL",
+      "in_nodes": [
+        14
+      ],
+      "sequence": 15
+    },
+    {
+      "operator": "QUERY",
+      "type": "NONE",
+      "query_index": 2,
+      "in_nodes": [
+        15
+      ],
+      "sequence": 16
+    }
+  ]
+}
+        """
+        self.assertEqual(expected.strip(), observed.strip())

--- a/src/beanmachine/ppl/inference/bmg_inference.py
+++ b/src/beanmachine/ppl/inference/bmg_inference.py
@@ -18,6 +18,7 @@ from beanmachine.ppl.compiler.gen_bmg_cpp import to_bmg_cpp
 from beanmachine.ppl.compiler.gen_bmg_graph import to_bmg_graph
 from beanmachine.ppl.compiler.gen_bmg_python import to_bmg_python
 from beanmachine.ppl.compiler.gen_dot import to_dot
+from beanmachine.ppl.compiler.gen_mini import to_mini
 from beanmachine.ppl.compiler.performance_report import PerformanceReport
 from beanmachine.ppl.compiler.runtime import BMGRuntime
 from beanmachine.ppl.inference.monte_carlo_samples import MonteCarloSamples
@@ -294,6 +295,16 @@ class BMGInference:
             label_edges,
             skip_optimizations,
         )
+
+    def _to_mini(
+        self,
+        queries: List[RVIdentifier],
+        observations: Dict[RVIdentifier, torch.Tensor],
+        indent=None,
+    ) -> str:
+        """Internal test method for Neal's MiniBMG prototype."""
+        bmg = self._accumulate_graph(queries, observations)._bmg
+        return to_mini(bmg, indent)
 
     def to_graphviz(
         self,


### PR DESCRIPTION
Summary:
Neal's experiment with a mini version of BMG will have a JSON-based serialization format for graphs; in this diff I add a private `_to_mini` method to `BMGInference` which accumulates a graph and then dumps it out in this JSON format without otherwise rewriting the graph or checking for correctness.

This is intended as an expedient way to get end-to-end testing of this experiment sooner rather than later.

Reviewed By: gafter

Differential Revision: D37157629

