### PR TITLE
Fix predict always uses training data

### DIFF
--- a/src/beanmachine/ppl/experimental/causal_inference/models/bart/bart_model.py
+++ b/src/beanmachine/ppl/experimental/causal_inference/models/bart/bart_model.py
@@ -288,7 +288,7 @@ class BART:
 
         prediction = torch.zeros((len(X), 1), dtype=torch.float)
         for single_tree in trees:
-            prediction += single_tree.predict(self.X)
+            prediction += single_tree.predict(X)
         return prediction
 
     def predict(self, X: torch.Tensor) -> torch.Tensor:

--- a/src/beanmachine/ppl/experimental/causal_inference/models/bart/bart_model.py
+++ b/src/beanmachine/ppl/experimental/causal_inference/models/bart/bart_model.py
@@ -299,13 +299,63 @@ class BART:
             X: Covariate matrix to predict on of shape (num_observations, input_dimensions).
 
         Returns:
-            prediction: Prediction corresponding to averaf of all samples of shape (num_observations, 1).
+            prediction: Prediction corresponding to average of all samples of shape (num_observations, 1).
         """
 
         prediction = torch.mean(
             self.get_posterior_predictive_samples(X), dim=-1, dtype=torch.float
         )
         return prediction.reshape(-1, 1)
+
+    def predict_with_intervals(
+        self, X: torch.Tensor, coverage: float = 0.95
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """
+        Returns the prediction along with lower and upper bounds for the interval defined by the given coverage.
+
+        Note:
+            Where possible, the interval is centered around the median of the predictive posterior samples.
+
+        Args:
+            X: Covariate matrix to predict on of shape (num_samples, input_dimensions).
+            coverage: Interval coverage required.
+
+        Returns:
+            prediction: Prediction corresponding to average of all samples of shape (num_samples, 1).
+            lower_bound: Lower bound of the interval defined by the coverage.
+            upper_bound: Upper bound of the interval defined by the coverage.
+
+        """
+        interval_len = self._get_interval_len(coverage=coverage)
+        if interval_len >= self.num_samples:
+            raise ValueError("Not enough samples for desired coverage")
+        prediction_samples, _ = torch.sort(
+            self.get_posterior_predictive_samples(X), dim=-1
+        )
+        median_dim = self.num_samples // 2
+        lower_bound = max(median_dim - (interval_len // 2), 0)
+        upper_bound = lower_bound + interval_len
+        if upper_bound >= self.num_samples:
+            raise ValueError("No proper interval defined at this coverage")
+        return (
+            self.predict(X),
+            prediction_samples[:, lower_bound],
+            prediction_samples[:, upper_bound],
+        )
+
+    def _get_interval_len(self, coverage: float) -> int:
+        """
+        Get the length of the interval with desired coverage using the formula :
+            coverage >= interval_length / (num_samples)
+
+        Args:
+            coverage: Interval coverage required.
+
+        Returns:
+            Coverage length.
+
+        """
+        return math.ceil(coverage * (self.num_samples + 1))
 
     def get_posterior_predictive_samples(self, X: torch.Tensor) -> torch.Tensor:
         """

--- a/src/beanmachine/ppl/experimental/tests/bart/bart_model_test.py
+++ b/src/beanmachine/ppl/experimental/tests/bart/bart_model_test.py
@@ -58,3 +58,19 @@ def test_prediction_with_intervals(X, y, bart):
     assert torch.all(torch.min(pred_samples, dim=1)[0] <= lower_bounds)
     assert torch.all(torch.median(pred_samples, axis=1)[0] <= upper_bounds)
     assert torch.all(torch.median(pred_samples, axis=1)[0] >= lower_bounds)
+
+
+@pytest.fixture
+def X_test():
+    return torch.Tensor([[3.1, 2.5]])
+
+
+@pytest.fixture
+def y_test(X_test):
+    return X_test[:, 0] + X_test[:, 1]
+
+
+def test_predict(X_test, y_test, bart):
+    y_pred = bart.predict(X_test)
+    assert len(X_test) == len(y_pred)
+    assert len(y_test) == len(y_pred)

--- a/src/beanmachine/ppl/experimental/tests/bart/bart_model_test.py
+++ b/src/beanmachine/ppl/experimental/tests/bart/bart_model_test.py
@@ -3,11 +3,11 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-
 import pytest
 import torch
 
 from beanmachine.ppl.experimental.causal_inference.models.bart.bart_model import (
+    BART,
     NoiseStandardDeviation,
 )
 
@@ -32,3 +32,29 @@ def test_sigma_sampling(sigma, X, residual):
     sample = sigma.sample(X=X, residual=residual)
     assert not prev_val == sigma.val
     assert sigma.val == sample
+
+
+@pytest.fixture
+def y(X):
+    return X[:, 0] + X[:, 1]
+
+
+@pytest.fixture
+def bart(X, y):
+    return BART(num_trees=1).fit(X=X, y=y, num_burn=1, num_samples=40)
+
+
+def test_prediction_with_intervals(X, y, bart):
+    coverage = 0.95
+    with pytest.raises(ValueError):
+        _ = bart.predict_with_intervals(X, coverage=coverage)
+    low_coverage = 0.2
+    _, lower_bounds, upper_bounds = bart.predict_with_intervals(
+        X, coverage=low_coverage
+    )
+    pred_samples = bart.get_posterior_predictive_samples(X)
+
+    assert torch.all(torch.max(pred_samples, dim=1)[0] >= upper_bounds)
+    assert torch.all(torch.min(pred_samples, dim=1)[0] <= lower_bounds)
+    assert torch.all(torch.median(pred_samples, axis=1)[0] <= upper_bounds)
+    assert torch.all(torch.median(pred_samples, axis=1)[0] >= lower_bounds)


### PR DESCRIPTION
Summary:
Background:
We are building Bayesian Additive Regression Trees (BART) as an experimental causal inference model in Bean
Machine.

In this diff:
This diff fixes a bug which causes the BART model to always predict on training data. This bug originates from an older iteration where the _predict_step() method was only used during training.
Unittest has been added and the integration test has been modified to detect this.

Differential Revision: D37837114

