### PR TITLE
Implement grow-from-root algorithm

### DIFF
--- a/src/beanmachine/ppl/experimental/causal_inference/models/bart/grow_from_root_tree_proposer.py
+++ b/src/beanmachine/ppl/experimental/causal_inference/models/bart/grow_from_root_tree_proposer.py
@@ -1,0 +1,469 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import math
+from collections import Counter, namedtuple
+from typing import cast, List, Optional, Tuple
+
+import torch
+
+from beanmachine.ppl.experimental.causal_inference.models.bart.node import LeafNode
+
+from beanmachine.ppl.experimental.causal_inference.models.bart.scalar_samplers import (
+    LeafMean,
+)
+from beanmachine.ppl.experimental.causal_inference.models.bart.split_rule import (
+    Operator,
+    SplitRule,
+)
+from beanmachine.ppl.experimental.causal_inference.models.bart.tree import Tree
+
+from torch import multinomial
+
+CutPoint = namedtuple("Cutpoint", ["dim", "cut_val"])
+SortedInvariants = namedtuple("SortedInvariants", ["O_", "uniq_vals", "val_counts"])
+
+
+class GrowFromRootTreeProposer:
+    """Implements the "Grow-from-root" backfitting algorithm as discribed in [1].
+
+    Reference:
+        [1] He J., Yalov S., Hahn P.R. (2018). "XBART: Accelerated Bayesian Additive Regression Trees"
+        https://arxiv.org/abs/1810.02215
+
+    """
+
+    def __init__(self):
+        self.num_cuts = None
+        self.num_null_cuts = None
+
+    def propose(
+        self,
+        X: torch.Tensor,
+        partial_residual: torch.Tensor,
+        m: int,
+        w: torch.Tensor,
+        sigma_val: float,
+        leaf_sampler: LeafMean,
+        alpha: float,
+        beta: float,
+        root_node: LeafNode,
+        num_cuts: int,
+        num_null_cuts: int = 1,
+    ) -> Tuple[Tree, torch.Tensor]:
+        """Propose a new tree and modified Dirichlet weights based on the grow-from-root algorithm [1].
+
+        Reference:
+            [1] He J., Yalov S., Hahn P.R. (2018). "XBART: Accelerated Bayesian Additive Regression Trees"
+        https://arxiv.org/abs/1810.02215
+
+        Args:
+            X: Training data / covariate matrix of shape (num_observations, input_dimensions).
+            partial_residual: Residual vector of shape (num_observations, 1).
+            m: Number of input dimensions / variables to sample. This is usually a subset of the total number of input dimensions in the input data.
+            w: Vector of weights or probabilities of picking an input dimension.
+            sigma_val: Current value of noise staqndard deviation.
+            leaf_sampler: A sampler to sample the posterior distribution of leaf means.
+            alpha: Hyperparameter controlling the prior probability of a node being terminal as discussed in [1].
+            beta: Hyperparameter controlling the prior probability of a node being terminal as discussed in [1].
+            root_node: Root of the tree to grow.
+            num_cuts: Number of cuts to make along each dimensions.
+            num_null_cuts: Weighting given to the no-split cut along each dimension as discussed in [1].
+
+        """
+        if num_cuts <= 0:
+            raise ValueError("num_cuts has to be nonnegative")
+        self.num_cuts = num_cuts
+        if num_null_cuts <= 0 or num_null_cuts >= num_cuts:
+            raise ValueError(
+                "num_null_cuts has to be greater than or equal to 1 and lesser than total number of cuts"
+            )
+        self.num_null_cuts = num_null_cuts
+
+        O_ = self._presort(X)
+        uniq_vals, val_counts = self._get_uniq_elems(X, O_)
+        root_invariants = SortedInvariants(
+            O_=O_, uniq_vals=uniq_vals, val_counts=val_counts
+        )
+        all_leaf_nodes = []
+        variable_counts = [0 for _ in range(X.shape[-1])]
+
+        self._grow_from_root(
+            current_node=root_node,
+            X=X,
+            partial_residual=partial_residual,
+            invariants=root_invariants,
+            m=m,
+            w=w,
+            sigma_val=sigma_val,
+            leaf_sampler=leaf_sampler,
+            alpha=alpha,
+            beta=beta,
+            all_leaf_nodes=all_leaf_nodes,
+            variable_counts=variable_counts,
+        )
+
+        out_tree = Tree(nodes=all_leaf_nodes)
+
+        return out_tree, torch.Tensor(variable_counts)
+
+    def _presort(self, X: torch.Tensor) -> torch.Tensor:
+        """Presort the input data to generate the O matrix as discussed in section 3.2 [1].
+
+        Reference:
+            [1] He J., Yalov S., Hahn P.R. (2018). "XBART: Accelerated Bayesian Additive Regression Trees"
+        https://arxiv.org/abs/1810.02215
+
+        Args:
+            X: Training data / covariate matrix of shape (num_observations, input_dimensions).
+
+        """
+        num_observations, num_dims = X.shape
+        O_ = torch.sort(X, 0)[-1]
+        return torch.transpose(O_, dim0=0, dim1=1)
+
+    def _get_uniq_elems(self, X: torch.Tensor, O_: torch.Tensor) -> Tuple[list, list]:
+        """Get the unique values along every input dimension and the counts for each unique value.
+
+        Args:
+            X: Training data / covariate matrix of shape (num_observations, input_dimensions).
+            O_: Index matrix of shape (input_dimensions, num_observations) contained the indexes
+                of input data sorted along each dimension.
+
+        """
+        num_dims, num_observations = O_.shape
+        uniq_vals = []
+        val_counts = []
+        for inp_dim in range(num_dims):
+            dim_uniq_vals = []
+            value_counter = Counter()
+            for obs in range(num_observations):
+                current_val = X[O_[inp_dim, obs], inp_dim].item()
+                if obs == 0 or (current_val > X[O_[inp_dim, obs - 1], inp_dim]):
+                    dim_uniq_vals.append(current_val)
+                value_counter[current_val] += 1
+            uniq_vals.append(dim_uniq_vals)
+            val_counts.append(value_counter)
+        return uniq_vals, val_counts
+
+    def _grow_from_root(
+        self,
+        current_node: LeafNode,
+        X: torch.Tensor,
+        partial_residual: torch.Tensor,
+        invariants: SortedInvariants,
+        m: int,
+        w: torch.Tensor,
+        sigma_val: float,
+        leaf_sampler: LeafMean,
+        alpha: float,
+        beta: float,
+        all_leaf_nodes: List[LeafNode],
+        variable_counts: List[int],
+    ):
+        """Implement the recursive grow-from-root strategy proposed in [1].
+
+        Reference:
+            [1] He J., Yalov S., Hahn P.R. (2018). "XBART: Accelerated Bayesian Additive Regression Trees"
+        https://arxiv.org/abs/1810.02215
+
+        Args:
+            current_node: The node being mutated.
+            X: Training data / covariate matrix of shape (num_observations, input_dimensions).
+            partial_residual: Residual vector of shape (num_observations, 1).
+            invariants: The sorted index matrix and unique values and unique counts used to maintain sorted order.
+            m: Number of input dimensions / variables to sample. This is usually a subset of the total number of input dimensions in the input data.
+            w: Vector of weights or probabilities of picking an input dimension.
+            sigma_val: Current value of noise staqndard deviation.
+            leaf_sampler: A sampler to sample the posterior distribution of leaf means.
+            alpha: Hyperparameter controlling the prior probability of a node being terminal as discussed in [1].
+            beta: Hyperparameter controlling the prior probability of a node being terminal as discussed in [1].
+            all_leaf_nodes: All the laf nodes of the grown tree.
+            variable_counts: The number of time each input dimensions / variable has been split while growing this tree.
+
+        """
+        dims_to_sample = self._sample_variables(m=m, w=w)
+        cut_points = self._select_cutpoints(
+            candidate_dims=dims_to_sample, uniq_vals=invariants.uniq_vals
+        )
+        sampled_cut_point = self._sample_cut_point(
+            candidate_cut_points=cut_points,
+            invariants=invariants,
+            partial_residual=partial_residual,
+            sigma_val=sigma_val,
+            leaf_sampler=leaf_sampler,
+            current_node=current_node,
+            alpha=alpha,
+            beta=beta,
+        )
+        if sampled_cut_point is None:
+            current_node.val = leaf_sampler.sample_posterior(
+                X=X, y=partial_residual, current_sigma_val=sigma_val, node=current_node
+            )
+            all_leaf_nodes.append(current_node)
+            return
+
+        variable_counts[sampled_cut_point.dim] += 1
+        left_rule, right_rule = SplitRule(
+            grow_dim=sampled_cut_point.dim,
+            grow_val=sampled_cut_point.cut_val,
+            operator=Operator.le,
+        ), SplitRule(
+            grow_dim=sampled_cut_point.dim,
+            grow_val=sampled_cut_point.cut_val,
+            operator=Operator.gt,
+        )
+        new_node = LeafNode.grow_node(
+            current_node, left_rule=left_rule, right_rule=right_rule
+        )
+        left_invariants, right_invariants = self._sift(
+            X=X, cut_point=sampled_cut_point, invariants=invariants
+        )
+
+        self._grow_from_root(
+            current_node=cast(LeafNode, new_node.left_child),
+            X=X,
+            partial_residual=partial_residual,
+            invariants=left_invariants,
+            m=m,
+            w=w,
+            sigma_val=sigma_val,
+            leaf_sampler=leaf_sampler,
+            alpha=alpha,
+            beta=beta,
+            all_leaf_nodes=all_leaf_nodes,
+            variable_counts=variable_counts,
+        )
+
+        self._grow_from_root(
+            current_node=cast(LeafNode, new_node.right_child),
+            X=X,
+            partial_residual=partial_residual,
+            invariants=right_invariants,
+            m=m,
+            w=w,
+            sigma_val=sigma_val,
+            leaf_sampler=leaf_sampler,
+            alpha=alpha,
+            beta=beta,
+            all_leaf_nodes=all_leaf_nodes,
+            variable_counts=variable_counts,
+        )
+
+    def _sample_variables(self, m: int, w: torch.Tensor) -> List[int]:
+        """
+        Sample a subset of input dimensions to split on as discussed in section 3.4 of [1].
+
+        Reference:
+            [1] He J., Yalov S., Hahn P.R. (2018). "XBART: Accelerated Bayesian Additive Regression Trees"
+        https://arxiv.org/abs/1810.02215.
+
+        Note:
+        The number of sampled variables are set to min(m, count_nonzero(w)).
+
+        Args:
+            m: number of dimensions to sample, corresponding to 'm' in [1].
+            w: Vector of weights of picking an input dimension.
+
+        """
+        m = cast(int, min(m, torch.count_nonzero(w).item()))
+        return [
+            _.item() for _ in multinomial(input=w, num_samples=m, replacement=False)
+        ]
+
+    def _select_cutpoints(
+        self,
+        candidate_dims: List[int],
+        uniq_vals: List[List[float]],
+    ) -> List[CutPoint]:
+        """Select cutpoints along every dimension.
+
+        Args:
+            candidate_dims: Dimensions that are being split along.
+            uniq_vals: Unique values along every dimension.
+
+        """
+        candidate_cuts = []
+        for inp_dim in candidate_dims:
+            # check for degeneracy
+            if len(uniq_vals[inp_dim]) < 2:
+                continue
+            if len(uniq_vals[inp_dim]) <= self.num_cuts:
+                skip_val_freq = 1
+            elif self.num_cuts == 1:
+                skip_val_freq = len(
+                    uniq_vals[inp_dim]
+                )  # just select the first val if only 1 cut required
+            else:
+                skip_val_freq = math.floor(
+                    (len(uniq_vals[inp_dim]) - 2) / (self.num_cuts - 1)
+                )
+            curr_id = 0
+            # all uniq vals except last get added to the bag
+            while curr_id < (len(uniq_vals[inp_dim]) - 1):
+                candidate_cuts.append(
+                    CutPoint(dim=inp_dim, cut_val=uniq_vals[inp_dim][curr_id])
+                )
+                curr_id += skip_val_freq
+        return candidate_cuts
+
+    def _sample_cut_point(
+        self,
+        candidate_cut_points: List[CutPoint],
+        partial_residual: torch.Tensor,
+        invariants: SortedInvariants,
+        sigma_val: float,
+        leaf_sampler: LeafMean,
+        current_node: LeafNode,
+        alpha: float,
+        beta: float,
+    ) -> Optional[CutPoint]:
+        """Select a sample cut point by using sampling probabilities calculated in eq. (4) of [1].
+
+        Args:
+            candidate_cut_points: DCut points to sample from.
+            partial_residual: Residual vector of shape (num_observations, 1).
+            invariants: The sorted index matrix and unique values and unique counts used to maintain sorted order.
+            sigma_val: Current value of noise standard deviation.
+            leaf_sampler: A sampler to sample the posterior distribution of leaf means.
+            current_node: The node being mutated.
+            alpha: Hyperparameter controlling the prior probability of a node being terminal as discussed in [1].
+            beta: Hyperparameter controlling the prior probability of a node being terminal as discussed in [1].
+
+        """
+        selection_probabs = []
+        sum_ = 0.0
+        total_num_observations = invariants.O_.shape[-1]
+        total_residual = torch.sum(partial_residual[invariants.O_[0]]).item()
+        tau = leaf_sampler.prior_scale**2
+
+        def _integrated_likelihood(num_observations: int, residual: float) -> float:
+            log_likelihood = math.log(
+                (sigma_val**2) / (sigma_val**2 + tau * num_observations)
+            )
+            log_likelihood += (tau * (residual**2)) / (
+                (sigma_val**2) * (sigma_val**2 + tau * num_observations)
+            )
+            log_likelihood /= 2
+            return math.exp(log_likelihood)
+
+        null_point_probab = _integrated_likelihood(
+            num_observations=total_num_observations, residual=total_residual
+        )
+        kappa = self.num_null_cuts * (
+            (math.pow((1 + current_node.depth), beta) / alpha) - 1
+        )
+        null_point_probab *= kappa
+
+        selection_probabs.append(null_point_probab)
+        sum_ += null_point_probab
+
+        current_O_id_, current_uniq_val_id_ = 0, 0
+        residuals_le_cutpoint, num_obs_le_cutpoint = [], []
+        for cut_id, cut_point in enumerate(candidate_cut_points):
+            current_residual = 0.0
+            current_num_obs = 0
+
+            if cut_id == 0 or cut_point.dim != candidate_cut_points[cut_id - 1].dim:
+                residuals_le_cutpoint = []
+                num_obs_le_cutpoint = []
+                current_O_id_ = 0
+                current_uniq_val_id_ = 0
+            else:
+                current_residual += residuals_le_cutpoint[-1]
+                current_num_obs += num_obs_le_cutpoint[-1]
+
+            while (
+                invariants.uniq_vals[cut_point.dim][current_uniq_val_id_]
+                <= cut_point.cut_val
+            ):
+                num_ties = invariants.val_counts[cut_point.dim][
+                    invariants.uniq_vals[cut_point.dim][current_uniq_val_id_]
+                ]
+                current_num_obs += num_ties
+                for _ in range(num_ties):
+                    current_residual += partial_residual[
+                        invariants.O_[cut_point.dim, current_O_id_]
+                    ].item()
+                    current_O_id_ += 1
+                current_uniq_val_id_ += 1
+            residuals_le_cutpoint.append(current_residual)
+            num_obs_le_cutpoint.append(current_num_obs)
+            cut_point_probab = _integrated_likelihood(
+                num_observations=current_num_obs, residual=current_residual
+            ) * _integrated_likelihood(
+                num_observations=(total_num_observations - current_num_obs),
+                residual=(total_residual - current_residual),
+            )
+            selection_probabs.append(cut_point_probab)
+            sum_ += cut_point_probab
+
+        selection_probabs = torch.tensor([_ / sum_ for _ in selection_probabs])
+        sampled_cut_id = cast(
+            int, multinomial(input=selection_probabs, num_samples=1).item()
+        )
+        if sampled_cut_id == 0:
+            # no split
+            return None
+        return candidate_cut_points[sampled_cut_id - 1]
+
+    def _sift(
+        self, X: torch.Tensor, invariants: SortedInvariants, cut_point: CutPoint
+    ) -> Tuple[SortedInvariants, SortedInvariants]:
+        """Sift all data into left and right partitions to maintain sorted order during recursion.
+
+        Args:
+            X: Training data / covariate matrix of shape (num_observations, input_dimensions).
+            invariants: The sorted index matrix and unique values and unique counts used to maintain sorted order.
+            cut_point: The cut point to split along.
+        """
+        num_dims, num_observations = invariants.O_.shape
+        O_left, O_right = [], []
+        uniq_vals_left, uniq_vals_right = [], []
+        val_counts_left, val_counts_right = [], []
+
+        for dim in range(num_dims):
+            dim_O_left, dim_O_right = [], []
+            dim_uniq_vals_left, dim_uniq_vals_right = [], []
+            dim_val_counts_left, dim_val_counts_right = Counter(), Counter()
+
+            for col in range(num_observations):
+                obs_id = invariants.O_[dim, col].item()
+                curr_observation_dim_val = X[obs_id, dim].item()
+
+                if X[obs_id, cut_point.dim] <= cut_point.cut_val:
+                    dim_O_left.append(obs_id)
+                    if (
+                        len(dim_uniq_vals_left) == 0
+                        or dim_uniq_vals_left[-1] != curr_observation_dim_val
+                    ):
+                        dim_uniq_vals_left.append(curr_observation_dim_val)
+                    dim_val_counts_left[curr_observation_dim_val] += 1
+
+                else:
+                    dim_O_right.append(obs_id)
+                    if (
+                        len(dim_uniq_vals_right) == 0
+                        or dim_uniq_vals_right[-1] != curr_observation_dim_val
+                    ):
+                        dim_uniq_vals_right.append(curr_observation_dim_val)
+                    dim_val_counts_right[curr_observation_dim_val] += 1
+            O_left.append(dim_O_left)
+            O_right.append(dim_O_right)
+            uniq_vals_left.append(dim_uniq_vals_left)
+            uniq_vals_right.append(dim_uniq_vals_right)
+            val_counts_left.append(dim_val_counts_left)
+            val_counts_right.append(dim_val_counts_right)
+        left_invariants = SortedInvariants(
+            O_=torch.tensor(O_left),
+            uniq_vals=uniq_vals_left,
+            val_counts=val_counts_left,
+        )
+        right_invariants = SortedInvariants(
+            O_=torch.tensor(O_right),
+            uniq_vals=uniq_vals_right,
+            val_counts=val_counts_right,
+        )
+        return left_invariants, right_invariants

