### PR TITLE
implement LOG1P and MATRIX_LOG1P in BMG

### DIFF
--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -344,6 +344,8 @@ enum class OperatorType {
   LOG_PROB,
   MATRIX_SUM,
   MATRIX_LOG,
+  LOG1P,
+  MATRIX_LOG1P,
 };
 
 enum class DistributionType {

--- a/src/beanmachine/graph/operator/backward.cpp
+++ b/src/beanmachine/graph/operator/backward.cpp
@@ -369,5 +369,21 @@ void MatrixSum::backward() {
   }
 }
 
+void Log1p::backward() {
+  assert(in_nodes.size() == 1);
+  if (in_nodes[0]->needs_gradient()) {
+    double jacob = 1 / (1 + in_nodes[0]->value._double);
+    in_nodes[0]->back_grad1 += back_grad1 * jacob;
+  }
+}
+
+void MatrixLog1p::backward() {
+  assert(in_nodes.size() == 1);
+  if (in_nodes[0]->needs_gradient()) {
+    in_nodes[0]->back_grad1 += back_grad1.as_matrix().cwiseQuotient(
+        (in_nodes[0]->value._matrix.array() + 1).matrix());
+  }
+}
+
 } // namespace oper
 } // namespace beanmachine

--- a/src/beanmachine/graph/operator/gradient.cpp
+++ b/src/beanmachine/graph/operator/gradient.cpp
@@ -600,5 +600,32 @@ void MatrixSum::compute_gradients() {
   grad2 = in_nodes[0]->Grad2.sum();
 }
 
+void Log1p::compute_gradients() {
+  assert(in_nodes.size() == 1);
+  // f(x) = log(g(x) + 1)
+  // f'(x) = g'(x) / (g(x) + 1)
+  // f''(x) = ((g(x) + 1) g''(x) - g'(x)^2)/(g(x) + 1)^2
+  auto g = in_nodes[0]->value._double;
+  auto gp1 = g + 1;
+  auto g1 = in_nodes[0]->grad1;
+  auto g2 = in_nodes[0]->grad2;
+  grad1 = g1 / gp1;
+  grad2 = (gp1 * g2 - g1 * g1) / (gp1 * gp1);
+}
+
+void MatrixLog1p::compute_gradients() {
+  assert(in_nodes.size() == 1);
+  // f(x) = log(g(x) + 1)
+  // f'(x) = g'(x) / (g(x) + 1)
+  // f''(x) = ((g(x) + 1) g''(x) - g'(x)^2)/(g(x) + 1)^2
+  auto g = in_nodes[0]->value._matrix;
+  auto gp1 = (g.array() + 1).matrix();
+  auto g1 = in_nodes[0]->Grad1;
+  auto g2 = in_nodes[0]->Grad2;
+  Grad1 = g1.cwiseQuotient(gp1);
+  Grad2 = (gp1.cwiseProduct(g2) - g1.cwiseProduct(g1))
+              .cwiseQuotient(gp1.cwiseProduct(gp1));
+}
+
 } // namespace oper
 } // namespace beanmachine

--- a/src/beanmachine/graph/operator/linalgop.cpp
+++ b/src/beanmachine/graph/operator/linalgop.cpp
@@ -504,5 +504,34 @@ void MatrixLog::eval(std::mt19937& /* gen */) {
   value._matrix = Eigen::log(in_nodes[0]->value._matrix.array());
 }
 
+MatrixLog1p::MatrixLog1p(const std::vector<graph::Node*>& in_nodes)
+    : Operator(graph::OperatorType::MATRIX_LOG1P) {
+  if (in_nodes.size() != 1) {
+    throw std::invalid_argument("MATRIX_LOG1P requires one parent node");
+  }
+  auto type = in_nodes[0]->value.type;
+  if (type.variable_type != graph::VariableType::BROADCAST_MATRIX) {
+    throw std::invalid_argument(
+        "the parent of MATRIX_LOG1P must be a BROADCAST_MATRIX");
+  }
+  auto atomic_type = type.atomic_type;
+  graph::AtomicType new_type;
+  if (atomic_type == graph::AtomicType::POS_REAL) {
+    new_type = graph::AtomicType::REAL;
+  } else if (atomic_type == graph::AtomicType::PROBABILITY) {
+    new_type = graph::AtomicType::NEG_REAL;
+  } else {
+    throw std::invalid_argument(
+        "operator MATRIX_LOG1P requires a probability or pos_real parent");
+  }
+  value = graph::NodeValue(graph::ValueType(
+      graph::VariableType::BROADCAST_MATRIX, new_type, type.rows, type.cols));
+}
+
+void MatrixLog1p::eval(std::mt19937& /* gen */) {
+  assert(in_nodes.size() == 1);
+  value._matrix = Eigen::log1p(in_nodes[0]->value._matrix.array());
+}
+
 } // namespace oper
 } // namespace beanmachine

--- a/src/beanmachine/graph/operator/linalgop.h
+++ b/src/beanmachine/graph/operator/linalgop.h
@@ -198,5 +198,20 @@ class MatrixLog : public Operator {
   }
 };
 
+class MatrixLog1p : public Operator {
+ public:
+  explicit MatrixLog1p(const std::vector<graph::Node*>& in_nodes);
+  ~MatrixLog1p() override {}
+
+  void eval(std::mt19937& gen) override;
+  void backward() override;
+  void compute_gradients() override;
+
+  static std::unique_ptr<Operator> new_op(
+      const std::vector<graph::Node*>& in_nodes) {
+    return std::make_unique<MatrixLog1p>(in_nodes);
+  }
+};
+
 } // namespace oper
 } // namespace beanmachine

