### PR TITLE
Remove Variable's duplicate attribute docstrings

### DIFF
--- a/src/beanmachine/ppl/world/variable.py
+++ b/src/beanmachine/ppl/world/variable.py
@@ -22,9 +22,16 @@ class Variable:
     """
 
     value: torch.Tensor
+    "Sampled value of random variable"
+
     distribution: dist.Distribution
+    "Distribution random variable was sampled from"
+
     parents: Set[RVIdentifier] = dataclasses.field(default_factory=set)
+    "Set containing the RVIdentifiers of the parents of the random variable"
+
     children: Set[RVIdentifier] = dataclasses.field(default_factory=set)
+    "Set containing the RVIdentifiers of the children of the random variable"
 
     @lazy_property
     def log_prob(self) -> torch.Tensor:

--- a/src/beanmachine/ppl/world/variable.py
+++ b/src/beanmachine/ppl/world/variable.py
@@ -19,12 +19,6 @@ class Variable:
     """
     Primitive used for maintaining metadata of random variables. Usually used
     in conjunction with `World` during inference.
-
-    Attributes:
-      value (torch.Tensor): Sampled value of random variable
-      distribution (torch.distributions.Distribution): Distribution random variable was sampled from
-      parents (set): Set containing the RVIdentifiers of the parents of the random variable
-      children (set): Set containing the RVIdentifiers of the children of the random variable
     """
 
     value: torch.Tensor


### PR DESCRIPTION
### Motivation
Discovered with @himaghna, `Attribute` annotations currently result in duplicated member documentation (such as https://beanmachine.org/api/beanmachine.ppl.world.variable.html):
![image](https://user-images.githubusercontent.com/990069/176307384-d4575a28-59c0-4040-8518-38940d3a28c0.png)

The RC is that we autodoc members (https://stackoverflow.com/questions/64588821/how-napoleon-and-autodoc-interact-documenting-members)

### Changes proposed

Since the convention is to rely on autodoc for members elsewhere, this PR resolves duplicated attribute documentation by removing the manual Attribute annotation from `Variable`'s classdoc

### Test Plan

GH Actions docs build

### Types of changes
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](https://github.com/facebookresearch/beanmachine/blob/main/CONTRIBUTING.md)** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] The title of my pull request is a short description of the requested changes.
