### PR TITLE
Rename tao to tau

### DIFF
--- a/src/beanmachine/ppl/experimental/causal_inference/models/bart/bart_model.py
+++ b/src/beanmachine/ppl/experimental/causal_inference/models/bart/bart_model.py
@@ -414,7 +414,7 @@ class XBART(BART):
             it defaults to 0 and is adaptively set as a function of the trianing data in the ```fit()``` method.
         alpha: Parameter used in the tree depth prior, Eq. 7 of [2].
         beta: Parameter used in the tree depth prior, Eq. 7 of [2].
-        tao: Prior variance of the leaf-specific mean paramete used in the u_i_j prior, section 2.2 of [1].
+        tau: Prior variance of the leaf-specific mean paramete used in the u_i_j prior, section 2.2 of [1].
         noise_sd_concentration: Concentration parameter (alpha) for the inverse gamma distribution prior of p(sigma).
         noise_sd_rate: Rate parameter (beta) for the inverse gamma distribution prior of p(sigma).
         tree_sampler: The tree sampling method used.
@@ -428,7 +428,7 @@ class XBART(BART):
         num_trees: int = 0,
         alpha: float = 0.95,
         beta: float = 2.0,
-        tao: Optional[float] = None,
+        tau: Optional[float] = None,
         noise_sd_concentration: float = 3.0,
         noise_sd_rate: float = 1.0,
         tree_sampler: Optional[GrowPruneTreeProposer] = None,
@@ -436,7 +436,7 @@ class XBART(BART):
         num_cuts: Optional[int] = None,
     ):
         self.num_cuts = num_cuts
-        self.tao = tao
+        self.tau = tau
 
         super().__init__(
             num_trees=num_trees,
@@ -467,10 +467,10 @@ class XBART(BART):
         if not self.num_trees > 0:
             self._adaptively_init_num_trees()
 
-        if self.tao is None:
-            self._adaptively_init_tao()
-        self.tao = cast(float, self.tao)
-        self.leaf_mean = LeafMean(prior_loc=0.0, prior_scale=math.sqrt(self.tao))
+        if self.tau is None:
+            self._adaptively_init_tau()
+        self.tau = cast(float, self.tau)
+        self.leaf_mean = LeafMean(prior_loc=0.0, prior_scale=math.sqrt(self.tau))
         if self.num_cuts is None:
             self._adaptively_init_num_cuts()
         self.samples = {"trees": [], "sigmas": []}
@@ -494,8 +494,8 @@ class XBART(BART):
         n = len(self.X)
         self.num_trees = int(math.pow(math.log(n), math.log(math.log(n))) / 4)
 
-    def _adaptively_init_tao(self):
-        """Implements the default for tao from section 3.1 of [1].
+    def _adaptively_init_tau(self):
+        """Implements the default for tau from section 3.1 of [1].
 
         Reference:
             [1] He J., Yalov S., Hahn P.R. (2018). "XBART: Accelerated Bayesian Additive Regression Trees"
@@ -503,7 +503,7 @@ class XBART(BART):
         """
         if not self.num_trees > 0:
             raise NotInitializedError("num_trees not set")
-        self.tao = (3 / 10) * (torch.var(self.y).item() / self.num_trees)
+        self.tau = (3 / 10) * (torch.var(self.y).item() / self.num_trees)
 
     def _adaptively_init_num_cuts(self):
         """Implements the default for number of cuts, C from section 3.3 of [1].

--- a/src/beanmachine/ppl/experimental/causal_inference/models/bart/bart_model.py
+++ b/src/beanmachine/ppl/experimental/causal_inference/models/bart/bart_model.py
@@ -19,12 +19,14 @@ from beanmachine.ppl.experimental.causal_inference.models.bart.grow_prune_tree_p
     GrowPruneTreeProposer,
 )
 from beanmachine.ppl.experimental.causal_inference.models.bart.node import LeafNode
+from beanmachine.ppl.experimental.causal_inference.models.bart.scalar_samplers import (
+    LeafMean,
+    NoiseStandardDeviation,
+)
 from beanmachine.ppl.experimental.causal_inference.models.bart.split_rule import (
     CompositeRules,
 )
 from beanmachine.ppl.experimental.causal_inference.models.bart.tree import Tree
