### PR TITLE
Alias _step() based on tree proposer chosen

### DIFF
--- a/src/beanmachine/ppl/experimental/causal_inference/models/bart/bart_model.py
+++ b/src/beanmachine/ppl/experimental/causal_inference/models/bart/bart_model.py
@@ -96,6 +96,13 @@ class BART:
         else:
             NotImplementedError("tree_sampler not implemented")
 
+        if isinstance(self.tree_sampler, GrowPruneTreeProposer):
+            self._step = self._grow_prune_step
+        else:
+            NotImplementedError(
+                "step function not defined"
+            )  # this should never be raised
+
     def fit(
         self,
         X: torch.Tensor,
@@ -200,8 +207,13 @@ class BART:
             (num_points, self.num_trees, 1), dtype=torch.float
         )
 
-    def _step(self) -> Tuple[List, float]:
-        """Take a single MCMC step"""
+    def _grow_prune_step(self) -> Tuple[List, float]:
+        """Take a single MCMC step using the GrowPrune approach of the original BART [1].
+
+        Reference:
+            [1] Hugh A. Chipman, Edward I. George, Robert E. McCulloch (2010). "BART: Bayesian additive regression trees"
+        https://projecteuclid.org/journals/annals-of-applied-statistics/volume-4/issue-1/BART-Bayesian-additive-regression-trees/10.1214/09-AOAS285.full
+        """
         if self.X is None or self.y is None:
             raise NotInitializedError("No training data")
 


### PR DESCRIPTION
Summary:
Background:
We have previously implemented Bayesian Additive Regression Trees (BART) as implemented by Chipman et al. (https://projecteuclid.org/journals/annals-of-applied-statistics/volume-4/issue-1/BART-Bayesian-additive-regression-trees/10.1214/09-AOAS285.full) with the GrowPrune tree sampler (https://arxiv.org/pdf/1309.1906.pdf). This is the "classic MCMC BART". We want to add further modifications of BART which modifies the MCMC step of the classic version (specifically, we want to implement xBART: https://arxiv.org/abs/1810.02215).

In this diff:
We are renaming the ```BART._step()``` method to ```BART._grow_prune_step()```. The internal alias ```BART._step()``` no points to ```BART._grow_prune_step()``` only when the ```GrowPrune``` tree sampler is chosen. The idea is that this alias can point to other modifications of BART as they are implemented (we immediately plan to implement xBART).

Differential Revision: D37934250

