### PR TITLE
Remove the try-except block in evaluating log prob of a variable

### DIFF
--- a/src/beanmachine/ppl/world/tests/variable_test.py
+++ b/src/beanmachine/ppl/world/tests/variable_test.py
@@ -3,6 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import pytest
 import torch
 import torch.distributions as dist
 from beanmachine.ppl.world.variable import Variable
@@ -18,8 +19,10 @@ def test_log_prob():
     var3 = var1.replace(distribution=dist.Normal(0.0, 1.0))
     assert var1.log_prob.sum() < var3.log_prob.sum()
 
+    # Expects an error here because support doesn't match
     var4 = var1.replace(distribution=dist.Categorical(logits=torch.rand(2, 4)))
-    assert torch.all(torch.isinf(var4.log_prob))
+    with pytest.raises(RuntimeError):
+        var4.log_prob
 
     var5 = Variable(
         value=torch.tensor(10).double(),

--- a/src/beanmachine/ppl/world/variable.py
+++ b/src/beanmachine/ppl/world/variable.py
@@ -39,23 +39,7 @@ class Variable:
         Returns
              The logprob of the `value` of the value given the distribution.
         """
-        try:
-            return self.distribution.log_prob(self.value)
-        # Numerical errors in Cholesky factorization are handled upstream
-        # in respective proposers or in `Sampler.send`.
-        # TODO: Change to torch.linalg.LinAlgError when in release.
-        except (RuntimeError, ValueError) as e:
-            err_msg = str(e)
-            if isinstance(e, RuntimeError) and (
-                "singular U" in err_msg or "input is not positive-definite" in err_msg
-            ):
-                raise e
-            dtype = (
-                self.value.dtype
-                if torch.is_floating_point(self.value)
-                else torch.float32
-            )
-            return torch.tensor(float("-inf"), device=self.value.device, dtype=dtype)
+        return self.distribution.log_prob(self.value)
 
     def replace(self, **changes) -> Variable:
         """Return a new Variable object with fields replaced by the changes"""


### PR DESCRIPTION
Summary:
We've been silently converting `RuntimeError` and `ValueError` to `-inf` when evaluating log prob of random variable, which was initially design to allow open universe model with change in support, but it ended up causing us quite a lot of trouble when we want to debug a model.

Thus, this diff removes the try-except block in the definition of `Variable` to make debugging easier.

It might sound like that we are going to have a regression in terms of models we can support, but the try-except didn't really fix anything either, because a log prob of `-inf` will lead to a rejection in MH step, so even if we aren't throwing the error, the inference will still get stuck.

Differential Revision: D39115109

