### PR TITLE
Implement MATRIX_LOG operator in BMG

### DIFF
--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -343,6 +343,7 @@ enum class OperatorType {
   MATRIX_EXP,
   LOG_PROB,
   MATRIX_SUM,
+  MATRIX_LOG,
 };
 
 enum class DistributionType {

--- a/src/beanmachine/graph/operator/backward.cpp
+++ b/src/beanmachine/graph/operator/backward.cpp
@@ -354,6 +354,14 @@ void MatrixExp::backward() {
   }
 }
 
+void MatrixLog::backward() {
+  assert(in_nodes.size() == 1);
+  if (in_nodes[0]->needs_gradient()) {
+    in_nodes[0]->back_grad1 +=
+        back_grad1.as_matrix().cwiseQuotient(in_nodes[0]->value._matrix);
+  }
+}
+
 void MatrixSum::backward() {
   assert(in_nodes.size() == 1);
   if (in_nodes[0]->needs_gradient()) {

--- a/src/beanmachine/graph/operator/gradient.cpp
+++ b/src/beanmachine/graph/operator/gradient.cpp
@@ -528,6 +528,19 @@ void MatrixExp::compute_gradients() {
       value._matrix.cwiseProduct(in_nodes[0]->Grad2);
 }
 
+void MatrixLog::compute_gradients() {
+  assert(in_nodes.size() == 1);
+  // f(x) = log(g(x))
+  // f'(x) = g'(x) / g(x)
+  // f''(x) = (g''(x) * g(x) + g'(x) * g'(x)) / (g(x) * g(x))
+  //        = g''(x) / g(x) + f'(x) * f'(x)
+  auto g = in_nodes[0]->value._matrix;
+  auto g1 = in_nodes[0]->Grad1;
+  auto g2 = in_nodes[0]->Grad2;
+  Grad1 = g1.cwiseQuotient(g);
+  Grad2 = g2.cwiseQuotient(g) + Grad1.cwiseProduct(Grad1);
+}
+
 void LogProb::compute_gradients() {
   auto dist = (Distribution*)in_nodes[0];
   auto value = in_nodes[1];

--- a/src/beanmachine/graph/operator/linalgop.cpp
+++ b/src/beanmachine/graph/operator/linalgop.cpp
@@ -475,5 +475,34 @@ void MatrixSum::eval(std::mt19937& /* gen */) {
   value._double = in_nodes[0]->value._matrix.sum();
 }
 
+MatrixLog::MatrixLog(const std::vector<graph::Node*>& in_nodes)
+    : Operator(graph::OperatorType::MATRIX_LOG) {
+  if (in_nodes.size() != 1) {
+    throw std::invalid_argument("MATRIX_LOG requires one parent node");
+  }
+  auto type = in_nodes[0]->value.type;
+  if (type.variable_type != graph::VariableType::BROADCAST_MATRIX) {
+    throw std::invalid_argument(
+        "the parent of MATRIX_LOG must be a BROADCAST_MATRIX");
+  }
+  auto atomic_type = type.atomic_type;
+  graph::AtomicType new_type;
+  if (atomic_type == graph::AtomicType::POS_REAL) {
+    new_type = graph::AtomicType::REAL;
+  } else if (atomic_type == graph::AtomicType::PROBABILITY) {
+    new_type = graph::AtomicType::NEG_REAL;
+  } else {
+    throw std::invalid_argument(
+        "operator MATRIX_LOG requires a probability or pos_real parent");
+  }
+  value = graph::NodeValue(graph::ValueType(
+      graph::VariableType::BROADCAST_MATRIX, new_type, type.rows, type.cols));
+}
+
+void MatrixLog::eval(std::mt19937& /* gen */) {
+  assert(in_nodes.size() == 1);
+  value._matrix = Eigen::log(in_nodes[0]->value._matrix.array());
+}
+
 } // namespace oper
 } // namespace beanmachine

--- a/src/beanmachine/graph/operator/linalgop.h
+++ b/src/beanmachine/graph/operator/linalgop.h
@@ -183,5 +183,20 @@ class MatrixSum : public Operator {
   static bool is_registered;
 };
 
+class MatrixLog : public Operator {
+ public:
+  explicit MatrixLog(const std::vector<graph::Node*>& in_nodes);
+  ~MatrixLog() override {}
+
+  void eval(std::mt19937& gen) override;
+  void backward() override;
+  void compute_gradients() override;
+
+  static std::unique_ptr<Operator> new_op(
+      const std::vector<graph::Node*>& in_nodes) {
+    return std::make_unique<MatrixLog>(in_nodes);
+  }
+};
+
 } // namespace oper
 } // namespace beanmachine

--- a/src/beanmachine/graph/operator/register.cpp
+++ b/src/beanmachine/graph/operator/register.cpp
@@ -136,6 +136,10 @@ bool ::beanmachine::oper::OperatorFactory::factories_are_registered =
         graph::OperatorType::MATRIX_EXP,
         &(MatrixExp::new_op)) &&
 
