### PR TITLE
Implement Node datastructure

### DIFF
--- a/src/beanmachine/ppl/experimental/causal_inference/__init__.py
+++ b/src/beanmachine/ppl/experimental/causal_inference/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/experimental/causal_inference/models/__init__.py
+++ b/src/beanmachine/ppl/experimental/causal_inference/models/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/src/beanmachine/ppl/experimental/causal_inference/models/bart/__init__.py
+++ b/src/beanmachine/ppl/experimental/causal_inference/models/bart/__init__.py
@@ -2,7 +2,3 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-
-from .exceptions import GrowError, NotInitializedError, PruneError, TreeStructureError
-
-__all__ = ["TreeStructureError", "PruneError", "GrowError", "NotInitializedError"]

--- a/src/beanmachine/ppl/experimental/causal_inference/models/bart/__init__.py
+++ b/src/beanmachine/ppl/experimental/causal_inference/models/bart/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from .exceptions import GrowError, NotInitializedError, PruneError, TreeStructureError
+
+__all__ = ["TreeStructureError", "PruneError", "GrowError", "NotInitializedError"]

--- a/src/beanmachine/ppl/experimental/causal_inference/models/bart/exceptions.py
+++ b/src/beanmachine/ppl/experimental/causal_inference/models/bart/exceptions.py
@@ -1,0 +1,31 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+class TreeStructureError(Exception):
+    """Base class for errors related to tree structure"""
+
+    pass
+
+
+class PruneError(TreeStructureError):
+    """Raised for errors in pruning operations on a tree such as trying to prune
+    a root node or trying to prune a node which would has non-terminal children."""
+
+    pass
+
+
+class GrowError(TreeStructureError):
+    """Raised for errors in growing a tree such as trying to grow from a node along
+    an input dimension which has no unique values."""
+
+    pass
+
+
+class NotInitializedError(AttributeError):
+    """Raised for errors in accessing model attributes which have not been initialized
+    for example trying to predict a model which has not been trained."""
+
+    pass