--- a/src/beanmachine/ppl/experimental/tests/bart/xbart_grow_from_root_proposer_test.py
+++ b/src/beanmachine/ppl/experimental/tests/bart/xbart_grow_from_root_proposer_test.py
@@ -1,0 +1,263 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+from beanmachine.ppl.experimental.causal_inference.models.bart.bart_model import (
+    LeafMean,
+)
+
+from beanmachine.ppl.experimental.causal_inference.models.bart.grow_from_root_tree_proposer import (
+    GrowFromRootTreeProposer,
+    SortedInvariants,
+)
+from beanmachine.ppl.experimental.causal_inference.models.bart.node import LeafNode
+from beanmachine.ppl.experimental.causal_inference.models.bart.split_rule import (
+    CompositeRules,
+)
+
+
+@pytest.fixture(autouse=True)
+def seed():
+    torch.manual_seed(5)
+
+
+@pytest.fixture
+def gfr_proposer():
+    gfr = GrowFromRootTreeProposer()
+    gfr.num_cuts = 2
+    gfr.num_null_cuts = 1
+    return gfr
+
+
+@pytest.fixture
+def X():
+    return torch.Tensor([[3.0, 1.0], [4.0, 1.0], [1.5, 1.0], [-1.0, 1.0]])
+
+
+@pytest.fixture
+def w(X):
+    num_vars = X.shape[-1]
+    weights = torch.Tensor([1 / num_vars for _ in range(num_vars - 1)])
+    return weights
+
+
+def test_sample_variables(gfr_proposer, w):
+    num_vars_to_sample = max(len(w) - 1, 1)
+    assert (
+        len(gfr_proposer._sample_variables(num_vars_to_sample, w)) == num_vars_to_sample
+    )
+    impossible_num_vars_to_sample = len(w) + 1
+    assert len(gfr_proposer._sample_variables(impossible_num_vars_to_sample, w)) == len(
+        w
+    )
+
+
+def test_presort(gfr_proposer, X):
+    O_ = gfr_proposer._presort(X)
+    num_observations, num_dims = X.shape
+    for inp_dim in range(num_dims):
+        for obs in range(1, num_observations):
+            assert X[O_[inp_dim, obs - 1], inp_dim] <= X[O_[inp_dim, obs], inp_dim]
+
+
+def test_get_uniq_elems(gfr_proposer, X):
+    O_ = gfr_proposer._presort(X)
+    uniq_vals, val_counts = gfr_proposer._get_uniq_elems(X=X, O_=O_)
+    num_observations, num_dims = X.shape
+    for inp_dim in range(num_dims):
+        dim_val_counts = val_counts[inp_dim]
+        assert sum(dim_val_counts.values()) == num_observations
+        for id_, uniq_val in enumerate(uniq_vals[inp_dim]):
+            assert dim_val_counts[uniq_val] > 0
+            if id_ > 0:
+                assert uniq_val >= uniq_vals[inp_dim][id_ - 1]
+        assert set(uniq_vals[inp_dim]) == {_.item() for _ in X[:, inp_dim]}
+
+
+@pytest.fixture
+def invariants(gfr_proposer, X):
+    O_ = gfr_proposer._presort(X)
+    uniq_vals, val_counts = gfr_proposer._get_uniq_elems(X=X, O_=O_)
+    return SortedInvariants(O_=O_, uniq_vals=uniq_vals, val_counts=val_counts)
+
+
+def test_select_cutpoints(gfr_proposer, X, invariants):
+    num_observations, num_dims = X.shape
+    cutpoints = gfr_proposer._select_cutpoints(
+        candidate_dims=list(range(num_dims)), uniq_vals=invariants.uniq_vals
+    )
+
+    num_dim_cuts = 0
+    for point_id, point in enumerate(cutpoints):
+        assert (
+            point.cut_val < invariants.uniq_vals[point.dim][-1]
+        )  # no degenerate splits
+        if point_id > 0 and cutpoints[point_id - 1].dim == point.dim:
+            assert cutpoints[point_id - 1].cut_val < point.cut_val
+            num_dim_cuts += 1
+        elif point_id > 0 and cutpoints[point_id - 1].dim != point.dim:
+            assert num_dim_cuts <= gfr_proposer.num_cuts
+            num_dim_cuts = 0
+        else:
+            num_dim_cuts += 1
+
+
+@pytest.fixture
+def partial_residual(X):
+    return torch.ones((len(X), 1)) * 0.2
+
+
+@pytest.fixture
+def sigma_val():
+    return 0.1
+
+
+@pytest.fixture
+def leaf_sampler():
+    return LeafMean(prior_loc=0.0, prior_scale=0.1)
+
+
+@pytest.fixture
+def current_node(X):
+    return LeafNode(
+        depth=0,
+        val=0.1,
+        composite_rules=CompositeRules(all_dims=list(range(X.shape[-1]))),
+    )
+
+
+@pytest.fixture
+def alpha():
+    return 0.95
+
+
+@pytest.fixture
+def beta():
+    return 1.25
+
+
+@pytest.fixture
+def cut_points(gfr_proposer, invariants):
+    num_dims = invariants.O_.shape[0]
+    return gfr_proposer._select_cutpoints(
+        candidate_dims=list(range(num_dims)), uniq_vals=invariants.uniq_vals
+    )
+
+
+def test_sample_cut_point(
+    gfr_proposer,
+    X,
+    invariants,
+    cut_points,
+    partial_residual,
+    sigma_val,
+    leaf_sampler,
+    current_node,
+    alpha,
+    beta,
+):
+
+    num_observations, num_dims = X.shape
+
+    num_trials = 10
+    all_sampled_cutpoints = []
+    for _ in range(num_trials):
+        all_sampled_cutpoints.append(
+            gfr_proposer._sample_cut_point(
+                candidate_cut_points=cut_points,
+                partial_residual=partial_residual,
+                invariants=invariants,
+                sigma_val=sigma_val,
+                leaf_sampler=leaf_sampler,
+                current_node=current_node,
+                alpha=alpha,
+                beta=beta,
+            )
+        )
+    for point in all_sampled_cutpoints:
+        if point is not None:
+            assert point in cut_points
+
+
+def test_sift(
+    gfr_proposer,
+    X,
+    invariants,
+    cut_points,
+    partial_residual,
+    sigma_val,
+    leaf_sampler,
+    current_node,
+    alpha,
+    beta,
+):
+    cut_point = gfr_proposer._sample_cut_point(
+        candidate_cut_points=cut_points,
+        partial_residual=partial_residual,
+        invariants=invariants,
+        sigma_val=sigma_val,
+        leaf_sampler=leaf_sampler,
+        current_node=current_node,
+        alpha=alpha,
+        beta=beta,
+    )
+    left_invariants, right_invariants = gfr_proposer._sift(
+        X=X, cut_point=cut_point, invariants=invariants
+    )
+    assert (
+        invariants.O_.shape[0] == left_invariants.O_.shape[0]
+        and invariants.O_.shape[0] == right_invariants.O_.shape[0]
+    )  # num dims shouldnt change
+    assert (
+        invariants.O_.shape[1]
+        == left_invariants.O_.shape[1] + right_invariants.O_.shape[1]
+    )
+
+    for dim in range(invariants.O_.shape[0]):
+        assert set(invariants.uniq_vals[dim]) == set(
+            left_invariants.uniq_vals[dim]
+        ).union(set(right_invariants.uniq_vals[dim]))
+        for val in invariants.uniq_vals[dim]:
+            assert (
+                invariants.val_counts[dim][val]
+                == left_invariants.val_counts[dim][val]
+                + right_invariants.val_counts[dim][val]
+            )
+
+
+def test_propose(
+    X,
+    invariants,
+    cut_points,
+    partial_residual,
+    sigma_val,
+    leaf_sampler,
+    current_node,
+    alpha,
+    beta,
+    w,
+):
+    proposer = GrowFromRootTreeProposer()
+    tree_, variable_counts = proposer.propose(
+        X=X,
+        partial_residual=partial_residual,
+        m=X.shape[-1],
+        w=w,
+        sigma_val=sigma_val,
+        leaf_sampler=leaf_sampler,
+        alpha=alpha,
+        beta=beta,
+        root_node=current_node,
+        num_cuts=2,
+        num_null_cuts=1,
+    )
+
+    all_leaves = tree_.leaf_nodes()
+    assert len(all_leaves) > 0
+    if len(all_leaves) > 0:
+        assert sum(variable_counts) > 0
+
+    assert tree_.predict(X).shape == partial_residual.shape


