### PR TITLE
Implement data structures to track and enforce dimensional relational operations in tree nodes

### DIFF
--- a/src/beanmachine/ppl/experimental/causal_inference/__init__.py
+++ b/src/beanmachine/ppl/experimental/causal_inference/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/experimental/causal_inference/models/__init__.py
+++ b/src/beanmachine/ppl/experimental/causal_inference/models/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/experimental/causal_inference/models/bart/__init__.py
+++ b/src/beanmachine/ppl/experimental/causal_inference/models/bart/__init__.py
@@ -2,7 +2,3 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-
-from .exceptions import GrowError, NotInitializedError, PruneError, TreeStructureError
-
-__all__ = ["TreeStructureError", "PruneError", "GrowError", "NotInitializedError"]

--- a/src/beanmachine/ppl/experimental/causal_inference/models/bart/__init__.py
+++ b/src/beanmachine/ppl/experimental/causal_inference/models/bart/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from .exceptions import GrowError, NotInitializedError, PruneError, TreeStructureError
+
+__all__ = ["TreeStructureError", "PruneError", "GrowError", "NotInitializedError"]

--- a/src/beanmachine/ppl/experimental/causal_inference/models/bart/exceptions.py
+++ b/src/beanmachine/ppl/experimental/causal_inference/models/bart/exceptions.py
@@ -1,0 +1,31 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+class TreeStructureError(Exception):
+    """Base class for errors related to tree structure"""
+
+    pass
+
+
+class PruneError(TreeStructureError):
+    """Raised for errors in pruning operations on a tree such as trying to prune
+    a root node or trying to prune a node which would has non-terminal children."""
+
+    pass
+
+
+class GrowError(TreeStructureError):
+    """Raised for errors in growing a tree such as trying to grow from a node along
+    an input dimension which has no unique values."""
+
+    pass
+
+
+class NotInitializedError(AttributeError):
+    """Raised for errors in accessing model attributes which have not been initialized
+    for example trying to predict a model which has not been trained."""
+
+    pass

