### PR TITLE
Implement BART Model

### DIFF
--- a/src/beanmachine/ppl/experimental/causal_inference/models/bart/bart_model.py
+++ b/src/beanmachine/ppl/experimental/causal_inference/models/bart/bart_model.py
@@ -1,0 +1,422 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# For now supports only ordered numeric variables
+from __future__ import annotations
+
+import math
+from typing import List, Optional, Tuple
+
+import torch
+from beanmachine.ppl.experimental.causal_inference.models.bart.exceptions import (
+    NotInitializedError,
+)
+from beanmachine.ppl.experimental.causal_inference.models.bart.grow_prune_tree_proposer import (
+    GrowPruneTreeProposer,
+)
+from beanmachine.ppl.experimental.causal_inference.models.bart.node import LeafNode
+from beanmachine.ppl.experimental.causal_inference.models.bart.split_rule import (
+    CompositeRules,
+)
+from beanmachine.ppl.experimental.causal_inference.models.bart.tree import Tree
+from torch.distributions.gamma import Gamma
+from torch.distributions.normal import Normal
+
+
+class BART:
+    """Bayesian Additive Regression Trees (BART) are Bayesian sum of trees models [1] Default parameters are taken from [1].
+
+    Reference:
+        [1] Hugh A. Chipman, Edward I. George, Robert E. McCulloch (2010). "BART: Bayesian additive regression trees"
+        https://projecteuclid.org/journals/annals-of-applied-statistics/volume-4/issue-1/BART-Bayesian-additive-regression-trees/10.1214/09-AOAS285.full
+
+    Args:
+        num_trees: Number of trees.
+        alpha: Parameter used in the tree depth prior, Eq. 7 of [1].
+        beta: Parameter used in the tree depth prior, Eq. 7 of [1].
+        k: Parameter used in the u_i_j prior, Eq. 8 of [1].
+        sigma_concentration: Concentration parameter (alpha) for the inverse gamma distribution prior of p(sigma).
+        sigma_rate: Rate parameter (beta) for the inverse gamma distribution prior of p(sigma).
+        num_burn: Number of samples burned-in.
+        tree_sampler: The tree sampling method used.
+        num_sample: Number of samples to collect.
+        p_grow: Probability of tree growth. Used by the tree sampler.
+        random_state: Random state used to seed.
+
+
+    """
+
+    def __init__(
+        self,
+        num_trees: int = 200,
+        alpha: float = 0.95,
+        beta: float = 2.0,
+        k: float = 2.0,
+        noise_sd_concentration: float = 3.0,
+        noise_sd_rate: float = 1.0,
+        tree_sampler: Optional[GrowPruneTreeProposer] = None,
+        random_state: Optional[int] = None,
+    ):
+
+        self.num_trees = num_trees
+        self.num_samples = None
+        self.all_trees = []
+        self.all_tree_predictions = None
+        self.k = k
+        self.leaf_mean = LeafMean(
+            prior_loc=0.0, prior_scale=0.5 / (self.k * math.sqrt(self.num_trees))
+        )
+        self.alpha = alpha
+        self.beta = beta
+
+        if noise_sd_concentration <= 0 or noise_sd_rate <= 0:
+            raise ValueError("Invalid specification of noise_sd distribution priors")
+        self.noise_sd_concentration = noise_sd_concentration
+        self.noise_sd_rate = noise_sd_rate
+        self.sigma = NoiseStandardDeviation(
+            prior_concentration=self.noise_sd_concentration,
+            prior_rate=self.noise_sd_rate,
+        )
+        self.samples = None
+        self.X = None
+        self.y = None
+        self.y_min = None
+        self.y_max = None
+        if random_state is not None:
+            torch.manual_seed(random_state)
+        if tree_sampler is None:
+            self.tree_sampler = GrowPruneTreeProposer(grow_probability=0.5)
+        elif isinstance(tree_sampler, GrowPruneTreeProposer):
+            self.tree_sampler = tree_sampler
+        else:
+            NotImplementedError("tree_sampler not implemented")
+
+    def fit(
+        self,
+        X: torch.Tensor,
+        y: torch.Tensor,
+        num_samples: int = 1000,
+        num_burn: int = 250,
+    ) -> BART:
+        """Fit the training data and learn the parameters of the model.
+
+        Args:
+            X: Training data / covariate matrix of shape (num_samples, input_dimensions).
+            y: Response vector of shape (num_samples, 1).
+        """
+        self.num_samples = num_samples
+        self._load_data(X, y)
+
+        self.samples = {"trees": [], "sigmas": []}
+        self._init_trees(X)
+
+        for iter_id in range(num_burn + num_samples):
+            print(f"Sampling iteration {iter_id}")
+            trees, sigma = self._step()
+            if iter_id >= num_burn:
+                self.samples["trees"].append(trees)
+                self.samples["sigmas"].append(sigma)
+        return self
+
+    def _load_data(self, X: torch.Tensor, y: torch.Tensor):
+        """
+        Load the training data. The response is scaled to [-1, 1] as per [1].
+
+        Reference:
+            [1] Hugh A. Chipman, Edward I. George, Robert E. McCulloch (2010). "BART: Bayesian additive regression trees"
+        https://projecteuclid.org/journals/annals-of-applied-statistics/volume-4/issue-1/BART-Bayesian-additive-regression-trees/10.1214/09-AOAS285.full
+
+
+        Args:
+            X: Training data / covariate matrix of shape (num_samples, input_dimensions).
+            y: Response vector of shape (num_samples, 1).
+
+        """
+        if not isinstance(X, torch.Tensor) or not isinstance(y, torch.Tensor):
+            raise ValueError("Expected type torch.Tensor")
+        if X.shape[0] != y.shape[0]:
+            raise ValueError(
+                f"Number of samples in X {X.shape[0]} not the same as in y {y.shape[0]}"
+            )
+        self.X = X
+        self.y_min = y.min()
+        self.y_max = y.max()
+        self.y = self._scale(y).reshape(-1, 1)
+
+    def _scale(self, y: torch.Tensor) -> torch.Tensor:
+        """
+        Scale tensor to [-1. ,1.]
+
+        Args:
+            y: Input tensor.
+        """
+        max_ = torch.ones_like(y)
+        min_ = -torch.ones_like(y)
+        y_std = (y - self.y_min) / (self.y_max - self.y_min)
+        return y_std * (max_ - min_) + min_
+
+    def _inverse_scale(self, y: torch.Tensor) -> torch.Tensor:
+        """
+        Rescale tensor back from [-1. ,1.].
+
+        Args:
+            y: Input tensor.
+        """
+        max_ = torch.ones_like(y)
+        min_ = -torch.ones_like(y)
+        y_std = (y - min_) / (max_ - min_)
+        return y_std * (self.y_max - self.y_min) + self.y_min
+
+    def _init_trees(self, X: torch.Tensor):
+        """
+        Initialize the trees of the model.
+
+        Args:
+            X: Training data / covariate matrix of shape (num_samples, input_dimensions).
+        """
+        num_dims = X.shape[-1]
+        num_points = X.shape[0]
+        for _ in range(self.num_trees):
+            self.all_trees.append(
+                Tree(
+                    nodes=[
+                        LeafNode(
+                            val=self.leaf_mean.sample_prior(),
+                            composite_rules=CompositeRules(
+                                all_dims=list(range(num_dims))
+                            ),
+                            depth=0,
+                        )
+                    ]
+                )
+            )
+        self.all_tree_predictions = torch.zeros(
+            (num_points, self.num_trees, 1), dtype=torch.float
+        )
+
+    def _step(self) -> Tuple[List, float]:
+        """Take a single MCMC step"""
+        if self.X is None or self.y is None:
+            raise NotInitializedError("No training data")
+
+        for tree_id in range(len(self.all_trees)):
+            partial_residual = (
+                self.y - self._predict_step() + self.all_tree_predictions[:, tree_id]
+            )
+            self.all_trees[tree_id] = self.tree_sampler.propose(
+                tree=self.all_trees[tree_id],
+                X=self.X,
+                partial_residual=partial_residual,
+                alpha=self.alpha,
+                beta=self.beta,
+                sigma_val=self.sigma.val,
+                leaf_mean_prior_scale=self.leaf_mean_prior_scale,
+            )
+            self._update_leaf_mean(self.all_trees[tree_id], partial_residual)
+            self.all_tree_predictions[:, tree_id] = self.all_trees[tree_id].predict(
+                self.X
+            )
+        self._update_sigma(self.y - self._predict_step())
+        return self.all_trees, self.sigma
+
+    def _update_leaf_mean(self, tree: Tree, partial_residual: torch.Tensor):
+        """
+        Use Eq. 2.10 of [1] to update leaf node values by sampling from posterior distribution.
+
+        Reference:
+            [1] Andrew Gelman et al. "Bayesian Data Analysis", 3rd ed.
+
+        Args:
+            tree: Tree whos leaf is being updated.
+            partial_residual: Current residual of the model excluding this tree of shape (num_samples, 1).
+
+        """
+        if self.X is None:
+            raise NotInitializedError("No training data")
+        for leaf_node in tree.leaf_nodes():
+            new_leaf_val = self.leaf_mean.sample_posterior(
+                node=leaf_node,
+                X=self.X,
+                y=partial_residual,
+                current_sigma_val=self.sigma.val,
+            )
+            if new_leaf_val is not None:
+                leaf_node.val = new_leaf_val
+
+    def _update_sigma(self, full_residual: torch.Tensor):
+        """
+        Use Eq. from section 2.6 of [1] to update sigma by sampling from posterior distribution.
+
+        Reference:
+            [1] Andrew Gelman et al. "Bayesian Data Analysis", 3rd ed.
+
+        Args:
+            partial_residual: Current residual of the model excluding this tree of shape (num_samples, 1).
+
+        """
+        self.sigma.sample(self.X, full_residual)
+
+    def _predict_step(
+        self,
+        X: Optional[torch.Tensor] = None,
+        trees: Optional[List[torch.Tensor]] = None,
+    ) -> torch.Tensor:
+        """Get a prediction from a list of trees.
+
+        Args:
+            X: Covariate matrix to predict on. If None provided, predictions are made on the  training set of shape (num_samples, input_dimensions).
+            trees: Trees to perform prediction. The prediction is the sum of predictions from these trees.
+                If None provided, the last drawn sample of trees is used for prediction.
+
+        Returns:
+            prediction: Prediction of shape (num_samples, 1).
+        """
+
+        if self.X is None or self.all_trees is None:
+            raise NotInitializedError("Model not trained")
+        if X is None:
+            X = self.X
+        if trees is None:
+            trees = self.all_trees
+
+        prediction = torch.zeros((len(X), 1), dtype=torch.float)
+        for single_tree in trees:
+            prediction += single_tree.predict(self.X)
+        return prediction
+
+    def predict(self, X: torch.Tensor) -> torch.Tensor:
+        """
+        Perform a prediction using all the samples collected in the model.
+
+        Args:
+            X: Covariate matrix to predict on of shape (num_samples, input_dimensions).
+
+        Returns:
+            prediction: Prediction corresponding to averaf of all samples of shape (num_samples, 1).
+        """
+
+        prediction = torch.zeros((len(X), 1), dtype=torch.float)
+        for sample_id in range(self.num_samples):
+            unscaled_prediction = self._predict_step(
+                X=X, trees=self.samples["trees"][sample_id]
+            )
+            prediction += self._inverse_scale(unscaled_prediction)
+        return prediction / self.num_samples
+
+    @property
+    def leaf_mean_prior_scale(self):
+        if self.leaf_mean is None:
+            raise NotInitializedError("LeafMean prior not set.")
+        return self.leaf_mean.prior_scale
+
+
+class NoiseStandardDeviation:
+    """The NoiseStandardDeviation class encapsulates the noise standard deviation.
+    The variance is parametrized by an inverse-gamma prior which is conjugate to a normal likelihood.
+
+    Args:
+        prior_concentration (float): Also called alpha. Must be greater than zero.
+        prior_rate (float): Also called beta. Must be greater than 0.
+        val (float): Current value of noise standard deviation.
+    """
+
+    def __init__(
+        self, prior_concentration: float, prior_rate: float, val: Optional[float] = None
+    ):
+        if prior_concentration <= 0 or prior_rate <= 0:
+            raise ValueError("Invalid prior hyperparameters")
+        self.prior_concentration = prior_concentration
+        self.prior_rate = prior_rate
+        if val is None:
+            self.sample(X=torch.Tensor([]), residual=torch.Tensor([]))  # prior init
+        else:
+            self._val = val
+
+    @property
+    def val(self) -> float:
+        return self._val
+
+    @val.setter
+    def val(self, val: float):
+        self._val = val
+
+    def sample(self, X: torch.Tensor, residual: torch.Tensor) -> float:
+        """Sample from the posterior distribution of sigma.
+        If empty tensors are passed for X and residual, there will be no update so the sampling will be from the prior.
+
+        Note:
+            This sets the value of the `val` attribute to the drawn sample.
+
+        Args:
+            X: Covariate matrix / training data shape (num_samples, input_dimensions).
+            residual: The current residual of the model shape (num_samples, 1).
+        """
+        self.val = self._get_sample(X, residual)
+        return self.val
+
+    def _get_sample(self, X: torch.Tensor, residual: torch.Tensor) -> float:
+        """
+        Draw a sample from the posterior.
+
+        Args:
+            X: Covariate matrix / training data of shape (num_samples, input_dimensions).
+            residual: The current residual of the model of shape (num_samples, 1).
+
+        """
+        posterior_concentration = self.prior_concentration + (len(X) / 2.0)
+        posterior_rate = self.prior_rate + (0.5 * (torch.sum(torch.square(residual))))
+        draw = torch.pow(Gamma(posterior_concentration, posterior_rate).sample(), -0.5)
+        return draw.item()
+
+
+class LeafMean:
+    """
+    Class to sample form the prior and posterior distributions of the leaf nodes in BART.
+
+    Reference:
+        [1] Hugh A. Chipman, Edward I. George, Robert E. McCulloch (2010). "BART: Bayesian additive regression trees"
+        https://projecteuclid.org/journals/annals-of-applied-statistics/volume-4/issue-1/BART-Bayesian-additive-regression-trees/10.1214/09-AOAS285.full
+
+    Args:
+        prior_loc: Prior location parameter.
+        prior_scale: Prior scale parameter.
+    """
+
+    def __init__(self, prior_loc: float, prior_scale: float):
+        if prior_scale < 0:
+            raise ValueError("Invalid prior hyperparameters")
+        self._prior_loc = prior_loc
+        self._prior_scale = prior_scale
+
+    @property
+    def prior_scale(self):
+        return self._prior_scale
+
+    def sample_prior(self):
+        return Normal(loc=self._prior_loc, scale=self._prior_scale).sample().item()
+
+    def sample_posterior(
+        self,
+        node: LeafNode,
+        X: torch.Tensor,
+        y: torch.Tensor,
+        current_sigma_val: float,
+    ):
+        X_in_node, y_in_node = node.data_in_node(X, y)
+        if len(X_in_node) == 0:
+            return None  # no new data
+        num_points_in_node = len(X_in_node)
+        prior_variance = (self._prior_scale) ** 2
+        likelihood_variance = (current_sigma_val**2) / num_points_in_node
+        likelihood_mean = torch.sum(y_in_node) / num_points_in_node
+        posterior_variance = 1.0 / (1.0 / prior_variance + 1.0 / likelihood_variance)
+        posterior_mean = (
+            likelihood_mean * prior_variance + self._prior_loc * likelihood_variance
+        ) / (likelihood_variance + prior_variance)
+        return (
+            Normal(loc=posterior_mean, scale=math.sqrt(posterior_variance))
+            .sample()
+            .item()
+        )

