### PR TITLE
Fix MALA nightly test

### DIFF
--- a/src/beanmachine/ppl/experimental/tests/mala/single_site_metropolis_adjusted_langevin_algorithm_conjugate_test_nightly.py
+++ b/src/beanmachine/ppl/experimental/tests/mala/single_site_metropolis_adjusted_langevin_algorithm_conjugate_test_nightly.py
@@ -22,7 +22,9 @@ class SingleSiteMetropolisAdapatedLangevinAlgorithmConjugateTest(
 
     def test_gamma_gamma_conjugate_run(self):
         mala = SingleSiteMetropolisAdapatedLangevinAlgorithm(0.05)
-        self.gamma_gamma_conjugate_run(mala, num_samples=500, num_adaptive_samples=500)
+        self.gamma_gamma_conjugate_run(
+            mala, num_samples=1000, num_adaptive_samples=1000
+        )
 
     def test_gamma_normal_conjugate_run(self):
         mala = SingleSiteMetropolisAdapatedLangevinAlgorithm(0.05)


### PR DESCRIPTION
Summary: The MALA single site test for gamma_gamma conjugate test was ocasionally failing (https://fburl.com/sandcastle/78v8wecc). This has been fixed in this diff by increasing the number of samples for the test from 500 to 1000.

Differential Revision: D37770405

