### PR TITLE
Add test cases showing that vectorized LROM model fails to compile

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/lromm_test.py
+++ b/src/beanmachine/ppl/compiler/tests/lromm_test.py
@@ -9,8 +9,8 @@ import unittest
 import beanmachine.ppl as bm
 from beanmachine.ppl.distributions.unit import Unit
 from beanmachine.ppl.inference.bmg_inference import BMGInference
-from torch import logaddexp, tensor
-from torch.distributions import Beta, Gamma, Normal
+from torch import logaddexp, ones, tensor
+from torch.distributions import Bernoulli, Beta, Gamma, Normal
 
 
 _x_obs = tensor([0, 3, 9])
@@ -38,18 +38,31 @@ def theta():
     return Beta(2, 5)
 
 
-@bm.random_variable
-def y():
+@bm.functional
+def f():
     mu = beta_0() + beta_1() * _x_obs
     ns = Normal(mu, sigma_out())
     ne = Normal(mu, _err_obs)
     log_likelihood_outlier = theta().log() + ns.log_prob(_y_obs)
     log_likelihood = (1 - theta()).log() + ne.log_prob(_y_obs)
-    return Unit(logaddexp(log_likelihood_outlier, log_likelihood))
+    return logaddexp(log_likelihood_outlier, log_likelihood)
+
+
+@bm.random_variable
+def y():
+    return Unit(f())
+
+
+# Same model, but with the "Bernoulli trick" instead of a Unit:
+
+
+@bm.random_variable
+def d():
+    return Bernoulli(f().exp())
 
 
 class LROMMTest(unittest.TestCase):
-    def test_lromm_to_dot(self) -> None:
+    def test_lromm_unit_to_dot(self) -> None:
         self.maxDiff = None
         queries = [beta_0(), beta_1(), sigma_out(), theta()]
         observations = {y(): _y_obs}
@@ -57,6 +70,27 @@ class LROMMTest(unittest.TestCase):
             BMGInference().to_dot(queries, observations)
         expected = """
 Function Unit is not supported by Bean Machine Graph.
+        """
+        observed = str(ex.exception)
+        self.assertEqual(observed.strip(), expected.strip())
+
+    def test_lromm_bern_to_dot(self) -> None:
+        self.maxDiff = None
+        queries = [beta_0(), beta_1(), sigma_out(), theta()]
+        observations = {d(): ones(len(_y_obs))}
+        with self.assertRaises(ValueError) as ex:
+            BMGInference().to_dot(queries, observations)
+        expected = """
+The mu of a normal is required to be a real but is a 3 x 1 real matrix.
+The normal was created in function call f().
+The mu of a normal is required to be a real but is a 3 x 1 real matrix.
+The normal was created in function call f().
+The sigma of a normal is required to be a positive real but is a 3 x 1 positive real matrix.
+The normal was created in function call f().
+The value of a log_prob is required to be a real but is a 3 x 1 natural matrix.
+The log_prob was created in function call f().
+The value of a log_prob is required to be a real but is a 3 x 1 natural matrix.
+The log_prob was created in function call f().
         """
         observed = str(ex.exception)
         self.assertEqual(observed.strip(), expected.strip())


### PR DESCRIPTION
Summary:
A "Bernoulli trick" version of the LROM model should compile successfully, but it does not because the devectorizer does not know how to devectorize a log_prob operator.

Unfortunately, this illustrates a flaw in the design of the devectorizer: when I implemented it, I assumed that the ONLY operator that would ever have a vectorized distribution as its operand was "sample".  "log_prob" has the novel property that it might have a vectorized distribution as its left operand AND a vectorized value as its right operand.

It is therefore not simply a matter of adding the log_prob operator to the list of devectorizable operators. We're going to have to come up with a more general algorithm that can handle operators whose operands are distributions.

I've added two test cases. One shows a simplified "Bernoulli trick" version of Todd's LROM model, and how it fails today. The other is an even more simplified version which just has the offending log prob operator.

Differential Revision: D38229153

