### PR TITLE
Clarify the logic of prune tree transition ratio

### DIFF
--- a/src/beanmachine/ppl/experimental/causal_inference/models/bart/grow_prune_tree_proposer.py
+++ b/src/beanmachine/ppl/experimental/causal_inference/models/bart/grow_prune_tree_proposer.py
@@ -316,7 +316,12 @@ class GrowPruneTreeProposer(TreeProposer):
             X: Covariate matrix / training data.
 
         """
-        num_growable_leaves_in_pruned_tree = tree.num_growable_leaf_nodes(X) - 1
+        num_growable_leaves_in_pruned_tree = (
+            tree.num_growable_leaf_nodes(X)
+            - mutation.old_node.left_child.is_growable(X=X)
+            - mutation.old_node.right_child.is_growable(X=X)
+            + mutation.new_node.is_growable(X=X)
+        )
 
         if num_growable_leaves_in_pruned_tree == 0:
             return -float("inf")  # impossible prune
@@ -324,7 +329,6 @@ class GrowPruneTreeProposer(TreeProposer):
         log_p_old_to_new_tree = math.log(self.prune_probability) - math.log(
             tree.num_prunable_split_nodes()
         )
-
         log_probability_selecting_leaf_to_grow = -math.log(
             num_growable_leaves_in_pruned_tree
         )


### PR DESCRIPTION
Summary: In the BART algorithm, it is required to calculate the prune_log_transition_ratio in the _prune_log_transition_ratio. This requires the calculation of number of growable leafs in the proposed ("pruned") tree. This diff clarifies the logic for the calculation of number of growable leafs in this tree as a function of the new and old nodes.

Differential Revision: D37808283

