### PR TITLE
Turn on unittest and release build for Python 3.7-3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: [3.7]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
     defaults:
       run:
         # https://github.com/conda-incubator/setup-miniconda/tree/v2#use-a-default-shell


### PR DESCRIPTION
Summary:
As discussed in [previous BM Infra meeting](https://fb.quip.com/mD06A3JrNavc#temp:C:BXQ25413eaabbab4865be9eb3ce9), we claim to support Python 3.7-3.9 but aren't testing them in every diff, which has been making it hard to backtrack the bug when error occurs.

(I'm also adding Python 3.10 here because it's the newest version supported by PyTorch and the NeuralPP library also relies on Python 3.10 features)

Differential Revision: D37318155

