### PR TITLE
Pin netCDF4 version to resolve build issue on Python 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,8 @@ INSTALL_REQUIRES = [
     "botorch>=0.5.1",
     "gpytorch>=1.3.0",
     "graphviz>=0.17",
+    "functorch>=0.1.0; platform_system!='Windows'",
+    "netCDF4<=1.5.8; python_version<'3.8'",
     "numpy>=1.18.1",
     "pandas>=0.24.2",
     "plotly>=2.2.1",
@@ -70,7 +72,6 @@ if platform.system() == "Windows":
     CPP_COMPILE_ARGS = ["/WX", "/permissive-", "/std:c++20"]
 else:
     CPP_COMPILE_ARGS = ["-std=c++2a", "-Werror"]
-    INSTALL_REQUIRES.append("functorch>=0.1.0")
 
 
 # Check for python version


### PR DESCRIPTION
Summary:
Our Python 3.7 CI is currently failing because the most recent release of netCDF4 (v1.6.0) does not include prebuild wheels for MacOS and Linux. As a result, pip falls back to build from source -- which requires HDF5 package to be present.

While waiting for potential fixes from netCDF4 side, we can temporarily pin netCDF4 to v1.5.8 for Python 3.7 with [`setuptool`'s conditional install dependency syntax](https://setuptools.pypa.io/en/latest/userguide/dependency_management.html#platform-specific-dependencies). I also take the chance to rewrite the functorch dependency with the same syntax.

Differential Revision: D37480732

