### PR TITLE
Make BART robust to torch version

### DIFF
--- a/src/beanmachine/ppl/experimental/causal_inference/models/bart/node.py
+++ b/src/beanmachine/ppl/experimental/causal_inference/models/bart/node.py
@@ -174,7 +174,9 @@ class LeafNode(BaseNode):
         """
 
         growable_vals = self.get_growable_vals(X, grow_dim)
-        return torch.mean(growable_vals.eq(grow_val), dtype=torch.float).item()
+        return torch.mean(
+            (growable_vals == grow_val).to(torch.float), dtype=torch.float
+        ).item()
 
     @staticmethod
     def grow_node(

--- a/src/beanmachine/ppl/experimental/tests/bart/bart_node_test.py
+++ b/src/beanmachine/ppl/experimental/tests/bart/bart_node_test.py
@@ -122,13 +122,16 @@ def test_prune_node(leaf_node, composite_rule):
     with pytest.raises(PruneError):
         SplitNode.prune_node(grandfather_node)
 
-    def test_partition_of_split(loose_leaf, X):
-        grow_val = X[0, 0]
-        growable_vals = loose_leaf.get_growable_vals(X=X, grow_dim=0)
 
-        assert torch.isclose(
-            torch.tensor(
-                [loose_leaf.get_partition_of_split(X=X, grow_dim=0, grow_val=grow_val)]
-            ),
-            torch.mean(growable_vals.eq(grow_val.item()), dtype=torch.float),
-        )
+def test_partition_of_split(loose_leaf, X):
+    grow_val = X[0, 0]
+    growable_vals = loose_leaf.get_growable_vals(X=X, grow_dim=0)
+
+    assert torch.isclose(
+        torch.tensor(
+            [loose_leaf.get_partition_of_split(X=X, grow_dim=0, grow_val=grow_val)]
+        ),
+        torch.mean(
+            (growable_vals == grow_val.item()).to(torch.float), dtype=torch.float
+        ),
+    )


### PR DESCRIPTION
Summary:
Background:
We are building Bayesian Additive Regression Trees (BART) as an experimental causal inference model in beanmachine. Details of the project can be found in https://docs.google.com/document/d/11nkB6UTGpvQBEC2yBjfgwAr8VabTlD7R9XufGQG0EvI/edit?usp=sharing and the proposed design can be found in the draft design document: https://docs.google.com/document/d/1o3J7yobDF0M9E27Y0tP2889fycmemXUZbHE5cebRqzs/edit?usp=sharing.
In this diff:

Differential Revision: D37606004

