### PR TITLE
beanmachine-graph: Fix warning and github actions test failure on github main

### DIFF
--- a/src/beanmachine/graph/transformation.h
+++ b/src/beanmachine/graph/transformation.h
@@ -10,7 +10,7 @@
 namespace beanmachine::graph {
 
 class NodeValue;
-class DoubleMatrix;
+struct DoubleMatrix;
 
 enum class TransformType { NONE = 0, LOG = 1 };
 


### PR DESCRIPTION
Summary: Fix a warning: some C++ compilers require an extern type declaration to use the "proper" struct vs class keyword.

Reviewed By: fizzxed

Differential Revision: D38442043