--- a/src/beanmachine/ppl/experimental/causal_inference/models/bart/split_rule.py
+++ b/src/beanmachine/ppl/experimental/causal_inference/models/bart/split_rule.py
@@ -1,0 +1,142 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import enum
+from dataclasses import dataclass
+from typing import List, Optional
+
+import torch
+
+
+class Operator(enum.Enum):
+    le = "less than equal to"
+    gt = "greater than"
+
+
+@dataclass(eq=True)
+class SplitRule:
+    """
+    A representation of a split in feature space as a result of a decision node node growing to a leaf node.
+
+    """
+
+    def __init__(
+        self,
+        grow_dim: int,
+        grow_val: float,
+        operator: Operator,
+    ):
+        """
+        Args:
+            grow_dim: The dimension used for the split.
+            grow_val: The value used for splitting.
+            operator: The relational operation used for the split. The two operators considered are
+                "less than or equal" for the left child and "greater than" for the right child.
+        """
+        self.grow_dim = grow_dim
+        self.grow_val = grow_val
+        self.operator = operator
+
+
+class DimensionalRule:
+    """
+    Represents the range of values along one dimension of the input which passes a rule.
+    For example, if input is X = [x1, x2] then a dimensional rule for x1 could be
+    x1 in [3, 4 , 5...20] representing the rule 3 < x1 <=20 (assuming x1 is an integer).
+    """
+
+    def __init__(self, grow_dim: int, min_val: float, max_val: float):
+        """
+        Args:
+            grow_dim: The dimension used for the rule.
+            min_val: The minimum value of grow_dim which satisfies the rule (exclusive i.e. min_val fails the rule).
+            max_val: The maximum value of grow_dim which satisfies the rule (inclusive i.e. max_val passes the rule).
+        """
+        self.grow_dim = grow_dim
+        self.min_val, self.max_val = min_val, max_val
+
+    def add_rule(self, new_rule: SplitRule) -> "DimensionalRule":
+        """Add a rule to the dimension. If the rule is less restrictive than an existing rule, nothing changes.
+
+        Args:
+            new_rule: The new rule to add.
+        """
+        if self.grow_dim != new_rule.grow_dim:
+            raise ValueError("New rule grow dimension does not match")
+        if new_rule.operator == Operator.gt and new_rule.grow_val > self.min_val:
+            return DimensionalRule(self.grow_dim, new_rule.grow_val, self.max_val)
+        elif new_rule.operator == Operator.le and new_rule.grow_val < self.max_val:
+            return DimensionalRule(self.grow_dim, self.min_val, new_rule.grow_val)
+        else:
+            # new rule is already covered by existing rule
+            return self
+
+
+class CompositeRules:
+    """
+    Represents a composition of `DimensionalRule`s along multiple dimensions of input.
+    For example, if input is X = [x1, x2] then a composite rule could be
+    x1 in [3, 4 , 5...20] and x2 in [-inf..-10] representing the rule 3 < x1 <=20
+    (assuming x1 is an integer) and x2<= -10.
+    """
+
+    def __init__(
+        self, all_dims: List[int], all_split_rules: Optional[List[SplitRule]] = None
+    ):
+        """
+        Args:
+            all_dims: All dimensions which have rules.
+            all_split_rules: All rules corresponding to each dimension in `all_dims`.
+        """
+        self.dimensional_rules = {
+            dim: DimensionalRule(dim, -float("inf"), float("inf")) for dim in all_dims
+        }
+        if all_split_rules is None:
+            self.all_split_rules = []
+        else:
+            self.all_split_rules = all_split_rules
+
+        for split_rule in self.all_split_rules:
+            self.dimensional_rules[split_rule.grow_dim] = self.dimensional_rules[
+                split_rule.grow_dim
+            ].add_rule(split_rule)
+        if len(self.all_split_rules) > 0:
+            self.grow_dim = self.all_split_rules[-1].grow_dim
+        else:
+            self.grow_dim = None
+
+    def condition_on_rules(self, X: torch.Tensor) -> torch.Tensor:
+        """Condition the input on a composite rule and get a mask such that X[mask]
+        satisfies the rule.
+
+        Args:
+            X: Input / covariate matrix.
+        """
+        mask = torch.ones(len(X), dtype=torch.bool)
+        for dim in self.dimensional_rules.keys():
+            mask = (
+                mask
+                & (X[:, dim].gt(self.dimensional_rules[dim].min_val))
+                & (X[:, dim].le(self.dimensional_rules[dim].max_val))
+            )
+        return mask
+
+    def add_rule(self, new_rule: SplitRule) -> "CompositeRules":
+        """Add a split rule to the composite ruleset. Returns a copy of `CompositeRules`"""
+        if new_rule.grow_dim not in self.dimensional_rules.keys():
+            raise ValueError(
+                "The dimension of new split rule is outside the scope of the composite rule"
+            )
+
+        return CompositeRules(
+            list(self.dimensional_rules.keys()), self.all_split_rules + [new_rule]
+        )
+
+    def most_recent_split_rule(self) -> Optional[SplitRule]:
+        """Returns the most recent split_rule added. Returns None if no rules were applied."""
+        if len(self.all_split_rules) == 0:
+            return None
+        else:
+            return self.all_split_rules[-1]

