### PR TITLE
Square sigma only once when calculating log likelihood

### DIFF
--- a/src/beanmachine/ppl/experimental/causal_inference/models/bart/grow_from_root_tree_proposer.py
+++ b/src/beanmachine/ppl/experimental/causal_inference/models/bart/grow_from_root_tree_proposer.py
@@ -374,9 +374,13 @@ class GrowFromRootTreeProposer:
             (math.pow((1 + current_node.depth), beta) / alpha) - 1
         )
 
-        null_log_likelihood = _integrated_log_likelihood(
-            num_observations=total_num_observations, residual=total_residual
-        ) + log(kappa)
+        null_log_likelihood = (
+            _integrated_log_likelihood(
+                num_observations=total_num_observations, residual=total_residual
+            )
+            + log(kappa)
+            + log(len(candidate_cut_points))
+        )
         if null_log_likelihood > MAX_LOG_LIKELIHOOD:
             MAX_LOG_LIKELIHOOD = null_log_likelihood
 

--- a/src/beanmachine/ppl/experimental/causal_inference/models/bart/grow_from_root_tree_proposer.py
+++ b/src/beanmachine/ppl/experimental/causal_inference/models/bart/grow_from_root_tree_proposer.py
@@ -5,6 +5,7 @@
 
 import math
 from collections import Counter
+from math import log
 from typing import cast, List, NamedTuple, Optional, Tuple
 
 import torch
@@ -350,32 +351,36 @@ class GrowFromRootTreeProposer:
         """
         if len(candidate_cut_points) == 0:
             return None
+        selection_log_likelihoods = []
         selection_probabs = []
-        sum_ = 0.0
         total_num_observations = invariants.O_.shape[-1]
         total_residual = torch.sum(partial_residual[invariants.O_[0]]).item()
         tau = leaf_sampler.prior_scale**2
+        MAX_LOG_LIKELIHOOD = -float("inf")
 
-        def _integrated_likelihood(num_observations: int, residual: float) -> float:
-            log_likelihood = math.log(
+        def _integrated_log_likelihood(
+            num_observations: int,
+            residual: float,
+        ) -> float:
+
+            log_likelihood = +0.5 * log(
                 (sigma_val**2) / (sigma_val**2 + tau * num_observations)
-            )
-            log_likelihood += (tau * (residual**2)) / (
+            ) + 0.5 * (tau * (residual**2)) / (
                 (sigma_val**2) * (sigma_val**2 + tau * num_observations)
             )
-            log_likelihood /= 2
-            return math.exp(log_likelihood)
+            return log_likelihood
 
-        null_point_probab = _integrated_likelihood(
-            num_observations=total_num_observations, residual=total_residual
-        )
         kappa = self.num_null_cuts * (
             (math.pow((1 + current_node.depth), beta) / alpha) - 1
         )
-        null_point_probab *= kappa
 
-        selection_probabs.append(null_point_probab)
-        sum_ += null_point_probab
+        null_log_likelihood = _integrated_log_likelihood(
+            num_observations=total_num_observations, residual=total_residual
+        ) + log(kappa)
+        if null_log_likelihood > MAX_LOG_LIKELIHOOD:
+            MAX_LOG_LIKELIHOOD = null_log_likelihood
+
+        selection_log_likelihoods.append(null_log_likelihood)
 
         current_O_id_, current_uniq_val_id_ = 0, 0
         residuals_le_cutpoint, num_obs_le_cutpoint = [], []
@@ -408,16 +413,25 @@ class GrowFromRootTreeProposer:
                 current_uniq_val_id_ += 1
             residuals_le_cutpoint.append(current_residual)
             num_obs_le_cutpoint.append(current_num_obs)
-            cut_point_probab = _integrated_likelihood(
-                num_observations=current_num_obs, residual=current_residual
-            ) * _integrated_likelihood(
+            cut_point_log_likelihood = _integrated_log_likelihood(
+                num_observations=current_num_obs,
+                residual=current_residual,
+            ) + _integrated_log_likelihood(
                 num_observations=(total_num_observations - current_num_obs),
                 residual=(total_residual - current_residual),
             )
-            selection_probabs.append(cut_point_probab)
-            sum_ += cut_point_probab
+            if cut_point_log_likelihood > MAX_LOG_LIKELIHOOD:
+                MAX_LOG_LIKELIHOOD = cut_point_log_likelihood
+            selection_log_likelihoods.append(cut_point_log_likelihood)
 
+        # turn it into likelihoods
+        sum_ = 0.0
+        for log_likelihood in selection_log_likelihoods:
+            likelihood = math.exp(log_likelihood - MAX_LOG_LIKELIHOOD)
+            sum_ += likelihood
+            selection_probabs.append(likelihood)
         selection_probabs = torch.tensor([_ / sum_ for _ in selection_probabs])
+
         sampled_cut_id = cast(
             int, multinomial(input=selection_probabs, num_samples=1).item()
         )

--- a/src/beanmachine/ppl/experimental/causal_inference/models/bart/grow_from_root_tree_proposer.py
+++ b/src/beanmachine/ppl/experimental/causal_inference/models/bart/grow_from_root_tree_proposer.py
@@ -356,6 +356,7 @@ class GrowFromRootTreeProposer:
         total_num_observations = invariants.O_.shape[-1]
         total_residual = torch.sum(partial_residual[invariants.O_[0]]).item()
         tau = leaf_sampler.prior_scale**2
+        sigma2 = sigma_val**2
         MAX_LOG_LIKELIHOOD = -float("inf")
 
         def _integrated_log_likelihood(
@@ -364,9 +365,9 @@ class GrowFromRootTreeProposer:
         ) -> float:
 
             log_likelihood = +0.5 * log(
-                (sigma_val**2) / (sigma_val**2 + tau * num_observations)
+                (sigma2) / (sigma2 + tau * num_observations)
             ) + 0.5 * (tau * (residual**2)) / (
-                (sigma_val**2) * (sigma_val**2 + tau * num_observations)
+                (sigma2) * (sigma2 + tau * num_observations)
             )
             return log_likelihood
 


### PR DESCRIPTION
Summary:
Background:
We are developing Accelerated Bayesian Additive Regression Trees (XBART) whic uses a grow-from-root tree sampler to from an ensemble of trees which predict the response surface.
In this diff:

10% gain in speed by avoiding the squaring of sigma inside _integrated_log_likelihood(
) which is called a lot. Instead calculated once outside since the sigma_val is constant in a single call of the tree proposer.

Differential Revision: D38563765