--- a/src/beanmachine/ppl/experimental/causal_inference/models/bart/node.py
+++ b/src/beanmachine/ppl/experimental/causal_inference/models/bart/node.py
@@ -1,0 +1,278 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import List, Optional, overload, Tuple, Union
+
+import torch
+
+from beanmachine.ppl.experimental.causal_inference.models.bart.exceptions import (
+    PruneError,
+)
+from beanmachine.ppl.experimental.causal_inference.models.bart.split_rule import (
+    CompositeRules,
+    SplitRule,
+)
+
+
+class BaseNode:
+    """
+    Base class for node structures.
+    Contains reference to a left and right child which can be used to traverse the tree.
+    """
+
+    def __init__(
+        self,
+        depth: int,
+        composite_rules: CompositeRules,
+        left_child: Optional["BaseNode"] = None,
+        right_child: Optional["BaseNode"] = None,
+    ):
+        """
+        Args:
+           depth: Distance of node from root node.
+           composite_rules: Dimensional rules that are satisfied by this node.
+           left_child: Left child of the node.
+           right_child: Right child of the node.
+        """
+        self.depth = depth
+        self.composite_rules = composite_rules
+        self._left_child = left_child
+        self._right_child = right_child
+
+    @property
+    def left_child(self) -> Optional["BaseNode"]:
+        """Returns the left_child of the node."""
+        return self._left_child
+
+    @property
+    def right_child(self) -> Optional["BaseNode"]:
+        """Returns the right_child of the node."""
+        return self._right_child
+
+    @overload
+    def data_in_node(
+        self, X: torch.Tensor, y: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        ...
+
+    @overload
+    def data_in_node(self, X: torch.Tensor) -> torch.Tensor:
+        ...
+
+    def data_in_node(
+        self, X: torch.Tensor, y: Optional[torch.Tensor] = None
+    ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+        """
+        Conditions the covariate matrix and (optionally) response vector to return the
+        respective subsets which satisfy the composite rules of this node.
+        Note that the conditioning only looks at the input / covariate matrix
+        to determine this conditioning.
+
+        Args:
+            X: Input / covariate matrix.
+            y: (Optional) response vector.
+        """
+        condition_mask = self.composite_rules.condition_on_rules(X)
+        if y is not None:
+            return X[condition_mask], y[condition_mask]
+        return X[condition_mask]
+
+
+class LeafNode(BaseNode):
+    """
+    A representation of a leaf node in the tree. Does not have children.
+    In addition to the normal work of a `BaseNode`, a `LeafNode` is responsible for
+    making predictions based on its value.
+    """
+
+    def __init__(
+        self,
+        depth: int,
+        composite_rules: CompositeRules,
+        val: float = 0.0,
+    ):
+        """
+        Args:
+            depth: Distance of node from root node.
+            composite_rules: Dimensional rules that are satisfied by this node.
+            val: The prediction value of the node.
+        """
+        self.val = val
+        super().__init__(
+            depth=depth,
+            composite_rules=composite_rules,
+            left_child=None,
+            right_child=None,
+        )
+
+    def predict(self) -> float:
+        """
+        Returns the val attribute as a prediction.
+        """
+        return self.val
+
+    def is_growable(self, X: torch.Tensor) -> bool:
+        """
+        Returns true if this leaf node can be grown.
+        This is checked by ensuring the input covariate matrix
+        has atleast more than 1 unique values along any dimension.
+
+        Args:
+            X: Input / covariate matrix.
+        """
+        return len(self.get_growable_dims(X)) > 0
+
+    def get_growable_dims(self, X: torch.Tensor) -> List[int]:
+        """
+        Returns the list of dimensions along which this leaf node can be gronw.
+        This is checked by ensuring the input covariate matrix
+        has atleast more than 1 unique values along any dimension.
+
+        Args:
+            X: Input / covariate matrix.
+        """
+        X_conditioned = self.data_in_node(X)
+        if len(X_conditioned) == 0:
+            return []
+
+        return [
+            dim
+            for dim in range(X_conditioned.shape[-1])
+            if len(torch.unique(self.get_growable_vals(X_conditioned, dim))) > 1
+        ]
+
+    def get_num_growable_dims(self, X: torch.Tensor) -> int:
+        """
+        Returns the number of dimensions along which this leaf node can be grown.
+        This is checked by ensuring the input covariate matrix
+        has atleast more than 1 unique values along any dimension.
+
+        Args:
+            X: Input / covariate matrix.
+        """
+        return len(self.get_growable_dims(X))
+
+    def get_growable_vals(self, X: torch.Tensor, grow_dim: int) -> torch.Tensor:
+        """Returns the values in a feature dimension.
+        Args:
+            X: Input / covariate matrix.
+            grow_dim: Input dimensions along which values are required
+        """
+        return self.data_in_node(X)[:, grow_dim]
+
+    def get_partition_of_split(
+        self, X: torch.Tensor, grow_dim: int, grow_val: float
+    ) -> float:
+        """
+        Get probability that a split value is chosen among possible values in an input dimension defined as
+        N(values_in_dimension == split_val) / N(values_in_dimension).
+        Args:
+            X: Input / covariate matrix.
+            grow_dim: Input dimensions along which values are required.
+            grow_va;: The value along which the split is being carried out.
+        """
+
+        growable_vals = self.get_growable_vals(X, grow_dim)
+        return torch.mean(growable_vals.eq(2), dtype=torch.float).item()
+
+    def deepcopy(self) -> "LeafNode":
+        """Return a deepcopy of the node"""
+        return LeafNode(
+            depth=self.depth,
+            composite_rules=self.composite_rules,
+            val=self.val,
+        )
+
+    @staticmethod
+    def grow_node(
+        node: "LeafNode",
+        left_rule: SplitRule,
+        right_rule: SplitRule,
+    ) -> "SplitNode":
+        """
+        Converts a LeafNode into an internal SplitNode by applying the split rules for the left and right nodes.
+        This returns a copy of the oriingal node.
+        Args:
+            left_rule: Rule applied to left child of the grown node.
+            right_rule: Rule applied to the right child of the grown node.
+        """
+        left_composite_rules = node.composite_rules.add_rule(left_rule)
+        right_composite_rules = node.composite_rules.add_rule(right_rule)
+
+        return SplitNode(
+            depth=node.depth,
+            composite_rules=node.composite_rules,
+            left_child=LeafNode(
+                depth=node.depth + 1, composite_rules=left_composite_rules
+            ),
+            right_child=LeafNode(
+                depth=node.depth + 1, composite_rules=right_composite_rules
+            ),
+        )
+
+
+class SplitNode(BaseNode):
+    """
+    Encapsulates internal node in the tree. It has the same attributes as BaseNode.
+    It contains the additional logic to determine if this node can be pruned.
+    """
+
+    def __init__(
+        self,
+        depth: int,
+        composite_rules: CompositeRules,
+        left_child: Optional["BaseNode"] = None,
+        right_child: Optional["BaseNode"] = None,
+    ):
+        """
+        Args:
+           depth: Distance of node from root node.
+           composite_rules: Dimensional rules that are satisfied by this node.
+           left_child: Left child of the node.
+           right_child: Right child of the node.
+        """
+        super().__init__(
+            depth=depth,
+            composite_rules=composite_rules,
+            left_child=left_child,
+            right_child=right_child,
+        )
+
+    def is_prunable(self) -> bool:
+        """Returns true if this node is prunable. This is decided by the fact if its children are `LeafNodes`."""
+        return isinstance(self.left_child, LeafNode) and isinstance(
+            self.right_child, LeafNode
+        )
+
+    def most_recent_rule(self) -> Optional[SplitRule]:
+        """Returns the rule which grew this node from a `LeafNode` and is specifically the rule which created its left child."""
+        if self.left_child is None:
+            raise AttributeError("This node is not split")
+        return self.left_child.composite_rules.most_recent_split_rule()
+
+    def deepcopy(self) -> "SplitNode":
+        """Returns a deepcopy of the node."""
+        return SplitNode(
+            depth=self.depth,
+            composite_rules=self.composite_rules,
+            left_child=self.left_child,
+            right_child=self.right_child,
+        )
+
+    @staticmethod
+    def prune_node(
+        node: "SplitNode",
+    ) -> LeafNode:
+        """
+        Converts a SplitNode to a LeafNode by eliminating its children (if they are leaf nodes). Returns a copy.
+
+        Args:
+            node: Node to prune.
+        Raises:
+            PruneError: If this node is not prunable.
+        """
+        if not node.is_prunable():
+            raise PruneError("Not a valid prunable node")
+        return LeafNode(depth=node.depth, composite_rules=node.composite_rules)

--- a/src/beanmachine/ppl/experimental/causal_inference/models/bart/split_rule.py
+++ b/src/beanmachine/ppl/experimental/causal_inference/models/bart/split_rule.py
@@ -1,0 +1,142 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import enum
+from dataclasses import dataclass
+from typing import List, Optional
+
+import torch
+
+
+class Operator(enum.Enum):
+    le = "less than equal to"
+    gt = "greater than"
+
+
+@dataclass(eq=True)
+class SplitRule:
+    """
+    A representation of a split in feature space as a result of a decision node node growing to a leaf node.
+
+    """
+
+    def __init__(
+        self,
+        grow_dim: int,
+        grow_val: float,
+        operator: Operator,
+    ):
+        """
+        Args:
+            grow_dim: The dimension used for the split.
+            grow_val: The value used for splitting.
+            operator: The relational operation used for the split. The two operators considered are
+                "less than or equal" for the left child and "greater than" for the right child.
+        """
+        self.grow_dim = grow_dim
+        self.grow_val = grow_val
+        self.operator = operator
+
+
+class DimensionalRule:
+    """
+    Represents the range of values along one dimension of the input which passes a rule.
+    For example, if input is X = [x1, x2] then a dimensional rule for x1 could be
+    x1 in [3, 4 , 5...20] representing the rule 3 < x1 <=20 (assuming x1 is an integer).
+    """
+
+    def __init__(self, grow_dim: int, min_val: float, max_val: float):
+        """
+        Args:
+            grow_dim: The dimension used for the rule.
+            min_val: The minimum value of grow_dim which satisfies the rule (exclusive i.e. min_val fails the rule).
+            max_val: The maximum value of grow_dim which satisfies the rule (inclusive i.e. max_val passes the rule).
+        """
+        self.grow_dim = grow_dim
+        self.min_val, self.max_val = min_val, max_val
+
+    def add_rule(self, new_rule: SplitRule) -> "DimensionalRule":
+        """Add a rule to the dimension. If the rule is less restrictive than an existing rule, nothing changes.
+
+        Args:
+            new_rule: The new rule to add.
+        """
+        if self.grow_dim != new_rule.grow_dim:
+            raise ValueError("New rule grow dimension does not match")
+        if new_rule.operator == Operator.gt and new_rule.grow_val > self.min_val:
+            return DimensionalRule(self.grow_dim, new_rule.grow_val, self.max_val)
+        elif new_rule.operator == Operator.le and new_rule.grow_val < self.max_val:
+            return DimensionalRule(self.grow_dim, self.min_val, new_rule.grow_val)
+        else:
+            # new rule is already covered by existing rule
+            return self
+
+
+class CompositeRules:
+    """
+    Represents a composition of `DimensionalRule`s along multiple dimensions of input.
+    For example, if input is X = [x1, x2] then a composite rule could be
+    x1 in [3, 4 , 5...20] and x2 in [-inf..-10] representing the rule 3 < x1 <=20
+    (assuming x1 is an integer) and x2<= -10.
+    """
+
+    def __init__(
+        self, all_dims: List[int], all_split_rules: Optional[List[SplitRule]] = None
+    ):
+        """
+        Args:
+            all_dims: All dimensions which have rules.
+            all_split_rules: All rules corresponding to each dimension in `all_dims`.
+        """
+        self.dimensional_rules = {
+            dim: DimensionalRule(dim, -float("inf"), float("inf")) for dim in all_dims
+        }
+        if all_split_rules is None:
+            self.all_split_rules = []
+        else:
+            self.all_split_rules = all_split_rules
+
+        for split_rule in self.all_split_rules:
+            self.dimensional_rules[split_rule.grow_dim] = self.dimensional_rules[
+                split_rule.grow_dim
+            ].add_rule(split_rule)
+        if len(self.all_split_rules) > 0:
+            self.grow_dim = self.all_split_rules[-1].grow_dim
+        else:
+            self.grow_dim = None
+
+    def condition_on_rules(self, X: torch.Tensor) -> torch.Tensor:
+        """Condition the input on a composite rule and get a mask such that X[mask]
+        satisfies the rule.
+
+        Args:
+            X: Input / covariate matrix.
+        """
+        mask = torch.ones(len(X), dtype=torch.bool)
+        for dim in self.dimensional_rules.keys():
+            mask = (
+                mask
+                & (X[:, dim].gt(self.dimensional_rules[dim].min_val))
+                & (X[:, dim].le(self.dimensional_rules[dim].max_val))
+            )
+        return mask
+
+    def add_rule(self, new_rule: SplitRule) -> "CompositeRules":
+        """Add a split rule to the composite ruleset. Returns a copy of `CompositeRules`"""
+        if new_rule.grow_dim not in self.dimensional_rules.keys():
+            raise ValueError(
+                "The dimension of new split rule is outside the scope of the composite rule"
+            )
+
+        return CompositeRules(
+            list(self.dimensional_rules.keys()), self.all_split_rules + [new_rule]
+        )
+
+    def most_recent_split_rule(self) -> Optional[SplitRule]:
+        """Returns the most recent split_rule added. Returns None if no rules were applied."""
+        if len(self.all_split_rules) == 0:
+            return None
+        else:
+            return self.all_split_rules[-1]

--- a/src/beanmachine/ppl/experimental/tests/bart/bart_node_test.py
+++ b/src/beanmachine/ppl/experimental/tests/bart/bart_node_test.py
@@ -1,0 +1,121 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import pytest
+import torch
+from beanmachine.ppl.experimental.causal_inference.models.bart.exceptions import (
+    PruneError,
+)
+from beanmachine.ppl.experimental.causal_inference.models.bart.node import (
+    BaseNode,
+    LeafNode,
+    SplitNode,
+)
+from beanmachine.ppl.experimental.causal_inference.models.bart.split_rule import (
+    CompositeRules,
+    Operator,
+    SplitRule,
+)
+
+
+@pytest.fixture
+def composite_rule():
+    all_rules = []
+    all_dims = [0, 1, 2]
+    for dim in all_dims:
+        all_rules.append(SplitRule(grow_dim=dim, grow_val=0, operator=Operator.le))
+    composite_rule = CompositeRules(all_dims=all_dims, all_split_rules=all_rules)
+    return composite_rule
+
+
+@pytest.fixture
+def left_rule():
+    return SplitRule(grow_dim=0, grow_val=-0.5, operator=Operator.le)
+
+
+@pytest.fixture
+def right_rule():
+    return SplitRule(grow_dim=0, grow_val=-0.5, operator=Operator.gt)
+
+
+@pytest.fixture
+def all_pass_composite_rule():
+    all_rules = []
+    all_dims = [0, 1, 2]
+    for dim in all_dims:
+        all_rules.append(
+            SplitRule(grow_dim=dim, grow_val=float("inf"), operator=Operator.le)
+        )
+    composite_rule = CompositeRules(all_dims=all_dims, all_split_rules=all_rules)
+    return composite_rule
+
+
+@pytest.fixture
+def X():
+    return torch.Tensor([[1.0, 3.0, 7.0], [-1.1, -1, -5]])
+
+
+def test_conditioning(X, composite_rule):
+    base_node = BaseNode(depth=0, composite_rules=composite_rule)
+    assert torch.all(
+        base_node.data_in_node(X) == X[composite_rule.condition_on_rules(X)]
+    )
+
+
+def test_leaf_node_prediction(composite_rule):
+    val = 10
+    leaf_node = LeafNode(composite_rules=composite_rule, depth=0, val=val)
+    assert leaf_node.predict() == val
+
+
+@pytest.fixture
+def leaf_node(composite_rule):
+    return LeafNode(composite_rules=composite_rule, depth=0)
+
+
+@pytest.fixture
+def loose_leaf(all_pass_composite_rule):
+    return LeafNode(composite_rules=all_pass_composite_rule, depth=0)
+
+
+def test_growable_dims(leaf_node, loose_leaf, X):
+    assert leaf_node.get_num_growable_dims(X) == 0  # only one row of X passes the test
+    assert loose_leaf.get_num_growable_dims(X) == X.shape[-1]  # everything passes
+
+
+def test_is_grow(leaf_node, loose_leaf, X):
+    assert not leaf_node.is_growable(X)  # no splittable_dims. Cannot grow.
+    assert loose_leaf.is_growable(X)
+
+
+def test_grow_node(leaf_node, left_rule, right_rule, X):
+    grown_leaf = LeafNode.grow_node(
+        leaf_node, left_rule=left_rule, right_rule=right_rule
+    )
+    assert isinstance(grown_leaf, SplitNode)
+    assert grown_leaf.left_child is not None
+    assert grown_leaf.right_child is not None
+    assert grown_leaf.most_recent_rule() == left_rule
+
+
+def test_prune_node(leaf_node, composite_rule):
+    split_node = SplitNode(
+        left_child=leaf_node,
+        right_child=leaf_node.deepcopy(),
+        depth=1,
+        composite_rules=composite_rule,
+    )
+    grandfather_node = SplitNode(
+        left_child=leaf_node,
+        right_child=split_node,
+        depth=0,
+        composite_rules=composite_rule,
+    )
+    assert split_node.is_prunable()
+    assert not grandfather_node.is_prunable()
+    assert isinstance(SplitNode.prune_node(split_node), LeafNode)
+    with pytest.raises(PruneError):
+        SplitNode.prune_node(grandfather_node)

--- a/src/beanmachine/ppl/experimental/tests/bart/bart_split_rule_test.py
+++ b/src/beanmachine/ppl/experimental/tests/bart/bart_split_rule_test.py
@@ -1,0 +1,105 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import pytest
+import torch
+from beanmachine.ppl.experimental.causal_inference.models.bart.split_rule import (
+    CompositeRules,
+    DimensionalRule,
+    Operator,
+    SplitRule,
+)
+
+
+@pytest.fixture
+def grow_dim():
+    return 1
+
+
+@pytest.fixture
+def grow_val():
+    return 2.1
+
+
+def test_dimensional_rule_addition(grow_dim, grow_val):
+    lax_rule = SplitRule(
+        grow_dim=grow_dim, grow_val=grow_val + 10, operator=Operator.le
+    )
+    existing_dimensional_rule = DimensionalRule(
+        grow_dim=grow_dim, min_val=grow_val - 20, max_val=grow_val
+    )
+    assert (
+        existing_dimensional_rule.max_val
+        == existing_dimensional_rule.add_rule(lax_rule).max_val
+    )
+    assert (
+        existing_dimensional_rule.min_val
+        == existing_dimensional_rule.add_rule(lax_rule).min_val
+    )
+
+    restrictive_rule_le = SplitRule(
+        grow_dim=grow_dim, grow_val=grow_val - 10, operator=Operator.le
+    )
+    assert (
+        existing_dimensional_rule.max_val
+        > existing_dimensional_rule.add_rule(restrictive_rule_le).max_val
+    )
+    assert (
+        existing_dimensional_rule.min_val
+        == existing_dimensional_rule.add_rule(restrictive_rule_le).min_val
+    )
+
+    restrictive_rule_gt = SplitRule(
+        grow_dim=grow_dim, grow_val=grow_val - 10, operator=Operator.gt
+    )
+    assert (
+        existing_dimensional_rule.max_val
+        == existing_dimensional_rule.add_rule(restrictive_rule_gt).max_val
+    )
+    assert (
+        existing_dimensional_rule.min_val
+        < existing_dimensional_rule.add_rule(restrictive_rule_gt).min_val
+    )
+
+
+@pytest.fixture
+def all_dims():
+    return [0, 2]
+
+
+@pytest.fixture
+def all_split_rules(all_dims):
+    all_rules = []
+    for dim in all_dims:
+        all_rules.append(SplitRule(grow_dim=dim, grow_val=5, operator=Operator.le))
+    return all_rules
+
+
+@pytest.fixture
+def X():
+    return torch.Tensor([[1.0, 3.0, 7.0], [-1.1, 100, 5]])
+
+
+def test_composite_rules(all_dims, all_split_rules, X):
+    composite_rule = CompositeRules(all_dims=all_dims, all_split_rules=all_split_rules)
+    X_cond = X[composite_rule.condition_on_rules(X)]
+    for dim in all_dims:
+        assert torch.all(X_cond[:, dim] > composite_rule.dimensional_rules[dim].min_val)
+        assert torch.all(
+            X_cond[:, dim] <= composite_rule.dimensional_rules[dim].max_val
+        )
+
+    invalid_split_rule = SplitRule(
+        grow_dim=max(all_dims) + 1, grow_val=12, operator=Operator.le
+    )
+    with pytest.raises(ValueError):
+        _ = composite_rule.add_rule(invalid_split_rule)
+
+    valid_split_rule = SplitRule(
+        grow_dim=max(all_dims), grow_val=1000.0, operator=Operator.gt
+    )
+    valid_new_composite_rule = composite_rule.add_rule(valid_split_rule)
+    assert valid_new_composite_rule.most_recent_split_rule() == valid_split_rule


### PR DESCRIPTION
Summary:
Background:
We are building Bayesian Additive Regression Trees (BART) as an experimental causal inference model in beanmachine. Details of the project can be found in https://docs.google.com/document/d/11nkB6UTGpvQBEC2yBjfgwAr8VabTlD7R9XufGQG0EvI/edit?usp=sharing and the proposed design can be found in the draft design document: https://docs.google.com/document/d/1o3J7yobDF0M9E27Y0tP2889fycmemXUZbHE5cebRqzs/edit?usp=sharing.

In this diff:
We have implemented the nodes of the tree.
Each node contains a set of rules used for conditioning or filtering the input data.  ```BaseNode``` class keeps track of left and right children and can condition / filter input based on its rules. ```LeafNode``` encapsulates the terminal nodes and can make a prediction based on its value. For a given input point, the prediction of the leaf node it is filtered to constitutes a prediction of the tree. It also contains the logic to "grow" which is the action of converting it to an internal node by growing terminal children based on some splitting rule.
```SplitNode``` encapsulates the internal nodes. It contains the logic of "pruning" which is the action of converting an internal node to a terminal node by removing its children, who must be leaves.

Differential Revision: D37478652

