### PR TITLE
Make AutoGuide's initialization World block scope

### DIFF
--- a/src/beanmachine/ppl/experimental/vi/autoguide.py
+++ b/src/beanmachine/ppl/experimental/vi/autoguide.py
@@ -30,16 +30,16 @@ class AutoGuideVI(VariationalInfer, metaclass=ABCMeta):
         queries_to_guides = {}
 
         # runs all queries to discover their dimensions
-        self._world = VariationalWorld(
+        world = VariationalWorld(
             observations=observations,
             params={},
             queries_to_guides=queries_to_guides,
         )
         # automatically instantiate `queries_to_guides`
         for query in queries:
-            self._world.call(query)
+            world.call(query)
             if query.is_random_variable:
-                distrib = self._world.get_variable(query).distribution
+                distrib = world.get_variable(query).distribution
                 queries_to_guides[query] = self.get_guide(query, distrib)
 
         super().__init__(


### PR DESCRIPTION
Summary: There's no need for this to be a private attribute; it is not used outside of the constructor

Differential Revision: D38099705

