### PR TITLE
Replicate graph-only-related MH class members in Graph

### DIFF
--- a/src/beanmachine/graph/distribution/distribution.h
+++ b/src/beanmachine/graph/distribution/distribution.h
@@ -33,10 +33,15 @@ class Distribution : public graph::Node {
     throw std::runtime_error(
         "internal error: eval() is not implemented for distribution");
   }
-  // tell the compiler that we want the base class log_prob method
-  // as well as the new one in this class
-  using graph::Node::log_prob;
+
   virtual double log_prob(const graph::NodeValue& value) const = 0;
+
+  // The base class declares a method log_prob() that we want to preserve.
+  // However, this class declared log_prob(const NodeValue&) which hides it.
+  // For this reason, we must use the following using directive which
+  // preserves the base class method as available.
+  using graph::Node::log_prob;
+
   virtual void log_prob_iid(
       const graph::NodeValue& /* value */,
       Eigen::MatrixXd& /* log_probs */) const {}

--- a/src/beanmachine/graph/gibbs.cpp
+++ b/src/beanmachine/graph/gibbs.cpp
@@ -17,6 +17,7 @@
 namespace beanmachine {
 namespace graph {
 
+// TODO: move this inference method out of Graph.
 void Graph::gibbs(uint num_samples, uint seed, InferConfig infer_config) {
   std::mt19937 gen(seed);
   std::set<uint> supp = compute_support();

--- a/src/beanmachine/graph/graph.cpp
+++ b/src/beanmachine/graph/graph.cpp
@@ -480,7 +480,7 @@ double Graph::log_prob(uint src_idx) {
 }
 
 // TODO: this is the one actually used in code (as opposed to full_log_prob used
-// in testing only, so why the _?)
+// in testing only, so why the _ indicating a private method?)
 double Graph::_full_log_prob(std::vector<Node*>& ordered_supp) {
   double sum_log_prob = 0.0;
   std::mt19937 generator(12131); // seed is irrelevant for deterministic ops
@@ -498,7 +498,7 @@ double Graph::_full_log_prob(std::vector<Node*>& ordered_supp) {
           // log(f_Y(y)) = log(f_X(x)) + log(|d/dy f^{-1}(y)|)
           //   = node->log_prob() + log_abs_jacobian_determinant()
           // TODO: rename log_abs_jacobian_determinant
-          // to log_abs_jacobian_detesrminant_of_inverse_transform
+          // to log_abs_jacobian_determinant_of_inverse_transform
           //
           // References on Change of Variables in statistics:
           // https://online.stat.psu.edu/stat414/lesson/22/22.2

--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -969,6 +969,116 @@ struct Graph {
   }
 
   void reindex_nodes();
+
+  // members brought in from MH class since they are really Graph properties
+ public:
+  // A graph maintains of a vector of nodes; the index into that vector is
+  // the id of the node. We often need to translate from node ids into node
+  // pointers; to do so quickly we obtain the address of
+  // every node in the graph up front and then look it up when we need it.
+  std::vector<Node*> node_ptrs;
+
+  // Every node in the graph has a value; when we propose a new graph state,
+  // we update the values. If we then reject the proposed new state, we need
+  // to restore the values. This vector stores the original values of the
+  // nodes that we change during the proposal step.
+  // We do the same for the log probability of the stochastic nodes
+  // affected by the last revertible set and propagate operation
+  // see (revertibly_set_and_propagate method).
+  std::vector<NodeValue> old_values;
+  double old_sto_affected_nodes_log_prob;
+
+  // The support is the set of all nodes in the graph that are queried or
+  // observed, directly or indirectly. We keep both node ids and node pointer
+  // forms.
+  std::set<uint> supp_ids;
+  std::vector<Node*> supp;
+
+  // Nodes in supp that are not directly observed. Note that
+  // the order of nodes in this vector matters! We must enumerate
+  // them in order from lowest node identifier to highest.
+  std::vector<Node*> unobserved_supp;
+
+  // Nodes in unobserved_supp that are stochastic; similarly, order matters.
+  std::vector<Node*> unobserved_sto_supp;
+
+  // A vector containing the index of a node in unobserved_sto_supp for each
+  // node_id. Since not all nodes are in unobserved_sto_support, some elements
+  // of this vector should never be accessed.
+  std::vector<uint> unobserved_sto_support_index_by_node_id;
+
+  // These vectors are the same size as unobserved_sto_support.
+  // The i-th elements are vectors of nodes which are
+  // respectively the vector of
+  // the immediate stochastic descendants of node with index i in the support,
+  // and the vector of the intervening deterministic nodes
+  // between the i-th node and its immediate stochastic descendants.
+  // In other words, these are the cached results of
+  // invoking graph::compute_affected_nodes
+  // for each node.
+  std::vector<std::vector<Node*>> sto_affected_nodes;
+  std::vector<std::vector<Node*>> det_affected_nodes;
+
+  // Methods
+
+  void initialize();
+
+  void collect_node_ptrs();
+
+  void compute_support_FROM_MH_DELETE_WHEN_DONE();
+
+  void ensure_all_nodes_are_supported();
+
+  void compute_initial_values();
+
+  void compute_affected_nodes();
+
+  void generate_sample();
+
+  void collect_samples(uint num_samples, InferConfig infer_config);
+
+  void collect_sample(InferConfig infer_config);
+
+  const std::vector<Node*>& get_det_affected_nodes(Node* node);
+
+  const std::vector<Node*>& get_sto_affected_nodes(Node* node);
+
+  // Sets a given node to a new value and
+  // updates its deterministically affected nodes.
+  // Does so in a revertible manner by saving old values and old stochastic
+  // affected nodes log prob.
+  // Old values can be accessed through get_old_* methods.
+  // The reversion is executed by invoking revert_set_and_propagate.
+  void revertibly_set_and_propagate(Node* node, const NodeValue& value);
+
+  // Revert the last revertibly_set_and_propagate
+  void revert_set_and_propagate(Node* node);
+
+  void save_old_value(const Node* node);
+
+  void save_old_values(const std::vector<Node*>& nodes);
+
+  NodeValue& get_old_value(const Node* node);
+
+  double get_old_sto_affected_nodes_log_prob() {
+    return old_sto_affected_nodes_log_prob;
+  }
+
+  void restore_old_value(Node* node);
+
+  void restore_old_values(const std::vector<Node*>& det_nodes);
+
+  void compute_gradients(const std::vector<Node*>& det_nodes);
+
+  void eval(const std::vector<Node*>& det_nodes);
+
+  void clear_gradients(Node* node);
+
+  void clear_gradients(const std::vector<Node*>& nodes);
+
+  void clear_gradients_of_node_and_its_affected_nodes(Node* node);
+
+  double compute_log_prob_of(const std::vector<Node*>& sto_nodes);
 };
 
 } // namespace graph

--- a/src/beanmachine/graph/mh.cpp
+++ b/src/beanmachine/graph/mh.cpp
@@ -24,10 +24,7 @@ namespace beanmachine {
 namespace graph {
 
 MH::MH(Graph* graph, uint seed, Stepper* stepper)
-    : unobserved_sto_support_index_by_node_id(graph->nodes.size(), 0),
-      stepper(stepper),
-      graph(graph),
-      gen(seed) {}
+    : stepper(stepper), graph(graph), gen(seed) {}
 
 void MH::infer(uint num_samples, InferConfig infer_config) {
   graph->pd_begin(ProfilerEvent::NMC_INFER);
@@ -62,6 +59,10 @@ void MH::compute_support() {
   for (uint node_id : supp_ids) {
     supp.push_back(node_ptrs[node_id]);
   }
+
+  unobserved_sto_support_index_by_node_id =
+      std::vector<uint>(graph->nodes.size(), 0);
+
   for (Node* node : supp) {
     bool node_is_not_observed =
         graph->observed.find(node->index) == graph->observed.end();

--- a/src/beanmachine/graph/rejection.cpp
+++ b/src/beanmachine/graph/rejection.cpp
@@ -10,6 +10,7 @@
 namespace beanmachine {
 namespace graph {
 
+// TODO: move this inference method out of Graph.
 void Graph::rejection(uint num_samples, uint seed, InferConfig infer_config) {
   std::mt19937 gen(seed);
   std::vector<Node*> ordered_supp;

--- a/src/beanmachine/graph/util.h
+++ b/src/beanmachine/graph/util.h
@@ -124,5 +124,12 @@ See: https://cran.r-project.org/web/packages/Rmpfr/vignettes/log1mexp-note.pdf
 */
 double log1mexp(double x);
 
+template <typename T>
+std::vector<T> make_reserved_vector(size_t n) {
+  std::vector<T> result;
+  result.reserve(n);
+  return result;
+}
+
 } // namespace util
 } // namespace beanmachine


### PR DESCRIPTION
Summary:
Replicate MH class members in Graph since they really refer to the graph and are often duplicated by algorithms using graphs.
Currently not used! This is just to decompose the refactoring in multiple easy-to-see steps.

Reviewed By: gafter

Differential Revision: D37098952

