### PR TITLE
Update link to tutorials in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@
 ## Overview
 
 Bean Machine is a probabilistic programming language for inference over statistical models written in the Python language using a declarative syntax. Bean Machine is built on top of PyTorch and Bean Machine Graph, a custom C++ backend.
-Check out our [tutorials](https://beanmachine.org/docs/tutorials/) and [Quick Start](https://beanmachine.org/docs/overview/quick_start/) to get started!
+Check out our [tutorials](https://beanmachine.org/docs/overview/tutorials/Coin_flipping/CoinFlipping/) and [Quick Start](https://beanmachine.org/docs/overview/quick_start/) to get started!
 
 ## Installation
-Bean Machine supports Python 3.7-3.9 and PyTorch 1.10.
+Bean Machine supports Python 3.7-3.10 and PyTorch 1.12.
 
 ### Install the Latest Release with Pip
 

--- a/docs/overview/installation/installation.md
+++ b/docs/overview/installation/installation.md
@@ -9,7 +9,7 @@ sidebar_label: 'Installation'
 The Google Colaboratory web service (Colab) is probably the quickest way to run Bean Machine. For example, [here is what our Coin Flipping tutorial looks like on Colab](https://colab.research.google.com/github/facebookresearch/beanmachine/blob/main/tutorials/Coin_flipping.ipynb). Similar links can be found for each of our tutorials in the Tutorials section.
 
 ## Requirements
-Python 3.7-3.9 and PyTorch 1.10.
+Python 3.7-3.10 and PyTorch 1.12.
 
 ## Latest Release
 


### PR DESCRIPTION
Summary: Since https://beanmachine.org/docs/tutorials/ no longer exists, it's time to update our readme so that people won't get confused when they open up to an empty page.

Differential Revision: D39123837

