### PR TITLE
Implement predict_with_intervals

### DIFF
--- a/src/beanmachine/ppl/experimental/tests/bart/bart_model_test.py
+++ b/src/beanmachine/ppl/experimental/tests/bart/bart_model_test.py
@@ -3,11 +3,11 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-
 import pytest
 import torch
 
 from beanmachine.ppl.experimental.causal_inference.models.bart.bart_model import (
+    BART,
     NoiseStandardDeviation,
 )
 
@@ -32,3 +32,29 @@ def test_sigma_sampling(sigma, X, residual):
     sample = sigma.sample(X=X, residual=residual)
     assert not prev_val == sigma.val
     assert sigma.val == sample
+
+
+@pytest.fixture
+def y(X):
+    return X[:, 0] + X[:, 1]
+
+
+@pytest.fixture
+def bart(X, y):
+    return BART(num_trees=1).fit(X=X, y=y, num_burn=1, num_samples=40)
+
+
+def test_prediction_with_intervals(X, y, bart):
+    coverage = 0.999
+    with pytest.raises(ValueError):
+        _ = bart.predict_with_intervals(X, coverage=coverage)
+    low_coverage = 0.2
+    _, lower_bounds, upper_bounds = bart.predict_with_intervals(
+        X, coverage=low_coverage
+    )
+    pred_samples = bart.get_posterior_predictive_samples(X)
+
+    assert torch.all(torch.max(pred_samples, dim=1)[0] >= upper_bounds)
+    assert torch.all(torch.min(pred_samples, dim=1)[0] <= lower_bounds)
+    assert torch.all(torch.median(pred_samples, axis=1)[0] <= upper_bounds)
+    assert torch.all(torch.median(pred_samples, axis=1)[0] >= lower_bounds)


### PR DESCRIPTION
Summary:
In this diff:
We implement a method predict_with_intervals() in the BART API which return not just a prediction but also an interval for each prediction at a desired coverage.

Differential Revision: D37729486

