### PR TITLE
Warn user against using torch tensors as arguments of random variables

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ filterwarnings = [
     "default:pandas.Int64Index is deprecated *:FutureWarning",
     # functorch 0.1.0 imports deprecated _stateless module
     "default:The `torch.nn.utils._stateless` code is deprecated*:DeprecationWarning",
+    # BM warns against using torch tensors as arguments of random variables
+    "default:PyTorch tensors are hashed by memory address instead of value.*:UserWarning",
 ]
 
 [tool.usort]

--- a/src/beanmachine/ppl/model/rv_identifier.py
+++ b/src/beanmachine/ppl/model/rv_identifier.py
@@ -3,8 +3,11 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import warnings
 from dataclasses import dataclass
 from typing import Callable, Tuple
+
+import torch
 
 
 @dataclass(eq=True, frozen=True)
@@ -16,6 +19,15 @@ class RVIdentifier:
 
     wrapper: Callable
     arguments: Tuple
+
+    def __post_init__(self):
+        for arg in self.arguments:
+            if torch.is_tensor(arg):
+                warnings.warn(
+                    "PyTorch tensors are hashed by memory address instead of value. "
+                    "Therefore, it is not recommended to use tensors as indices of random variables.",
+                    stacklevel=3,
+                )
 
     def __str__(self):
         return str(self.function.__name__) + str(self.arguments)


### PR DESCRIPTION
Summary:
Bean Machine uses the hash value of the arguments of random variables to identify them, which means that foo(1) and foo(tensor(1)) are considered two different random variables. Further in PyTorch, tensors are hashed by memory address instead of by value, so we can have hash(tensor(1)) != hash(tensor(1)). Therefore, it’s not recommended to use tensors as indices of random variables.
In this change,
1. In `rv_identifier.py` we identify if tensors are used as arguments to RVs and warn the user against its use.
2. Added a test case to `rv_identifier_test.py` to check if the warning is triggered correctly when the user provides a tensor instead of a primitive argument.

Differential Revision: D39169577

