### PR TITLE
Define all the exceptions to be used for BART

### DIFF
--- a/src/beanmachine/ppl/experimental/causal_inference/__init__.py
+++ b/src/beanmachine/ppl/experimental/causal_inference/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/experimental/causal_inference/models/__init__.py
+++ b/src/beanmachine/ppl/experimental/causal_inference/models/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/experimental/causal_inference/models/bart/__init__.py
+++ b/src/beanmachine/ppl/experimental/causal_inference/models/bart/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from .exceptions import GrowError, NotInitializedError, PruneError, TreeStructureError
+
+__all__ = ["TreeStructureError", "PruneError", "GrowError", "NotInitializedError"]

--- a/src/beanmachine/ppl/experimental/causal_inference/models/bart/exceptions.py
+++ b/src/beanmachine/ppl/experimental/causal_inference/models/bart/exceptions.py
@@ -1,0 +1,31 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+class TreeStructureError(Exception):
+    """Base class for errors related to tree structure"""
+
+    pass
+
+
+class PruneError(TreeStructureError):
+    """Raised for errors in pruning operations on a tree such as trying to prune
+    a root node or trying to prune a node which would has non-terminal children."""
+
+    pass
+
+
+class GrowError(TreeStructureError):
+    """Raised for errors in growing a tree such as trying to grow from a node along
+    an input dimension which has no unique values."""
+
+    pass
+
+
+class NotInitializedError(AttributeError):
+    """Raised for errors in accessing model attributes which have not been initialized
+    for example trying to predict a model which has not been trained."""
+
+    pass


### PR DESCRIPTION
Summary:
We are building Bayesian Additive Regression Trees (BART) as an experimental causal inference model in beanmachine. Details of the project can be found in https://docs.google.com/document/d/11nkB6UTGpvQBEC2yBjfgwAr8VabTlD7R9XufGQG0EvI/edit?usp=sharing and the proposed design can be found in the draft design document: https://docs.google.com/document/d/1o3J7yobDF0M9E27Y0tP2889fycmemXUZbHE5cebRqzs/edit?usp=sharing.
This diff sets up the exceptions that will be used by the project.

Differential Revision: D37448771

