### PR TITLE
Remove negate-negate paths in graph

### DIFF
--- a/src/beanmachine/ppl/compiler/fix_arithmetic.py
+++ b/src/beanmachine/ppl/compiler/fix_arithmetic.py
@@ -170,3 +170,19 @@ def log1mexp_fixer(bmg: BMGraphBuilder, typer: LatticeTyper) -> NodeFixer:
         return bmg.add_log1mexp(x)
 
     return _log1mexp_fixer
+
+
+def neg_neg_fixer(bmg: BMGraphBuilder) -> NodeFixer:
+    # We can easily end up in a situation where another rewriter causes
+    # the graph to contain X -->  NEG  -->  NEG  which could be replaced
+    # with just X.
+
+    def _neg_neg_fixer(node: bn.BMGNode) -> NodeFixerResult:
+        if not isinstance(node, bn.NegateNode):
+            return Inapplicable
+        neg = node.inputs[0]
+        if not isinstance(neg, bn.NegateNode):
+            return Inapplicable
+        return neg.inputs[0]
+
+    return _neg_neg_fixer

--- a/src/beanmachine/ppl/compiler/fix_logsumexp.py
+++ b/src/beanmachine/ppl/compiler/fix_logsumexp.py
@@ -13,12 +13,12 @@ from beanmachine.ppl.compiler.fix_problem import (
 from beanmachine.ppl.compiler.lattice_typer import LatticeTyper
 
 
-def logsumexp_fixer(bmg: BMGraphBuilder, typer: LatticeTyper) -> NodeFixer:
+def logsumexp_fixer(bmg: BMGraphBuilder) -> NodeFixer:
     """This fixer attempts to rewrite log expressions of the form
     log( exp(a) + exp(b) + exp(c) ...) -> logsumexp(a,b,c, ...)
     """
 
-    def fixer(node: bn.BMGNode) -> NodeFixerResult:
+    def logsumexp_fixer(node: bn.BMGNode) -> NodeFixerResult:
         if not isinstance(node, bn.LogNode):
             return Inapplicable
         addition = node.operand
@@ -28,4 +28,4 @@ def logsumexp_fixer(bmg: BMGraphBuilder, typer: LatticeTyper) -> NodeFixer:
             return Inapplicable
         return bmg.add_logsumexp(*[i.operand for i in addition.inputs])
 
-    return fixer
+    return logsumexp_fixer

--- a/src/beanmachine/ppl/compiler/fix_multiary_ops.py
+++ b/src/beanmachine/ppl/compiler/fix_multiary_ops.py
@@ -146,8 +146,7 @@ class MultiaryOperatorFixer:
         return acc
 
 
-# TODO: typer is unused
-def multiary_addition_fixer(bmg: BMGraphBuilder, typer: TyperBase) -> NodeFixer:
+def multiary_addition_fixer(bmg: BMGraphBuilder) -> NodeFixer:
     """This fixer transforms graphs with long chains of binary addition nodes
     into multiary addition. This greatly decreases both the number of nodes
     and the number of edges in the graph, which can lead to performance wins
@@ -155,27 +154,26 @@ def multiary_addition_fixer(bmg: BMGraphBuilder, typer: TyperBase) -> NodeFixer:
 
     maf = MultiaryOperatorFixer(bmg, bn.AdditionNode)
 
-    def fixer(node: bn.BMGNode) -> NodeFixerResult:
+    def multiary_addition_fixer(node: bn.BMGNode) -> NodeFixerResult:
         if not maf._needs_fixing(node):
             return Inapplicable
         acc = maf.accumulate_input_nodes(node)
         return bmg.add_multi_addition(*acc)
 
-    return fixer
+    return multiary_addition_fixer
 
 
-# TODO: typer is unused
-def multiary_multiplication_fixer(bmg: BMGraphBuilder, typer: TyperBase) -> NodeFixer:
+def multiary_multiplication_fixer(bmg: BMGraphBuilder) -> NodeFixer:
     """This fixer transforms graphs with long chains of binary multiplication nodes
     into multiary multiplication. This greatly decreases both the number of nodes
     and the number of edges in the graph, which can lead to performance wins
     during inference."""
     maf = MultiaryOperatorFixer(bmg, bn.MultiplicationNode)
 
-    def fixer(node: bn.BMGNode) -> NodeFixerResult:
+    def multiary_multiplication_fixer(node: bn.BMGNode) -> NodeFixerResult:
         if not maf._needs_fixing(node):
             return Inapplicable
         acc = maf.accumulate_input_nodes(node)
         return bmg.add_multi_multiplication(*acc)
 
-    return fixer
+    return multiary_multiplication_fixer

--- a/src/beanmachine/ppl/compiler/tests/bmg_arithmetic_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_arithmetic_test.py
@@ -3510,11 +3510,8 @@ digraph "graph" {
 
     def test_bmg_neg_of_neg(self) -> None:
         # This test shows that we treat torch.neg the same as the unary negation
-        # operator when generating a graph.
-        #
-        # TODO: This test also shows that we do NOT optimize away negative-of-negative
-        # which we certainly could. Once we implement that optimization, come back
-        # and fix up this test accordingly.
+        # operator when generating a graph.  Note that since this this produces
+        # a neg-of-neg situation, the optimizer then removes both of them.
 
         self.maxDiff = None
         observed = BMGInference().to_dot([neg_of_neg()], {})
@@ -3524,20 +3521,16 @@ digraph "graph" {
   N1[label=1.0];
   N2[label=Normal];
   N3[label=Sample];
-  N4[label="-"];
-  N5[label="-"];
-  N6[label=Normal];
-  N7[label=Sample];
-  N8[label=Query];
+  N4[label=Normal];
+  N5[label=Sample];
+  N6[label=Query];
   N0 -> N2;
   N1 -> N2;
-  N1 -> N6;
+  N1 -> N4;
   N2 -> N3;
   N3 -> N4;
   N4 -> N5;
   N5 -> N6;
-  N6 -> N7;
-  N7 -> N8;
 }
 """
         self.assertEqual(observed.strip(), expected.strip())


### PR DESCRIPTION
Summary: The negative real multiplication diff earlier in this stack can cause a graph to contain `MULT  --> NEGATE --> NEGATE --> X`  paths. We now rewrite the graph to `MULT --> X`.

Reviewed By: yucenli

Differential Revision: D35819874