--- a/src/beanmachine/graph/operator/register.cpp
+++ b/src/beanmachine/graph/operator/register.cpp
@@ -107,6 +107,10 @@ bool ::beanmachine::oper::OperatorFactory::factories_are_registered =
 
     OperatorFactory::register_op(graph::OperatorType::LOG, &(Log::new_op)) &&
 
+    OperatorFactory::register_op(
+        graph::OperatorType::LOG1P,
+        &(Log1p::new_op)) &&
+
     // linear algebra op
     OperatorFactory::register_op(
         graph::OperatorType::TRANSPOSE,
@@ -139,6 +143,10 @@ bool ::beanmachine::oper::OperatorFactory::factories_are_registered =
     OperatorFactory::register_op(
         graph::OperatorType::MATRIX_LOG,
         &(MatrixLog::new_op)) &&
+
+    OperatorFactory::register_op(
+        graph::OperatorType::MATRIX_LOG1P,
+        &(MatrixLog1p::new_op)) &&
 
     // matrix index
     OperatorFactory::register_op(

--- a/src/beanmachine/graph/operator/unaryop.cpp
+++ b/src/beanmachine/graph/operator/unaryop.cpp
@@ -560,5 +560,27 @@ void LogSumExpVector::eval(std::mt19937& /* gen */) {
   }
 }
 
+Log1p::Log1p(const std::vector<graph::Node*>& in_nodes)
+    : UnaryOperator(graph::OperatorType::LOG1P, in_nodes) {
+  graph::ValueType type0 = in_nodes[0]->value.type;
+  if (type0 != graph::AtomicType::POS_REAL &&
+      type0 != graph::AtomicType::REAL) {
+    throw std::invalid_argument(
+        "operator LOG1P requires a real or pos_real parent");
+  }
+  value = graph::NodeValue(graph::AtomicType::REAL);
+
+  if (in_nodes.size() != 1) {
+    throw std::invalid_argument("LOG1P requires one parent node");
+  }
+  value = graph::NodeValue(graph::AtomicType::REAL);
+}
+
+void Log1p::eval(std::mt19937& /* gen */) {
+  assert(in_nodes.size() == 1);
+  const graph::NodeValue& parent = in_nodes[0]->value;
+  value = graph::NodeValue(graph::AtomicType::REAL, std::log1p(parent._double));
+}
+
 } // namespace oper
 } // namespace beanmachine

--- a/src/beanmachine/graph/operator/unaryop.h
+++ b/src/beanmachine/graph/operator/unaryop.h
@@ -290,5 +290,20 @@ class LogSumExpVector : public UnaryOperator {
   }
 };
 
+class Log1p : public UnaryOperator {
+ public:
+  explicit Log1p(const std::vector<graph::Node*>& in_nodes);
+  ~Log1p() override {}
+
+  void eval(std::mt19937& gen) override;
+  void compute_gradients() override;
+  void backward() override;
+
+  static std::unique_ptr<Operator> new_op(
+      const std::vector<graph::Node*>& in_nodes) {
+    return std::make_unique<Log1p>(in_nodes);
+  }
+};
+
 } // namespace oper
 } // namespace beanmachine

--- a/src/beanmachine/graph/pybindings.cpp
+++ b/src/beanmachine/graph/pybindings.cpp
@@ -72,6 +72,7 @@ PYBIND11_MODULE(graph, module) {
       .value("LOGSUMEXP", OperatorType::LOGSUMEXP)
       .value("IF_THEN_ELSE", OperatorType::IF_THEN_ELSE)
       .value("LOG", OperatorType::LOG)
+      .value("LOG1P", OperatorType::LOG1P)
       .value("POW", OperatorType::POW)
       .value("TRANSPOSE", OperatorType::TRANSPOSE)
       .value("MATRIX_MULTIPLY", OperatorType::MATRIX_MULTIPLY)
@@ -91,7 +92,8 @@ PYBIND11_MODULE(graph, module) {
       .value("CHOLESKY", OperatorType::CHOLESKY)
       .value("MATRIX_EXP", OperatorType::MATRIX_EXP)
       .value("MATRIX_SUM", OperatorType::MATRIX_SUM)
-      .value("MATRIX_LOG", OperatorType::MATRIX_LOG);
+      .value("MATRIX_LOG", OperatorType::MATRIX_LOG)
+      .value("MATRIX_LOG1P", OperatorType::MATRIX_LOG1P);
 
   py::enum_<DistributionType>(module, "DistributionType")
       .value("TABULAR", DistributionType::TABULAR)

--- a/src/beanmachine/graph/to_dot.cpp
+++ b/src/beanmachine/graph/to_dot.cpp
@@ -169,6 +169,8 @@ class DOT {
         return "LogSumExp";
       case OperatorType::LOG:
         return "Log";
+      case OperatorType::LOG1P:
+        return "Log1p";
       case OperatorType::POW:
         return "^";
       case OperatorType::LOG1MEXP:
@@ -203,6 +205,8 @@ class DOT {
         return "MatrixSum";
       case OperatorType::MATRIX_LOG:
         return "MatrixLog";
+      case OperatorType::MATRIX_LOG1P:
+        return "MatrixLog1p";
       default:
         throw std::invalid_argument(
             "internal error: missing case for OperatorType");


### PR DESCRIPTION
Summary:
Implement the scalar operator LOG1P for log(1 + x)
And the corresponding elementwise matrix operator MATRIX_LOG1P

Reviewed By: ericlippert

Differential Revision: D38923743

