### PR TITLE
Fix error message when an unsupported non-torch distribution is used

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/lromm_test.py
+++ b/src/beanmachine/ppl/compiler/tests/lromm_test.py
@@ -53,15 +53,10 @@ class LROMMTest(unittest.TestCase):
         self.maxDiff = None
         queries = [beta_0(), beta_1(), sigma_out(), theta()]
         observations = {y(): _y_obs}
-
-        # TODO: This test demonstrates that we crash when attempting
-        # to compile a model with an unsupported distribution that
-        # does not come from the torch distributions module.
-
-        with self.assertRaises(RuntimeError) as ex:
+        with self.assertRaises(ValueError) as ex:
             BMGInference().to_dot(queries, observations)
         expected = """
-Could not infer dtype of LogAddExpNode
+Function Unit is not supported by Bean Machine Graph.
         """
         observed = str(ex.exception)
         self.assertEqual(observed.strip(), expected.strip())


### PR DESCRIPTION
Summary:
All functions -- including type constructors -- in the torch modules are treated as "special" by the compiler. For special functions we have a "can have stochastic arguments" allow list; if your function call has stochastic arguments and is a special function, but not on the allowed list, then you get an error message saying that the function is not supported by BMG.

The idea here is that user-supplied functions we will attempt to rewrite, and models which have calls to third party libraries we will just pass the graph node and hope for the best, but torch functions that we do not support we *strongly believe* will not work, and so we should stop compilation and let the user know.

The case I missed here was: constructors for distributions that *inherit* from torch.Distribution but are not *declared* in torch.distributions.  Such as our Unit distribution.

We now treat any constructor of a distribution as a special function and give an appropriate error message if an attempt is made to call an unsupported one with stochastic arguments.

As noted in the code, we do not yet treat instance methods of such distributions as special. We should. That will be in a later diff.

Reviewed By: ToddSmall

Differential Revision: D38224341

