### PR TITLE
Avoid expensive likelihood calculation if all split dimensions are degenerate

### DIFF
--- a/src/beanmachine/ppl/experimental/causal_inference/models/bart/grow_from_root_tree_proposer.py
+++ b/src/beanmachine/ppl/experimental/causal_inference/models/bart/grow_from_root_tree_proposer.py
@@ -348,6 +348,8 @@ class GrowFromRootTreeProposer:
             beta: Hyperparameter controlling the prior probability of a node being terminal as discussed in [1].
 
         """
+        if len(candidate_cut_points) == 0:
+            return None
         selection_probabs = []
         sum_ = 0.0
         total_num_observations = invariants.O_.shape[-1]


### PR DESCRIPTION
Summary:
Background:
XBART recursiveley grows trees by splitting along non-degenerate dimensions (i.e. dimensions of the input which have more than 1 unique values in the input). It selects a split point based on a likelihood calcualtion of each split point.
In this diff:
If there are no feasible cut points, we premptively end the recursion bypassing the expensive no cut likelihood calculation. This speeds up the algorithm significantly especially in deeper trees. We have observed about a 5x improvement in speed.

Differential Revision: D38368870

