### PR TITLE
Support parameters in World

### DIFF
--- a/src/beanmachine/ppl/experimental/vi/gradient_estimator.py
+++ b/src/beanmachine/ppl/experimental/vi/gradient_estimator.py
@@ -41,7 +41,7 @@ def monte_carlo_approximate_reparam(
             params=params,
             queries_to_guides=queries_to_guides,
         )
-        world = World.initialize_world(
+        world = VariationalWorld.initialize_world(
             queries=[],
             observations={
                 **{
@@ -50,6 +50,7 @@ def monte_carlo_approximate_reparam(
                 },
                 **observations,
             },
+            params=params,
         )
 
         # form log density ratio logu = logp - logq

--- a/src/beanmachine/ppl/experimental/vi/variational_infer.py
+++ b/src/beanmachine/ppl/experimental/vi/variational_infer.py
@@ -56,7 +56,8 @@ class VariationalInfer:
             params={},
             queries_to_guides=queries_to_guides,
         )
-        for guide in queries_to_guides.values():
+        for query, guide in queries_to_guides.items():
+            world.call(query)
             world.call(guide)
         self.params = world._params
         self._optimizer = optimizer(self.params.values())


### PR DESCRIPTION
Summary:
To support the use of `bm.param`s in the generative model, beanmachine's VI now:
 * Traces through `World` in addition to `VariationalWorld` so that `param`s used in `World` are added to the optimizer
 * Utilizes a `VariationalWorld` for both the generative and guide distributions in `gradient_estimators` so that `params` can be used in the generative model

This is needed to support PPCA (N2358633)

Differential Revision: D38754091