--- a/src/beanmachine/ppl/experimental/tests/bart/bart_split_rule_test.py
+++ b/src/beanmachine/ppl/experimental/tests/bart/bart_split_rule_test.py
@@ -1,0 +1,105 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import pytest
+import torch
+from beanmachine.ppl.experimental.causal_inference.models.bart.split_rule import (
+    CompositeRules,
+    DimensionalRule,
+    Operator,
+    SplitRule,
+)
+
+
+@pytest.fixture
+def grow_dim():
+    return 1
+
+
+@pytest.fixture
+def grow_val():
+    return 2.1
+
+
+def test_dimensional_rule_addition(grow_dim, grow_val):
+    lax_rule = SplitRule(
+        grow_dim=grow_dim, grow_val=grow_val + 10, operator=Operator.le
+    )
+    existing_dimensional_rule = DimensionalRule(
+        grow_dim=grow_dim, min_val=grow_val - 20, max_val=grow_val
+    )
+    assert (
+        existing_dimensional_rule.max_val
+        == existing_dimensional_rule.add_rule(lax_rule).max_val
+    )
+    assert (
+        existing_dimensional_rule.min_val
+        == existing_dimensional_rule.add_rule(lax_rule).min_val
+    )
+
+    restrictive_rule_le = SplitRule(
+        grow_dim=grow_dim, grow_val=grow_val - 10, operator=Operator.le
+    )
+    assert (
+        existing_dimensional_rule.max_val
+        > existing_dimensional_rule.add_rule(restrictive_rule_le).max_val
+    )
+    assert (
+        existing_dimensional_rule.min_val
+        == existing_dimensional_rule.add_rule(restrictive_rule_le).min_val
+    )
+
+    restrictive_rule_gt = SplitRule(
+        grow_dim=grow_dim, grow_val=grow_val - 10, operator=Operator.gt
+    )
+    assert (
+        existing_dimensional_rule.max_val
+        == existing_dimensional_rule.add_rule(restrictive_rule_gt).max_val
+    )
+    assert (
+        existing_dimensional_rule.min_val
+        < existing_dimensional_rule.add_rule(restrictive_rule_gt).min_val
+    )
+
+
+@pytest.fixture
+def all_dims():
+    return [0, 2]
+
+
+@pytest.fixture
+def all_split_rules(all_dims):
+    all_rules = []
+    for dim in all_dims:
+        all_rules.append(SplitRule(grow_dim=dim, grow_val=5, operator=Operator.le))
+    return all_rules
+
+
+@pytest.fixture
+def X():
+    return torch.Tensor([[1.0, 3.0, 7.0], [-1.1, 100, 5]])
+
+
+def test_composite_rules(all_dims, all_split_rules, X):
+    composite_rule = CompositeRules(all_dims=all_dims, all_split_rules=all_split_rules)
+    X_cond = X[composite_rule.condition_on_rules(X)]
+    for dim in all_dims:
+        assert torch.all(X_cond[:, dim] > composite_rule.dimensional_rules[dim].min_val)
+        assert torch.all(
+            X_cond[:, dim] <= composite_rule.dimensional_rules[dim].max_val
+        )
+
+    invalid_split_rule = SplitRule(
+        grow_dim=max(all_dims) + 1, grow_val=12, operator=Operator.le
+    )
+    with pytest.raises(ValueError):
+        _ = composite_rule.add_rule(invalid_split_rule)
+
+    valid_split_rule = SplitRule(
+        grow_dim=max(all_dims), grow_val=1000.0, operator=Operator.gt
+    )
+    valid_new_composite_rule = composite_rule.add_rule(valid_split_rule)
+    assert valid_new_composite_rule.most_recent_split_rule() == valid_split_rule


### PR DESCRIPTION
Summary:
Background:
We are building Bayesian Additive Regression Trees (BART) as an experimental causal inference model in beanmachine. Details of the project can be found in https://docs.google.com/document/d/11nkB6UTGpvQBEC2yBjfgwAr8VabTlD7R9XufGQG0EvI/edit?usp=sharing and the proposed design can be found in the draft design document: https://docs.google.com/document/d/1o3J7yobDF0M9E27Y0tP2889fycmemXUZbHE5cebRqzs/edit?usp=sharing.

In this diff:
BART works by sorting (conditioning) the data according to rules applied to the input. These rules are relational and numeric (lesser than equal to, greater than). We are implementing datastructures to keep track of these rules(SplitRule), split up one input dimension according to these rules(DimensionalRule) and combine rules from different dimensions to construct a "bucketed" input space (CompositeRule).

Differential Revision: D37462612

