### PR TITLE
Speed up BART by avoiding _predict_step() during training

### DIFF
--- a/src/beanmachine/ppl/experimental/causal_inference/models/bart/bart_model.py
+++ b/src/beanmachine/ppl/experimental/causal_inference/models/bart/bart_model.py
@@ -244,7 +244,7 @@ class BART:
             self._update_leaf_mean(new_trees[tree_id], partial_residual)
             all_tree_predictions[:, tree_id] = new_trees[tree_id].predict(self.X)
         self.all_tree_predictions = all_tree_predictions
-        self._update_sigma(self.y - self._predict_step())
+        self._update_sigma(self.y - torch.sum(all_tree_predictions, dim=1))
         return new_trees, self.sigma.val
 
     def _update_leaf_mean(self, tree: Tree, partial_residual: torch.Tensor):


### PR DESCRIPTION
Summary:
Bayesian Additive Regression Trees (BART) are tree ensemble models.
In this diff:
We are speeding up BART's implementation. Specifically, in the fitting state, we are avoiding a ```BART._predict_step()```, instead using the attribute ```all_tree_predictions``` to calculate the residual.
The gain in time is about 10-20%.

Differential Revision: D38358536

