### PR TITLE
Pin GPyTorch to be < 1.9.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ INSTALL_REQUIRES = [
     "astor>=0.7.1",
     "black==22.3.0",
     "botorch>=0.5.1",
-    "gpytorch>=1.3.0",
+    "gpytorch>=1.3.0, <1.9.0",
     "graphviz>=0.17",
     "functorch>=0.2.0",
     "netCDF4<=1.5.8; python_version<'3.8'",


### PR DESCRIPTION
Summary:
GPyTorch released 1.9.0.

They deprecated the `.utils.cholesky ` module and moved it to `linear_operator.utils`. But, they didn't change their own import statements (https://github.com/cornellius-gp/gpytorch/blob/master/gpytorch/priors/lkj_prior.py). This caused errors and warning in our CI. BoTorch also uses the util module that they deprecated

Differential Revision: D39145667

