### PR TITLE
Adding Python 3.10 binary wheels to release workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        python-version: ['3.7', '3.8', '3.9']  # TODO: Add python 3.10 with next PyTorch version
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         include:
           - python-version: '3.8'  # source distribution only needs to be build once
             os: ubuntu-latest
@@ -87,7 +87,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        cibw_build: ['cp37-*', 'cp38-*', 'cp39-*']
+        cibw_build: ['cp37-*', 'cp38-*', 'cp39-*', 'cp310-*']
 
     steps:
     - name: Checkout


### PR DESCRIPTION
Summary: PyTorch is supporting Python 3.10, and [so does Bean Machine](https://github.com/facebookresearch/beanmachine/runs/6993220079?check_suite_focus=true). However, Python 3.10 users have to build and install Bean Machine from source at the moment because there isn't prebuilt wheels. Since it's already possible to build and run BM on Python 3.10 without any issue, why don't we add Python 3.10 to our deployment script so the wheels will be included in the next release?

Differential Revision: D37326625

