### PR TITLE
Fix pi namespace issue in LKJ Cholesky

### DIFF
--- a/src/beanmachine/graph/distribution/lkj_cholesky.h
+++ b/src/beanmachine/graph/distribution/lkj_cholesky.h
@@ -43,7 +43,7 @@ class LKJCholesky : public Distribution {
 
   Eigen::VectorXd beta_conc1;
   Eigen::VectorXd beta_conc0;
-  int d;
+  uint d;
 
  private:
   Eigen::ArrayXd order;


### PR DESCRIPTION
Summary: D38595562 (https://github.com/facebookresearch/beanmachine/commit/b346237641f06f502375b051181e01e60ffeed45) broke the open source tests in Beanmachine since those builds don't have `std::numbers::pi`. This fixes it with `M_PI` instead, which is used in other parts of BMG and should be fine.

Differential Revision: D38880771

