### PR TITLE
NUTS bug fix

### DIFF
--- a/src/beanmachine/graph/global/proposer/hmc_proposer.cpp
+++ b/src/beanmachine/graph/global/proposer/hmc_proposer.cpp
@@ -63,7 +63,7 @@ void HmcProposer::warmup(
     double acceptance_prob,
     int iteration,
     int num_warmup_samples) {
-  step_size = step_size_adapter.update_step_size(iteration, acceptance_prob);
+  step_size = step_size_adapter.update_step_size(acceptance_prob);
 
   if (adapt_mass_matrix) {
     Eigen::VectorXd sample;

--- a/src/beanmachine/graph/global/proposer/hmc_util.cpp
+++ b/src/beanmachine/graph/global/proposer/hmc_util.cpp
@@ -15,6 +15,7 @@ StepSizeAdapter::StepSizeAdapter(double optimal_acceptance_prob) {
 }
 
 void StepSizeAdapter::initialize(double step_size) {
+  iteration = 0;
   gamma = 0.05;
   t = 10.0;
   kappa = 0.75;
@@ -23,9 +24,8 @@ void StepSizeAdapter::initialize(double step_size) {
   closeness = 0.0;
 }
 
-double StepSizeAdapter::update_step_size(
-    int iteration,
-    double acceptance_prob) {
+double StepSizeAdapter::update_step_size(double acceptance_prob) {
+  iteration++;
   double iter = (double)iteration;
 
   double closeness_frac = 1.0 / (iter + t);

--- a/src/beanmachine/graph/global/proposer/hmc_util.h
+++ b/src/beanmachine/graph/global/proposer/hmc_util.h
@@ -14,10 +14,11 @@ class StepSizeAdapter {
  public:
   explicit StepSizeAdapter(double optimal_acceptance_prob);
   void initialize(double step_size);
-  double update_step_size(int iteration, double acceptance_prob);
+  double update_step_size(double acceptance_prob);
   double finalize_step_size();
 
  private:
+  int iteration;
   double gamma;
   double t;
   double kappa;

--- a/src/beanmachine/graph/global/proposer/nuts_proposer.cpp
+++ b/src/beanmachine/graph/global/proposer/nuts_proposer.cpp
@@ -46,8 +46,7 @@ void NutsProposer::warmup(
     double /*acceptance_prob*/,
     int iteration,
     int num_warmup_samples) {
-  step_size =
-      step_size_adapter.update_step_size(iteration, warmup_acceptance_prob);
+  step_size = step_size_adapter.update_step_size(warmup_acceptance_prob);
 
   if (adapt_mass_matrix) {
     Eigen::VectorXd sample;
@@ -56,6 +55,7 @@ void NutsProposer::warmup(
     bool window_end = mass_matrix_adapter.is_end_window(iteration);
 
     if (window_end) {
+      mass_matrix_adapter.get_mass_matrix_and_reset(iteration, mass_inv);
       mass_matrix_diagonal = mass_inv.diagonal().array().sqrt().inverse();
       Eigen::VectorXd position;
       state.get_flattened_unconstrained_values(position);

--- a/src/beanmachine/graph/global/proposer/tests/hmc_util_test.cpp
+++ b/src/beanmachine/graph/global/proposer/tests/hmc_util_test.cpp
@@ -16,12 +16,12 @@ using namespace graph;
 TEST(testglobal, hmc_util_step_size) {
   StepSizeAdapter step_size_adapter = StepSizeAdapter(0.65);
   step_size_adapter.initialize(1.0);
-  step_size_adapter.update_step_size(1, 0.5);
+  step_size_adapter.update_step_size(0.5);
   EXPECT_NEAR(step_size_adapter.finalize_step_size(), 7.613, 1e-4);
 
   step_size_adapter.initialize(0.5);
-  step_size_adapter.update_step_size(1, 0.0);
-  step_size_adapter.update_step_size(2, 0.9);
+  step_size_adapter.update_step_size(0.0);
+  step_size_adapter.update_step_size(0.9);
   EXPECT_NEAR(step_size_adapter.finalize_step_size(), 1.7678, 1e-4);
 }
 

--- a/src/beanmachine/graph/global/tests/hmc_mass_matrix_test.cpp
+++ b/src/beanmachine/graph/global/tests/hmc_mass_matrix_test.cpp
@@ -26,14 +26,11 @@ TEST(testglobal, global_hmc_mass_matrix_normal_normal) {
 }
 
 TEST(testglobal, global_hmc_mass_matrix_gamma_gamma) {
-  int num_samples = 10000;
-  int num_warmup_samples = 5000;
   bool adapt_mass_matrix = true;
   Graph g;
   auto expected_moments = build_gamma_gamma_model(g);
   HMC mh = HMC(g, 1.0, 0.5, adapt_mass_matrix);
-  test_conjugate_model_moments(
-      mh, expected_moments, num_samples, num_warmup_samples);
+  test_conjugate_model_moments(mh, expected_moments);
 }
 
 TEST(testglobal, global_hmc_mass_matrix_beta_binomial) {


### PR DESCRIPTION
Summary:
Fixing bug where
1. step size adapter was using the total iteration number rather than the iteration within the window to adjust the step size
2. NUTS was not using a new mass matrix every window

To fix this, I
- added `iteration` to `StepSizeAdapter` that resets to 0 when ` step_size_adapter.initialize(step_size)` is called at the end of each window
- added missing line that updates the mass matrix in `nuts_proposer.cpp`

Reviewed By: ToddSmall

Differential Revision: D37723669

