### PR TITLE
Implement xBART class structure

### DIFF
--- a/src/beanmachine/ppl/experimental/tests/bart/bart_model_test.py
+++ b/src/beanmachine/ppl/experimental/tests/bart/bart_model_test.py
@@ -9,6 +9,7 @@ import torch
 from beanmachine.ppl.experimental.causal_inference.models.bart.bart_model import (
     BART,
     NoiseStandardDeviation,
+    XBART,
 )
 
 
@@ -73,5 +74,16 @@ def y_test(X_test):
 
 def test_predict(X_test, y_test, bart):
     y_pred = bart.predict(X_test)
+    assert len(X_test) == len(y_pred)
+    assert len(y_test) == len(y_pred)
+
+
+@pytest.fixture
+def xbart(X, y):
+    return XBART(num_trees=1).fit(X=X, y=y, num_burn=1, num_samples=40)
+
+
+def test_predict_xbart(X_test, y_test, xbart):
+    y_pred = xbart.predict(X_test)
     assert len(X_test) == len(y_pred)
     assert len(y_test) == len(y_pred)


### PR DESCRIPTION
Summary:
xBART is a faster implementation of Bayesian Additive Regression Trees (BART). xBART uses a "grow from root" backfitting algorithm wherein new trees are grown recursively at each MCMC step (instead of pointwise mutations to existing trees in classical BART). As a result xBART uses different hyperparameters and defaults than BART. Since xBART uses more hyperparameters than BART while sharing almost all of BART's hyperparmaters, we decided to subclass BART to xBART.

In this diff:
We subclass and overload ```BART```'s constructor (to take in more hyperparameters) and the ```fit()``` method to initialize some hyperparams such as ```num_trees``` which xBART defaults adaptively as a function of the training data. This leads to some lines of code duplicaiton in the ```fit``` method but no alternatives to this design could be found without more significant changes to the existing BART API.

Note:
In this current form, xBART uses BART's grow prune tree proposer and its ```_step()```. This works (see test) and was done intentionally to keep the diff focused. A future diff will implement the grow from root algorithm and the modified ```_step()``` method.

Differential Revision: D37962384

