### PR TITLE
Fix a bug in code due to hardcoded value

### DIFF
--- a/src/beanmachine/ppl/experimental/causal_inference/models/bart/mutation.py
+++ b/src/beanmachine/ppl/experimental/causal_inference/models/bart/mutation.py
@@ -1,0 +1,95 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from abc import ABC
+from dataclasses import dataclass
+from typing import Union
+
+from beanmachine.ppl.experimental.causal_inference.models.bart.exceptions import (
+    GrowError,
+    PruneError,
+)
+from beanmachine.ppl.experimental.causal_inference.models.bart.node import (
+    LeafNode,
+    SplitNode,
+)
+
+
+@dataclass
+class Mutation(ABC):
+    """
+    A data class for storing the nodes before and after a mutation to a tree.
+    These mutations are applied to traverse the space of tree structures. The possible mutations considered here are:
+    - **Grow**: Where a `LeafNode` of the tree is split based on a decision rule, turning it into an internal `SplitNode`.
+    - **Prune**: Where an internal `SplitNode` with only terminal children is converted into a `LeafNode`.
+    These steps constitute the Grow-Prune approach of Pratola [1] where the additional steps of
+    BART (Change and Swap) are eliminated.
+
+    Reference:
+        [1] Pratola MT, Chipman H, Higdon D, McCulloch R, Rust W (2013). “Parallel Bayesian Additive Regression Trees.”
+        Technical report, University of Chicago.
+        https://arxiv.org/pdf/1309.1906.pdf
+
+    Args:
+        old_node: The node before mutation.
+        new_node: The node after mutation.
+
+    """
+
+    __slots__ = ["old_node", "new_node"]
+
+    def __init__(
+        self,
+        old_node: Union[SplitNode, LeafNode],
+        new_node: Union[SplitNode, LeafNode],
+    ):
+        self.old_node = old_node
+        self.new_node = new_node
+
+
+@dataclass
+class PruneMutation(Mutation):
+    """Encapsulates the prune action where an internal `SplitNode` with only terminal children
+    is converted into a `LeafNode`.
+
+    Args:
+        old_node: The node before mutation.
+        new_node: The node after mutation.
+    """
+
+    def __init__(self, old_node: SplitNode, new_node: LeafNode):
+        """
+        Raises:
+            PruneError: if the prune mutation is invalid.
+        """
+
+        if not isinstance(old_node, SplitNode) or not old_node.is_prunable():
+            raise PruneError("Pruning only valid on prunable SplitNodes")
+        if not isinstance(new_node, LeafNode):
+            raise PruneError("Pruning can only create a LeafNode")
+        super().__init__(old_node, new_node)
+
+
+@dataclass
+class GrowMutation(Mutation):
+    """Encapsulates the grow action where a `LeafNode` of the tree is split based on a decision rule,
+    turning it into an internal `SplitNode`.
+
+    Args:
+        old_node: The node before mutation.
+        new_node: The node after mutation.
+
+    """
+
+    def __init__(self, old_node: LeafNode, new_node: SplitNode):
+        """
+        Raises:
+            GrowError: if the grow mutation is invalid.
+        """
+        if not isinstance(old_node, LeafNode):
+            raise GrowError("Can only grow LeafNodes")
+        if not isinstance(new_node, SplitNode):
+            raise GrowError("Growing a LeafNode turns it into a SplitNode")
+        super().__init__(old_node, new_node)

--- a/src/beanmachine/ppl/experimental/causal_inference/models/bart/node.py
+++ b/src/beanmachine/ppl/experimental/causal_inference/models/bart/node.py
@@ -136,7 +136,6 @@ class LeafNode(BaseNode):
         X_conditioned = self.data_in_node(X)
         if len(X_conditioned) == 0:
             return []