-from torch.distributions.gamma import Gamma
-from torch.distributions.normal import Normal
 from tqdm.auto import trange
 
 
@@ -512,113 +514,3 @@ class XBART(BART):
         """
         n = len(self.X)
         self.num_cuts = max(int(math.sqrt(n)), 100)
-
-
-class NoiseStandardDeviation:
-    """The NoiseStandardDeviation class encapsulates the noise standard deviation.
-    The variance is parametrized by an inverse-gamma prior which is conjugate to a normal likelihood.
-
-    Args:
-        prior_concentration (float): Also called alpha. Must be greater than zero.
-        prior_rate (float): Also called beta. Must be greater than 0.
-        val (float): Current value of noise standard deviation.
-    """
-
-    def __init__(
-        self, prior_concentration: float, prior_rate: float, val: Optional[float] = None
-    ):
-        if prior_concentration <= 0 or prior_rate <= 0:
-            raise ValueError("Invalid prior hyperparameters")
-        self.prior_concentration = prior_concentration
-        self.prior_rate = prior_rate
-        if val is None:
-            self.sample(X=torch.Tensor([]), residual=torch.Tensor([]))  # prior init
-        else:
-            self._val = val
-
-    @property
-    def val(self) -> float:
-        return self._val
-
-    @val.setter
-    def val(self, val: float):
-        self._val = val
-
-    def sample(self, X: torch.Tensor, residual: torch.Tensor) -> float:
-        """Sample from the posterior distribution of sigma.
-        If empty tensors are passed for X and residual, there will be no update so the sampling will be from the prior.
-
-        Note:
-            This sets the value of the `val` attribute to the drawn sample.
-
-        Args:
-            X: Covariate matrix / training data shape (num_observations, input_dimensions).
-            residual: The current residual of the model shape (num_observations, 1).
-        """
-        self.val = self._get_sample(X, residual)
-        return self.val
-
-    def _get_sample(self, X: torch.Tensor, residual: torch.Tensor) -> float:
-        """
-        Draw a sample from the posterior.
-
-        Args:
-            X: Covariate matrix / training data of shape (num_observations, input_dimensions).
-            residual: The current residual of the model of shape (num_observations, 1).
-
-        """
-        posterior_concentration = self.prior_concentration + (len(X) / 2.0)
-        posterior_rate = self.prior_rate + (0.5 * (torch.sum(torch.square(residual))))
-        draw = torch.pow(Gamma(posterior_concentration, posterior_rate).sample(), -0.5)
-        return draw.item()
-
-
-class LeafMean:
-    """
-    Class to sample form the prior and posterior distributions of the leaf nodes in BART.
-
-    Reference:
-        [1] Hugh A. Chipman, Edward I. George, Robert E. McCulloch (2010). "BART: Bayesian additive regression trees"
-        https://projecteuclid.org/journals/annals-of-applied-statistics/volume-4/issue-1/BART-Bayesian-additive-regression-trees/10.1214/09-AOAS285.full
-
-    Args:
-        prior_loc: Prior location parameter.
-        prior_scale: Prior scale parameter.
-    """
-
-    def __init__(self, prior_loc: float, prior_scale: float):
-        if prior_scale < 0:
-            raise ValueError("Invalid prior hyperparameters")
-        self._prior_loc = prior_loc
-        self._prior_scale = prior_scale
-
-    @property
-    def prior_scale(self):
-        return self._prior_scale
-
-    def sample_prior(self):
-        return Normal(loc=self._prior_loc, scale=self._prior_scale).sample().item()
-
-    def sample_posterior(
-        self,
-        node: LeafNode,
-        X: torch.Tensor,
-        y: torch.Tensor,
-        current_sigma_val: float,
-    ):
-        X_in_node, y_in_node = node.data_in_node(X, y)
-        if len(X_in_node) == 0:
-            return None  # no new data
-        num_points_in_node = len(X_in_node)
-        prior_variance = (self._prior_scale) ** 2
-        likelihood_variance = (current_sigma_val**2) / num_points_in_node
-        likelihood_mean = torch.sum(y_in_node) / num_points_in_node
-        posterior_variance = 1.0 / (1.0 / prior_variance + 1.0 / likelihood_variance)
-        posterior_mean = (
-            likelihood_mean * prior_variance + self._prior_loc * likelihood_variance
-        ) / (likelihood_variance + prior_variance)
-        return (
-            Normal(loc=posterior_mean, scale=math.sqrt(posterior_variance))
-            .sample()
-            .item()
-        )

--- a/src/beanmachine/ppl/experimental/causal_inference/models/bart/scalar_samplers.py
+++ b/src/beanmachine/ppl/experimental/causal_inference/models/bart/scalar_samplers.py
@@ -1,0 +1,123 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import math
+from typing import Optional
+
+import torch
+
+from beanmachine.ppl.experimental.causal_inference.models.bart.node import LeafNode
+from torch.distributions.gamma import Gamma
+from torch.distributions.normal import Normal
+
+
+class NoiseStandardDeviation:
+    """The NoiseStandardDeviation class encapsulates the noise standard deviation.
+    The variance is parametrized by an inverse-gamma prior which is conjugate to a normal likelihood.
+
+    Args:
+        prior_concentration (float): Also called alpha. Must be greater than zero.
+        prior_rate (float): Also called beta. Must be greater than 0.
+        val (float): Current value of noise standard deviation.
+    """
+
+    def __init__(
+        self, prior_concentration: float, prior_rate: float, val: Optional[float] = None
+    ):
+        if prior_concentration <= 0 or prior_rate <= 0:
+            raise ValueError("Invalid prior hyperparameters")
+        self.prior_concentration = prior_concentration
+        self.prior_rate = prior_rate
+        if val is None:
+            self.sample(X=torch.Tensor([]), residual=torch.Tensor([]))  # prior init
+        else:
+            self._val = val
+
+    @property
+    def val(self) -> float:
+        return self._val
+
+    @val.setter
+    def val(self, val: float):
+        self._val = val
+
+    def sample(self, X: torch.Tensor, residual: torch.Tensor) -> float:
+        """Sample from the posterior distribution of sigma.
+        If empty tensors are passed for X and residual, there will be no update so the sampling will be from the prior.
+
+        Note:
+            This sets the value of the `val` attribute to the drawn sample.
+
+        Args:
+            X: Covariate matrix / training data shape (num_observations, input_dimensions).
+            residual: The current residual of the model shape (num_observations, 1).
+        """
+        self.val = self._get_sample(X, residual)
+        return self.val
+
+    def _get_sample(self, X: torch.Tensor, residual: torch.Tensor) -> float:
+        """
+        Draw a sample from the posterior.
+
+        Args:
+            X: Covariate matrix / training data of shape (num_observations, input_dimensions).
+            residual: The current residual of the model of shape (num_observations, 1).
+
+        """
+        posterior_concentration = self.prior_concentration + (len(X) / 2.0)
+        posterior_rate = self.prior_rate + (0.5 * (torch.sum(torch.square(residual))))
+        draw = torch.pow(Gamma(posterior_concentration, posterior_rate).sample(), -0.5)
+        return draw.item()
+
+
+class LeafMean:
+    """
+    Class to sample form the prior and posterior distributions of the leaf nodes in BART.
+
+    Reference:
+        [1] Hugh A. Chipman, Edward I. George, Robert E. McCulloch (2010). "BART: Bayesian additive regression trees"
+        https://projecteuclid.org/journals/annals-of-applied-statistics/volume-4/issue-1/BART-Bayesian-additive-regression-trees/10.1214/09-AOAS285.full
+
+    Args:
+        prior_loc: Prior location parameter.
+        prior_scale: Prior scale parameter.
+    """
+
+    def __init__(self, prior_loc: float, prior_scale: float):
+        if prior_scale < 0:
+            raise ValueError("Invalid prior hyperparameters")
+        self._prior_loc = prior_loc
+        self._prior_scale = prior_scale
+
+    @property
+    def prior_scale(self):
+        return self._prior_scale
+
+    def sample_prior(self):
+        return Normal(loc=self._prior_loc, scale=self._prior_scale).sample().item()
+
+    def sample_posterior(
+        self,
+        node: LeafNode,
+        X: torch.Tensor,
+        y: torch.Tensor,
+        current_sigma_val: float,
+    ):
+        X_in_node, y_in_node = node.data_in_node(X, y)
+        if len(X_in_node) == 0:
+            return None  # no new data
+        num_points_in_node = len(X_in_node)
+        prior_variance = (self._prior_scale) ** 2
+        likelihood_variance = (current_sigma_val**2) / num_points_in_node
+        likelihood_mean = torch.sum(y_in_node) / num_points_in_node
+        posterior_variance = 1.0 / (1.0 / prior_variance + 1.0 / likelihood_variance)
+        posterior_mean = (
+            likelihood_mean * prior_variance + self._prior_loc * likelihood_variance
+        ) / (likelihood_variance + prior_variance)
+        return (
+            Normal(loc=posterior_mean, scale=math.sqrt(posterior_variance))
+            .sample()
+            .item()
+        )

--- a/src/beanmachine/ppl/experimental/tests/bart/bart_model_test.py
+++ b/src/beanmachine/ppl/experimental/tests/bart/bart_model_test.py
@@ -8,7 +8,6 @@ import torch
 
 from beanmachine.ppl.experimental.causal_inference.models.bart.bart_model import (
     BART,
-    NoiseStandardDeviation,
     XBART,
 )
 
@@ -16,23 +15,6 @@ from beanmachine.ppl.experimental.causal_inference.models.bart.bart_model import
 @pytest.fixture
 def X():
     return torch.Tensor([[3.0, 1.0], [4.0, 1.0], [1.5, 1.0], [-1.0, 1.0]])
-
-
-@pytest.fixture
-def residual(X):
-    return X * 0.1
-
-
-@pytest.fixture
-def sigma():
-    return NoiseStandardDeviation(prior_concentration=0.1, prior_rate=0.2)
-
-
-def test_sigma_sampling(sigma, X, residual):
-    prev_val = sigma.val
-    sample = sigma.sample(X=X, residual=residual)
-    assert not prev_val == sigma.val
-    assert sigma.val == sample
 
 
 @pytest.fixture

--- a/src/beanmachine/ppl/experimental/tests/bart/bart_scalar_sampler_test.py
+++ b/src/beanmachine/ppl/experimental/tests/bart/bart_scalar_sampler_test.py
@@ -1,0 +1,32 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+from beanmachine.ppl.experimental.causal_inference.models.bart.scalar_samplers import (
+    NoiseStandardDeviation,
+)
+
+
+@pytest.fixture
+def X():
+    return torch.Tensor([[3.0, 1.0], [4.0, 1.0], [1.5, 1.0], [-1.0, 1.0]])
+
+
+@pytest.fixture
+def residual(X):
+    return X * 0.1
+
+
+@pytest.fixture
+def sigma():
+    return NoiseStandardDeviation(prior_concentration=0.1, prior_rate=0.2)
+
+
+def test_sigma_sampling(sigma, X, residual):
+    prev_val = sigma.val
+    sample = sigma.sample(X=X, residual=residual)
+    assert not prev_val == sigma.val
+    assert sigma.val == sample


### PR DESCRIPTION
Summary:
xBART is a faster implementation of Bayesian Additive Regression Trees (BART). xBART uses a "grow from root" backfitting algorithm wherein new trees are grown recursively at each MCMC step (instead of pointwise mutations to existing trees in classical BART). As a result xBART uses different hyperparameters and defaults than BART. Since xBART uses more hyperparameters than BART while sharing almost all of BART's hyperparmaters, we decided to subclass BART to xBART.

In this diff:

We are renaming the ```tao``` attribute in ```XBART``` to ```tau``` in keeping with a comment on diff D37962384 (https://github.com/facebookresearch/beanmachine/commit/ad82e4c49c76e721faf2f63c41e106971f177a6d).

Differential Revision: D38060891

