### PR TITLE
Use RE GPUs to run GPU VI tests

### DIFF
--- a/src/beanmachine/ppl/experimental/tests/vi/vi_gpu_test.py
+++ b/src/beanmachine/ppl/experimental/tests/vi/vi_gpu_test.py
@@ -1,0 +1,62 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Optional
+
+import beanmachine.ppl as bm
+import pytest
+import torch
+import torch.distributions as dist
+from beanmachine.ppl.experimental.vi import VariationalInfer
+
+cpu_device = torch.device("cpu")
+
+
+class NormalNormal:
+    def __init__(self, device: Optional[torch.device] = cpu_device):
+        self.device = device
+
+    @bm.random_variable
+    def mu(self):
+        return dist.Normal(
+            torch.zeros(1).to(self.device), 10 * torch.ones(1).to(self.device)
+        )
+
+    @bm.random_variable
+    def x(self, i):
+        return dist.Normal(self.mu(), torch.ones(1).to(self.device))
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="requires GPU access to train the model"
+)
+def test_normal_normal_guide_step_gpu():
+    device = torch.device("cuda:0")
+    model = NormalNormal(device=device)
+
+    @bm.param
+    def phi():
+        return torch.zeros(2).to(device)  # mean, log std
+
+    @bm.random_variable
+    def q_mu():
+        params = phi()
+        return dist.Normal(params[0], params[1].exp())
+
+    world = VariationalInfer(
+        queries_to_guides={model.mu(): q_mu()},
+        observations={
+            model.x(1): torch.tensor(9.0),
+            model.x(2): torch.tensor(10.0),
+        },
+        optimizer=lambda params: torch.optim.Adam(params, lr=1e-1),
+        device=device,
+    ).infer(
+        num_steps=1000,
+    )
+    mu_approx = world.get_variable(q_mu()).distribution
+
+    assert (mu_approx.mean - 9.6).norm() < 1.0
+    assert (mu_approx.stddev - 0.7).norm() < 0.3

--- a/src/beanmachine/ppl/experimental/tests/vi/vi_test.py
+++ b/src/beanmachine/ppl/experimental/tests/vi/vi_test.py
@@ -304,33 +304,6 @@ class TestStochasticVariationalInfer:
         sample_var = mu_approx.sample((100, 1)).var()
         assert sample_var > 0.1
 
-    @pytest.mark.skipif(
-        not torch.cuda.is_available(), reason="requires GPU access to train the model"
-    )
-    def test_normal_normal_guide_step_gpu(self):
-        device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
-        normal_normal_model = NormalNormal(device=device)
-        log_scale_normal_model = LogScaleNormal()
-
-        world = VariationalInfer(
-            queries_to_guides={normal_normal_model.mu(): log_scale_normal_model.q_mu()},
-            observations={
-                normal_normal_model.x(1): torch.tensor(9.0),
-                normal_normal_model.x(2): torch.tensor(10.0),
-            },
-            optimizer=lambda params: torch.optim.Adam(params, lr=1e0),
-            device=device,
-        ).infer(
-            num_steps=100,
-        )
-        mu_approx = world.get_variable(log_scale_normal_model.q_mu()).distribution
-
-        sample_mean = mu_approx.sample((100, 1)).mean()
-        assert sample_mean > 5.0
-
-        sample_var = mu_approx.sample((100, 1)).var()
-        assert sample_var > 0.1
-
     def test_normal_normal_guide_step(self):
         normal_normal_model = NormalNormal()
         log_scale_normal_model = LogScaleNormal()

--- a/src/beanmachine/ppl/experimental/vi/variational_infer.py
+++ b/src/beanmachine/ppl/experimental/vi/variational_infer.py
@@ -60,6 +60,7 @@ class VariationalInfer:
             world.call(guide)
         self.params = world._params
         self._optimizer = optimizer(self.params.values())
+        self._device = device
 
     def infer(
         self,
@@ -131,6 +132,7 @@ class VariationalInfer:
             self.params,
             self.queries_to_guides,
             subsample_factor=subsample_factor,
+            device=self._device,
         )
         if not torch.isnan(loss) and not torch.isinf(loss):
             loss.backward()


### PR DESCRIPTION
Summary:
Enables RE GPU so VI tests are not skipped (T124893023)

Also fixes a bug in GPU VI by storing device provided at instantiation and respecting placement of loss tensor

Reviewed By: mootaz77

Differential Revision: D37761345