-
         return [
             dim
             for dim in range(X_conditioned.shape[-1])
@@ -175,7 +174,7 @@ class LeafNode(BaseNode):
         """
 
         growable_vals = self.get_growable_vals(X, grow_dim)
-        return torch.mean(growable_vals.eq(2), dtype=torch.float).item()
+        return torch.mean(growable_vals.eq(grow_val), dtype=torch.float).item()
 
     @staticmethod
     def grow_node(

--- a/src/beanmachine/ppl/experimental/causal_inference/models/bart/tree.py
+++ b/src/beanmachine/ppl/experimental/causal_inference/models/bart/tree.py
@@ -1,0 +1,136 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import List, Optional, Union
+
+import torch
+from beanmachine.ppl.experimental.causal_inference.models.bart.exceptions import (
+    TreeStructureError,
+)
+from beanmachine.ppl.experimental.causal_inference.models.bart.mutation import (
+    GrowMutation,
+    PruneMutation,
+)
+
+from beanmachine.ppl.experimental.causal_inference.models.bart.node import (
+    LeafNode,
+    SplitNode,
+)
+
+
+class Tree:
+    """
+    Encapsulates a tree structure where each node is either a nonterminal `SplitNode` or a terminal `LeafNode`.
+    This class consists of methods to track and modify overall tree structure.
+
+    Args:
+        nodes: List of nodes comprising the tree.
+    """
+
+    def __init__(self, nodes: List[Union[LeafNode, SplitNode]]):
+        self._nodes = nodes
+
+    def num_nodes(self) -> int:
+        """
+        Returns the total number of nodes in the tree.
+        """
+        return len(self._nodes)
+
+    def leaf_nodes(self) -> List[LeafNode]:
+        """
+        Returns a list of all of the leaf nodes in the tree.
+        """
+        return [node for node in self._nodes if isinstance(node, LeafNode)]
+
+    def growable_leaf_nodes(self, X: torch.Tensor) -> List[LeafNode]:
+        """
+        List of all leaf nodes in the tree which can be grown in a non-degenerate way
+        i.e. such that not all values in the column of the covariate matrix are duplicates
+        conditioned on the rules of that node.
+
+        Args:
+            X: Input / covariate matrix.
+        """
+        return [node for node in self.leaf_nodes() if node.is_growable(X)]
+
+    def num_growable_leaf_nodes(self, X: torch.Tensor) -> int:
+        """
+        Returns the number of nodes which can be grown in the tree.
+        """
+        return len(self.growable_leaf_nodes(X))
+
+    def split_nodes(self) -> List[SplitNode]:
+        """
+        List of internal `SplitNode`s in the tree.
+        """
+        return [node for node in self._nodes if isinstance(node, SplitNode)]
+
+    def prunable_split_nodes(self) -> List[SplitNode]:
+        """
+        List of decision nodes in the tree that are suitable for pruning
+        i.e., `SplitNode`s` that have two terminal `LeafNode` children
+        """
+        return [node for node in self.split_nodes() if node.is_prunable()]
+
+    def num_prunable_split_nodes(self) -> int:
+        """
+        Number of prunable split nodes in tree.
+        """
+        return len(self.prunable_split_nodes())
+
+    def predict(self, X: torch.Tensor) -> torch.Tensor:
+        """
+        Generate a set of predictions with the same dimensionality as the target array
+        Note that the prediction is from one tree, so represents only (1 / number_of_trees) of the target.
+        """
+        prediction = torch.zeros((len(X), 1), dtype=torch.float)
+        for leaf in self.leaf_nodes():
+            prediction[leaf.composite_rules.condition_on_rules(X)] = leaf.predict()
+        return prediction
+
+    def mutate(self, mutation: Union[GrowMutation, PruneMutation]) -> None:
+        """
+        Apply a change to the structure of the tree.
+        Args:
+            mutation: The mutation to apply to the tree.
+                Only grow and prune mutations are accepted.
+        """
+
+        if isinstance(mutation, PruneMutation):
+            self._remove_node(mutation.old_node.left_child)
+            self._remove_node(mutation.old_node.right_child)
+            self._remove_node(mutation.old_node)
+            self._add_node(mutation.new_node)
+
+        elif isinstance(mutation, GrowMutation):
+            self._remove_node(mutation.old_node)
+            self._add_node(mutation.new_node)
+            self._add_node(mutation.new_node.left_child)
+            self._add_node(mutation.new_node.right_child)
+
+        else:
+            raise TreeStructureError("Only Grow and Prune mutations are valid.")
+
+        for node in self._nodes:
+            if node.right_child == mutation.old_node:
+                node._right_child = mutation.new_node
+            if node.left_child == mutation.old_node:
+                node._left_child = mutation.new_node
+
+    def _remove_node(self, node: Optional[Union[LeafNode, SplitNode]] = None) -> None:
+        """
+        Remove a single node from the tree non-recursively.
+        Only drops the node and not any children.
+        """
+        if node is not None:
+            self._nodes.remove(node)
+
+    def _add_node(self, node: Optional[Union[LeafNode, SplitNode]] = None) -> None:
+        """
+        Add a node to the tree non-recursively.
+        Only adds the node and does not link it to any node.
+        """
+        if node is not None:
+            self._nodes.append(node)

--- a/src/beanmachine/ppl/experimental/tests/bart/bart_node_test.py
+++ b/src/beanmachine/ppl/experimental/tests/bart/bart_node_test.py
@@ -85,6 +85,7 @@ def loose_leaf(all_pass_composite_rule):
 def test_growable_dims(leaf_node, loose_leaf, X):
     assert leaf_node.get_num_growable_dims(X) == 0  # only one row of X passes the test
     assert loose_leaf.get_num_growable_dims(X) == X.shape[-1]  # everything passes
+    assert len(loose_leaf.get_growable_dims(X)) == loose_leaf.get_num_growable_dims(X)
 
 
 def test_is_grow(leaf_node, loose_leaf, X):
@@ -120,3 +121,14 @@ def test_prune_node(leaf_node, composite_rule):
     assert isinstance(SplitNode.prune_node(split_node), LeafNode)
     with pytest.raises(PruneError):
         SplitNode.prune_node(grandfather_node)
+
+    def test_partition_of_split(loose_leaf, X):
+        grow_val = X[0, 0]
+        growable_vals = loose_leaf.get_growable_vals(X=X, grow_dim=0)
+
+        assert torch.isclose(
+            torch.tensor(
+                [loose_leaf.get_partition_of_split(X=X, grow_dim=0, grow_val=grow_val)]
+            ),
+            torch.mean(growable_vals.eq(grow_val.item()), dtype=torch.float),
+        )

--- a/src/beanmachine/ppl/experimental/tests/bart/bart_tree_test.py
+++ b/src/beanmachine/ppl/experimental/tests/bart/bart_tree_test.py
@@ -1,0 +1,199 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import pytest
+import torch
+
+from beanmachine.ppl.experimental.causal_inference.models.bart.exceptions import (
+    GrowError,
+    PruneError,
+)
+from beanmachine.ppl.experimental.causal_inference.models.bart.mutation import (
+    GrowMutation,
+    PruneMutation,
+)
+from beanmachine.ppl.experimental.causal_inference.models.bart.node import (
+    LeafNode,
+    SplitNode,
+)
+from beanmachine.ppl.experimental.causal_inference.models.bart.split_rule import (
+    CompositeRules,
+    Operator,
+    SplitRule,
+)
+from beanmachine.ppl.experimental.causal_inference.models.bart.tree import Tree
+
+
+@pytest.fixture
+def X():
+    return torch.Tensor(
+        [[3.0], [4.0], [1.5], [-1.0]]
+    )  # only r1 containing all positive entries is growable
+
+
+@pytest.fixture
+def l1_non_growable():
+    return LeafNode(
+        depth=1,
+        composite_rules=CompositeRules(
+            all_dims=[0],
+            all_split_rules=[SplitRule(grow_dim=0, grow_val=0, operator=Operator.le)],
+        ),
+        val=-10,
+    )
+
+
+@pytest.fixture
+def l2_non_growable():
+    return LeafNode(
+        depth=2,
+        composite_rules=CompositeRules(
+            all_dims=[0],
+            all_split_rules=[
+                SplitRule(grow_dim=0, grow_val=1.5, operator=Operator.le),
+                SplitRule(grow_dim=0, grow_val=0, operator=Operator.gt),
+            ],
+        ),
+        val=15,
+    )
+
+
+@pytest.fixture
+def r2_growable():
+    return LeafNode(
+        depth=2,
+        composite_rules=CompositeRules(
+            all_dims=[0],
+            all_split_rules=[
+                SplitRule(grow_dim=0, grow_val=1.5, operator=Operator.gt),
+                SplitRule(grow_dim=0, grow_val=0, operator=Operator.gt),
+            ],
+        ),
+        val=15,
+    )
+
+
+@pytest.fixture
+def r1_grown(r2_growable, l2_non_growable):
+    return SplitNode(
+        depth=1,
+        left_child=l2_non_growable,
+        right_child=r2_growable,
+        composite_rules=CompositeRules(
+            all_dims=[0],
+            all_split_rules=[SplitRule(grow_dim=0, grow_val=0, operator=Operator.gt)],
+        ),
+    )
+
+
+@pytest.fixture
+def root(l1_non_growable, r1_grown):
+    return SplitNode(
+        depth=0,
+        left_child=l1_non_growable,
+        right_child=r1_grown,
+        composite_rules=CompositeRules(all_dims=[0]),
+    )
+
+
+@pytest.fixture
+def tree(root, r1_grown, l1_non_growable, r2_growable, l2_non_growable):
+    """
+                root_node
+                /\
+    (x1 <= 0)l1   r1 (x1 > 0)
+                /   \
+    (x1 <= 1.5) l2  r2 (x1 > 1.5)
+
+    The tree is made such that all positive input gets a positive prediciton and vice-versa.
+
+    """
+
+    tree_ = Tree(nodes=[root, l1_non_growable, r1_grown, l2_non_growable, r2_growable])
+    return tree_
+
+
+def test_num_nodes(tree):
+    assert tree.num_nodes() == 5
+
+
+def test_leaf_split_nodes(tree):
+    for node in tree.split_nodes():
+        assert isinstance(node, SplitNode)
+    for node in tree.split_nodes():
+        assert isinstance(node, SplitNode)
+
+
+def test_prunable_split_nodes(tree):
+    for node in tree.prunable_split_nodes():
+        assert isinstance(node.left_child, LeafNode)
+        assert isinstance(node.left_child, LeafNode)
+    assert len(tree.prunable_split_nodes()) == tree.num_prunable_split_nodes()
+
+
+def test_growable_leaves(tree, r2_growable, l1_non_growable, X):
+    assert tree.num_growable_leaf_nodes(X) == 1
+    growable_leaves = tree.growable_leaf_nodes(X)
+    assert len(tree.growable_leaf_nodes(X)) == len(growable_leaves)
+    assert r2_growable in growable_leaves
+    assert l1_non_growable not in growable_leaves
+    assert l2_non_growable not in growable_leaves
+
+
+def test_prediction(tree, X):
+    for x1 in X:
+        x1 = x1.reshape(1, 1)
+        assert float(x1) * tree.predict(x1) >= 0
+
+
+def test_mutate_prune(tree, root, l1_non_growable, r1_grown):
+    old_tree_len = tree.num_nodes()
+    pruned_r1 = SplitNode.prune_node(r1_grown)
+
+    # pruning an internal node
+    with pytest.raises(PruneError):
+        _ = PruneMutation(old_node=root, new_node=l1_non_growable)
+
+    mutation = PruneMutation(old_node=r1_grown, new_node=pruned_r1)
+    tree.mutate(mutation)
+    assert tree.num_nodes() == old_tree_len - 2
+
+
+def test_mutate_grow(tree, r2_growable):
+    old_tree_len = tree.num_nodes()
+
+    l3 = LeafNode(
+        depth=3,
+        composite_rules=CompositeRules(
+            all_dims=[0],
+            all_split_rules=[SplitRule(grow_dim=0, grow_val=3, operator=Operator.le)],
+        ),
+        val=15,
+    )
+    r3 = LeafNode(
+        depth=3,
+        composite_rules=CompositeRules(
+            all_dims=[0],
+            all_split_rules=[SplitRule(grow_dim=0, grow_val=1.5, operator=Operator.gt)],
+        ),
+        val=15,
+    )
+    r2_grown = SplitNode(
+        depth=2,
+        left_child=l3,
+        right_child=r3,
+        composite_rules=CompositeRules(
+            all_dims=[0],
+            all_split_rules=[SplitRule(grow_dim=0, grow_val=1.5, operator=Operator.gt)],
+        ),
+    )
+    # growing an internal node
+    with pytest.raises(GrowError):
+        _ = GrowMutation(old_node=r2_grown, new_node=r2_growable)
+
+    mutation = GrowMutation(old_node=r2_growable, new_node=r2_grown)
+    tree.mutate(mutation)
+    assert tree.num_nodes() == old_tree_len + 2


### PR DESCRIPTION
Summary: I discovered a bug in ```LeafNode```s ```get_partition_of_split()``` method where a hardcoded value of 2 was being used instead of  ```grow_val```. I corrected the bug and added a test that catches the bug.

Differential Revision: D37535222

