### PR TITLE
Remove references to VerboseLevel in tutorials

### DIFF
--- a/tutorials/Bayesian_Structural_Time_Series.ipynb
+++ b/tutorials/Bayesian_Structural_Time_Series.ipynb
@@ -847,7 +847,6 @@
     "    num_samples,\n",
     "    num_chains=4,\n",
     "    num_adaptive_samples=num_adaptive_samples,\n",
-    "    verbose=False\n",
     ")"
    ]
   },


### PR DESCRIPTION
Summary: This is a followup of `verbose: VerboseLevel` by `show_progress_bar: bool` in D38295920 (https://github.com/facebookresearch/beanmachine/commit/9e4d00006d701716c6bb6f8b19f9b371686b7403)

Differential Revision: D38878633

