### PR TITLE
Bumping version number in preparation for v0.1.2 release

### DIFF
--- a/src/beanmachine/__init__.py
+++ b/src/beanmachine/__init__.py
@@ -3,4 +3,4 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"


### PR DESCRIPTION
Summary: The 0.1.2 release we've been talked about for a while internally is finally going to be there, following PyTorch 1.12 release :). Once this diff is merged in, we can then create a new release on GitHub then trigger the deployment workflow.

Differential Revision: D37635707

