### PR TITLE
Cholesky non-positive definite error

### DIFF
--- a/src/beanmachine/graph/operator/linalgop.cpp
+++ b/src/beanmachine/graph/operator/linalgop.cpp
@@ -7,6 +7,7 @@
 
 #include "beanmachine/graph/operator/linalgop.h"
 #include <beanmachine/graph/graph.h>
+#include <stdexcept>
 #include "beanmachine/graph/graph.h"
 
 /*
@@ -412,7 +413,11 @@ Cholesky::Cholesky(const std::vector<graph::Node*>& in_nodes)
 
 void Cholesky::eval(std::mt19937& /* gen */) {
   assert(in_nodes.size() == 1);
-  value._matrix = in_nodes[0]->value._matrix.llt().matrixL();
+  Eigen::LLT<Eigen::MatrixXd> llt_matrix = in_nodes[0]->value._matrix.llt();
+  value._matrix = llt_matrix.matrixL();
+  if (llt_matrix.info() == Eigen::NumericalIssue) {
+    throw std::runtime_error("CHOLESKY requires a positive definite matrix");
+  }
 }
 
 MatrixExp::MatrixExp(const std::vector<graph::Node*>& in_nodes)


### PR DESCRIPTION
Summary: Add runtime error when input for cholesky operator is not positive definite.

Reviewed By: shannyang

Differential Revision: D37649980

