### PR TITLE
robust uturn

### DIFF
--- a/src/beanmachine/graph/global/nuts.cpp
+++ b/src/beanmachine/graph/global/nuts.cpp
@@ -12,8 +12,10 @@
 namespace beanmachine {
 namespace graph {
 
-NUTS::NUTS(Graph& g, bool adapt_mass_matrix) : GlobalMH(g), graph(g) {
-  proposer = std::make_unique<NutsProposer>(NutsProposer(adapt_mass_matrix));
+NUTS::NUTS(Graph& g, bool adapt_mass_matrix, bool multinomial_sampling)
+    : GlobalMH(g), graph(g) {
+  proposer = std::make_unique<NutsProposer>(
+      NutsProposer(adapt_mass_matrix, multinomial_sampling));
 }
 
 void NUTS::prepare_graph() {

--- a/src/beanmachine/graph/global/nuts.h
+++ b/src/beanmachine/graph/global/nuts.h
@@ -21,7 +21,10 @@ Reference:
 */
 class NUTS : public GlobalMH {
  public:
-  explicit NUTS(Graph& g, bool adapt_mass_matrix = true);
+  explicit NUTS(
+      Graph& g,
+      bool adapt_mass_matrix = true,
+      bool multinomial_sampling = true);
   /*
   NUTS by default transforms all unobserved random variables in the
   constrained space to the unconstrained space, similar to Stan in

--- a/src/beanmachine/graph/global/proposer/nuts_proposer.cpp
+++ b/src/beanmachine/graph/global/proposer/nuts_proposer.cpp
@@ -212,6 +212,26 @@ NutsProposer::Tree NutsProposer::build_tree(
           compute_no_turn(
               tree.momentum_left, tree.momentum_right, tree.momentum_sum);
 
+      Tree left_tree;
+      Tree right_tree;
+      if (direction > 0) {
+        left_tree = subtree1;
+        right_tree = subtree2;
+      } else {
+        left_tree = subtree2;
+        right_tree = subtree1;
+      }
+      tree.no_turn = tree.no_turn and
+          compute_no_turn(
+                         left_tree.momentum_left,
+                         right_tree.momentum_left,
+                         left_tree.momentum_sum + right_tree.momentum_left);
+      tree.no_turn = tree.no_turn and
+          compute_no_turn(
+                         right_tree.momentum_right,
+                         left_tree.momentum_right,
+                         right_tree.momentum_sum + left_tree.momentum_right);
+
       return tree;
     }
   }
@@ -308,6 +328,17 @@ double NutsProposer::propose(GlobalState& state, std::mt19937& gen) {
                        left_tree.momentum_left,
                        right_tree.momentum_right,
                        left_tree.momentum_sum + right_tree.momentum_sum);
+    // check condition of left tree and leftmost node of right tree
+    no_turn &= compute_no_turn(
+        left_tree.momentum_left,
+        right_tree.momentum_left,
+        left_tree.momentum_sum + right_tree.momentum_left);
+    // check condition of right tree and rightmost node of left tree
+    no_turn &= compute_no_turn(
+        right_tree.momentum_right,
+        left_tree.momentum_right,
+        right_tree.momentum_sum + left_tree.momentum_right);
+
     current_tree.momentum_sum += new_tree.momentum_sum;
     if (!no_turn) {
       break;

--- a/src/beanmachine/graph/global/proposer/nuts_proposer.cpp
+++ b/src/beanmachine/graph/global/proposer/nuts_proposer.cpp
@@ -6,14 +6,17 @@
  */
 
 #include "beanmachine/graph/global/proposer/nuts_proposer.h"
+#include "beanmachine/graph/util.h"
 
 namespace beanmachine {
 namespace graph {
 
 NutsProposer::NutsProposer(
     bool adapt_mass_matrix,
+    bool multinomial_sampling,
     double optimal_acceptance_prob)
     : HmcProposer(0.0, 1.0, adapt_mass_matrix, optimal_acceptance_prob) {
+  this->multinomial_sampling = multinomial_sampling;
   step_size = 1.0; // will be updated in `find_reasonable_step_size`
   delta_max = 1000;
   max_tree_depth = 10;
@@ -102,24 +105,26 @@ NutsProposer::Tree NutsProposer::build_tree_base_case(
   double hamiltonian_new =
       compute_hamiltonian(state, tree.position_new, momentum_new);
   if (std::isnan(hamiltonian_new)) {
-    tree.valid_nodes = 0.0;
+    tree.log_weight = -std::numeric_limits<double>::infinity();
     tree.no_turn = false;
     tree.acceptance_sum = 0.0;
     return tree;
   }
 
-  tree.valid_nodes = slice <= -hamiltonian_new;
-  // check for divergence
-  tree.no_turn = slice < (delta_max - hamiltonian_new);
-
   double hamiltonian_diff = hamiltonian_init - hamiltonian_new;
-  if (std::isnan(hamiltonian_diff)) {
-    tree.acceptance_sum = 0.0;
-  } else if (hamiltonian_diff > 0) {
+  if (hamiltonian_diff > 0) {
     tree.acceptance_sum = 1.0;
   } else {
     tree.acceptance_sum = std::exp(hamiltonian_diff);
   }
+
+  if (multinomial_sampling) {
+    tree.log_weight = hamiltonian_diff;
+  } else {
+    tree.log_weight = std::log(slice <= -hamiltonian_new);
+  }
+  // check for divergence
+  tree.no_turn = slice < (delta_max - hamiltonian_new);
 
   return tree;
 }
@@ -147,7 +152,10 @@ NutsProposer::Tree NutsProposer::build_tree(
         tree_depth - 1,
         hamiltonian_init);
     if (!subtree1.no_turn) {
-      return subtree1;
+      Tree tree = subtree1;
+      tree.momentum_sum = Eigen::VectorXd::Zero(subtree1.momentum_sum.size());
+      tree.log_weight = -std::numeric_limits<double>::infinity();
+      return tree;
     } else {
       Tree tree = Tree();
       tree.position_new = subtree1.position_new;
@@ -183,21 +191,26 @@ NutsProposer::Tree NutsProposer::build_tree(
         tree.momentum_right = subtree2.momentum_right;
       }
 
-      double update_prob = subtree2.valid_nodes /
-          std::max(1.0, subtree1.valid_nodes + subtree2.valid_nodes);
-      std::bernoulli_distribution update_dist(update_prob);
-      if (update_dist(gen)) {
+      tree.total_nodes = subtree1.total_nodes + subtree2.total_nodes;
+      tree.acceptance_sum = subtree1.acceptance_sum + subtree2.acceptance_sum;
+      if (!subtree2.no_turn) {
+        tree.momentum_sum = Eigen::VectorXd::Zero(subtree1.momentum_sum.size());
+        tree.log_weight = -std::numeric_limits<double>::infinity();
+        return tree;
+      }
+
+      tree.log_weight =
+          util::log_sum_exp(subtree1.log_weight, subtree2.log_weight);
+      double update_log_prob = subtree2.log_weight - tree.log_weight;
+      if (util::sample_logprob(gen, update_log_prob)) {
         tree.position_new = subtree2.position_new;
       }
 
-      tree.acceptance_sum = subtree1.acceptance_sum + subtree2.acceptance_sum;
-      tree.total_nodes = subtree1.total_nodes + subtree2.total_nodes;
       tree.momentum_sum = subtree1.momentum_sum + subtree2.momentum_sum;
       tree.no_turn =
           subtree2.no_turn and
           compute_no_turn(
               tree.momentum_left, tree.momentum_right, tree.momentum_sum);
-      tree.valid_nodes = subtree1.valid_nodes + subtree2.valid_nodes;
 
       return tree;
     }
@@ -214,20 +227,28 @@ double NutsProposer::propose(GlobalState& state, std::mt19937& gen) {
   // sample slice
   std::uniform_real_distribution<double> uniform_dist(0.0, 1.0);
   double hamiltonian_init = compute_hamiltonian(state, position, momentum_init);
-  double slice = std::log(uniform_dist(gen)) - hamiltonian_init;
-
-  Eigen::VectorXd position_left = position;
-  Eigen::VectorXd position_right = position;
-  Eigen::VectorXd momentum_left = momentum_init;
-  Eigen::VectorXd momentum_right = momentum_init;
-  Eigen::VectorXd momentum_sum = momentum_init;
-
-  double valid_nodes = 1;
-  double acceptance_sum = 0.0;
-  double total_nodes = 0.0;
+  double slice;
+  if (multinomial_sampling) {
+    slice = -hamiltonian_init;
+  } else {
+    slice = std::log(uniform_dist(gen)) - hamiltonian_init;
+  }
 
   std::bernoulli_distribution coin_flip(0.5);
 
+  Tree current_tree = {
+      position,
+      momentum_init,
+      position,
+      momentum_init,
+      position,
+      momentum_init,
+      0.0,
+      true,
+      0.0,
+      0.0};
+  Tree left_tree;
+  Tree right_tree;
   for (int tree_depth = 0; tree_depth < max_tree_depth; tree_depth++) {
     // sample direction
     double direction = -1.0;
@@ -235,57 +256,68 @@ double NutsProposer::propose(GlobalState& state, std::mt19937& gen) {
       direction = 1.0;
     }
 
-    Tree tree;
+    Tree new_tree;
     if (direction < 0) {
-      tree = build_tree(
+      // build tree to the left
+      new_tree = build_tree(
           state,
           gen,
-          position_left,
-          momentum_left,
+          current_tree.position_left,
+          current_tree.momentum_left,
           slice,
           direction,
           tree_depth,
           hamiltonian_init);
-      position_left = tree.position_left;
-      momentum_left = tree.momentum_left;
+      right_tree = current_tree;
+      left_tree = new_tree;
     } else {
-      tree = build_tree(
+      // build tree to the right
+      new_tree = build_tree(
           state,
           gen,
-          position_right,
-          momentum_right,
+          current_tree.position_right,
+          current_tree.momentum_right,
           slice,
           direction,
           tree_depth,
           hamiltonian_init);
-      position_right = tree.position_right;
-      momentum_right = tree.momentum_right;
+      left_tree = current_tree;
+      right_tree = new_tree;
     }
 
-    acceptance_sum += tree.acceptance_sum;
-    total_nodes += tree.total_nodes;
-    if (!tree.no_turn) {
+    current_tree.position_left = left_tree.position_left;
+    current_tree.momentum_left = left_tree.momentum_left;
+    current_tree.position_right = right_tree.position_right;
+    current_tree.momentum_right = right_tree.momentum_right;
+
+    current_tree.acceptance_sum += new_tree.acceptance_sum;
+    current_tree.total_nodes += new_tree.total_nodes;
+    if (!new_tree.no_turn) {
       break;
     }
 
-    double update_prob = std::min(1.0, tree.valid_nodes / valid_nodes);
-    std::bernoulli_distribution update_dist(update_prob);
-    if (update_dist(gen)) {
-      position = tree.position_new;
+    double update_log_prob = new_tree.log_weight - current_tree.log_weight;
+    if (util::sample_logprob(gen, update_log_prob)) {
+      current_tree.position_new = new_tree.position_new;
     }
-    valid_nodes += tree.valid_nodes;
+    current_tree.log_weight =
+        util::log_sum_exp(current_tree.log_weight, new_tree.log_weight);
 
-    momentum_sum += tree.momentum_sum;
-    bool no_turn = tree.no_turn and
-        compute_no_turn(momentum_left, momentum_right, momentum_sum);
+    bool no_turn = new_tree.no_turn and
+        compute_no_turn(
+                       left_tree.momentum_left,
+                       right_tree.momentum_right,
+                       left_tree.momentum_sum + right_tree.momentum_sum);
+    current_tree.momentum_sum += new_tree.momentum_sum;
     if (!no_turn) {
       break;
     }
   }
 
-  warmup_acceptance_prob = acceptance_sum / total_nodes;
+  warmup_acceptance_prob =
+      current_tree.acceptance_sum / current_tree.total_nodes;
 
-  state.set_flattened_unconstrained_values(position);
+  state.set_flattened_unconstrained_values(current_tree.position_new);
   state.update_log_prob();
 
   return 0.0;

--- a/src/beanmachine/graph/global/proposer/nuts_proposer.h
+++ b/src/beanmachine/graph/global/proposer/nuts_proposer.h
@@ -14,6 +14,7 @@ class NutsProposer : public HmcProposer {
  public:
   explicit NutsProposer(
       bool adapt_mass_matrix = true,
+      bool multinomial_sampling = true,
       double optimal_acceptance_prob = 0.8);
   void initialize(GlobalState& state, std::mt19937& gen, int num_warmup_samples)
       override;
@@ -33,11 +34,12 @@ class NutsProposer : public HmcProposer {
     Eigen::VectorXd momentum_right;
     Eigen::VectorXd position_new;
     Eigen::VectorXd momentum_sum;
-    double valid_nodes;
+    double log_weight;
     bool no_turn;
     double acceptance_sum;
     double total_nodes;
   };
+  bool multinomial_sampling;
   double warmup_acceptance_prob;
   double delta_max;
   double max_tree_depth;

--- a/src/beanmachine/graph/global/tests/nuts_multinomial_test.cpp
+++ b/src/beanmachine/graph/global/tests/nuts_multinomial_test.cpp
@@ -14,53 +14,51 @@
 using namespace beanmachine;
 using namespace graph;
 
-TEST(testglobal, global_nuts_mass_matrix_normal_normal) {
-  int num_samples = 10000;
-  int num_warmup_samples = 5000;
-  bool adapt_mass_matrix = true;
-  bool multinomial_sampling = false;
+TEST(testglobal, global_nuts_multinomial_normal_normal) {
+  bool adapt_mass_matrix = false;
+  bool multinomial_sampling = true;
   Graph g;
   auto expected_moments = build_normal_normal_model(g);
   NUTS mh = NUTS(g, adapt_mass_matrix, multinomial_sampling);
-  test_conjugate_model_moments(
-      mh, expected_moments, num_samples, num_warmup_samples);
+  test_conjugate_model_moments(mh, expected_moments);
 }
 
-TEST(testglobal, global_nuts_mass_matrix_gamma_gamma) {
-  bool adapt_mass_matrix = true;
-  bool multinomial_sampling = false;
+TEST(testglobal, global_nuts_multinomial_gamma_gamma) {
+  bool adapt_mass_matrix = false;
+  bool multinomial_sampling = true;
   Graph g;
   auto expected_moments = build_gamma_gamma_model(g);
   NUTS mh = NUTS(g, adapt_mass_matrix, multinomial_sampling);
   test_conjugate_model_moments(mh, expected_moments);
 }
 
-TEST(testglobal, global_nuts_mass_matrix_gamma_normal) {
-  bool adapt_mass_matrix = true;
-  bool multinomial_sampling = false;
+TEST(testglobal, global_nuts_multinomial_gamma_normal) {
+  bool adapt_mass_matrix = false;
+  bool multinomial_sampling = true;
   Graph g;
   auto expected_moments = build_gamma_normal_model(g);
   NUTS mh = NUTS(g, adapt_mass_matrix, multinomial_sampling);
   test_conjugate_model_moments(mh, expected_moments);
 }
 
-TEST(testglobal, global_nuts_mass_matrix_beta_binomial) {
+TEST(testglobal, global_nuts_multinomial_beta_binomial) {
   // TODO: enable after supporting stickbreaking transform
 }
 
-TEST(testglobal, global_nuts_mass_matrix_half_cauchy) {
-  int num_samples = 10000;
-  bool adapt_mass_matrix = true;
-  bool multinomial_sampling = false;
+TEST(testglobal, global_nuts_multinomial_half_cauchy) {
+  int num_samples = 5000;
+  int num_warmup_samples = 1000;
+  bool adapt_mass_matrix = false;
+  bool multinomial_sampling = true;
   Graph g;
   build_half_cauchy_model(g);
   NUTS mh = NUTS(g, adapt_mass_matrix, multinomial_sampling);
-  test_half_cauchy_model(mh, num_samples);
+  test_half_cauchy_model(mh, num_samples, num_warmup_samples);
 }
 
-TEST(testglobal, global_nuts_mass_matrix_mixed) {
-  bool adapt_mass_matrix = true;
-  bool multinomial_sampling = false;
+TEST(testglobal, global_nuts_multinomial_mixed) {
+  bool adapt_mass_matrix = false;
+  bool multinomial_sampling = true;
   Graph g;
   auto expected_moments = build_mixed_model(g);
   NUTS mh = NUTS(g, adapt_mass_matrix, multinomial_sampling);

--- a/src/beanmachine/graph/global/tests/nuts_test.cpp
+++ b/src/beanmachine/graph/global/tests/nuts_test.cpp
@@ -18,26 +18,31 @@ TEST(testglobal, global_nuts_normal_normal) {
   int num_samples = 10000;
   int num_warmup_samples = 5000;
   bool adapt_mass_matrix = false;
+  bool multinomial_sampling = false;
   Graph g;
   auto expected_moments = build_normal_normal_model(g);
-  NUTS mh = NUTS(g, adapt_mass_matrix);
+  NUTS mh = NUTS(g, adapt_mass_matrix, multinomial_sampling);
   test_conjugate_model_moments(
       mh, expected_moments, num_samples, num_warmup_samples);
 }
 
 TEST(testglobal, global_nuts_gamma_gamma) {
+  int num_samples = 10000;
+  int num_warmup = 5000;
   bool adapt_mass_matrix = false;
+  bool multinomial_sampling = false;
   Graph g;
   auto expected_moments = build_gamma_gamma_model(g);
-  NUTS mh = NUTS(g, adapt_mass_matrix);
-  test_conjugate_model_moments(mh, expected_moments);
+  NUTS mh = NUTS(g, adapt_mass_matrix, multinomial_sampling);
+  test_conjugate_model_moments(mh, expected_moments, num_samples, num_warmup);
 }
 
 TEST(testglobal, global_nuts_gamma_normal) {
   bool adapt_mass_matrix = false;
+  bool multinomial_sampling = false;
   Graph g;
   auto expected_moments = build_gamma_normal_model(g);
-  NUTS mh = NUTS(g, adapt_mass_matrix);
+  NUTS mh = NUTS(g, adapt_mass_matrix, multinomial_sampling);
   test_conjugate_model_moments(mh, expected_moments);
 }
 
@@ -47,16 +52,18 @@ TEST(testglobal, global_nuts_beta_binomial) {
 
 TEST(testglobal, global_nuts_half_cauchy) {
   bool adapt_mass_matrix = false;
+  bool multinomial_sampling = false;
   Graph g;
   build_half_cauchy_model(g);
-  NUTS mh = NUTS(g, adapt_mass_matrix);
+  NUTS mh = NUTS(g, adapt_mass_matrix, multinomial_sampling);
   test_half_cauchy_model(mh);
 }
 
 TEST(testglobal, global_nuts_mixed) {
   bool adapt_mass_matrix = false;
+  bool multinomial_sampling = false;
   Graph g;
   auto expected_moments = build_mixed_model(g);
-  NUTS mh = NUTS(g, adapt_mass_matrix);
+  NUTS mh = NUTS(g, adapt_mass_matrix, multinomial_sampling);
   test_conjugate_model_moments(mh, expected_moments);
 }

--- a/src/beanmachine/graph/pybindings.cpp
+++ b/src/beanmachine/graph/pybindings.cpp
@@ -378,7 +378,7 @@ PYBIND11_MODULE(graph, module) {
           "performance report");
 
   py::class_<NUTS>(module, "NUTS")
-      .def(py::init<Graph&, bool>())
+      .def(py::init<Graph&, bool, bool>())
       .def(
           "infer",
           &NUTS::infer,


### PR DESCRIPTION
Summary:
As described in [a Stan forum](https://discourse.mc-stan.org/t/nuts-misses-u-turns-runs-in-circles-until-max-treedepth/9727), the NUTS stopping condition doesn't work properly in some instances.

This diff adds additional u-turn checks between subtrees to prevent this behavior. It adds a u-turn check between the leftmost node of the right tree and the left tree, as well as the rightmost node of the left tree and the right tree.

Reviewed By: mootaz77

Differential Revision: D32954189