### PR DESCRIPTION
Summary:
XBART is a faster variant of BART which grows a new tree recursively at each MCMC step instead of modifying an existing tree. This is known as the grow from root algorithm. It consists of
1. Selecting a subset of variables to split on (as opposed to BART which considers all the variables as split candidates).
2. Sampling a cutpoint (which can also be a stop-split sample) by sampling a variable from the subset and a unique value of that variable as a decision threshhold.
3. Either stopping the recursion or "growing the node" based on the sampling step in 2.
4. If stopped, the leaf node mean value is sampled otherwise the children of the node are grown.
5. The ordering of the covariates along each dimensions (i.e. each variable) are maintained using an index matrix.

In this diff:
We implement the grow-from-root algorithm. This is a standalone implementation. We will link it up with the XBART API in a future diff.

Notes:
1. The original paper relies on unique values of covariates to maintain pre-sorting during recursion. Since our variables are more likely to be categorical, a modified approach is implemented here wherein two additional data structures are used to maintain pre-sorting. One to keep track of all unique values along a dimension and another to keep track on the count of each unique value.

2. One of the bottlenecks of the original BART was copying over all the nodes. This will be addressed in task T124884399. This algorithm bypasses that by only storing the leaf nodes and the cumulative rules. This is the minimum data required to make a "prediction". Once task T124884399 is completed, this can be changed to keep track of only the node.

3. The exp() operation in L350 is sometimes unstable because its args may be of the order 1e2-1e3, especially when the residuals are high. This is being investigated.

Differential Revision: D38090274

