### PR TITLE
Reword docstring so num_observation refers to length of dataset instead of num_samples

### DIFF
--- a/src/beanmachine/ppl/experimental/causal_inference/models/bart/bart_model.py
+++ b/src/beanmachine/ppl/experimental/causal_inference/models/bart/bart_model.py
@@ -106,8 +106,8 @@ class BART:
         """Fit the training data and learn the parameters of the model.
 
         Args:
-            X: Training data / covariate matrix of shape (num_samples, input_dimensions).
-            y: Response vector of shape (num_samples, 1).
+            X: Training data / covariate matrix of shape (num_observations, input_dimensions).
+            y: Response vector of shape (num_observations, 1).
         """
         self.num_samples = num_samples
         self._load_data(X, y)
@@ -133,8 +133,8 @@ class BART:
 
 
         Args:
-            X: Training data / covariate matrix of shape (num_samples, input_dimensions).
-            y: Response vector of shape (num_samples, 1).
+            X: Training data / covariate matrix of shape (num_observations, input_dimensions).
+            y: Response vector of shape (num_observations, 1).
 
         """
         if not isinstance(X, torch.Tensor) or not isinstance(y, torch.Tensor):
@@ -177,7 +177,7 @@ class BART:
         Initialize the trees of the model.
 
         Args:
-            X: Training data / covariate matrix of shape (num_samples, input_dimensions).
+            X: Training data / covariate matrix of shape (num_observations, input_dimensions).
         """
         num_dims = X.shape[-1]
         num_points = X.shape[0]
@@ -235,7 +235,7 @@ class BART:
 
         Args:
             tree: Tree whos leaf is being updated.
-            partial_residual: Current residual of the model excluding this tree of shape (num_samples, 1).
+            partial_residual: Current residual of the model excluding this tree of shape (num_observations, 1).
 
         """
         if self.X is None:
@@ -258,7 +258,7 @@ class BART:
             [1] Andrew Gelman et al. "Bayesian Data Analysis", 3rd ed.
 
         Args:
-            partial_residual: Current residual of the model excluding this tree of shape (num_samples, 1).
+            partial_residual: Current residual of the model excluding this tree of shape (num_observations, 1).
 
         """
         self.sigma.sample(self.X, full_residual)
@@ -296,10 +296,10 @@ class BART:
         Perform a prediction using all the samples collected in the model.
 
         Args:
-            X: Covariate matrix to predict on of shape (num_samples, input_dimensions).
+            X: Covariate matrix to predict on of shape (num_observations, input_dimensions).
 
         Returns:
-            prediction: Prediction corresponding to averaf of all samples of shape (num_samples, 1).
+            prediction: Prediction corresponding to averaf of all samples of shape (num_observations, 1).
         """
 
         prediction = torch.mean(
@@ -370,8 +370,8 @@ class NoiseStandardDeviation:
             This sets the value of the `val` attribute to the drawn sample.
 
         Args:
-            X: Covariate matrix / training data shape (num_samples, input_dimensions).
-            residual: The current residual of the model shape (num_samples, 1).
+            X: Covariate matrix / training data shape (num_observations, input_dimensions).
+            residual: The current residual of the model shape (num_observations, 1).
         """
         self.val = self._get_sample(X, residual)
         return self.val
@@ -381,8 +381,8 @@ class NoiseStandardDeviation:
         Draw a sample from the posterior.
 
         Args:
-            X: Covariate matrix / training data of shape (num_samples, input_dimensions).
-            residual: The current residual of the model of shape (num_samples, 1).
+            X: Covariate matrix / training data of shape (num_observations, input_dimensions).
+            residual: The current residual of the model of shape (num_observations, 1).
 
         """
         posterior_concentration = self.prior_concentration + (len(X) / 2.0)

--- a/src/beanmachine/ppl/experimental/causal_inference/models/bart/grow_prune_tree_proposer.py
+++ b/src/beanmachine/ppl/experimental/causal_inference/models/bart/grow_prune_tree_proposer.py
@@ -316,7 +316,12 @@ class GrowPruneTreeProposer(TreeProposer):
             X: Covariate matrix / training data.
 
         """
-        num_growable_leaves_in_pruned_tree = tree.num_growable_leaf_nodes(X) - 1
+        num_growable_leaves_in_pruned_tree = (
+            tree.num_growable_leaf_nodes(X)
+            - mutation.old_node.left_child.is_growable(X=X)
+            - mutation.old_node.right_child.is_growable(X=X)
+            + mutation.new_node.is_growable(X=X)
+        )
 
         if num_growable_leaves_in_pruned_tree == 0:
             return -float("inf")  # impossible prune
@@ -324,7 +329,6 @@ class GrowPruneTreeProposer(TreeProposer):
         log_p_old_to_new_tree = math.log(self.prune_probability) - math.log(
             tree.num_prunable_split_nodes()
         )
-
         log_probability_selecting_leaf_to_grow = -math.log(
             num_growable_leaves_in_pruned_tree
         )


### PR DESCRIPTION
Summary: BART is a tree based Bayesian regression model which fits a covariate matrix, X to estimate the response surface (E[y(0), y(1) | X]). In this diff the docstring was edited for clarity. Previously, the docstrings referred to the length of the dataset (len(X)) as num_samples. However, it was realized that this is confusing with the number of samples along the MCMC dimension. Therefore, we now refer to len(X) as num_observations to avoid this confusion.

Differential Revision: D37820250

