### PR TITLE
Bug fix in Robust Linear Regression Tutorial

### DIFF
--- a/tutorials/Robust_Linear_Regression.ipynb
+++ b/tutorials/Robust_Linear_Regression.ipynb
@@ -207,7 +207,7 @@
     "We are interested in fitting posterior distributions for $\\beta$, $\\alpha$, $\\sigma$,\n",
     "and $\\nu$ given a collection of training data $\\{x, y\\}_{i=1}^N$.\n",
     "\n",
-    "Let's visualize the Gamma distribution that we used as our prior for $\\epsilon$:"
+    "Let's visualize the Gamma distribution that we used as our prior for $\\nu$:"
    ]
   },
   {
@@ -579,9 +579,9 @@
     "\n",
     "gamma_prior_plot = plots.line_plot(\n",
     "    plot_sources=[cds],\n",
-    "    tooltips=[[(\"Density\", \"@y{0.000}\"), (\"ϵ\", \"@x{0.000}\")]],\n",
+    "    tooltips=[[(\"Density\", \"@y{0.000}\"), (\"ν\", \"@x{0.000}\")]],\n",
     "    figure_kwargs={\n",
-    "        \"x_axis_label\": \"epsilon\",\n",
+    "        \"x_axis_label\": \"nu\",\n",
     "        \"y_axis_label\": \"density\",\n",
     "        \"title\": f\"Γ({concentration}, {rate}) prior\",\n",
     "    },\n",


### PR DESCRIPTION
Summary:
In the [Robust Linear Regression Tutorial](https://beanmachine.org/docs/overview/tutorials/Robust_Linear_Regression/RobustLinearRegression/#model), the variable `ϵ` is used instead of `ν` when visualizing the Gamma dist. for the degrees of freedom of the Student's T:

{F764068443}
{F764068552}

The `ϵ` is nowhere else in the tutorial, other than this visualization.

Differential Revision: D39038611

