### PR TITLE
Optimize nested matrix scale

### DIFF
--- a/src/beanmachine/ppl/compiler/fix_problems.py
+++ b/src/beanmachine/ppl/compiler/fix_problems.py
@@ -21,7 +21,10 @@ from beanmachine.ppl.compiler.fix_beta_conjugate_prior import (
 from beanmachine.ppl.compiler.fix_bool_arithmetic import bool_arithmetic_fixer
 from beanmachine.ppl.compiler.fix_bool_comparisons import bool_comparison_fixer
 from beanmachine.ppl.compiler.fix_logsumexp import logsumexp_fixer
-from beanmachine.ppl.compiler.fix_matrix_scale import trivial_matmul_fixer
+from beanmachine.ppl.compiler.fix_matrix_scale import (
+    nested_matrix_scale_fixer,
+    trivial_matmul_fixer,
+)
 from beanmachine.ppl.compiler.fix_multiary_ops import (
     multiary_addition_fixer,
     multiary_multiplication_fixer,
@@ -70,6 +73,7 @@ def arithmetic_graph_fixer(skip: Set[str], bmg: BMGraphBuilder) -> GraphFixer:
         multiary_multiplication_fixer(bmg),
         neg_neg_fixer(bmg),
         negative_real_multiplication_fixer(bmg, typer),
+        nested_matrix_scale_fixer(bmg),
         sum_fixer(bmg, typer),
         trivial_matmul_fixer(bmg, typer),
         unsupported_node_fixer(bmg, typer),


### PR DESCRIPTION
Summary:
We can easily get into a situation where multiple matrix scale operations are emitted into the graph in the "wrong" order; that is, if we have matrix valued node `M` and scalar valued nodes `S1` and `S2`, with matrix scale nodes `MS1` and `MS2`, we can get this graph:

           S2   M
            \  /
        S1   MS2
          \  /
           MS1
            |
            X

But that is less efficient when doing BMG inference than the mathematically equivalent graph:

         S1  S2
          \ /
           *    M
            \  /
             MS
             |
             X

Why? Because in the first graph we have an extra matrix-valued node that we then have to propagate around a matrix value, compute its matrix-valued derivative, and so on.  Much better to do all the scalar multiplication *first*.

We now have a pass which rewrites graphs of the first form into the second.

Suppose then we had three or more such nested matrix scales. You'd think that the multiary multiplication rewriter would detect that and rewrite it to be even more efficient; we could do all the scalar multiplications in one node.  However due to an unforseen design flaw in that rewriter, it does not produce that optimization. Why not? Because all the old outgoing edges in the graph are still there! They are just pointing to "orphaned" nodes that will never be emitted (because they have no descendants that are observed or queried.) That optimizer assumes that nodes that have two or more outgoing edges are needed for their intermediate values and should not be folded into one node.

To fix this problem, we should probably implement a graph trimming pass that removes such orphaned nodes entirely. However, doing so is not trivial because of yet another unforseen problem: our choice of deduplication strategy assumes that if you add a node that has been added *already* to the graph, that it is *still there*, and an orphan-deleting pass would violate that invariant.

So the long term solution here is (1) fix the deduplicator first, and (2) then add an orphan-deleting pass that runs along with the other optimization passes. We can then rely on knowing that outgoing edges on nodes actually go towards an observation or query.

Reviewed By: yucenli

Differential Revision: D35831310

