### PR TITLE
Include a setter for Node children

### DIFF
--- a/src/beanmachine/ppl/experimental/causal_inference/models/bart/node.py
+++ b/src/beanmachine/ppl/experimental/causal_inference/models/bart/node.py
@@ -46,10 +46,18 @@ class BaseNode:
         """Returns the left_child of the node."""
         return self._left_child
 
+    @left_child.setter
+    def left_child(self, left_child: Optional["BaseNode"]):
+        self._left_child = left_child
+
     @property
     def right_child(self) -> Optional["BaseNode"]:
         """Returns the right_child of the node."""
         return self._right_child
+
+    @right_child.setter
+    def right_child(self, right_child: Optional["BaseNode"]):
+        self._right_child = right_child
 
     @overload
     def data_in_node(


### PR DESCRIPTION
Summary:
Background

BART and XBART are tree based prediction algorithm which construct ensemble of tree structures to make a prediction. These tree structures are composed of nodes.

In this diff:
We are adding a setter to ```BaseNode```. This is useful for pointwise modifications to ancestors during mutation (for task T124884399) and for typecasting children to ```LeafNode``` during xBART grow-from-root recursion.

Differential Revision: D38079458

