### PR TITLE
Return prediction mean with intervals

### DIFF
--- a/src/beanmachine/ppl/experimental/causal_inference/models/bart/bart_model.py
+++ b/src/beanmachine/ppl/experimental/causal_inference/models/bart/bart_model.py
@@ -339,7 +339,7 @@ class BART:
             lower_bound -= interval_shift
             upper_bound -= interval_shift
         return (
-            prediction_samples,
+            torch.mean(prediction_samples, dim=-1, dtype=torch.float).reshape(-1, 1),
             sorted_prediction_samples[:, lower_bound],
             sorted_prediction_samples[:, upper_bound],
         )

--- a/src/beanmachine/ppl/experimental/tests/bart/bart_model_test.py
+++ b/src/beanmachine/ppl/experimental/tests/bart/bart_model_test.py
@@ -49,7 +49,7 @@ def test_prediction_with_intervals(X, y, bart):
     with pytest.raises(ValueError):
         _ = bart.predict_with_intervals(X, coverage=coverage)
     low_coverage = 0.2
-    _, lower_bounds, upper_bounds = bart.predict_with_intervals(
+    y_pred, lower_bounds, upper_bounds = bart.predict_with_intervals(
         X, coverage=low_coverage
     )
     pred_samples = bart.get_posterior_predictive_samples(X)
@@ -58,6 +58,7 @@ def test_prediction_with_intervals(X, y, bart):
     assert torch.all(torch.min(pred_samples, dim=1)[0] <= lower_bounds)
     assert torch.all(torch.median(pred_samples, axis=1)[0] <= upper_bounds)
     assert torch.all(torch.median(pred_samples, axis=1)[0] >= lower_bounds)
+    assert torch.all(y_pred == bart.predict(X))
 
 
 @pytest.fixture


### PR DESCRIPTION
Summary:
We are building BART (Batesian Additive Regression Trees) in Bean Machine.
In this diff:
We are returning the mean of the samples in the get_prediction_with_intervals instead of all the samples.

Differential Revision: D37858510