--- a/src/beanmachine/ppl/experimental/causal_inference/models/bart/grow_prune_tree_proposer.py
+++ b/src/beanmachine/ppl/experimental/causal_inference/models/bart/grow_prune_tree_proposer.py
@@ -1,0 +1,604 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import enum
+import math
+from typing import Union
+
+import torch
+
+from beanmachine.ppl.experimental.causal_inference.models.bart.exceptions import (
+    GrowError,
+    PruneError,
+    TreeStructureError,
+)
+from beanmachine.ppl.experimental.causal_inference.models.bart.mutation import (
+    GrowMutation,
+    Mutation,
+    PruneMutation,
+)
+from beanmachine.ppl.experimental.causal_inference.models.bart.node import (
+    LeafNode,
+    SplitNode,
+)
+from beanmachine.ppl.experimental.causal_inference.models.bart.split_rule import (
+    Operator,
+    SplitRule,
+)
+from beanmachine.ppl.experimental.causal_inference.models.bart.tree import Tree
+from beanmachine.ppl.experimental.causal_inference.models.bart.tree_proposer import (
+    TreeProposer,
+)
+from numpy.random import choice
+from torch.distributions.uniform import Uniform
+
+
+class MutationKind(enum.Enum):
+    grow = "grow operation"
+    prune = "prune operation"
+
+
+class GrowPruneTreeProposer(TreeProposer):
+    """This implements the Grow Prune tree sampling approach of Pratola [1] where the additional steps of
+    BART (Change and Swap) are eliminated for computational efficiency.
+
+    Reference:
+        [1] Pratola MT, Chipman H, Higdon D, McCulloch R, Rust W (2013). “Parallel Bayesian Additive Regression Trees.”
+        Technical report, University of Chicago.
+        https://arxiv.org/pdf/1309.1906.pdf
+
+    Args:
+        grow_probability: Probability of growing a node.
+
+    """
+
+    def __init__(self, grow_probability: float = 0.5):
+        if grow_probability > 1.0 or grow_probability < 0.0:
+            raise ValueError(
+                f"Grow probability {grow_probability} not a valid probabiity"
+            )
+        self.grow_probability = grow_probability
+        self.prune_probability = 1 - self.grow_probability
+        self._uniform = Uniform(0.0, 1.0)
+
+    def propose(
+        self,
+        tree: Tree,
+        X: torch.Tensor,
+        partial_residual: torch.Tensor,
+        alpha: float,
+        beta: float,
+        sigma_val: float,
+        leaf_mean_prior_scale: float,
+    ) -> Tree:
+        """Propose a tree  based on a Metropolis-Hastings step. Refer to [1] for details.
+
+        Reference:
+            [1] Adam Kapelner & Justin Bleich (2014). "bartMachine: Machine Learning with Bayesian
+                Additive Regression Trees".
+                https://arxiv.org/pdf/1312.2171.pdf
+
+        Args:
+            tree: Previous tree.
+            X: Covariate matrix / training data.
+            partial_residual: Partial residual of the current tree model with respect to the training data.
+            alpha: Hyperparameter used in tree prior.
+            beta: Hyperparameter used in tree prior.
+            sigma_val: Current estimate of noise standard deviation in the data.
+            leaf_mean_prior_scale: Prior of the scale hyperparameter in the normal distribution of the leaf mean.
+
+        """
+        new_mutation = self._get_new_mutation(tree, X)
+
+        # carry out move
+        if new_mutation == MutationKind.grow:
+            try:
+                leaf_to_grow = self._select_leaf_to_grow(tree=tree, X=X)
+            except GrowError:
+                return self.propose(
+                    tree,
+                    X,
+                    partial_residual,
+                    alpha,
+                    beta,
+                    sigma_val,
+                    leaf_mean_prior_scale,
+                )
+            grow_dim = self._select_grow_dim(leaf_to_grow, X)
+            grow_val = self._get_grow_val(
+                leaf_to_grow=leaf_to_grow, grow_dim=grow_dim, X=X
+            )
+            left_rule, right_rule = SplitRule(
+                grow_dim=grow_dim, grow_val=grow_val, operator=Operator.le
+            ), SplitRule(grow_dim=grow_dim, grow_val=grow_val, operator=Operator.gt)
+            mutation = GrowMutation(
+                old_node=leaf_to_grow,
+                new_node=LeafNode.grow_node(
+                    leaf_to_grow, left_rule=left_rule, right_rule=right_rule
+                ),
+            )
+        elif new_mutation == MutationKind.prune:
+            try:
+                split_node_to_prune = self._select_split_node_to_prune(tree)
+            except PruneError:
+                return self.propose(
+                    tree,
+                    X,
+                    partial_residual,
+                    alpha,
+                    beta,
+                    sigma_val,
+                    leaf_mean_prior_scale,
+                )
+            mutation = PruneMutation(
+                old_node=split_node_to_prune,
+                new_node=SplitNode.prune_node(split_node_to_prune),
+            )
+        else:
+            raise TreeStructureError("Can only grow or prune")
+
+        # Metropolis-Hasting step
+        log_draw_probability = (
+            self._get_log_transition_ratio(
+                tree=tree,
+                mutation=mutation,
+                X=X,
+            )
+            + self._get_log_likelihood_ratio(
+                mutation=mutation,
+                X=X,
+                partial_residual=partial_residual,
+                sigma_val=sigma_val,
+                leaf_mean_prior_scale=leaf_mean_prior_scale,
+            )
+            + self._get_log_structure_ratio(
+                mutation=mutation,
+                alpha=alpha,
+                beta=beta,
+                X=X,
+            )
+        )
+
+        if self._uniform.sample().item() < math.exp(log_draw_probability):
+            tree.mutate(mutation)
+            return tree
+        return tree
+
+    def _get_new_mutation(self, tree: Tree, X: torch.Tensor) -> MutationKind:
+        """Get a new mutation.
+
+        Args:
+            tree: Previous tree.
+            X: Covariate matrix / training data.
+        """
+        if tree.num_nodes() == 1 or tree.num_prunable_split_nodes() == 0:
+            return MutationKind.grow
+        if tree.num_growable_leaf_nodes(X) == 0:
+            return MutationKind.prune
+        if bool(torch.bernoulli(torch.Tensor([self.grow_probability])).item()):
+            return MutationKind.grow
+        return MutationKind.prune
+
+    def _select_leaf_to_grow(self, tree: Tree, X: torch.Tensor) -> LeafNode:
+        """
+        Select which leaf to grow.
+
+        Args:
+            tree: Previous tree.
+            X: Covariate matrix / training data.
+        """
+        growable_leaf_nodes = tree.growable_leaf_nodes(X)
+        if len(growable_leaf_nodes) < 1:
+            raise GrowError("Leaf cannot be grown")
+        return choice(growable_leaf_nodes)
+
+    def _select_grow_dim(self, leaf_to_grow: LeafNode, X: torch.Tensor) -> int:
+        """
+        Select an input dimension to grow along.
+
+        Args:
+            tree: Previous tree.
+            leaf_to_grow: Leaf currently being grown.
+            X: Covariate matrix / training data.
+        """
+        if not leaf_to_grow.is_growable(X):
+            raise GrowError("Leaf cannot be grown")
+        return choice(leaf_to_grow.get_growable_dims(X))
+
+    def _get_grow_val(
+        self, leaf_to_grow: LeafNode, grow_dim: int, X: torch.Tensor
+    ) -> float:
+        """
+        Select a value in the chosen input dimension to grow along.
+
+        Args:
+            tree: Previous tree.
+            leaf_to_grow: Leaf currently being grown.
+            grow_dim: Input dimension to grow along.
+            X: Covariate matrix / training data.
+        """
+        if not leaf_to_grow.is_growable(X):
+            raise GrowError("Leaf cannot be grown")
+        growable_vals = leaf_to_grow.get_growable_vals(X, grow_dim)
+        max_growable_val = torch.max(growable_vals)
+        candidate_val = choice(growable_vals)
+        degenerate_grow_condition = candidate_val == max_growable_val
+        while degenerate_grow_condition:
+            return choice(growable_vals)
+        return candidate_val
+
+    def _select_split_node_to_prune(self, tree: Tree) -> SplitNode:
+        """
+        Select and internal node to prune.
+
+        Args:
+            tree: Previous tree.
+        """
+        prunable_split_nodes = tree.prunable_split_nodes()
+        if len(prunable_split_nodes) < 1:
+            raise PruneError
+        return choice(prunable_split_nodes)
+
+    def _get_log_transition_ratio(
+        self,
+        tree: Tree,
+        mutation: Mutation,
+        X: torch.Tensor,
+    ) -> float:
+        """
+        Get the log transition ratio as discussed in [1].
+
+        [1] Adam Kapelner & Justin Bleich (2014). "bartMachine: Machine Learning with Bayesian
+            Additive Regression Trees".
+            https://arxiv.org/pdf/1312.2171.pdf
+
+        Args:
+            tree: Previous tree.
+            mutation: Proposed mutation,
+            X: Covariate matrix / training data.
+        """
+        if isinstance(mutation, GrowMutation):
+            return self._grow_log_transition_ratio(tree=tree, mutation=mutation, X=X)
+        elif isinstance(mutation, PruneMutation):
+            return self._prune_log_transition_ratio(tree=tree, mutation=mutation, X=X)
+        else:
+            raise TreeStructureError("Can only grow or prune")
+
+    def _grow_log_transition_ratio(
+        self,
+        tree: Tree,
+        mutation: GrowMutation,
+        X: torch.Tensor,
+    ) -> float:
+        """
+        Implement expression for log( P(T -> T*) / P(T* -> T) ) in a GROW move as discussed in eq. 8 of [1]
+
+        Reference:
+            [1] Adam Kapelner & Justin Bleich. "bartMachine: Machine Learning with Bayesian Additive Regression Trees" (2013).
+            https://arxiv.org/abs/1312.2171
+
+        Args:
+            tree: Previous tree.
+            mutation: Proposed mutation,
+            X: Covariate matrix / training data.
+
+        """
+        log_p_new_to_old_tree = math.log(self.prune_probability) - math.log(
+            tree.num_prunable_split_nodes() + 1
+        )
+        log_p_old_to_new_tree = math.log(
+            self.grow_probability
+        ) + _log_probability_of_growing_a_tree(
+            tree=tree,
+            mutation=mutation,
+            X=X,
+        )
+        return log_p_new_to_old_tree - log_p_old_to_new_tree
+
+    def _prune_log_transition_ratio(
+        self,
+        tree: Tree,
+        mutation: PruneMutation,
+        X: torch.Tensor,
+    ) -> float:
+        """
+        Implement expression for log( P(T -> T*) / P(T* -> T) ) in a PRUNE move as discussed in section A.2 of [1]
+
+        Reference:
+            [1] Adam Kapelner & Justin Bleich. "bartMachine: Machine Learning with Bayesian Additive Regression Trees" (2013).
+            https://arxiv.org/abs/1312.2171
+
+        Args:
+            tree: Previous tree.
+            mutation: Proposed mutation,
+            X: Covariate matrix / training data.
+
+        """
+        num_growable_leaves_in_pruned_tree = tree.num_growable_leaf_nodes(X) - 1
+
+        if num_growable_leaves_in_pruned_tree == 0:
+            return -float("inf")  # impossible prune
+
+        log_p_old_to_new_tree = math.log(self.prune_probability) - math.log(
+            tree.num_prunable_split_nodes()
+        )
+
+        log_probability_selecting_leaf_to_grow = -math.log(
+            num_growable_leaves_in_pruned_tree
+        )
+        log_probability_growing_leaf = _log_probability_of_growing_node(
+            mutation=GrowMutation(
+                old_node=mutation.new_node, new_node=mutation.old_node
+            ),
+            X=X,
+        )
+        log_p_new_to_old_tree = (
+            math.log(self.grow_probability)
+            + log_probability_selecting_leaf_to_grow
+            + log_probability_growing_leaf
+        )
+        return log_p_new_to_old_tree - log_p_old_to_new_tree
+
+    def _get_log_likelihood_ratio(
+        self,
+        mutation: Mutation,
+        X: torch.Tensor,
+        partial_residual: torch.Tensor,
+        sigma_val: float,
+        leaf_mean_prior_scale: float,
+    ) -> float:
+        """
+        Implement expression for log( P(R | T*, sigma) / P(R | T, sigma) ) in a GROW move as discussed in  [1]
+
+        Reference:
+            [1] Adam Kapelner & Justin Bleich. "bartMachine: Machine Learning with Bayesian Additive Regression Trees" (2013).
+            https://arxiv.org/abs/1312.2171
+
+        Args:
+            tree: Previous tree.
+            mutation: Proposed mutation,
+            sigma_val:urrent estimate of noise standard deviation in the data.
+            leaf_mean_prior_scale: Prior of the scale hyperparameter in the normal distribution of the leaf mean.
+            X: Covariate matrix / training data.
+            partial_residual: Partial residual of the current tree model with respect to the training data.
+
+
+        """
+        if isinstance(mutation, GrowMutation):
+            return self._grow_log_likelihood_ratio(
+                mutation=mutation,
+                sigma_val=sigma_val,
+                leaf_mean_prior_scale=leaf_mean_prior_scale,
+                X=X,
+                partial_residual=partial_residual,
+            )
+        elif isinstance(mutation, PruneMutation):
+            return -self._grow_log_likelihood_ratio(
+                mutation=GrowMutation(
+                    old_node=mutation.new_node, new_node=mutation.old_node
+                ),
+                sigma_val=sigma_val,
+                leaf_mean_prior_scale=leaf_mean_prior_scale,
+                X=X,
+                partial_residual=partial_residual,
+            )
+        else:
+            raise TreeStructureError(" Can only grow or prune")
+
+    def _grow_log_likelihood_ratio(
+        self,
+        mutation: GrowMutation,
+        sigma_val: float,
+        leaf_mean_prior_scale: float,
+        X: torch.Tensor,
+        partial_residual: torch.Tensor,
+    ) -> float:
+        """
+        Implement expression for log( P(R | T*, sigma) / P(R | T, sigma) ) in a GROW move as discussed in eq. 10 of [1]
+
+        Reference:
+            [1] Adam Kapelner & Justin Bleich. "bartMachine: Machine Learning with Bayesian Additive Regression Trees" (2013).
+            https://arxiv.org/abs/1312.2171
+
+        Args:
+            tree: Previous tree.
+            mutation: Proposed mutation,
+            sigma_val:urrent estimate of noise standard deviation in the data.
+            leaf_mean_prior_scale: Prior of the scale hyperparameter in the normal distribution of the leaf mean.
+            X: Covariate matrix / training data.
+            partial_residual: Partial residual of the current tree model with respect to the training data.
+
+        """
+
+        var = sigma_val**2
+        var_mu = leaf_mean_prior_scale**2
+        nodes = {
+            "parent": mutation.old_node,
+            "left": mutation.new_node.left_child,
+            "right": mutation.new_node.right_child,
+        }
+        y_sum, num_points = {}, {}
+        for node_label, node in nodes.items():
+            X_conditioned, y_conditioned = node.data_in_node(X, partial_residual)
+            y_sum[node_label] = torch.sum(y_conditioned)
+            num_points[node_label] = len(X_conditioned)
+
+        first_term = (var * (var + num_points["parent"] * leaf_mean_prior_scale)) / (
+            (var + num_points["left"] * var_mu) * (var + num_points["right"] * var_mu)
+        )
+        first_term = math.log(math.sqrt(first_term))
+
+        left_contribution = torch.square(y_sum["left"]) / (
+            var + num_points["left"] * leaf_mean_prior_scale
+        )
+        right_contribution = torch.square(y_sum["right"]) / (
+            var + num_points["right"] * leaf_mean_prior_scale
+        )
+        parent_contribution = torch.square(y_sum["parent"]) / (
+            var + num_points["parent"] * leaf_mean_prior_scale
+        )
+
+        second_term = left_contribution + right_contribution - parent_contribution
+
+        return first_term + (var_mu / (2 * var)) * second_term.item()
+
+    def _get_log_structure_ratio(
+        self,
+        mutation: Mutation,
+        alpha: float,
+        beta: float,
+        X: torch.Tensor,
+    ) -> float:
+        """
+        Implement expression for log( P(T*) / P(T) ) in as discussed in [1].
+
+        Reference:
+            [1] Adam Kapelner & Justin Bleich. "bartMachine: Machine Learning with Bayesian Additive Regression Trees" (2013).
+            https://arxiv.org/abs/1312.2171
+
+        Args:
+            mutation: Proposed mutation,
+            X: Covariate matrix / training data.
+            alpha: Hyperparameter used in tree prior.
+            beta: Hyperparameter used in tree prior.
+        """
+        if isinstance(mutation, GrowMutation):
+            return self._grow_log_structure_ratio(
+                mutation=mutation,
+                alpha=alpha,
+                beta=beta,
+                X=X,
+            )
+        elif isinstance(mutation, PruneMutation):
+            return -self._grow_log_structure_ratio(
+                mutation=GrowMutation(
+                    old_node=mutation.new_node, new_node=mutation.old_node
+                ),
+                alpha=alpha,
+                beta=beta,
+                X=X,
+            )
+        else:
+            raise TreeStructureError("Only grow or prune mutations are allowed")
+
+    def _grow_log_structure_ratio(
+        self,
+        mutation: GrowMutation,
+        alpha: float,
+        beta: float,
+        X: torch.Tensor,
+    ) -> float:
+        """
+        Implement expression for log( P(T*) / P(T) ) in a GROW step as discussed in section A.1 of [1].
+
+        Reference:
+            [1] Adam Kapelner & Justin Bleich. "bartMachine: Machine Learning with Bayesian Additive Regression Trees" (2013).
+            https://arxiv.org/abs/1312.2171
+
+        Args:
+            mutation: Proposed mutation,
+            X: Covariate matrix / training data.
+            alpha: Hyperparameter used in tree prior.
+            beta: Hyperparameter used in tree prior.
+        """
+
+        denominator = _log_probability_node_is_terminal(alpha, beta, mutation.old_node)
+
+        log_probability_left_is_terminal = _log_probability_node_is_terminal(
+            alpha, beta, mutation.new_node.left_child
+        )
+        log_probability_right_is_terminal = _log_probability_node_is_terminal(
+            alpha, beta, mutation.new_node.right_child
+        )
+        log_probability_parent_is_nonterminal = _log_probability_node_is_nonterminal(
+            alpha, beta, mutation.old_node
+        )
+        log_probability_rule = _log_probability_of_growing_node(mutation=mutation, X=X)
+        numerator = (
+            log_probability_left_is_terminal
+            + log_probability_right_is_terminal
+            + log_probability_parent_is_nonterminal
+            + log_probability_rule
+        )
+        return numerator - denominator
+
+
+def _log_probability_node_is_nonterminal(
+    alpha: float, beta: float, node: Union[LeafNode, SplitNode]
+) -> float:
+    """Get log probability of node being non-terminal (internal node) as discussed in Eq. 7 of [1].
+
+    Reference:
+        [1] Hugh A. Chipman, Edward I. George, Robert E. McCulloch (2010). "BART: Bayesian additive regression trees"
+        https://projecteuclid.org/journals/annals-of-applied-statistics/volume-4/issue-1/BART-Bayesian-additive-regression-trees/10.1214/09-AOAS285.full
+
+    Args:
+        alpha: Hyperparameter used in tree prior.
+        beta: Hyperparameter used in tree prior.
+        node: Node for which probability is being calculated.
+
+    """
+    return math.log(alpha * math.pow(1 + node.depth, -beta))
+
+
+def _log_probability_node_is_terminal(
+    alpha: float, beta: float, node: Union[LeafNode, SplitNode]
+) -> float:
+    """Get log probability of node being terminal (leaf node) as discussed in Eq. 7 of [1].
+
+    Reference:
+        [1] Hugh A. Chipman, Edward I. George, Robert E. McCulloch (2010). "BART: Bayesian additive regression trees"
+        https://projecteuclid.org/journals/annals-of-applied-statistics/volume-4/issue-1/BART-Bayesian-additive-regression-trees/10.1214/09-AOAS285.full
+
+    Args:
+        alpha: Hyperparameter used in tree prior.
+        beta: Hyperparameter used in tree prior.
+        node: Node for which probability is being calculated.
+
+    """
+    return 1 - _log_probability_node_is_nonterminal(alpha=alpha, beta=beta, node=node)
+
+
+def _log_probability_of_growing_a_tree(
+    tree: Tree, mutation: GrowMutation, X: torch.Tensor
+) -> float:
+    """
+    Get probability of choosing a node and growing it as discussed in section A.1 of [1].
+
+    Reference:
+        [1] Adam Kapelner & Justin Bleich. "bartMachine: Machine Learning with Bayesian Additive Regression Trees" (2013).
+        https://arxiv.org/abs/1312.2171
+
+    Args:
+        tree: Previous tree.
+        mutation: Growth mutation being applied.
+        X: Covariate matrix / training data.
+    """
+
+    return -math.log(tree.num_growable_leaf_nodes(X))
+    +_log_probability_of_growing_node(mutation=mutation, X=X)
+
+
+def _log_probability_of_growing_node(mutation: GrowMutation, X: torch.Tensor) -> float:
+    """
+    Get probability of growing a node as discussed in section A.1 of [1].
+
+    Reference:
+        [1] Adam Kapelner & Justin Bleich. "bartMachine: Machine Learning with Bayesian Additive Regression Trees" (2013).
+        https://arxiv.org/abs/1312.2171
+
+    Args:
+        mutation: Growth mutation being applied.
+        X: Covariate matrix / training data.
+    """
+    log_probability_of_selecting_dim = -math.log(
+        mutation.old_node.get_num_growable_dims(X)
+    )
+    grow_dim = mutation.new_node.most_recent_rule().grow_dim
+    grow_val = mutation.new_node.most_recent_rule().grow_val
+    log_probability_of_growing_at_val = -math.log(
+        mutation.old_node.get_partition_of_split(X, grow_dim, grow_val)
+    )
+    return log_probability_of_selecting_dim + log_probability_of_growing_at_val

