### PR TITLE
Support functionals in autoguide VI

### DIFF
--- a/src/beanmachine/ppl/experimental/tests/vi/vi_test.py
+++ b/src/beanmachine/ppl/experimental/tests/vi/vi_test.py
@@ -158,6 +158,17 @@ class BinaryGaussianMixture:
 
 class TestAutoGuide:
     @pytest.mark.parametrize("auto_guide_inference", [ADVI, MAP])
+    def test_can_use_functionals(self, auto_guide_inference):
+        test_rv = bm.random_variable(lambda: dist.Normal(0, 1))
+        test_functional = bm.functional(lambda: test_rv() ** 2)
+        auto_guide = auto_guide_inference(
+            queries=[test_rv(), test_functional()],
+            observations={},
+        )
+        world = auto_guide.infer(num_steps=10)
+        assert world.call(test_functional()) is not None
+
+    @pytest.mark.parametrize("auto_guide_inference", [ADVI, MAP])
     def test_neals_funnel(self, auto_guide_inference):
         nf = bm.random_variable(NealsFunnel)
 

--- a/src/beanmachine/ppl/experimental/vi/autoguide.py
+++ b/src/beanmachine/ppl/experimental/vi/autoguide.py
@@ -38,8 +38,9 @@ class AutoGuideVI(VariationalInfer, metaclass=ABCMeta):
         # automatically instantiate `queries_to_guides`
         for query in queries:
             self._world.call(query)
-            distrib = self._world.get_variable(query).distribution
-            queries_to_guides[query] = self.get_guide(query, distrib)
+            if query.is_random_variable:
+                distrib = self._world.get_variable(query).distribution
+                queries_to_guides[query] = self.get_guide(query, distrib)
 
         super().__init__(
             queries_to_guides=queries_to_guides,

--- a/src/beanmachine/ppl/experimental/vi/variational_infer.py
+++ b/src/beanmachine/ppl/experimental/vi/variational_infer.py
@@ -68,7 +68,7 @@ class VariationalInfer:
         discrepancy_fn=kl_reverse,
         mc_approx=monte_carlo_approximate_reparam,  # TODO: support both reparam and SF in same guide
         step_callback: Optional[
-            Callable[[torch.Tensor, VariationalInfer], None]
+            Callable[[int, torch.Tensor, VariationalInfer], None]
         ] = None,
         subsample_factor: float = 1,
     ) -> VariationalWorld:
@@ -88,12 +88,12 @@ class VariationalInfer:
             initialized with optimized parameters
         """
         assert subsample_factor > 0 and subsample_factor <= 1
-        for _ in tqdm(range(num_steps)):
+        for it in tqdm(range(num_steps)):
             loss, _ = self.step(
                 num_samples, discrepancy_fn, mc_approx, subsample_factor
             )
             if step_callback:
-                step_callback(loss, self)
+                step_callback(it, loss, self)
 
         return VariationalWorld.initialize_world(
             queries=self.queries_to_guides.values(),


### PR DESCRIPTION
Summary: Fixes an error with autoguides on functionals by skipping them during guide initialization

Differential Revision: D38105114