+    OperatorFactory::register_op(
+        graph::OperatorType::MATRIX_LOG,
+        &(MatrixLog::new_op)) &&
+
     // matrix index
     OperatorFactory::register_op(
         graph::OperatorType::INDEX,

--- a/src/beanmachine/graph/pybindings.cpp
+++ b/src/beanmachine/graph/pybindings.cpp
@@ -90,7 +90,8 @@ PYBIND11_MODULE(graph, module) {
       .value("CHOICE", OperatorType::CHOICE)
       .value("CHOLESKY", OperatorType::CHOLESKY)
       .value("MATRIX_EXP", OperatorType::MATRIX_EXP)
-      .value("MATRIX_SUM", OperatorType::MATRIX_SUM);
+      .value("MATRIX_SUM", OperatorType::MATRIX_SUM)
+      .value("MATRIX_LOG", OperatorType::MATRIX_LOG);
 
   py::enum_<DistributionType>(module, "DistributionType")
       .value("TABULAR", DistributionType::TABULAR)

--- a/src/beanmachine/graph/to_dot.cpp
+++ b/src/beanmachine/graph/to_dot.cpp
@@ -189,6 +189,18 @@ class DOT {
         return "ToMatrix";
       case OperatorType::COLUMN_INDEX:
         return "ColumnIndex";
+      case OperatorType::BROADCAST_ADD:
+        return "BroadcastAdd";
+      case OperatorType::CHOLESKY:
+        return "Cholesky";
+      case OperatorType::MATRIX_EXP:
+        return "MatrixExp";
+      case OperatorType::LOG_PROB:
+        return "LogProb";
+      case OperatorType::MATRIX_SUM:
+        return "MatrixSum";
+      case OperatorType::MATRIX_LOG:
+        return "MatrixLog";
       default:
         return "Operator";
     }

--- a/src/beanmachine/ppl/compiler/tests/fix_matrix_type_test.py
+++ b/src/beanmachine/ppl/compiler/tests/fix_matrix_type_test.py
@@ -19,6 +19,7 @@ def _rv_id() -> RVIdentifier:
 
 class FixMatrixOpTest(unittest.TestCase):
     def test_fix_matrix_addition(self) -> None:
+        self.maxDiff = None
         bmg = BMGraphBuilder()
         zeros = bmg.add_real_matrix(torch.zeros(2))
         ones = bmg.add_pos_real_matrix(torch.ones(2))
@@ -149,7 +150,7 @@ digraph "graph" {
   N11[label="~"];
   N12[label="2"];
   N13[label="ToMatrix"];
-  N14[label="Operator"];
+  N14[label="MatrixExp"];
   N15[label="ToReal"];
   N16[label="ElementwiseMultiply"];
   N17[label="MatrixAdd"];
@@ -184,6 +185,7 @@ digraph "graph" {
         self.assertEqual(expectation.strip(), observed.strip())
 
     def test_fix_elementwise_multiply(self) -> None:
+        self.maxDiff = None
         bmg = BMGraphBuilder()
         zeros = bmg.add_real_matrix(torch.zeros(2))
         ones = bmg.add_pos_real_matrix(torch.ones(2))
@@ -319,11 +321,11 @@ digraph "graph" {
   N11[label="~"];
   N12[label="2"];
   N13[label="ToMatrix"];
-  N14[label="Operator"];
+  N14[label="MatrixExp"];
   N15[label="ToReal"];
   N16[label="MatrixAdd"];
   N17[label="ElementwiseMultiply"];
-  N18[label="Operator"];
+  N18[label="MatrixSum"];
   N0 -> N2;
   N0 -> N8;
   N1 -> N2;
@@ -356,6 +358,7 @@ digraph "graph" {
         self.assertEqual(expectation.strip(), observed.strip())
 
     def test_fix_matrix_sum(self) -> None:
+        self.maxDiff = None
         bmg = BMGraphBuilder()
         probs = bmg.add_real_matrix(torch.tensor([[0.75, 0.25], [0.125, 0.875]]))
         tensor_elements = []
@@ -466,7 +469,7 @@ digraph "graph" {
   N21[label="2"];
   N22[label="ToMatrix"];
   N23[label="ToReal"];
-  N24[label="Operator"];
+  N24[label="MatrixSum"];
   N0 -> N2;
   N0 -> N12;
   N1 -> N2;
@@ -506,6 +509,7 @@ digraph "graph" {
         self.assertEqual(expectation.strip(), observed_bmg.strip())
 
     def test_fix_matrix_exp(self) -> None:
+        self.maxDiff = None
         bmg = BMGraphBuilder()
         probs = bmg.add_real_matrix(torch.tensor([[0.75, 0.25], [0.125, 0.875]]))
         tensor_elements = []
@@ -615,7 +619,7 @@ digraph "graph" {
   N21[label="2"];
   N22[label="ToMatrix"];
   N23[label="ToReal"];
-  N24[label="Operator"];
+  N24[label="MatrixExp"];
   N0 -> N2;
   N0 -> N12;
   N1 -> N2;


### PR DESCRIPTION
Summary:
In order to not blow up the size of the compiled state of some important models, it would be nice to have matrix versions of some common operators; here's an implementation of the matrix log operation in BMG.

We will add support to the compiler in an upcoming diff.

Reviewed By: gafter

Differential Revision: D38875972