--- a/src/beanmachine/ppl/experimental/causal_inference/models/bart/node.py
+++ b/src/beanmachine/ppl/experimental/causal_inference/models/bart/node.py
@@ -174,7 +174,9 @@ class LeafNode(BaseNode):
         """
 
         growable_vals = self.get_growable_vals(X, grow_dim)
-        return torch.mean(growable_vals.eq(grow_val), dtype=torch.float).item()
+        return torch.mean(
+            (growable_vals == grow_val).to(torch.float), dtype=torch.float
+        ).item()
 
     @staticmethod
     def grow_node(

--- a/src/beanmachine/ppl/experimental/causal_inference/models/bart/tree_proposer.py
+++ b/src/beanmachine/ppl/experimental/causal_inference/models/bart/tree_proposer.py
@@ -1,0 +1,16 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from abc import ABCMeta, abstractmethod
+
+import torch
+
+from .tree import Tree
+
+
+class TreeProposer(metaclass=ABCMeta):
+    @abstractmethod
+    def propose(self, tree: Tree, X: torch.Tensor) -> Tree:
+        raise NotImplementedError

--- a/src/beanmachine/ppl/experimental/tests/bart/bart_model_test.py
+++ b/src/beanmachine/ppl/experimental/tests/bart/bart_model_test.py
@@ -1,0 +1,34 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import pytest
+import torch
+
+from beanmachine.ppl.experimental.causal_inference.models.bart.bart_model import (
+    NoiseStandardDeviation,
+)
+
+
+@pytest.fixture
+def X():
+    return torch.Tensor([[3.0, 1.0], [4.0, 1.0], [1.5, 1.0], [-1.0, 1.0]])
+
+
+@pytest.fixture
+def residual(X):
+    return X * 0.1
+
+
+@pytest.fixture
+def sigma():
+    return NoiseStandardDeviation(prior_concentration=0.1, prior_rate=0.2)
+
+
+def test_sigma_sampling(sigma, X, residual):
+    prev_val = sigma.val
+    sample = sigma.sample(X=X, residual=residual)
+    assert not prev_val == sigma.val
+    assert sigma.val == sample

--- a/src/beanmachine/ppl/experimental/tests/bart/bart_node_test.py
+++ b/src/beanmachine/ppl/experimental/tests/bart/bart_node_test.py
@@ -122,13 +122,16 @@ def test_prune_node(leaf_node, composite_rule):
     with pytest.raises(PruneError):
         SplitNode.prune_node(grandfather_node)
 
-    def test_partition_of_split(loose_leaf, X):
-        grow_val = X[0, 0]
-        growable_vals = loose_leaf.get_growable_vals(X=X, grow_dim=0)
 
-        assert torch.isclose(
-            torch.tensor(
-                [loose_leaf.get_partition_of_split(X=X, grow_dim=0, grow_val=grow_val)]
-            ),
-            torch.mean(growable_vals.eq(grow_val.item()), dtype=torch.float),
-        )
+def test_partition_of_split(loose_leaf, X):
+    grow_val = X[0, 0]
+    growable_vals = loose_leaf.get_growable_vals(X=X, grow_dim=0)
+
+    assert torch.isclose(
+        torch.tensor(
+            [loose_leaf.get_partition_of_split(X=X, grow_dim=0, grow_val=grow_val)]
+        ),
+        torch.mean(
+            (growable_vals == grow_val.item()).to(torch.float), dtype=torch.float
+        ),
+    )

--- a/src/beanmachine/ppl/experimental/tests/bart/bart_tree_proposer_test.py
+++ b/src/beanmachine/ppl/experimental/tests/bart/bart_tree_proposer_test.py
@@ -1,0 +1,201 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import pytest
+import torch
+
+from beanmachine.ppl.experimental.causal_inference.models.bart.exceptions import (
+    PruneError,
+)
+from beanmachine.ppl.experimental.causal_inference.models.bart.grow_prune_tree_proposer import (
+    GrowPruneTreeProposer,
+    MutationKind,
+)
+
+from beanmachine.ppl.experimental.causal_inference.models.bart.node import (
+    LeafNode,
+    SplitNode,
+)
+from beanmachine.ppl.experimental.causal_inference.models.bart.split_rule import (
+    CompositeRules,
+    Operator,
+    SplitRule,
+)
+
+from beanmachine.ppl.experimental.causal_inference.models.bart.tree import Tree
+
+
+@pytest.fixture(autouse=True)
+def seed():
+    torch.manual_seed(5)
+
+
+@pytest.fixture
+def X():
+    return torch.Tensor([[3.0, 1.0], [4.0, 1.0], [1.5, 1.0], [-1.0, 1.0]])
+
+
+@pytest.fixture
+def root_node(X):
+    return SplitNode(
+        depth=0,
+        composite_rules=CompositeRules(all_dims=list(range(X.shape[-1]))),
+    )
+
+
+@pytest.fixture
+def single_node_tree(X):
+    leaf_root = LeafNode(
+        depth=0,
+        composite_rules=CompositeRules(all_dims=list(range(X.shape[-1]))),
+    )
+    tree_ = Tree(nodes=[leaf_root])
+    return tree_
+
+
+@pytest.fixture
+def r1_growable(X):
+    return LeafNode(
+        depth=1,
+        composite_rules=CompositeRules(
+            all_dims=list(range(X.shape[-1])),
+            all_split_rules=[SplitRule(grow_dim=0, grow_val=0, operator=Operator.gt)],
+        ),
+        val=-10,
+    )
+
+
+@pytest.fixture
+def l1_non_growable(X):
+    return LeafNode(
+        depth=1,
+        composite_rules=CompositeRules(
+            all_dims=list(range(X.shape[-1])),
+            all_split_rules=[SplitRule(grow_dim=0, grow_val=0, operator=Operator.le)],
+        ),
+        val=-10,
+    )
+
+
+@pytest.fixture
+def single_layer_tree(root_node, r1_growable, l1_non_growable):
+    """
+                root_node
+                /\
+    (x1 <= 0)l1   r1 (x1 > 0)
+
+    The tree is made such that all positive input gets a positive prediciton and vice-versa.
+
+    """
+
+    root_node._left_child = l1_non_growable
+    root_node._right_child = r1_growable
+    tree_ = Tree(nodes=[root_node, l1_non_growable, r1_growable])
+    return tree_
+
+
+@pytest.fixture
+def l2_non_growable(X):
+    return LeafNode(
+        depth=2,
+        composite_rules=CompositeRules(
+            all_dims=list(range(X.shape[-1])),
+            all_split_rules=[SplitRule(grow_dim=0, grow_val=3, operator=Operator.le)],
+        ),
+        val=-10,
+    )
+
+
+@pytest.fixture
+def r2_growable(X):
+    return LeafNode(
+        depth=1,
+        composite_rules=CompositeRules(
+            all_dims=list(range(X.shape[-1])),
+            all_split_rules=[SplitRule(grow_dim=0, grow_val=0, operator=Operator.gt)],
+        ),
+        val=-10,
+    )
+
+
+@pytest.fixture
+def r1_grown(X):
+    return SplitNode(
+        depth=1,
+        composite_rules=CompositeRules(
+            all_dims=list(range(X.shape[-1])),
+            all_split_rules=[SplitRule(grow_dim=0, grow_val=3, operator=Operator.gt)],
+        ),
+    )
+
+
+@pytest.fixture
+def double_layer_tree(
+    root_node, r1_grown, l1_non_growable, r2_growable, l2_non_growable
+):
+    """
+                root_node
+                /\
+    (x1 <= 0)l1   r1 (x1 > 0)
+                 /\
+         (<=3)l2   r2 (>3)
+
+    """
+
+    root_node._left_child = l1_non_growable
+    root_node._right_child = r1_grown
+    r1_grown._left_child = l2_non_growable
+    r1_grown._right_child = r2_growable
+    tree_ = Tree(
+        nodes=[root_node, l1_non_growable, r1_grown, l2_non_growable, r2_growable]
+    )
+    return tree_
+
+
+@pytest.fixture
+def proposer():
+    return GrowPruneTreeProposer()
+
+
+def test_new_mutation(proposer, single_node_tree, X):
+    assert proposer._get_new_mutation(X=X, tree=single_node_tree) == MutationKind.grow
+
+
+def test_select_root_to_grow(proposer, single_node_tree, X):
+    assert (
+        proposer._select_leaf_to_grow(single_node_tree, X) == single_node_tree._nodes[0]
+    )
+
+
+def test_select_leaf_to_grow(proposer, single_layer_tree, X, r1_growable):
+    assert proposer._select_leaf_to_grow(single_layer_tree, X) == r1_growable
+
+
+def test_select_dim_to_grow(proposer, single_node_tree, X):
+    assert proposer._select_grow_dim(leaf_to_grow=single_node_tree._nodes[0], X=X) == 0
+
+
+def test_select_node_to_prune(proposer, single_node_tree, double_layer_tree, r1_grown):
+    assert proposer._select_split_node_to_prune(tree=double_layer_tree) == r1_grown
+    with pytest.raises(PruneError):
+        _ = proposer._select_split_node_to_prune(tree=single_node_tree)
+
+
+def test_propose(proposer, single_node_tree, X):
+    proposed_tree = proposer.propose(
+        tree=single_node_tree,
+        X=X,
+        partial_residual=torch.zeros(X.shape[0], 1),
+        alpha=0.5,
+        beta=0.5,
+        sigma_val=0.01,
+        leaf_mean_prior_scale=1,
+    )
+    assert isinstance(proposed_tree, Tree)
+    assert abs(proposed_tree.num_nodes() - single_node_tree.num_nodes()) in [
+        0,
+        2,
+    ]  # 2: grow or prune, 0 for no change


### PR DESCRIPTION
Summary:
Background:
We are building Bayesian Additive Regression Trees (BART) as an experimental causal inference model in beanmachine. Details of the project can be found in https://docs.google.com/document/d/11nkB6UTGpvQBEC2yBjfgwAr8VabTlD7R9XufGQG0EvI/edit?usp=sharing and the proposed design can be found in the draft design document: https://docs.google.com/document/d/1o3J7yobDF0M9E27Y0tP2889fycmemXUZbHE5cebRqzs/edit?usp=sharing.
In this diff:
We are implementing the BART model which uses the Bayesian Backfitting algorithm for constructing the tree ensemble and use it to make predictions.

Differential Revision: D37565950

