### PR TITLE
Remove need for `Graph`'s client code to compute `ordered_support`

### DIFF
--- a/src/beanmachine/graph/cavi.cpp
+++ b/src/beanmachine/graph/cavi.cpp
@@ -29,7 +29,7 @@ void Graph::cavi(
     var_samples.push_back(std::vector<NodeValue>());
   }
   assert(node_ptrs.size() > 0); // keep linter happy
-  std::set<uint> supp = compute_support();
+  std::set<uint> ordered_support_node_ids = compute_ordered_support_node_ids();
   // the variational parameter probability for each node (initially 0.5)
   std::vector<double> param_probability =
       std::vector<double>(nodes.size(), 0.5);
@@ -43,7 +43,7 @@ void Graph::cavi(
       uint,
       std::tuple<std::vector<uint>, std::vector<uint>, std::vector<uint>>>
       pool;
-  for (uint node_id : supp) {
+  for (uint node_id : ordered_support_node_ids) {
     Node* node = node_ptrs[node_id];
     if (not node->is_observed) {
       node->eval(gen); // evaluate the value of non-observed operator nodes
@@ -60,7 +60,8 @@ void Graph::cavi(
       // log_prob. We will call these nodes the log_prob_nodes.
       std::vector<uint> det_desc;
       std::vector<uint> logprob_nodes;
-      std::tie(det_desc, logprob_nodes) = compute_affected_nodes(node_id, supp);
+      std::tie(det_desc, logprob_nodes) =
+          compute_affected_nodes(node_id, ordered_support_node_ids);
       // In order to compute the log_prob of these nodes we need to
       // materialize their ancestors both deterministic and stochastic.
       // The unobserved stochastic ancestors are to be sampled while the
@@ -148,7 +149,7 @@ void Graph::cavi(
       // and log Q(Z) is the log of the variational distribution for the pool.
       double elbo = 0;
       for (uint step = 0; step < elbo_samples; step++) {
-        for (uint node_id : supp) {
+        for (uint node_id : ordered_support_node_ids) {
           Node* node = node_ptrs[node_id];
           if (node->is_stochastic()) {
             if (not node->is_observed) {

--- a/src/beanmachine/graph/distribution/distribution.h
+++ b/src/beanmachine/graph/distribution/distribution.h
@@ -33,10 +33,15 @@ class Distribution : public graph::Node {
     throw std::runtime_error(
         "internal error: eval() is not implemented for distribution");
   }
-  // tell the compiler that we want the base class log_prob method
-  // as well as the new one in this class
-  using graph::Node::log_prob;
+
   virtual double log_prob(const graph::NodeValue& value) const = 0;
+
+  // The base class declares a method log_prob() that we want to preserve.
+  // However, this class declared log_prob(const NodeValue&) which hides it.
+  // For this reason, we must use the following using directive which
+  // preserves the base class method as available.
+  using graph::Node::log_prob;
+
   virtual void log_prob_iid(
       const graph::NodeValue& /* value */,
       Eigen::MatrixXd& /* log_probs */) const {}

--- a/src/beanmachine/graph/gibbs.cpp
+++ b/src/beanmachine/graph/gibbs.cpp
@@ -20,7 +20,7 @@ namespace graph {
 // TODO: move this inference method out of Graph.
 void Graph::gibbs(uint num_samples, uint seed, InferConfig infer_config) {
   std::mt19937 gen(seed);
-  std::set<uint> supp = compute_support();
+  std::set<uint> ordered_support_node_ids = compute_ordered_support_node_ids();
   // eval each node so that we have a starting value and verify that these
   // values are all scalar
   // also compute the pool of variables that we will infer over and
@@ -36,7 +36,7 @@ void Graph::gibbs(uint num_samples, uint seed, InferConfig infer_config) {
   // this is a temp object which is needed to construct markov_blanket (below)
   std::map<uint, std::set<uint>> inv_sto;
   std::vector<Node*> ordered_supp;
-  for (uint node_id : supp) {
+  for (uint node_id : ordered_support_node_ids) {
     Node* node = nodes[node_id].get();
     bool node_is_not_observed = observed.find(node_id) == observed.end();
     if (node_is_not_observed) {
@@ -45,7 +45,8 @@ void Graph::gibbs(uint num_samples, uint seed, InferConfig infer_config) {
     if (node->is_stochastic() and node_is_not_observed) {
       std::vector<uint> det_nodes;
       std::vector<uint> sto_nodes;
-      std::tie(det_nodes, sto_nodes) = compute_affected_nodes(node_id, supp);
+      std::tie(det_nodes, sto_nodes) =
+          compute_affected_nodes(node_id, ordered_support_node_ids);
       pool[node_id] = std::make_tuple(det_nodes, sto_nodes);
       cache_logodds[node_id] = NAN; // nan => needs to be re-computed
       for (auto sto : sto_nodes) {

--- a/src/beanmachine/graph/gibbs.cpp
+++ b/src/beanmachine/graph/gibbs.cpp
@@ -17,6 +17,7 @@
 namespace beanmachine {
 namespace graph {
 
+// TODO: move this inference method out of Graph.
 void Graph::gibbs(uint num_samples, uint seed, InferConfig infer_config) {
   std::mt19937 gen(seed);
   std::set<uint> supp = compute_support();

--- a/src/beanmachine/graph/gibbs.cpp
+++ b/src/beanmachine/graph/gibbs.cpp
@@ -35,7 +35,6 @@ void Graph::gibbs(uint num_samples, uint seed, InferConfig infer_config) {
   // x in sto_desc[y] => y in inv_sto[x]
   // this is a temp object which is needed to construct markov_blanket (below)
   std::map<uint, std::set<uint>> inv_sto;
-  std::vector<Node*> ordered_supp;
   for (uint node_id : ordered_support_node_ids) {
     Node* node = nodes[node_id].get();
     bool node_is_not_observed = observed.find(node_id) == observed.end();
@@ -55,9 +54,6 @@ void Graph::gibbs(uint num_samples, uint seed, InferConfig infer_config) {
         }
         inv_sto[sto].insert(node_id);
       }
-    }
-    if (infer_config.keep_log_prob) {
-      ordered_supp.push_back(node);
     }
   }
   // markov_blanket of a node is the set of other nodes whose conditional
@@ -169,7 +165,7 @@ void Graph::gibbs(uint num_samples, uint seed, InferConfig infer_config) {
       }
     }
     if (infer_config.keep_log_prob) {
-      collect_log_prob(_full_log_prob(ordered_supp));
+      collect_log_prob(full_log_prob());
     }
     if (infer_config.keep_warmup or snum >= infer_config.num_warmup) {
       collect_sample();

--- a/src/beanmachine/graph/global/global_state.cpp
+++ b/src/beanmachine/graph/global/global_state.cpp
@@ -20,8 +20,9 @@ namespace graph {
 
 GlobalState::GlobalState(Graph& g) : graph(g) {
   flat_size = 0;
-  std::set<uint> supp = graph.compute_support();
-  for (uint node_id : supp) {
+  std::set<uint> ordered_support_node_ids =
+      graph.compute_ordered_support_node_ids();
+  for (uint node_id : ordered_support_node_ids) {
     ordered_support.push_back(graph.nodes[node_id].get());
   }
 

--- a/src/beanmachine/graph/global/global_state.cpp
+++ b/src/beanmachine/graph/global/global_state.cpp
@@ -20,15 +20,11 @@ namespace graph {
 
 GlobalState::GlobalState(Graph& g) : graph(g) {
   flat_size = 0;
-  std::set<uint> ordered_support_node_ids =
-      graph.compute_ordered_support_node_ids();
-  for (uint node_id : ordered_support_node_ids) {
-    ordered_support.push_back(graph.nodes[node_id].get());
-  }
+  graph.initialize();
 
   // initialize unconstrained value types
   // TODO: rename to initialize_unconstrained_value_types
-  for (auto node : ordered_support) {
+  for (auto node : graph.supp) {
     if (node->is_stochastic() and node->node_type == NodeType::OPERATOR) {
       auto sto_node = static_cast<oper::StochasticOperator*>(node);
       sto_node->get_unconstrained_value(true);
@@ -36,7 +32,7 @@ GlobalState::GlobalState(Graph& g) : graph(g) {
   }
 
   // save stochastic and deterministic nodes
-  for (auto node : ordered_support) {
+  for (auto node : graph.supp) {
     if (node->is_stochastic() and !node->is_observed) {
       stochastic_nodes.push_back(node);
       // initialize vals_backup and grads_backup to correct size
@@ -215,11 +211,11 @@ double GlobalState::get_log_prob() {
 }
 
 void GlobalState::update_log_prob() {
-  log_prob = graph._full_log_prob(ordered_support);
+  log_prob = graph.full_log_prob();
 }
 
 void GlobalState::update_backgrad() {
-  graph.update_backgrad(ordered_support);
+  graph.update_backgrad(graph.supp);
 }
 
 } // namespace graph

--- a/src/beanmachine/graph/global/global_state.h
+++ b/src/beanmachine/graph/global/global_state.h
@@ -31,7 +31,6 @@ class GlobalState {
  private:
   int flat_size;
   Graph& graph;
-  std::vector<Node*> ordered_support;
   std::vector<Node*> stochastic_nodes;
   std::vector<Node*> deterministic_nodes;
   std::vector<NodeValue> stochastic_unconstrained_vals_backup;

--- a/src/beanmachine/graph/global/util.cpp
+++ b/src/beanmachine/graph/global/util.cpp
@@ -17,7 +17,7 @@ void set_default_transforms(Graph& g) {
   // to transform all variables to the unconstrained space
   // POS_REAL variables -> LOG transform
   // TODO: add simplex transform
-  for (uint node_id : g.compute_support()) {
+  for (uint node_id : g.compute_ordered_support_node_ids()) {
     // @lint-ignore CLANGTIDY
     auto node = g.nodes[node_id].get();
     if (node->is_stochastic() and !node->is_observed) {

--- a/src/beanmachine/graph/graph.cpp
+++ b/src/beanmachine/graph/graph.cpp
@@ -1237,12 +1237,15 @@ Graph::Graph(const Graph& other) {
 // need during inference, and verifies that the MH algorithm can
 // compute gradients of every node we need to.
 void Graph::initialize() {
-  pd_begin(ProfilerEvent::NMC_INFER_INITIALIZE);
-  collect_node_ptrs();
-  compute_support_FROM_MH_DELETE_WHEN_DONE();
-  compute_affected_nodes();
-  old_values = std::vector<NodeValue>(nodes.size());
-  pd_finish(ProfilerEvent::NMC_INFER_INITIALIZE);
+  if (not initialized) {
+    pd_begin(ProfilerEvent::NMC_INFER_INITIALIZE);
+    collect_node_ptrs();
+    compute_support_FROM_MH_DELETE_WHEN_DONE();
+    compute_affected_nodes();
+    old_values = std::vector<NodeValue>(nodes.size());
+    pd_finish(ProfilerEvent::NMC_INFER_INITIALIZE);
+    initialized = true;
+  }
 }
 
 void Graph::collect_node_ptrs() {

--- a/src/beanmachine/graph/graph.cpp
+++ b/src/beanmachine/graph/graph.cpp
@@ -480,7 +480,7 @@ double Graph::log_prob(uint src_idx) {
 }
 
 // TODO: this is the one actually used in code (as opposed to full_log_prob used
-// in testing only, so why the _?)
+// in testing only, so why the _ indicating a private method?)
 double Graph::_full_log_prob(std::vector<Node*>& ordered_supp) {
   double sum_log_prob = 0.0;
   std::mt19937 generator(12131); // seed is irrelevant for deterministic ops
@@ -498,7 +498,7 @@ double Graph::_full_log_prob(std::vector<Node*>& ordered_supp) {
           // log(f_Y(y)) = log(f_X(x)) + log(|d/dy f^{-1}(y)|)
           //   = node->log_prob() + log_abs_jacobian_determinant()
           // TODO: rename log_abs_jacobian_determinant
-          // to log_abs_jacobian_detesrminant_of_inverse_transform
+          // to log_abs_jacobian_determinant_of_inverse_transform
           //
           // References on Change of Variables in statistics:
           // https://online.stat.psu.edu/stat414/lesson/22/22.2

--- a/src/beanmachine/graph/graph.cpp
+++ b/src/beanmachine/graph/graph.cpp
@@ -488,12 +488,11 @@ double Graph::log_prob(uint src_idx) {
   return log_prob;
 }
 
-// TODO: this is the one actually used in code (as opposed to full_log_prob used
-// in testing only, so why the _ indicating a private method?)
-double Graph::_full_log_prob(std::vector<Node*>& ordered_supp) {
+double Graph::full_log_prob() {
+  initialize();
   double sum_log_prob = 0.0;
   std::mt19937 generator(12131); // seed is irrelevant for deterministic ops
-  for (auto node : ordered_supp) {
+  for (auto node : supp) {
     if (node->is_stochastic()) {
       sum_log_prob += node->log_prob();
       if (node->node_type == NodeType::OPERATOR) {
@@ -521,18 +520,6 @@ double Graph::_full_log_prob(std::vector<Node*>& ordered_supp) {
     }
   }
   return sum_log_prob;
-}
-
-/* TODO: used in testing only; it looks like there has not been a need for it in
- * actual code so far; notheless we can leave it here as it is a natural
- * operation */
-double Graph::full_log_prob() {
-  std::set<uint> ordered_support_node_ids = compute_ordered_support_node_ids();
-  std::vector<Node*> ordered_supp;
-  for (uint node_id : ordered_support_node_ids) {
-    ordered_supp.push_back(nodes[node_id].get());
-  }
-  return _full_log_prob(ordered_supp);
 }
 
 // TODO: from now on, we have methods for adding nodes, checking validity,

--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -969,6 +969,116 @@ struct Graph {
   }
 
   void reindex_nodes();
+
+  // members brought in from MH class since they are really Graph properties
+ public:
+  // A graph maintains of a vector of nodes; the index into that vector is
+  // the id of the node. We often need to translate from node ids into node
+  // pointers; to do so quickly we obtain the address of
+  // every node in the graph up front and then look it up when we need it.
+  std::vector<Node*> node_ptrs;
+
+  // Every node in the graph has a value; when we propose a new graph state,
+  // we update the values. If we then reject the proposed new state, we need
+  // to restore the values. This vector stores the original values of the
+  // nodes that we change during the proposal step.
+  // We do the same for the log probability of the stochastic nodes
+  // affected by the last revertible set and propagate operation
+  // see (revertibly_set_and_propagate method).
+  std::vector<NodeValue> old_values;
+  double old_sto_affected_nodes_log_prob;
+
+  // The support is the set of all nodes in the graph that are queried or
+  // observed, directly or indirectly. We keep both node ids and node pointer
+  // forms.
+  std::set<uint> supp_ids;
+  std::vector<Node*> supp;
+
+  // Nodes in supp that are not directly observed. Note that
+  // the order of nodes in this vector matters! We must enumerate
+  // them in order from lowest node identifier to highest.
+  std::vector<Node*> unobserved_supp;
+
+  // Nodes in unobserved_supp that are stochastic; similarly, order matters.
+  std::vector<Node*> unobserved_sto_supp;
+
+  // A vector containing the index of a node in unobserved_sto_supp for each
+  // node_id. Since not all nodes are in unobserved_sto_support, some elements
+  // of this vector should never be accessed.
+  std::vector<uint> unobserved_sto_support_index_by_node_id;
+
+  // These vectors are the same size as unobserved_sto_support.
+  // The i-th elements are vectors of nodes which are
+  // respectively the vector of
+  // the immediate stochastic descendants of node with index i in the support,
+  // and the vector of the intervening deterministic nodes
+  // between the i-th node and its immediate stochastic descendants.
+  // In other words, these are the cached results of
+  // invoking graph::compute_affected_nodes
+  // for each node.
+  std::vector<std::vector<Node*>> sto_affected_nodes;
+  std::vector<std::vector<Node*>> det_affected_nodes;
+
+  // Methods
+
+  void initialize();
+
+  void collect_node_ptrs();
+
+  void compute_support_FROM_MH_DELETE_WHEN_DONE();
+
+  void ensure_all_nodes_are_supported();
+
+  void compute_initial_values();
+
+  void compute_affected_nodes();
+
+  void generate_sample();
+
+  void collect_samples(uint num_samples, InferConfig infer_config);
+
+  void collect_sample(InferConfig infer_config);
+
+  const std::vector<Node*>& get_det_affected_nodes(Node* node);
+
+  const std::vector<Node*>& get_sto_affected_nodes(Node* node);
+
+  // Sets a given node to a new value and
+  // updates its deterministically affected nodes.
+  // Does so in a revertible manner by saving old values and old stochastic
+  // affected nodes log prob.
+  // Old values can be accessed through get_old_* methods.
+  // The reversion is executed by invoking revert_set_and_propagate.
+  void revertibly_set_and_propagate(Node* node, const NodeValue& value);
+
+  // Revert the last revertibly_set_and_propagate
+  void revert_set_and_propagate(Node* node);
+
+  void save_old_value(const Node* node);
+
+  void save_old_values(const std::vector<Node*>& nodes);
+
+  NodeValue& get_old_value(const Node* node);
+
+  double get_old_sto_affected_nodes_log_prob() {
+    return old_sto_affected_nodes_log_prob;
+  }
+
+  void restore_old_value(Node* node);
+
+  void restore_old_values(const std::vector<Node*>& det_nodes);
+
+  void compute_gradients(const std::vector<Node*>& det_nodes);
+
+  void eval(const std::vector<Node*>& det_nodes);
+
+  void clear_gradients(Node* node);
+
+  void clear_gradients(const std::vector<Node*>& nodes);
+
+  void clear_gradients_of_node_and_its_affected_nodes(Node* node);
+
+  double compute_log_prob_of(const std::vector<Node*>& sto_nodes);
 };
 
 } // namespace graph

--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -1019,6 +1019,8 @@ struct Graph {
   std::vector<std::vector<Node*>> sto_affected_nodes;
   std::vector<std::vector<Node*>> det_affected_nodes;
 
+  bool initialized = false;
+
   // Methods
 
   void initialize();

--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -943,7 +943,6 @@ stochastic.
 
   // TODO: Review what members of this class can be made static.
 
-  static double _full_log_prob(std::vector<Node*>& ordered_supp);
   void collect_log_prob(double log_prob);
   std::vector<double> log_prob_vals;
   std::vector<std::vector<double>> log_prob_allchains;

--- a/src/beanmachine/graph/marginalization/marginalized_graph.cpp
+++ b/src/beanmachine/graph/marginalization/marginalized_graph.cpp
@@ -25,11 +25,12 @@ void MarginalizedGraph::marginalize(uint discrete_sample_node_id) {
   SubGraph* subgraph = subgraph_ptr.get();
 
   // compute nodes up to and including stochastic children of discrete_sample
-  std::set<uint> supp_ids = compute_full_support();
+  std::set<uint> ordered_support_node_ids =
+      compute_full_ordered_support_node_ids();
   std::vector<uint> det_node_ids;
   std::vector<uint> sto_node_ids;
   std::tie(det_node_ids, sto_node_ids) =
-      compute_children(discrete_sample->index, supp_ids);
+      compute_children(discrete_sample->index, ordered_support_node_ids);
 
   // create MarginalDistribution
   std::unique_ptr<distribution::DummyMarginal>

--- a/src/beanmachine/graph/mh.cpp
+++ b/src/beanmachine/graph/mh.cpp
@@ -93,7 +93,7 @@ void MH::collect_samples(uint num_samples, InferConfig infer_config) {
 void MH::collect_sample(InferConfig infer_config) {
   graph->pd_begin(ProfilerEvent::NMC_INFER_COLLECT_SAMPLE);
   if (infer_config.keep_log_prob) {
-    graph->collect_log_prob(graph->_full_log_prob(graph->supp)); // TODO: clean
+    graph->collect_log_prob(graph->full_log_prob());
   }
   graph->collect_sample();
   graph->pd_finish(ProfilerEvent::NMC_INFER_COLLECT_SAMPLE);

--- a/src/beanmachine/graph/mh.cpp
+++ b/src/beanmachine/graph/mh.cpp
@@ -37,51 +37,13 @@ void MH::infer(uint num_samples, InferConfig infer_config) {
 // need during inference, and verifies that the MH algorithm can
 // compute gradients of every node we need to.
 void MH::initialize() {
-  graph->pd_begin(ProfilerEvent::NMC_INFER_INITIALIZE);
-  collect_node_ptrs();
-  compute_support();
+  graph->initialize();
   ensure_all_nodes_are_supported();
   compute_initial_values();
-  compute_affected_nodes();
-  old_values = std::vector<NodeValue>(graph->nodes.size());
-  graph->pd_finish(ProfilerEvent::NMC_INFER_INITIALIZE);
-}
-
-void MH::collect_node_ptrs() {
-  for (uint node_id = 0; node_id < static_cast<uint>(graph->nodes.size());
-       node_id++) {
-    node_ptrs.push_back(graph->nodes[node_id].get());
-  }
-}
-
-void MH::compute_support() {
-  supp_ids = graph->compute_support();
-  for (uint node_id : supp_ids) {
-    supp.push_back(node_ptrs[node_id]);
-  }
-
-  unobserved_sto_support_index_by_node_id =
-      std::vector<uint>(graph->nodes.size(), 0);
-
-  for (Node* node : supp) {
-    bool node_is_not_observed =
-        graph->observed.find(node->index) == graph->observed.end();
-    if (node_is_not_observed) {
-      unobserved_supp.push_back(node);
-      if (node->is_stochastic()) {
-        uint index_of_next_unobserved_sto_supp_node =
-            static_cast<uint>(unobserved_sto_supp.size());
-        unobserved_sto_supp.push_back(node);
-        uint node_id = node->index;
-        unobserved_sto_support_index_by_node_id[node_id] =
-            index_of_next_unobserved_sto_supp_node;
-      }
-    }
-  }
 }
 
 void MH::ensure_all_nodes_are_supported() {
-  for (Node* node : unobserved_sto_supp) {
+  for (Node* node : graph->unobserved_sto_supp) {
     std::string error_message = is_not_supported(node);
     if (error_message != "") {
       throw std::runtime_error(error_message);
@@ -97,38 +59,11 @@ void MH::ensure_all_nodes_are_supported() {
 // indices less than those of their children, and unobserved_supp
 // respects index order.
 void MH::compute_initial_values() {
-  for (Node* unobs_node : unobserved_supp) {
+  for (Node* unobs_node : graph->unobserved_supp) {
     if (unobs_node->is_stochastic()) {
       proposer::default_initializer(gen, unobs_node);
     } else { // non-stochastic operator node, so just evaluate
       unobs_node->eval(gen);
-    }
-  }
-}
-
-// For every unobserved stochastic node in the graph, we will need to
-// repeatedly know the set of immediate stochastic descendants
-// and intervening deterministic nodes.
-// Because this can be expensive, we compute those sets once and cache them.
-void MH::compute_affected_nodes() {
-  for (Node* node : unobserved_sto_supp) {
-    std::vector<uint> det_node_ids;
-    std::vector<uint> sto_node_ids;
-    std::vector<Node*> det_nodes;
-    std::vector<Node*> sto_nodes;
-    std::tie(det_node_ids, sto_node_ids) =
-        graph->compute_affected_nodes(node->index, supp_ids);
-    for (uint id : det_node_ids) {
-      det_nodes.push_back(node_ptrs[id]);
-    }
-    for (uint id : sto_node_ids) {
-      sto_nodes.push_back(node_ptrs[id]);
-    }
-    det_affected_nodes.push_back(det_nodes);
-    sto_affected_nodes.push_back(sto_nodes);
-    if (graph->_collect_performance_data) {
-      graph->profiler_data.det_supp_count[static_cast<uint>(node->index)] =
-          static_cast<int>(det_nodes.size());
     }
   }
 }
@@ -158,125 +93,10 @@ void MH::collect_samples(uint num_samples, InferConfig infer_config) {
 void MH::collect_sample(InferConfig infer_config) {
   graph->pd_begin(ProfilerEvent::NMC_INFER_COLLECT_SAMPLE);
   if (infer_config.keep_log_prob) {
-    graph->collect_log_prob(graph->_full_log_prob(supp));
+    graph->collect_log_prob(graph->_full_log_prob(graph->supp)); // TODO: clean
   }
   graph->collect_sample();
   graph->pd_finish(ProfilerEvent::NMC_INFER_COLLECT_SAMPLE);
-}
-
-const std::vector<Node*>& MH::get_det_affected_nodes(Node* node) {
-  return det_affected_nodes
-      [unobserved_sto_support_index_by_node_id[node->index]];
-}
-
-const std::vector<Node*>& MH::get_sto_affected_nodes(Node* node) {
-  return sto_affected_nodes
-      [unobserved_sto_support_index_by_node_id[node->index]];
-}
-
-void MH::revertibly_set_and_propagate(Node* node, const NodeValue& value) {
-  save_old_value(node);
-  save_old_values(get_det_affected_nodes(node));
-  old_sto_affected_nodes_log_prob =
-      compute_log_prob_of(get_sto_affected_nodes(node));
-  node->value = value;
-  eval(get_det_affected_nodes(node));
-}
-
-void MH::revert_set_and_propagate(Node* node) {
-  restore_old_value(node);
-  restore_old_values(get_det_affected_nodes(node));
-}
-
-void MH::save_old_value(const Node* node) {
-  old_values[node->index] = node->value;
-}
-
-void MH::save_old_values(const std::vector<Node*>& nodes) {
-  graph->pd_begin(ProfilerEvent::NMC_SAVE_OLD);
-  for (Node* node : nodes) {
-    old_values[node->index] = node->value;
-  }
-  graph->pd_finish(ProfilerEvent::NMC_SAVE_OLD);
-}
-
-NodeValue& MH::get_old_value(const Node* node) {
-  return old_values[node->index];
-}
-
-void MH::restore_old_value(Node* node) {
-  node->value = old_values[node->index];
-}
-
-void MH::restore_old_values(const std::vector<Node*>& det_nodes) {
-  graph->pd_begin(ProfilerEvent::NMC_RESTORE_OLD);
-  for (Node* node : det_nodes) {
-    node->value = old_values[node->index];
-  }
-  graph->pd_finish(ProfilerEvent::NMC_RESTORE_OLD);
-}
-
-void MH::compute_gradients(const std::vector<Node*>& det_nodes) {
-  graph->pd_begin(ProfilerEvent::NMC_COMPUTE_GRADS);
-  for (Node* node : det_nodes) {
-    node->compute_gradients();
-  }
-  graph->pd_finish(ProfilerEvent::NMC_COMPUTE_GRADS);
-}
-
-void MH::eval(const std::vector<Node*>& det_nodes) {
-  graph->pd_begin(ProfilerEvent::NMC_EVAL);
-  for (Node* node : det_nodes) {
-    node->eval(gen);
-  }
-  graph->pd_finish(ProfilerEvent::NMC_EVAL);
-}
-
-void MH::clear_gradients(Node* node) {
-  // TODO: eventually we want to have different classes of Node
-  // and have this be a virtual method
-  switch (node->value.type.variable_type) {
-    case VariableType::SCALAR:
-      node->grad1 = 0;
-      node->grad2 = 0;
-      break;
-    case VariableType::BROADCAST_MATRIX:
-    case VariableType::COL_SIMPLEX_MATRIX: {
-      auto rows = node->value._matrix.rows();
-      auto cols = node->value._matrix.cols();
-      node->Grad1 = Eigen::MatrixXd::Zero(rows, cols);
-      node->Grad2 = Eigen::MatrixXd::Zero(rows, cols);
-      break;
-    }
-    default:
-      throw std::runtime_error(
-          "clear_gradients invoked for nodes of an unsupported variable type " +
-          std::to_string(int(node->value.type.variable_type)));
-  }
-}
-
-void MH::clear_gradients(const std::vector<Node*>& nodes) {
-  graph->pd_begin(ProfilerEvent::NMC_CLEAR_GRADS);
-  for (Node* node : nodes) {
-    clear_gradients(node);
-  }
-  graph->pd_finish(ProfilerEvent::NMC_CLEAR_GRADS);
-}
-
-void MH::clear_gradients_of_node_and_its_affected_nodes(Node* node) {
-  clear_gradients(node);
-  clear_gradients(get_det_affected_nodes(node));
-  clear_gradients(get_sto_affected_nodes(node));
-}
-
-// Computes the log probability with respect to a given
-// set of stochastic nodes.
-double MH::compute_log_prob_of(const std::vector<Node*>& sto_nodes) {
-  double log_prob = 0;
-  for (Node* node : sto_nodes) {
-    log_prob += node->log_prob();
-  }
-  return log_prob;
 }
 
 NodeValue MH::sample(const std::unique_ptr<proposer::Proposer>& prop) {

--- a/src/beanmachine/graph/mh.cpp
+++ b/src/beanmachine/graph/mh.cpp
@@ -24,10 +24,7 @@ namespace beanmachine {
 namespace graph {
 
 MH::MH(Graph* graph, uint seed, Stepper* stepper)
-    : unobserved_sto_support_index_by_node_id(graph->nodes.size(), 0),
-      stepper(stepper),
-      graph(graph),
-      gen(seed) {}
+    : stepper(stepper), graph(graph), gen(seed) {}
 
 void MH::infer(uint num_samples, InferConfig infer_config) {
   graph->pd_begin(ProfilerEvent::NMC_INFER);
@@ -62,6 +59,10 @@ void MH::compute_support() {
   for (uint node_id : supp_ids) {
     supp.push_back(node_ptrs[node_id]);
   }
+
+  unobserved_sto_support_index_by_node_id =
+      std::vector<uint>(graph->nodes.size(), 0);
+
   for (Node* node : supp) {
     bool node_is_not_observed =
         graph->observed.find(node->index) == graph->observed.end();

--- a/src/beanmachine/graph/mh.h
+++ b/src/beanmachine/graph/mh.h
@@ -30,56 +30,9 @@ namespace beanmachine {
 namespace graph {
 
 class MH {
- protected:
-  // A graph maintains of a vector of nodes; the index into that vector is
-  // the id of the node. We often need to translate from node ids into node
-  // pointers in this algorithm; to do so quickly we obtain the address of
-  // every node in the graph up front and then look it up when we need it.
-  std::vector<Node*> node_ptrs;
-
-  // Every node in the graph has a value; when we propose a new graph state,
-  // we update the values. If we then reject the proposed new state, we need
-  // to restore the values. This vector stores the original values of the
-  // nodes that we change during the proposal step.
-  // We do the same for the log probability of the stochastic nodes
-  // affected by the last revertible set and propagate operation
-  // see (revertibly_set_and_propagate method).
-  std::vector<NodeValue> old_values;
-  double old_sto_affected_nodes_log_prob;
-
-  // The support is the set of all nodes in the graph that are queried or
-  // observed, directly or indirectly. We need both the support as nodes
-  // and as pointers in this algorithm.
-  std::set<uint> supp_ids;
-  std::vector<Node*> supp;
-
-  // Nodes in supp that are not directly observed. Note that
-  // the order of nodes in this vector matters! We must enumerate
-  // them in order from lowest node identifier to highest.
-  std::vector<Node*> unobserved_supp;
-
-  // Nodes in unobserved_supp that are stochastic; similarly, order matters.
-  std::vector<Node*> unobserved_sto_supp;
-
-  // A vector containing the index of a node in unobserved_sto_supp for each
-  // node_id. Since not all nodes are in unobserved_sto_support, some elements
-  // of this vector should never be accessed.
-  std::vector<uint> unobserved_sto_support_index_by_node_id;
-
   // The stepper responsible for taking steps over the Markov chain.
+  // Owned by this class; destructor deletes it.
   Stepper* stepper;
-
-  // These vectors are the same size as unobserved_sto_support.
-  // The i-th elements are vectors of nodes which are
-  // respectively the vector of
-  // the immediate stochastic descendants of node with index i in the support,
-  // and the vector of the intervening deterministic nodes
-  // between the i-th node and its immediate stochastic descendants.
-  // In other words, these are the cached results of
-  // invoking graph::compute_affected_nodes
-  // for each node.
-  std::vector<std::vector<Node*>> sto_affected_nodes;
-  std::vector<std::vector<Node*>> det_affected_nodes;
 
  public:
   Graph* graph;
@@ -101,23 +54,13 @@ class MH {
   // Takes ownership of stepper instance.
   MH(Graph* graph, unsigned int seed, Stepper* stepper);
 
-  const std::vector<Node*>& unobserved_stochastic_support() {
-    return unobserved_sto_supp;
-  }
-
   void infer(uint num_samples, InferConfig infer_config);
 
   void initialize();
 
-  void collect_node_ptrs();
-
-  void compute_support();
-
   void ensure_all_nodes_are_supported();
 
   void compute_initial_values();
-
-  void compute_affected_nodes();
 
   void generate_sample();
 
@@ -127,47 +70,6 @@ class MH {
   void collect_samples(uint num_samples, InferConfig infer_config);
 
   void collect_sample(InferConfig infer_config);
-
-  const std::vector<Node*>& get_det_affected_nodes(Node* node);
-
-  const std::vector<Node*>& get_sto_affected_nodes(Node* node);
-
-  // Sets a given node to a new value and
-  // updates its deterministically affected nodes.
-  // Does so in a revertible manner by saving old values and old stochastic
-  // affected nodes log prob.
-  // Old values can be accessed through get_old_* methods.
-  // The reversion is executed by invoking revert_set_and_propagate.
-  void revertibly_set_and_propagate(Node* node, const NodeValue& value);
-
-  // Revert the last revertibly_set_and_propagate
-  void revert_set_and_propagate(Node* node);
-
-  void save_old_value(const Node* node);
-
-  void save_old_values(const std::vector<Node*>& nodes);
-
-  NodeValue& get_old_value(const Node* node);
-
-  double get_old_sto_affected_nodes_log_prob() {
-    return old_sto_affected_nodes_log_prob;
-  }
-
-  void restore_old_value(Node* node);
-
-  void restore_old_values(const std::vector<Node*>& det_nodes);
-
-  void compute_gradients(const std::vector<Node*>& det_nodes);
-
-  void eval(const std::vector<Node*>& det_nodes);
-
-  void clear_gradients(Node* node);
-
-  void clear_gradients(const std::vector<Node*>& nodes);
-
-  void clear_gradients_of_node_and_its_affected_nodes(Node* node);
-
-  double compute_log_prob_of(const std::vector<Node*>& sto_nodes);
 
   NodeValue sample(const std::unique_ptr<proposer::Proposer>& prop);
 

--- a/src/beanmachine/graph/rejection.cpp
+++ b/src/beanmachine/graph/rejection.cpp
@@ -15,8 +15,9 @@ void Graph::rejection(uint num_samples, uint seed, InferConfig infer_config) {
   std::mt19937 gen(seed);
   std::vector<Node*> ordered_supp;
   if (infer_config.keep_log_prob) {
-    std::set<uint> supp = compute_support();
-    for (uint node_id : supp) {
+    std::set<uint> ordered_support_node_ids =
+        compute_ordered_support_node_ids();
+    for (uint node_id : ordered_support_node_ids) {
       ordered_supp.push_back(nodes[static_cast<uint>(node_id)].get());
     }
   }

--- a/src/beanmachine/graph/rejection.cpp
+++ b/src/beanmachine/graph/rejection.cpp
@@ -13,14 +13,6 @@ namespace graph {
 // TODO: move this inference method out of Graph.
 void Graph::rejection(uint num_samples, uint seed, InferConfig infer_config) {
   std::mt19937 gen(seed);
-  std::vector<Node*> ordered_supp;
-  if (infer_config.keep_log_prob) {
-    std::set<uint> ordered_support_node_ids =
-        compute_ordered_support_node_ids();
-    for (uint node_id : ordered_support_node_ids) {
-      ordered_supp.push_back(nodes[static_cast<uint>(node_id)].get());
-    }
-  }
   for (uint snum = 0; snum < num_samples + infer_config.num_warmup; snum++) {
     // rejection sampling
     bool rejected;
@@ -48,7 +40,7 @@ void Graph::rejection(uint num_samples, uint seed, InferConfig infer_config) {
       }
     } while (rejected);
     if (infer_config.keep_log_prob) {
-      collect_log_prob(_full_log_prob(ordered_supp));
+      collect_log_prob(full_log_prob());
     }
     if (infer_config.keep_warmup or snum >= infer_config.num_warmup) {
       collect_sample();

--- a/src/beanmachine/graph/rejection.cpp
+++ b/src/beanmachine/graph/rejection.cpp
@@ -10,6 +10,7 @@
 namespace beanmachine {
 namespace graph {
 
+// TODO: move this inference method out of Graph.
 void Graph::rejection(uint num_samples, uint seed, InferConfig infer_config) {
   std::mt19937 gen(seed);
   std::vector<Node*> ordered_supp;

--- a/src/beanmachine/graph/stepper/single_site/nmc_dirichlet_beta_single_site_stepping_method.cpp
+++ b/src/beanmachine/graph/stepper/single_site/nmc_dirichlet_beta_single_site_stepping_method.cpp
@@ -42,6 +42,8 @@ NMCDirichletBetaSingleSiteSteppingMethod::get_proposal_distribution(
     Node* tgt_node) {
   assert(static_cast<uint>(tgt_node->value._matrix.size()) == 2);
 
+  auto graph = mh->graph;
+
   auto sto_tgt_node = static_cast<oper::StochasticOperator*>(tgt_node);
   double x = sto_tgt_node->value._matrix.coeff(0);
 
@@ -59,7 +61,7 @@ NMCDirichletBetaSingleSiteSteppingMethod::get_proposal_distribution(
   Grad1 << 1, -1;
   sto_tgt_node->Grad1 = Grad1;
   sto_tgt_node->Grad2 = Eigen::MatrixXd::Zero(2, 1);
-  mh->compute_gradients(mh->get_det_affected_nodes(tgt_node));
+  graph->compute_gradients(graph->get_det_affected_nodes(tgt_node));
 
   // Use gradients to obtain NMC proposal
   // @lint-ignore CLANGTIDY
@@ -72,7 +74,7 @@ NMCDirichletBetaSingleSiteSteppingMethod::get_proposal_distribution(
   double grad1 = 0;
   double grad2 = 0;
 
-  for (Node* node : mh->get_sto_affected_nodes(tgt_node)) {
+  for (Node* node : graph->get_sto_affected_nodes(tgt_node)) {
     if (node == tgt_node) {
       // X ~ Beta(param_a, param_b)
       grad1 += (param_a - 1) / x - (param_b - 1) / (1 - x);

--- a/src/beanmachine/graph/stepper/single_site/nmc_scalar_single_site_stepping_method.cpp
+++ b/src/beanmachine/graph/stepper/single_site/nmc_scalar_single_site_stepping_method.cpp
@@ -39,22 +39,24 @@ ProfilerEvent NMCScalarSingleSiteSteppingMethod::get_step_profiler_event() {
 // evaluated according to the target node's value.
 std::unique_ptr<proposer::Proposer>
 NMCScalarSingleSiteSteppingMethod::get_proposal_distribution(Node* tgt_node) {
-  mh->graph->pd_begin(ProfilerEvent::NMC_CREATE_PROP);
+  auto graph = mh->graph;
+
+  graph->pd_begin(ProfilerEvent::NMC_CREATE_PROP);
 
   tgt_node->grad1 = 1;
   tgt_node->grad2 = 0;
-  mh->compute_gradients(mh->get_det_affected_nodes(tgt_node));
+  graph->compute_gradients(graph->get_det_affected_nodes(tgt_node));
 
   double grad1 = 0;
   double grad2 = 0;
-  for (Node* node : mh->get_sto_affected_nodes(tgt_node)) {
+  for (Node* node : graph->get_sto_affected_nodes(tgt_node)) {
     node->gradient_log_prob(tgt_node, /* in-out */ grad1, /* in-out */ grad2);
   }
 
   // TODO: generalize so it works with any proposer, not just nmc_proposer:
   std::unique_ptr<proposer::Proposer> prop =
       proposer::nmc_proposer(tgt_node->value, grad1, grad2);
-  mh->graph->pd_finish(ProfilerEvent::NMC_CREATE_PROP);
+  graph->pd_finish(ProfilerEvent::NMC_CREATE_PROP);
   return prop;
 }
 

--- a/src/beanmachine/graph/stepper/single_site/sequential_single_site_stepper.cpp
+++ b/src/beanmachine/graph/stepper/single_site/sequential_single_site_stepper.cpp
@@ -39,10 +39,7 @@ std::vector<Stepper*>& SequentialSingleSiteStepper::get_steppers() {
 }
 
 void SequentialSingleSiteStepper::make_steppers() {
-  for (uint i = 0;
-       i < static_cast<uint>(mh->unobserved_stochastic_support().size());
-       ++i) {
-    auto tgt_node = mh->unobserved_stochastic_support()[i];
+  for (auto tgt_node : mh->graph->unobserved_sto_supp) {
     auto single_site_stepping_method =
         find_applicable_single_site_stepping_method(tgt_node);
     steppers.push_back(

--- a/src/beanmachine/graph/util.h
+++ b/src/beanmachine/graph/util.h
@@ -124,5 +124,12 @@ See: https://cran.r-project.org/web/packages/Rmpfr/vignettes/log1mexp-note.pdf
 */
 double log1mexp(double x);
 
+template <typename T>
+std::vector<T> make_reserved_vector(size_t n) {
+  std::vector<T> result;
+  result.reserve(n);
+  return result;
+}
+
 } // namespace util
 } // namespace beanmachine


### PR DESCRIPTION
Summary: The method for computing a Graph's full_log_prob required the client code to provide its `ordered_support`, which is unnecessary since the graph itself has that information. This diff removes those situations.

Reviewed By: gafter

Differential Revision: D37164347

