### PR TITLE
Refactor numeric classes to have operations defined outside the class

### DIFF
--- a/minibmg/ad/num2.h
+++ b/minibmg/ad/num2.h
@@ -25,147 +25,99 @@ namespace beanmachine::minibmg {
 template <class Underlying>
 requires Number<Underlying>
 class Num2 {
- private:
-  Underlying m_primal, m_derivative1;
-
  public:
+  Underlying primal, derivative1;
+
   /* implicit */ Num2(double primal);
   /* implicit */ Num2(Underlying primal);
   Num2(Underlying primal, Underlying derivative1);
   Num2(const Num2<Underlying>& other);
-  Num2<Underlying>& operator=(const Num2<Underlying>& other);
-  Underlying primal() const;
-  Underlying derivative1() const;
+  Num2<Underlying>& operator=(const Num2<Underlying>& other) = default;
   double as_double() const;
-  Num2<Underlying> operator+(const Num2<Underlying>& other) const;
-  Num2<Underlying> operator-(const Num2<Underlying>& other) const;
-  Num2<Underlying> operator-() const;
-  Num2<Underlying> operator*(const Num2<Underlying>& other) const;
-  Num2<Underlying> operator/(const Num2<Underlying>& other) const;
-  Num2<Underlying> pow(const Num2<Underlying>& other) const;
-  Num2<Underlying> exp() const;
-  Num2<Underlying> log() const;
-  Num2<Underlying> atan() const;
-  Num2<Underlying> lgamma() const;
-  Num2<Underlying> polygamma(double n) const;
-  Num2<Underlying> if_equal(
-      const Num2<Underlying>& comparand,
-      const Num2<Underlying>& when_equal,
-      const Num2<Underlying>& when_not_equal) const;
-  Num2<Underlying> if_less(
-      const Num2<Underlying>& comparand,
-      const Num2<Underlying>& when_less,
-      const Num2<Underlying>& when_not_less) const;
-  bool is_constant(double& value) const;
-  bool is_constant(const double& value) const;
-  std::string to_string() const;
 };
 
 template <class Underlying>
 requires Number<Underlying> Num2<Underlying>::Num2(double primal)
-    : m_primal(primal), m_derivative1(0.0) {}
+    : primal(primal), derivative1(0.0) {}
 
 template <class Underlying>
 requires Number<Underlying> Num2<Underlying>::Num2(Underlying primal)
-    : m_primal(primal), m_derivative1(0.0) {}
+    : primal(primal), derivative1(0.0) {}
 
 template <class Underlying>
 requires Number<Underlying> Num2<Underlying>::Num2(
     Underlying primal,
     Underlying derivative1)
-    : m_primal(primal), m_derivative1(derivative1) {}
+    : primal(primal), derivative1(derivative1) {}
 
 template <class Underlying>
 requires Number<Underlying> Num2<Underlying>::Num2(
     const Num2<Underlying>& other)
-    : m_primal(other.m_primal), m_derivative1(other.m_derivative1) {}
-
-template <class Underlying>
-requires Number<Underlying> Num2<Underlying>
-&Num2<Underlying>::operator=(const Num2<Underlying>& other) {
-  this->m_primal = other.m_primal;
-  this->m_derivative1 = other.m_derivative1;
-  return *this;
-}
-
-template <class Underlying>
-requires Number<Underlying> Underlying Num2<Underlying>::primal()
-const {
-  return m_primal;
-}
-
-template <class Underlying>
-requires Number<Underlying> Underlying Num2<Underlying>::derivative1()
-const {
-  return m_derivative1;
-}
+    : primal(other.primal), derivative1(other.derivative1) {}
 
 template <class Underlying>
 requires Number<Underlying>
 double Num2<Underlying>::as_double() const {
-  return m_primal.as_double();
+  return primal.as_double();
 }
 
 template <class Underlying>
-requires Number<Underlying> Num2<Underlying> Num2<Underlying>::operator+(
-    const Num2<Underlying>& other) const {
+requires Number<Underlying> Num2<Underlying>
+operator+(const Num2<Underlying>& left, const Num2<Underlying>& right) {
   return Num2<Underlying>{
-      this->m_primal + other.m_primal,
-      this->m_derivative1 + other.m_derivative1};
+      left.primal + right.primal, left.derivative1 + right.derivative1};
 }
 
 template <class Underlying>
-requires Number<Underlying> Num2<Underlying> Num2<Underlying>::operator-(
-    const Num2<Underlying>& other) const {
+requires Number<Underlying> Num2<Underlying>
+operator-(const Num2<Underlying>& left, const Num2<Underlying>& right) {
   return Num2<Underlying>{
-      this->m_primal - other.m_primal,
-      this->m_derivative1 - other.m_derivative1};
+      left.primal - right.primal, left.derivative1 - right.derivative1};
 }
 
 template <class Underlying>
-requires Number<Underlying> Num2<Underlying> Num2<Underlying>::operator-()
-    const {
-  return Num2<Underlying>{-this->m_primal, -this->m_derivative1};
+requires Number<Underlying> Num2<Underlying>
+operator-(const Num2<Underlying>& x) {
+  return Num2<Underlying>{-x.primal, -x.derivative1};
 }
 
 template <class Underlying>
-requires Number<Underlying> Num2<Underlying> Num2<Underlying>::operator*(
-    const Num2<Underlying>& other) const {
+requires Number<Underlying> Num2<Underlying>
+operator*(const Num2<Underlying>& left, const Num2<Underlying>& right) {
   return Num2<Underlying>{
-      this->m_primal * other.m_primal,
-      this->m_primal * other.m_derivative1 +
-          this->m_derivative1 * other.m_primal};
+      left.primal * right.primal,
+      left.primal * right.derivative1 + left.derivative1 * right.primal};
 }
 
 template <class Underlying>
-requires Number<Underlying> Num2<Underlying> Num2<Underlying>::operator/(
-    const Num2<Underlying>& other) const {
+requires Number<Underlying> Num2<Underlying>
+operator/(const Num2<Underlying>& left, const Num2<Underlying>& right) {
   // a / b
-  Underlying new_primal = this->m_primal / other.m_primal;
+  Underlying new_primal = left.primal / right.primal;
 
   // Using https://www.wolframalpha.com/
   // D[a(x) / b(x), x] -> (b[x] a'[x] - a[x] b'[x])/b[x]^2
-  auto other2 = other.m_primal * other.m_primal;
-  Underlying new_derivative1 = (other.m_primal * this->m_derivative1 -
-                                this->m_primal * other.m_derivative1) /
+  auto other2 = right.primal * right.primal;
+  Underlying new_derivative1 =
+      (right.primal * left.derivative1 - left.primal * right.derivative1) /
       other2;
   return Num2<Underlying>{new_primal, new_derivative1};
 }
 
 template <class Underlying>
-requires Number<Underlying> Num2<Underlying> Num2<Underlying>::pow(
-    const Num2<Underlying>& other)
-const {
+requires Number<Underlying> Num2<Underlying> pow(
+    const Num2<Underlying>& base,
+    const Num2<Underlying>& exponent) {
   double power;
   // shortcut some cases.
-  if (other.is_constant(power)) {
+  if (is_constant(exponent, power)) {
     if (power == 0)
       return 1;
     if (power == 1)
-      return *this;
+      return base;
   }
 
-  const Underlying new_primal = this->m_primal.pow(other.m_primal);
+  const Underlying new_primal = pow(base.primal, exponent.primal);
 
   // From https://www.wolframalpha.com/
   // D[a(x) ^ (b(x)), x] ->
@@ -175,116 +127,110 @@ const {
   // We avoid using the log (e.g. of a negative number) when not needed.
   // t0 = a[x] Log[a[x]] b'[x]
   const Underlying t0 =
-      other.m_derivative1.is_constant(0) || this->m_primal.is_constant(0)
+      is_constant(exponent.derivative1, 0) || is_constant(base.primal, 0)
       ? 0
-      : this->m_primal * this->m_primal.log() * other.m_derivative1;
+      : base.primal * log(base.primal) * exponent.derivative1;
 
   // b[x] * a'[x] + a[x] Log[a[x]] b'[x]
-  const Underlying x0 = other.m_primal * this->m_derivative1 + t0;
+  const Underlying x0 = exponent.primal * base.derivative1 + t0;
 
   // a[x]^(b[x] - 1) (b[x] a'[x] + a[x] Log[a[x]] b'[x])
-  Underlying new_derivative1 = x0 * this->m_primal.pow(other.m_primal - 1);
+  Underlying new_derivative1 = x0 * pow(base.primal, exponent.primal - 1);
 
   return Num2<Underlying>{new_primal, new_derivative1};
 }
 
 template <class Underlying>
-requires Number<Underlying> Num2<Underlying> Num2<Underlying>::exp()
-const {
-  Underlying new_primal = this->m_primal.exp();
-  Underlying new_derivative1 = new_primal * this->m_derivative1;
+requires Number<Underlying> Num2<Underlying> exp(const Num2<Underlying>& x) {
+  Underlying new_primal = exp(x.primal);
+  Underlying new_derivative1 = new_primal * x.derivative1;
   return Num2<Underlying>{new_primal, new_derivative1};
 }
 
 template <class Underlying>
-requires Number<Underlying> Num2<Underlying> Num2<Underlying>::log()
-const {
-  Underlying new_primal = this->m_primal.log();
-  Underlying new_derivative1 = this->m_derivative1 / this->m_primal;
+requires Number<Underlying> Num2<Underlying> log(const Num2<Underlying>& x) {
+  Underlying new_primal = log(x.primal);
+  Underlying new_derivative1 = x.derivative1 / x.primal;
   return Num2<Underlying>{new_primal, new_derivative1};
 }
 
 template <class Underlying>
-requires Number<Underlying> Num2<Underlying> Num2<Underlying>::atan()
-const {
-  Underlying new_primal = this->m_primal.atan();
-  Underlying new_derivative1 =
-      this->m_derivative1 / (this->m_primal * this->m_primal + 1.0f);
+requires Number<Underlying> Num2<Underlying> atan(const Num2<Underlying>& x) {
+  Underlying new_primal = atan(x.primal);
+  Underlying new_derivative1 = x.derivative1 / (x.primal * x.primal + 1.0f);
   return Num2<Underlying>{new_primal, new_derivative1};
 }
 
 template <class Underlying>
-requires Number<Underlying> Num2<Underlying> Num2<Underlying>::lgamma()
-const {
-  Underlying new_primal = this->m_primal.lgamma();
-  Underlying new_derivative1 =
-      this->m_derivative1 * this->m_primal.polygamma(0);
+requires Number<Underlying> Num2<Underlying> lgamma(const Num2<Underlying>& x) {
+  Underlying new_primal = lgamma(x.primal);
+  Underlying new_derivative1 = x.derivative1 * polygamma(0, x.primal);
   return Num2<Underlying>{new_primal, new_derivative1};
 }
 
 template <class Underlying>
-requires Number<Underlying> Num2<Underlying> Num2<Underlying>::polygamma(
-    double n)
-const {
-  Underlying new_primal = this->m_primal.polygamma(n);
-  Underlying new_derivative1 =
-      this->m_derivative1 * this->m_primal.polygamma(n + 1);
+requires Number<Underlying> Num2<Underlying> polygamma(
+    int n,
+    const Num2<Underlying>& x) {
+  Underlying new_primal = polygamma(n, x.primal);
+  Underlying new_derivative1 = x.derivative1 * polygamma(n + 1, x.primal);
   return Num2<Underlying>{new_primal, new_derivative1};
 }
 
 template <class Underlying>
-requires Number<Underlying> Num2<Underlying> Num2<Underlying>::if_equal(
+requires Number<Underlying> Num2<Underlying> if_equal(
+    const Num2<Underlying>& value,
     const Num2<Underlying>& comparand,
     const Num2<Underlying>& when_equal,
-    const Num2<Underlying>& when_not_equal)
-const {
-  // Note: we discard and ignore this->m_derivative1 and
-  // comparand->m_derivative1
-  Underlying new_primal = this->m_primal.if_equal(
-      comparand.m_primal, when_equal.m_primal, when_not_equal.m_primal);
-  Underlying new_derivative1 = this->m_primal.if_equal(
-      comparand.m_primal,
-      when_equal.m_derivative1,
-      when_not_equal.m_derivative1);
+    const Num2<Underlying>& when_not_equal) {
+  // Note: we discard and ignore left.derivative1 and
+  // comparand->derivative1
+  Underlying new_primal = if_equal(
+      value.primal, comparand.primal, when_equal.primal, when_not_equal.primal);
+  Underlying new_derivative1 = if_equal(
+      value.primal,
+      comparand.primal,
+      when_equal.derivative1,
+      when_not_equal.derivative1);
   return Num2<Underlying>{new_primal, new_derivative1};
 }
 
 template <class Underlying>
-requires Number<Underlying> Num2<Underlying> Num2<Underlying>::if_less(
+requires Number<Underlying> Num2<Underlying> if_less(
+    const Num2<Underlying>& value,
     const Num2<Underlying>& comparand,
     const Num2<Underlying>& when_less,
-    const Num2<Underlying>& when_not_less)
-const {
-  // Note: we discard and ignore this->m_derivative1 and
-  // comparand->m_derivative1
-  Underlying new_primal = this->m_primal.if_less(
-      comparand.m_primal, when_less.m_primal, when_not_less.m_primal);
-  Underlying new_derivative1 = this->m_primal.if_less(
-      comparand.m_primal, when_less.m_derivative1, when_not_less.m_derivative1);
+    const Num2<Underlying>& when_not_less) {
+  // Note: we discard and ignore left.derivative1 and
+  // comparand->derivative1
+  Underlying new_primal = if_less(
+      value.primal, comparand.primal, when_less.primal, when_not_less.primal);
+  Underlying new_derivative1 = if_less(
+      value.primal,
+      comparand.primal,
+      when_less.derivative1,
+      when_not_less.derivative1);
   return Num2<Underlying>{new_primal, new_derivative1};
 }
 
 template <class Underlying>
 requires Number<Underlying>
-bool Num2<Underlying>::is_constant(double& value) const {
-  return this->m_derivative1.is_constant(0) &&
-      this->m_primal.is_constant(value);
+bool is_constant(const Num2<Underlying>& x, double& value) {
+  return is_constant(x.derivative1, 0) && is_constant(x.primal, value);
 }
 
 template <class Underlying>
 requires Number<Underlying>
-bool Num2<Underlying>::is_constant(const double& value) const {
-  return this->m_derivative1.is_constant(0) &&
-      this->m_primal.is_constant(value);
+bool is_constant(const Num2<Underlying>& x, const double& value) {
+  return is_constant(x.derivative1, 0) && is_constant(x.primal, value);
 }
 
 template <class Underlying>
-requires Number<Underlying> std::string Num2<Underlying>::to_string()
-const {
+requires Number<Underlying> std::string to_string(const Num2<Underlying>& x) {
   return fmt::format(
       "[primal={0}, derivative={1}]",
-      this->m_primal.to_string(),
-      this->m_derivative1.to_string);
+      to_string(x.primal),
+      to_string(x.derivative1));
 }
 
 static_assert(Number<Num2<Real>>);

--- a/minibmg/ad/num3.h
+++ b/minibmg/ad/num3.h
@@ -25,156 +25,102 @@ namespace beanmachine::minibmg {
 template <class Underlying>
 requires Number<Underlying>
 class Num3 {
- private:
-  Underlying m_primal, m_derivative1, m_derivative2;
-
  public:
+  Underlying primal;
+  Underlying derivative1;
+  Underlying derivative2;
+
   /* implicit */ Num3(double primal);
   /* implicit */ Num3(Underlying primal);
   Num3(Underlying primal, Underlying derivative1, Underlying derivative2);
   Num3(const Num3<Underlying>& other);
-  Num3<Underlying>& operator=(const Num3<Underlying>& other);
-  Underlying primal() const;
-  Underlying derivative1() const;
-  Underlying derivative2() const;
+  Num3<Underlying>& operator=(const Num3<Underlying>& other) = default;
   double as_double() const;
-  Num3<Underlying> operator+(const Num3<Underlying>& other) const;
-  Num3<Underlying> operator-(const Num3<Underlying>& other) const;
-  Num3<Underlying> operator-() const;
-  Num3<Underlying> operator*(const Num3<Underlying>& other) const;
-  Num3<Underlying> operator/(const Num3<Underlying>& other) const;
-  Num3<Underlying> pow(const Num3<Underlying>& other) const;
-  Num3<Underlying> exp() const;
-  Num3<Underlying> log() const;
-  Num3<Underlying> atan() const;
-  Num3<Underlying> lgamma() const;
-  Num3<Underlying> polygamma(double n) const;
-  Num3<Underlying> if_equal(
-      const Num3<Underlying>& comparand,
-      const Num3<Underlying>& when_equal,
-      const Num3<Underlying>& when_not_equal) const;
-  Num3<Underlying> if_less(
-      const Num3<Underlying>& comparand,
-      const Num3<Underlying>& when_less,
-      const Num3<Underlying>& when_not_less) const;
-  bool is_constant(double& value) const;
-  bool is_constant(const double& value) const;
-  std::string to_string() const;
 };
 
 template <class Underlying>
 requires Number<Underlying> Num3<Underlying>::Num3(double primal)
-    : m_primal{primal}, m_derivative1{0}, m_derivative2{0} {}
+    : primal{primal}, derivative1{0}, derivative2{0} {}
 
 template <class Underlying>
 requires Number<Underlying> Num3<Underlying>::Num3(Underlying primal)
-    : m_primal{primal}, m_derivative1{0}, m_derivative2{0} {}
+    : primal{primal}, derivative1{0}, derivative2{0} {}
 
 template <class Underlying>
 requires Number<Underlying> Num3<Underlying>::Num3(
     Underlying primal,
     Underlying derivative1,
     Underlying derivative2)
-    : m_primal{primal},
-      m_derivative1{derivative1},
-      m_derivative2{derivative2} {}
+    : primal{primal}, derivative1{derivative1}, derivative2{derivative2} {}
 
 template <class Underlying>
 requires Number<Underlying> Num3<Underlying>::Num3(
     const Num3<Underlying>& other)
-    : m_primal(other.m_primal),
-      m_derivative1(other.m_derivative1),
-      m_derivative2(other.m_derivative2) {}
-
-template <class Underlying>
-requires Number<Underlying> Num3<Underlying>
-&Num3<Underlying>::operator=(const Num3<Underlying>& other) {
-  this->m_primal = other.m_primal;
-  this->m_derivative1 = other.m_derivative1;
-  this->m_derivative2 = other.m_derivative2;
-  return *this;
-}
-
-template <class Underlying>
-requires Number<Underlying> Underlying Num3<Underlying>::primal()
-const {
-  return m_primal;
-}
-
-template <class Underlying>
-requires Number<Underlying> Underlying Num3<Underlying>::derivative1()
-const {
-  return m_derivative1;
-}
-
-template <class Underlying>
-requires Number<Underlying> Underlying Num3<Underlying>::derivative2()
-const {
-  return m_derivative2;
-}
+    : primal(other.primal),
+      derivative1(other.derivative1),
+      derivative2(other.derivative2) {}
 
 template <class Underlying>
 requires Number<Underlying>
 double Num3<Underlying>::as_double() const {
-  return m_primal.as_double();
+  return this->primal.as_double();
 }
 
 template <class Underlying>
-requires Number<Underlying> Num3<Underlying> Num3<Underlying>::operator+(
-    const Num3<Underlying>& other) const {
+requires Number<Underlying> Num3<Underlying>
+operator+(const Num3<Underlying>& left, const Num3<Underlying>& right) {
   return Num3<Underlying>{
-      this->m_primal + other.m_primal,
-      this->m_derivative1 + other.m_derivative1,
-      this->m_derivative2 + other.m_derivative2};
+      left.primal + right.primal,
+      left.derivative1 + right.derivative1,
+      left.derivative2 + right.derivative2};
 }
 
 template <class Underlying>
-requires Number<Underlying> Num3<Underlying> Num3<Underlying>::operator-(
-    const Num3<Underlying>& other) const {
+requires Number<Underlying> Num3<Underlying>
+operator-(const Num3<Underlying>& left, const Num3<Underlying>& right) {
   return Num3<Underlying>{
-      this->m_primal - other.m_primal,
-      this->m_derivative1 - other.m_derivative1,
-      this->m_derivative2 - other.m_derivative2};
+      left.primal - right.primal,
+      left.derivative1 - right.derivative1,
+      left.derivative2 - right.derivative2};
 }
 
 template <class Underlying>
-requires Number<Underlying> Num3<Underlying> Num3<Underlying>::operator-()
-    const {
-  return Num3<Underlying>{
-      -this->m_primal, -this->m_derivative1, -this->m_derivative2};
+requires Number<Underlying> Num3<Underlying>
+operator-(const Num3<Underlying>& x) {
+  return Num3<Underlying>{-x.primal, -x.derivative1, -x.derivative2};
 }
 
 template <class Underlying>
-requires Number<Underlying> Num3<Underlying> Num3<Underlying>::operator*(
-    const Num3<Underlying>& other) const {
+requires Number<Underlying> Num3<Underlying>
+operator*(const Num3<Underlying>& left, const Num3<Underlying>& right) {
   // a * b
-  Underlying new_primal = this->m_primal * other.m_primal;
+  Underlying new_primal = left.primal * right.primal;
   // Derivative: d/dx (a * b)
   //             = a' * b + b' * a (product rule)
-  Underlying new_derivative1 = this->m_derivative1 * other.m_primal +
-      other.m_derivative1 * this->m_primal;
+  Underlying new_derivative1 =
+      left.derivative1 * right.primal + right.derivative1 * left.primal;
   // Second derivative: d/dx d/dx (a * b)
   //             = d/dx (a' * b + a * b') (product rule)
   //             = d/dx (a' * b) + d/dx (a * b') // sum rule
   //             = (a'' * b + a' * b') + (a' * b' + a * b'') // product rule
   //             = a'' * b + 2 * a' * b' + a * b'' // gather terms
-  Underlying new_derivative2 = this->m_derivative2 * other.m_primal +
-      2 * this->m_derivative1 * other.m_derivative1 +
-      this->m_primal * other.m_derivative2;
+  Underlying new_derivative2 = left.derivative2 * right.primal +
+      2 * left.derivative1 * right.derivative1 +
+      left.primal * right.derivative2;
   return Num3<Underlying>{new_primal, new_derivative1, new_derivative2};
 }
 
 template <class Underlying>
-requires Number<Underlying> Num3<Underlying> Num3<Underlying>::operator/(
-    const Num3<Underlying>& other) const {
+requires Number<Underlying> Num3<Underlying>
+operator/(const Num3<Underlying>& left, const Num3<Underlying>& right) {
   // a / b
-  Underlying new_primal = this->m_primal / other.m_primal;
+  Underlying new_primal = left.primal / right.primal;
 
   // Using https://www.wolframalpha.com/
   // D[a(x) / b(x), x] -> (b[x] a'[x] - a[x] b'[x])/b[x]^2
-  auto other2 = other.m_primal * other.m_primal;
-  Underlying new_derivative1 = (other.m_primal * this->m_derivative1 -
-                                this->m_primal * other.m_derivative1) /
+  auto other2 = right.primal * right.primal;
+  Underlying new_derivative1 =
+      (right.primal * left.derivative1 - left.primal * right.derivative1) /
       other2;
 
   // D[a(x) / b(x), {x, 2}] ->
@@ -182,32 +128,32 @@ requires Number<Underlying> Num3<Underlying> Num3<Underlying>::operator/(
   //        b[x]^2 a''[x] -
   //        b[x] (2 a'[x] b'[x] + a[x] b''[x]))
   //              / b[x]^3
-  auto other3 = other2 * other.m_primal;
+  auto other3 = other2 * right.primal;
   Underlying new_derivative2 =
-      (2 * this->m_primal * other.m_derivative1 * other.m_derivative1 +
-       other2 * this->m_derivative2 -
-       other.m_primal *
-           (2 * this->m_derivative1 * other.m_derivative1 +
-            this->m_primal * other.m_derivative2)) /
+      (2 * left.primal * right.derivative1 * right.derivative1 +
+       other2 * left.derivative2 -
+       right.primal *
+           (2 * left.derivative1 * right.derivative1 +
+            left.primal * right.derivative2)) /
       other3;
 
   return Num3<Underlying>{new_primal, new_derivative1, new_derivative2};
 }
 
 template <class Underlying>
-requires Number<Underlying> Num3<Underlying> Num3<Underlying>::pow(
-    const Num3<Underlying>& other)
-const {
+requires Number<Underlying> Num3<Underlying> pow(
+    const Num3<Underlying>& base,
+    const Num3<Underlying>& exponent) {
   double power;
   // shortcut some cases.
-  if (this->is_constant(power)) {
+  if (is_constant(exponent, power)) {
     if (power == 0)
       return 1;
     if (power == 1)
-      return *this;
+      return base;
   }
 
-  const Underlying new_primal = this->m_primal.pow(other.m_primal);
+  const Underlying new_primal = pow(base.primal, exponent.primal);
 
   // From https://www.wolframalpha.com/
   // D[a(x) ^ (b(x)), x] ->
@@ -215,15 +161,14 @@ const {
   //        = a[x]^b[x] (b[x] a'[x] / a[x] + Log[a[x]] b'[x])
 
   // avoid using the log (e.g. of a negative number) when not needed.
-  const Underlying loga = this->m_primal.log();
+  const Underlying loga = log(base.primal);
 
   // Log[a[x]] b'[x]
   const Underlying t0 =
-      other.m_derivative1.is_constant(0) ? 0 : loga * other.m_derivative1;
+      is_constant(exponent.derivative1, 0) ? 0 : loga * exponent.derivative1;
 
   // b[x] * a'[x] / a[x] + Log[a[x]] b'[x]
-  const Underlying x0 =
-      other.m_primal * this->m_derivative1 / this->m_primal + t0;
+  const Underlying x0 = exponent.primal * base.derivative1 / base.primal + t0;
 
   // a[x]^b[x] (b[x] a'[x] / a[x] + Log[a[x]] b'[x])
   Underlying new_derivative1 = new_primal * x0;
@@ -236,22 +181,22 @@ const {
   //                     Log[a[x]] b''[x])
 
   // ((b[x] a'[x])/a[x] + Log[a[x]] b'[x])^2
-  const Underlying t1 = x0.pow(2);
+  const Underlying t1 = pow(x0, 2);
 
   // -((b[x] a'[x]^2)/a[x]^2)
   const Underlying t2 =
-      -(other.m_primal * this->m_derivative1.pow(2) / this->m_primal.pow(2));
+      -(exponent.primal * pow(base.derivative1, 2) / pow(base.primal, 2));
 
   // (2 a'[x] b'[x])/a[x]
   const Underlying t3 =
-      2 * other.m_derivative1 * this->m_derivative1 / this->m_primal;
+      2 * exponent.derivative1 * base.derivative1 / base.primal;
 
   // (b[x] a''[x])/a[x]
-  const Underlying t4 = other.m_primal * this->m_derivative2 / this->m_primal;
+  const Underlying t4 = exponent.primal * base.derivative2 / base.primal;
 
   // Log[a[x]] b''[x]
   const Underlying t5 =
-      other.m_derivative2.is_constant(0) ? 0 : loga * other.m_derivative2;
+      is_constant(exponent.derivative2, 0) ? 0 : loga * exponent.derivative2;
 
   const Underlying new_derivative2 = new_primal * (t1 + t2 + t3 + t4 + t5);
 
@@ -259,51 +204,45 @@ const {
 }
 
 template <class Underlying>
-requires Number<Underlying> Num3<Underlying> Num3<Underlying>::exp()
-const {
-  const Underlying new_primal = this->m_primal.exp();
-  const Underlying new_derivative1 = new_primal * this->m_derivative1;
-  const Underlying new_derivative2 = (new_primal * this->m_derivative2) +
-      (this->m_derivative1 * new_derivative1);
+requires Number<Underlying> Num3<Underlying> exp(const Num3<Underlying>& x) {
+  const Underlying new_primal = exp(x.primal);
+  const Underlying new_derivative1 = new_primal * x.derivative1;
+  const Underlying new_derivative2 =
+      (new_primal * x.derivative2) + (x.derivative1 * new_derivative1);
   return Num3<Underlying>{new_primal, new_derivative1, new_derivative2};
 }
 
 template <class Underlying>
-requires Number<Underlying> Num3<Underlying> Num3<Underlying>::log()
-const {
-  const Underlying new_primal = this->m_primal.log();
-  const Underlying new_derivative1 = this->m_derivative1 / this->m_primal;
-  const Underlying new_derivative2 = (this->m_derivative2 / this->m_primal) -
-      (this->m_derivative1 * (this->m_derivative1 * this->m_primal.pow(-2.0f)));
+requires Number<Underlying> Num3<Underlying> log(const Num3<Underlying>& x) {
+  const Underlying new_primal = log(x.primal);
+  const Underlying new_derivative1 = x.derivative1 / x.primal;
+  const Underlying new_derivative2 = (x.derivative2 / x.primal) -
+      (x.derivative1 * (x.derivative1 * pow(x.primal, -2.0f)));
   return Num3<Underlying>{new_primal, new_derivative1, new_derivative2};
 }
 
 template <class Underlying>
-requires Number<Underlying> Num3<Underlying> Num3<Underlying>::atan()
-const {
-  const Underlying new_primal = this->m_primal.atan();
+requires Number<Underlying> Num3<Underlying> atan(const Num3<Underlying>& x) {
+  const Underlying new_primal = atan(x.primal);
 
   // D[ArcTan[f[x]], x] ->
   //        f'[x]/(1 + f[x]^2)
 
   // (1 + f[x]^2)
-  auto t1 = 1 + this->m_primal.pow(2);
+  auto t1 = 1 + pow(x.primal, 2);
   // f'[x]/(1 + f[x]^2)
-  const Underlying new_derivative1 = this->m_derivative1 / t1;
+  const Underlying new_derivative1 = x.derivative1 / t1;
 
   // D[ArcTan[f[x]], {x, 2}] ->
   //        (-2 f[x] f'[x]^2 + (1 + f[x]^2) f''[x])/(1 + f[x]^2)^2
   const Underlying new_derivative2 =
-      (-2 * this->m_primal * this->m_derivative1.pow(2) +
-       t1 * this->m_derivative2) /
-      t1.pow(2);
+      (-2 * x.primal * pow(x.derivative1, 2) + t1 * x.derivative2) / pow(t1, 2);
 
   return Num3<Underlying>{new_primal, new_derivative1, new_derivative2};
 }
 
 template <class Underlying>
-requires Number<Underlying> Num3<Underlying> Num3<Underlying>::lgamma()
-const {
+requires Number<Underlying> Num3<Underlying> lgamma(const Num3<Underlying>& x) {
   // Note: First order chain rule:
   // d/dx[f(g(x))]
   //     = f’(g(x)) g’(x)
@@ -318,86 +257,91 @@ const {
   // Here f is lgamma, g is the value of the parameter to the function
   // being differentiated, and g' and g'' are the incoming gradients of
   // the value.
-  Underlying new_primal = this->m_primal.lgamma();
-  auto t1 = this->m_primal.polygamma(0); // f’(g(x))
-  Underlying new_derivative1 = this->m_derivative1 * t1;
+  Underlying new_primal = lgamma(x.primal);
+  auto t1 = polygamma(0, x.primal); // f’(g(x))
+  Underlying new_derivative1 = x.derivative1 * t1;
   Underlying new_derivative2 =
-      this->m_primal.polygamma(1) * this->m_derivative1 * this->m_derivative1 +
-      this->m_derivative2 * t1;
+      polygamma(1, x.primal) * x.derivative1 * x.derivative1 +
+      x.derivative2 * t1;
   return Num3<Underlying>{new_primal, new_derivative1, new_derivative2};
 }
 
 template <class Underlying>
-requires Number<Underlying> Num3<Underlying> Num3<Underlying>::polygamma(
-    double n)
-const {
-  Underlying new_primal = this->m_primal.polygamma(n);
-  auto t1 = this->m_primal.polygamma(n + 1);
-  Underlying new_derivative1 = this->m_derivative1 * t1;
-  Underlying new_derivative2 = this->m_primal.polygamma(n + 2) *
-          this->m_derivative1 * this->m_derivative1 +
-      this->m_derivative2 * t1;
+requires Number<Underlying> Num3<Underlying> polygamma(
+    int n,
+    const Num3<Underlying>& x) {
+  Underlying new_primal = polygamma(n, x.primal);
+  auto t1 = polygamma(n + 1, x.primal);
+  Underlying new_derivative1 = x.derivative1 * t1;
+  Underlying new_derivative2 =
+      polygamma(n + 2, x.primal) * x.derivative1 * x.derivative1 +
+      x.derivative2 * t1;
   return Num3<Underlying>{new_primal, new_derivative1, new_derivative2};
 }
 
 template <class Underlying>
-requires Number<Underlying> Num3<Underlying> Num3<Underlying>::if_equal(
+requires Number<Underlying> Num3<Underlying> if_equal(
+    const Num3<Underlying>& value,
     const Num3<Underlying>& comparand,
     const Num3<Underlying>& when_equal,
-    const Num3<Underlying>& when_not_equal)
-const {
-  // Note: we discard and ignore this->derivative* and comparand->derivative*
-  Underlying new_primal = this->m_primal.if_equal(
-      comparand.m_primal, when_equal.m_primal, when_not_equal.m_primal);
-  Underlying new_derivative1 = this->m_primal.if_equal(
-      comparand.m_primal,
-      when_equal.m_derivative1,
-      when_not_equal.m_derivative1);
-  Underlying new_derivative2 = this->m_primal.if_equal(
-      comparand.m_primal,
-      when_equal.m_derivative2,
-      when_not_equal.m_derivative2);
+    const Num3<Underlying>& when_not_equal) {
+  // Note: we discard and ignore left.derivative* and comparand->derivative*
+  Underlying new_primal = if_equal(
+      value.primal, comparand.primal, when_equal.primal, when_not_equal.primal);
+  Underlying new_derivative1 = if_equal(
+      value.primal,
+      comparand.primal,
+      when_equal.derivative1,
+      when_not_equal.derivative1);
+  Underlying new_derivative2 = if_equal(
+      value.primal,
+      comparand.primal,
+      when_equal.derivative2,
+      when_not_equal.derivative2);
   return Num3<Underlying>{new_primal, new_derivative1, new_derivative2};
 }
 
 template <class Underlying>
-requires Number<Underlying> Num3<Underlying> Num3<Underlying>::if_less(
+requires Number<Underlying> Num3<Underlying> if_less(
+    const Num3<Underlying>& value,
     const Num3<Underlying>& comparand,
     const Num3<Underlying>& when_less,
-    const Num3<Underlying>& when_not_less)
-const {
-  // Note: we discard and ignore this->derivative* and comparand->derivative*
-  Underlying new_primal = this->m_primal.if_less(
-      comparand.m_primal, when_less.m_primal, when_not_less.m_primal);
-  Underlying new_derivative1 = this->m_primal.if_less(
-      comparand.m_primal, when_less.m_derivative1, when_not_less.m_derivative1);
-  Underlying new_derivative2 = this->m_primal.if_less(
-      comparand.m_primal, when_less.m_derivative2, when_not_less.m_derivative2);
+    const Num3<Underlying>& when_not_less) {
+  // Note: we discard and ignore left.derivative* and comparand->derivative*
+  Underlying new_primal = if_less(
+      value.primal, comparand.primal, when_less.primal, when_not_less.primal);
+  Underlying new_derivative1 = if_less(
+      value.primal,
+      comparand.primal,
+      when_less.derivative1,
+      when_not_less.derivative1);
+  Underlying new_derivative2 = if_less(
+      value.primal,
+      comparand.primal,
+      when_less.derivative2,
+      when_not_less.derivative2);
   return Num3<Underlying>{new_primal, new_derivative1, new_derivative2};
 }
 
 template <class Underlying>
 requires Number<Underlying>
-bool Num3<Underlying>::is_constant(double& value) const {
-  return this->m_derivative1.is_constant(0) &&
-      this->m_primal.is_constant(value);
+bool is_constant(const Num3<Underlying>& x, double& value) {
+  return is_constant(x.derivative1, 0) && is_constant(x.primal, value);
 }
 
 template <class Underlying>
 requires Number<Underlying>
-bool Num3<Underlying>::is_constant(const double& value) const {
-  return this->m_derivative1.is_constant(0) &&
-      this->m_primal.is_constant(value);
+bool is_constant(const Num3<Underlying>& x, const double& value) {
+  return is_constant(x.derivative1, 0) && x.primal.is_constant(value);
 }
 
 template <class Underlying>
-requires Number<Underlying> std::string Num3<Underlying>::to_string()
-const {
+requires Number<Underlying> std::string to_string(const Num3<Underlying>& x) {
   return fmt::format(
       "[primal={0}, derivative={1}, derivative2={2}]",
-      this->m_primal.to_string(),
-      this->m_derivative1.to_string(),
-      this->m_derivative2.to_string());
+      x.primal.to_string(),
+      x.derivative1.to_string(),
+      x.derivative2.to_string());
 }
 
 static_assert(Number<Num3<Real>>);

--- a/minibmg/ad/number.h
+++ b/minibmg/ad/number.h
@@ -16,7 +16,13 @@ namespace beanmachine::minibmg {
 // a Number.  A type T satisfies the concept Number<T> if it supports
 // all of the following operations.
 template <typename T>
-concept Number = requires(T a, T b, T c, T d, double n) {
+concept Number = requires(
+    const T& a,
+    const T& b,
+    const T& c,
+    const T& d,
+    int n,
+    double dbl) {
   // there should be a conversion from double to T.
   std::convertible_to<double, T>;
   // it should support the arithmetic oeprators.
@@ -26,52 +32,70 @@ concept Number = requires(T a, T b, T c, T d, double n) {
   { (a * b) } -> std::convertible_to<T>;
   { a / b } -> std::convertible_to<T>;
   // it should support the following transcendental operations.
-  { a.pow(b) } -> std::convertible_to<T>;
-  { a.exp() } -> std::convertible_to<T>;
-  { a.log() } -> std::convertible_to<T>;
-  { a.atan() } -> std::convertible_to<T>;
-  { a.lgamma() } -> std::convertible_to<T>;
-  { a.polygamma(n) } -> std::convertible_to<T>;
+  { pow(a, b) } -> std::convertible_to<T>;
+  { exp(a) } -> std::convertible_to<T>;
+  { log(a) } -> std::convertible_to<T>;
+  { atan(a) } -> std::convertible_to<T>;
+  { lgamma(a) } -> std::convertible_to<T>;
+  { polygamma(n, a) } -> std::convertible_to<T>;
   // conditional for equality, less-than.
-  { a.if_equal(b, c, d) } -> std::convertible_to<T>;
-  { a.if_less(b, c, d) } -> std::convertible_to<T>;
+  { if_equal(a, b, c, d) } -> std::convertible_to<T>;
+  { if_less(a, b, c, d) } -> std::convertible_to<T>;
   // There should be a conservative (meaning it may return false even when
   // a number satisfies the test) way to sometimes know if a value is exactly
   // a constant.
-  { a.is_constant(n) } -> std::same_as<bool>;
-  { a.to_string() } -> std::same_as<std::string>;
+  { is_constant(a, dbl) } -> std::same_as<bool>;
+  { to_string(a) } -> std::same_as<std::string>;
 };
 
-// Support binary operators with double on the left.
-
 template <typename T>
-requires Number<T>
-inline T operator+(double a, T b) {
-  return T(a) + b;
+requires Number<T> T operator+(double l, const T& r) {
+  return T{l} + r;
 }
 
 template <typename T>
-requires Number<T>
-inline T operator-(double a, T b) {
-  return T(a) - b;
+requires Number<T> T operator+(const T& l, double r) {
+  return l + T{r};
 }
 
 template <typename T>
-requires Number<T>
-inline T operator*(double a, T b) {
-  return T(a) * b;
+requires Number<T> T operator-(double l, const T& r) {
+  return T{l} - r;
 }
 
 template <typename T>
-requires Number<T>
-inline T operator/(double a, T b) {
-  return T(a) / b;
+requires Number<T> T operator-(const T& l, double r) {
+  return l - T{r};
 }
 
 template <typename T>
-requires Number<T>
-inline T pow(double a, T b) {
-  return T(a).pow(b);
+requires Number<T> T operator*(double l, const T& r) {
+  return T{l} * r;
+}
+
+template <typename T>
+requires Number<T> T operator*(const T& l, double r) {
+  return l * T{r};
+}
+
+template <typename T>
+requires Number<T> T operator/(double l, const T& r) {
+  return T{l} / r;
+}
+
+template <typename T>
+requires Number<T> T operator/(const T& l, double r) {
+  return l / T{r};
+}
+
+template <typename T>
+requires Number<T> T pow(double l, const T& r) {
+  return pow(T{l}, r);
+}
+
+template <typename T>
+requires Number<T> T pow(const T& l, double r) {
+  return pow(l, T{r});
 }
 
 } // namespace beanmachine::minibmg

--- a/minibmg/ad/real.h
+++ b/minibmg/ad/real.h
@@ -23,75 +23,80 @@ namespace beanmachine::minibmg {
  * a double that implements the Number concept.
  */
 class Real {
- private:
+ public:
   double value;
 
- public:
   INLINE double as_double() const {
     return value;
   }
   /* implicit */ inline Real(double value) : value{value} {}
   INLINE Real& operator=(const Real&) = default;
-  INLINE Real operator+(Real other) const {
-    return this->value + other.value;
-  }
-  INLINE Real operator-(Real other) const {
-    return this->value - other.value;
-  }
-  INLINE Real operator-() const {
-    return -this->value;
-  }
-  INLINE Real operator*(Real other) const {
-    return this->value * other.value;
-  }
-  INLINE Real operator/(Real other) const {
-    return this->value / other.value;
-  }
-  INLINE Real pow(Real other) const {
-    return std::pow(this->value, other.value);
-  }
-  INLINE Real exp() const {
-    return std::exp(this->value);
-  }
-  INLINE Real log() const {
-    return std::log(this->value);
-  }
-  INLINE Real atan() const {
-    return std::atan(this->value);
-  }
-  INLINE Real lgamma() const {
-    return std::lgamma(this->value);
-  }
-  INLINE Real polygamma(Real other) const {
-    // Note the order of operands here.
-    return boost::math::polygamma(other.value, this->value);
-  }
-  template <class T>
-  INLINE const T&
-  if_equal(Real comparand, const T& when_equal, const T& when_not_equal) const {
-    return (this->value == comparand.value) ? when_equal : when_not_equal;
-  }
-  template <class T>
-  INLINE const T&
-  if_less(Real comparand, const T& when_less, const T& when_not_less) const {
-    return (this->value < comparand.value) ? when_less : when_not_less;
-  }
-  INLINE bool is_constant(double& value) const {
-    value = this->value;
-    return true;
-  }
-  INLINE bool is_constant(const double& value) const {
-    double v = 0;
-    return is_constant(v) && v == value;
-  }
-  inline std::string to_string() const {
-    // The behavior of std::to_string(double) is that it uses a fixed number of
-    // digits of precision.  We would prefer to use the minimum number of digits
-    // that round-trips to the same value, so we use fmt::format.
-    return fmt::format("{0}", value);
-  }
 };
 
-static_assert(Number<Real>);
+INLINE Real operator+(const Real left, const Real right) {
+  return left.value + right.value;
+}
+INLINE Real operator-(const Real left, const Real right) {
+  return left.value - right.value;
+}
+INLINE Real operator-(const Real x) {
+  return -x.value;
+}
+INLINE Real operator*(const Real left, const Real right) {
+  return left.value * right.value;
+}
+INLINE Real operator/(const Real left, const Real right) {
+  return left.value / right.value;
+}
+INLINE Real pow(const Real left, const Real right) {
+  return std::pow(left.value, right.value);
+}
+INLINE Real exp(const Real x) {
+  return std::exp(x.value);
+}
+INLINE Real log(const Real x) {
+  return std::log(x.value);
+}
+INLINE Real atan(const Real x) {
+  return std::atan(x.value);
+}
+INLINE Real lgamma(const Real x) {
+  return std::lgamma(x.value);
+}
+INLINE Real polygamma(const int n, const Real x) {
+  return boost::math::polygamma(n, x.value);
+}
+template <class T>
+INLINE const T& if_equal(
+    const Real value,
+    const Real comparand,
+    const T& when_equal,
+    const T& when_not_equal) {
+  return (value.value == comparand.value) ? when_equal : when_not_equal;
+}
+template <class T>
+INLINE const T& if_less(
+    const Real value,
+    const Real comparand,
+    const T& when_less,
+    const T& when_not_less) {
+  return (value.value < comparand.value) ? when_less : when_not_less;
+}
+INLINE bool is_constant(const Real x, double& value) {
+  value = x.value;
+  return true;
+}
+INLINE bool is_constant(const Real x, const double& value) {
+  double v = 0;
+  return is_constant(x, v) && v == value;
+}
+inline std::string to_string(const Real x) {
+  // The behavior of std::to_string(double) is that it uses a fixed number of
+  // digits of precision.  We would prefer to use the minimum number of digits
+  // that round-trips to the same value, so we use fmt::format.
+  return fmt::format("{0}", x.value);
+}
+
+static_assert(Number<const Real>);
 
 } // namespace beanmachine::minibmg

--- a/minibmg/ad/tests/num2_test.cpp
+++ b/minibmg/ad/tests/num2_test.cpp
@@ -17,98 +17,98 @@ using namespace beanmachine::minibmg;
 using Dual = Num2<Real>;
 
 TEST(num2_test, convert) {
-  Dual d0{0};
-  EXPECT_TRUE(d0.is_constant(0));
-  EXPECT_FALSE(d0.is_constant(1));
-  Dual d1(1);
-  EXPECT_FALSE(d1.is_constant(0));
-  EXPECT_TRUE(d1.is_constant(1));
-  Dual d2(2);
-  EXPECT_FALSE(d2.is_constant(1));
-  EXPECT_FALSE(d2.is_constant(1));
+  const Dual d0{0};
+  EXPECT_TRUE(is_constant(d0, 0));
+  EXPECT_FALSE(is_constant(d0, 1));
+  const Dual d1(1);
+  EXPECT_FALSE(is_constant(d1, 0));
+  EXPECT_TRUE(is_constant(d1, 1));
+  const Dual d2(2);
+  EXPECT_FALSE(is_constant(d2, 0));
+  EXPECT_FALSE(is_constant(d2, 1));
 }
 
 TEST(num2_test, grad1) {
-  Dual d0{0, 1};
-  EXPECT_FALSE(d0.is_constant(0));
-  EXPECT_FALSE(d0.is_constant(1));
-  Dual d1(1, 1);
-  EXPECT_FALSE(d1.is_constant(0));
-  EXPECT_FALSE(d1.is_constant(1));
-  Dual d2(2, 1);
-  EXPECT_FALSE(d2.is_constant(0));
-  EXPECT_FALSE(d2.is_constant(1));
+  const Dual d0{0, 1};
+  EXPECT_FALSE(is_constant(d0, 0));
+  EXPECT_FALSE(is_constant(d0, 1));
+  const Dual d1(1, 1);
+  EXPECT_FALSE(is_constant(d1, 0));
+  EXPECT_FALSE(is_constant(d1, 1));
+  const Dual d2(2, 1);
+  EXPECT_FALSE(is_constant(d2, 0));
+  EXPECT_FALSE(is_constant(d2, 1));
 }
 
 TEST(num2_test, grad2) {
-  Dual d0{0, 0};
-  EXPECT_TRUE(d0.is_constant(0));
-  EXPECT_FALSE(d0.is_constant(1));
-  Dual d1(1, 0);
-  EXPECT_FALSE(d1.is_constant(0));
-  EXPECT_TRUE(d1.is_constant(1));
-  Dual d2(2, 0);
-  EXPECT_FALSE(d2.is_constant(0));
-  EXPECT_FALSE(d2.is_constant(1));
+  const Dual d0{0, 0};
+  EXPECT_TRUE(is_constant(d0, 0));
+  EXPECT_FALSE(is_constant(d0, 1));
+  const Dual d1(1, 0);
+  EXPECT_FALSE(is_constant(d1, 0));
+  EXPECT_TRUE(is_constant(d1, 1));
+  const Dual d2(2, 0);
+  EXPECT_FALSE(is_constant(d2, 0));
+  EXPECT_FALSE(is_constant(d2, 1));
 }
 
 TEST(num2_test, add1) {
   Dual a{1.1, 2.2};
   Dual b(3.3, 4.4);
   Dual sum = a + b;
-  EXPECT_CLOSE(4.4, sum.primal().as_double());
-  EXPECT_CLOSE(6.6, sum.derivative1().as_double());
+  EXPECT_CLOSE(4.4, sum.primal.as_double());
+  EXPECT_CLOSE(6.6, sum.derivative1.as_double());
 }
 
 TEST(num2_test, add2) {
   Dual a{1.1, 2.2};
-  Dual sum = a + 4;
-  EXPECT_CLOSE(5.1, sum.primal().as_double());
-  EXPECT_CLOSE(2.2, sum.derivative1().as_double());
+  Dual sum = a + 4.0;
+  EXPECT_CLOSE(5.1, sum.primal.as_double());
+  EXPECT_CLOSE(2.2, sum.derivative1.as_double());
 }
 
 TEST(num2_test, sub1) {
   Dual a{1.1, 2.2};
   Dual b(3.3, 4.4);
   Dual diff = b - a;
-  EXPECT_CLOSE(2.2, diff.primal().as_double());
-  EXPECT_CLOSE(2.2, diff.derivative1().as_double());
+  EXPECT_CLOSE(2.2, diff.primal.as_double());
+  EXPECT_CLOSE(2.2, diff.derivative1.as_double());
 }
 
 TEST(num2_test, sub2) {
   Dual a{1.1, 2.2};
   Dual diff = a - 1;
-  EXPECT_CLOSE(0.1, diff.primal().as_double());
-  EXPECT_CLOSE(2.2, diff.derivative1().as_double());
+  EXPECT_CLOSE(0.1, diff.primal.as_double());
+  EXPECT_CLOSE(2.2, diff.derivative1.as_double());
 }
 
 TEST(num2_test, negate) {
   Dual a{1.1, 2.2};
   Dual neg = -a;
-  EXPECT_CLOSE(-1.1, neg.primal().as_double());
-  EXPECT_CLOSE(-2.2, neg.derivative1().as_double());
+  EXPECT_CLOSE(-1.1, neg.primal.as_double());
+  EXPECT_CLOSE(-2.2, neg.derivative1.as_double());
 }
 
 TEST(num2_test, mul1) {
   Dual a{1.1, 2.2};
   Dual b(3.3, 4.4);
   Dual prod = a * b;
-  EXPECT_CLOSE(1.1 * 3.3, prod.primal().as_double());
-  EXPECT_CLOSE(1.1 * 4.4 + 2.2 * 3.3, prod.derivative1().as_double());
+  EXPECT_CLOSE(1.1 * 3.3, prod.primal.as_double());
+  EXPECT_CLOSE(1.1 * 4.4 + 2.2 * 3.3, prod.derivative1.as_double());
 }
 
 TEST(num2_test, div1) {
   Dual a{1.1, 2.2};
   Dual b(3.3, 4.4);
   Dual prod = a / b;
-  EXPECT_CLOSE(1.0 / 3, prod.primal().as_double());
-  EXPECT_CLOSE(2.0 / 9, prod.derivative1().as_double());
+  EXPECT_CLOSE(1.0 / 3, prod.primal.as_double());
+  EXPECT_CLOSE(2.0 / 9, prod.derivative1.as_double());
 }
 
 TEST(num2_test, pow1) {
   Dual a{1.1, 2.2};
   Dual b(3.3, 4.4);
-  Dual pow = a.pow(b);
+  Dual p = pow(a, b);
   double expected_primal = std::pow(a.as_double(), b.as_double());
   // a^b = exp(b log a)
   // d/dx a^b
@@ -117,56 +117,56 @@ TEST(num2_test, pow1) {
   // = pow(a, b) * (b d/dx (log a) + d/dx (b) log a)
   // = pow(a, b) * (b a' / a + b' log a)
   double expected_grad1 = expected_primal *
-      (b.as_double() * a.derivative1().as_double() / a.as_double() +
-       b.derivative1().as_double() * std::log(a.as_double()));
-  EXPECT_CLOSE(expected_primal, pow.primal().as_double());
-  EXPECT_CLOSE(expected_grad1, pow.derivative1().as_double());
+      (b.as_double() * a.derivative1.as_double() / a.as_double() +
+       b.derivative1.as_double() * std::log(a.as_double()));
+  EXPECT_CLOSE(expected_primal, p.primal.as_double());
+  EXPECT_CLOSE(expected_grad1, p.derivative1.as_double());
 }
 
 TEST(num2_test, exp) {
   Dual a{1.1, 2.2};
-  Dual value = a.exp();
+  Dual value = exp(a);
   double expected_primal = std::exp(a.as_double());
-  double expected_grad1 = a.derivative1().as_double() * expected_primal;
-  EXPECT_CLOSE(expected_primal, value.primal().as_double());
-  EXPECT_CLOSE(expected_grad1, value.derivative1().as_double());
+  double expected_grad1 = a.derivative1.as_double() * expected_primal;
+  EXPECT_CLOSE(expected_primal, value.primal.as_double());
+  EXPECT_CLOSE(expected_grad1, value.derivative1.as_double());
 }
 
 TEST(num2_test, log) {
   Dual a{1.1, 2.3};
-  Dual value = a.log();
+  Dual value = log(a);
   double expected_primal = std::log(a.as_double());
-  double expected_grad1 = a.derivative1().as_double() / a.as_double();
-  EXPECT_CLOSE(expected_primal, value.primal().as_double());
-  EXPECT_CLOSE(expected_grad1, value.derivative1().as_double());
+  double expected_grad1 = a.derivative1.as_double() / a.as_double();
+  EXPECT_CLOSE(expected_primal, value.primal.as_double());
+  EXPECT_CLOSE(expected_grad1, value.derivative1.as_double());
 }
 
 TEST(num2_test, atan) {
   Dual a{1.1, 2.2};
-  Dual value = a.atan();
+  Dual value = atan(a);
   double expected_primal = std::atan(a.as_double());
-  double expected_grad1 = a.derivative1().as_double() /
-      (1 + a.primal().as_double() * a.primal().as_double());
-  EXPECT_CLOSE(expected_primal, value.primal().as_double());
-  EXPECT_CLOSE(expected_grad1, value.derivative1().as_double());
+  double expected_grad1 = a.derivative1.as_double() /
+      (1 + a.primal.as_double() * a.primal.as_double());
+  EXPECT_CLOSE(expected_primal, value.primal.as_double());
+  EXPECT_CLOSE(expected_grad1, value.derivative1.as_double());
 }
 
 TEST(num2_test, lgamma) {
   Dual a{1.1, 2.2};
-  Dual value = a.lgamma();
+  Dual value = lgamma(a);
   double expected_primal = std::lgamma(a.as_double());
   double expected_grad1 =
-      a.derivative1().as_double() * boost::math::polygamma(0, a.as_double());
-  EXPECT_CLOSE(expected_primal, value.primal().as_double());
-  EXPECT_CLOSE(expected_grad1, value.derivative1().as_double());
+      a.derivative1.as_double() * boost::math::polygamma(0, a.as_double());
+  EXPECT_CLOSE(expected_primal, value.primal.as_double());
+  EXPECT_CLOSE(expected_grad1, value.derivative1.as_double());
 }
 
 TEST(num2_test, polygamma) {
   Dual a{1.1, 2.2};
-  Dual value = a.polygamma(2);
+  Dual value = polygamma(2, a);
   double expected_primal = boost::math::polygamma(2, a.as_double());
   double expected_grad1 =
-      a.derivative1().as_double() * boost::math::polygamma(3, a.as_double());
-  EXPECT_CLOSE(expected_primal, value.primal().as_double());
-  EXPECT_CLOSE(expected_grad1, value.derivative1().as_double());
+      a.derivative1.as_double() * boost::math::polygamma(3, a.as_double());
+  EXPECT_CLOSE(expected_primal, value.primal.as_double());
+  EXPECT_CLOSE(expected_grad1, value.derivative1.as_double());
 }

--- a/minibmg/ad/tests/num3_test.cpp
+++ b/minibmg/ad/tests/num3_test.cpp
@@ -29,9 +29,9 @@ TEST(num3_test, division_denominator) {
   double k2 = 7.0;
   const Triune x{k1, 1, 0};
   const Triune& y = k2 / x;
-  EXPECT_CLOSE(k2 / k1, y.primal().as_double());
-  EXPECT_CLOSE(-(k2 / (k1 * k1)), y.derivative1().as_double());
-  EXPECT_CLOSE(2 * k2 / (k1 * k1 * k1), y.derivative2().as_double());
+  EXPECT_CLOSE(k2 / k1, y.primal.as_double());
+  EXPECT_CLOSE(-(k2 / (k1 * k1)), y.derivative1.as_double());
+  EXPECT_CLOSE(2 * k2 / (k1 * k1 * k1), y.derivative2.as_double());
 }
 
 template <class N>
@@ -47,20 +47,20 @@ requires Number<T> std::vector<BinaryFunction<T>> functions() {
       [](T a, T b) { return a - b; },
       [](T a, T b) { return a * b; },
       [](T a, T b) { return a / b; },
-      [](T a, T b) { return a.pow(b); },
-      [](T a, T b) { return (a + b).exp(); },
-      [](T a, T b) { return (a + b + 4).log(); },
-      [](T a, T b) { return (a + b).atan(); },
-      [](T a, T b) { return (a + b).lgamma(); },
-      [](T a, T b) { return (a + b).polygamma(0); },
-      [](T a, T b) { return (a + b).polygamma(1); },
-      [](T a, T b) { return (a + b).polygamma(2); },
-      [](T a, T b) { return (a + b).polygamma(3); },
-      [](T a, T b) { return a.if_equal(a, b, a); },
-      [](T a, T b) { return a.if_equal(b, b, a); },
-      [](T a, T b) { return a.if_less(b, a, b); },
-      [](T a, T b) { return b.if_less(a, b, a); },
-      [](T a, T b) { return (a.exp() + b.exp()).log(); },
+      [](T a, T b) { return pow(a, b); },
+      [](T a, T b) { return exp(a + b); },
+      [](T a, T b) { return log(a + b + 4); },
+      [](T a, T b) { return atan(a + b); },
+      [](T a, T b) { return lgamma(a + b); },
+      [](T a, T b) { return polygamma(0, a + b); },
+      [](T a, T b) { return polygamma(1, a + b); },
+      [](T a, T b) { return polygamma(2, a + b); },
+      [](T a, T b) { return polygamma(3, a + b); },
+      [](T a, T b) { return if_equal(a, a, b, a); },
+      [](T a, T b) { return if_equal(a, b, b, a); },
+      [](T a, T b) { return if_less(a, b, a, b); },
+      [](T a, T b) { return if_less(b, a, b, a); },
+      [](T a, T b) { return log(exp(a) + exp(b)); },
       [](T a, T b) {
         return 1.2 * a * a * a + 2.6 * a * a * b + 3.14 * a * b * b +
             4.41 * b * b * b;
@@ -108,12 +108,11 @@ TEST(num3_test, compare_to_num2) {
       const auto& d3 = f2(d1, d2);
 
       EXPECT_CLOSE(t3.as_double(), d3.as_double());
-      EXPECT_CLOSE(t3.derivative1().as_double(), d3.derivative1().as_double());
+      EXPECT_CLOSE(t3.derivative1.as_double(), d3.derivative1.as_double());
       EXPECT_CLOSE(
-          t3.derivative1().as_double(), d3.primal().derivative1().as_double());
+          t3.derivative1.as_double(), d3.primal.derivative1.as_double());
       EXPECT_CLOSE(
-          t3.derivative2().as_double(),
-          d3.derivative1().derivative1().as_double());
+          t3.derivative2.as_double(), d3.derivative1.derivative1.as_double());
     }
   }
 }

--- a/minibmg/ad/tests/real_test.cpp
+++ b/minibmg/ad/tests/real_test.cpp
@@ -45,23 +45,23 @@ TEST(real_test, computations) {
     EXPECT_RSAME(-r1, -d1);
     EXPECT_RSAME(r1 * r2, d1 * d2);
     EXPECT_RSAME(r1 / r2, d1 / d2);
-    EXPECT_RSAME((r1 + 2).pow(r2), std::pow(d1 + 2, d2));
-    EXPECT_RSAME(r1.exp(), std::exp(d1));
-    EXPECT_RSAME((r1 + 2).log(), std::log(d1 + 2));
-    EXPECT_RSAME(r1.atan(), std::atan(d1));
-    EXPECT_RSAME(r1.polygamma(0), boost::math::polygamma(0, d1));
-    EXPECT_RSAME(r1.polygamma(1), boost::math::polygamma(1, d1));
-    EXPECT_RSAME(r1.polygamma(2), boost::math::polygamma(2, d1));
-    EXPECT_RSAME(r1.if_equal(r1, r2, r3), d2);
-    EXPECT_RSAME(r1.if_equal(r2, r3, r4), d4);
-    EXPECT_RSAME(r1.if_less(r2, r3, r4), (d1 < d2) ? d3 : d4);
-    EXPECT_RSAME(r2.if_less(r1, r3, r4), (d2 < d1) ? d3 : d4);
+    EXPECT_RSAME(pow(r1 + 2, r2), std::pow(d1 + 2, d2));
+    EXPECT_RSAME(exp(r1), std::exp(d1));
+    EXPECT_RSAME(log(r1 + 2), std::log(d1 + 2));
+    EXPECT_RSAME(atan(r1), std::atan(d1));
+    EXPECT_RSAME(polygamma(0, r1), boost::math::polygamma(0, d1));
+    EXPECT_RSAME(polygamma(1, r1), boost::math::polygamma(1, d1));
+    EXPECT_RSAME(polygamma(2, r1), boost::math::polygamma(2, d1));
+    EXPECT_RSAME(if_equal(r1, r1, r2, r3), d2);
+    EXPECT_RSAME(if_equal(r1, r2, r3, r4), d4);
+    EXPECT_RSAME(if_less(r1, r2, r3, r4), (d1 < d2) ? d3 : d4);
+    EXPECT_RSAME(if_less(r2, r1, r3, r4), (d2 < d1) ? d3 : d4);
   }
 }
 
 TEST(real_test, definite) {
-  EXPECT_TRUE(Real(0).is_constant(0));
-  EXPECT_FALSE(Real(0.001).is_constant(0));
-  EXPECT_TRUE(Real(1).is_constant(1));
-  EXPECT_FALSE(Real(1.001).is_constant(1));
+  EXPECT_TRUE(is_constant(Real(0), 0));
+  EXPECT_FALSE(is_constant(Real(0.001), 0));
+  EXPECT_TRUE(is_constant(Real(1), 1));
+  EXPECT_FALSE(is_constant(Real(1.001), 1));
 }

--- a/minibmg/ad/tests/traced_test.cpp
+++ b/minibmg/ad/tests/traced_test.cpp
@@ -14,28 +14,27 @@ using namespace ::beanmachine::minibmg;
 
 TEST(traced_test, simple1) {
   Traced x = Traced::variable("x", 0);
-  auto r = 100 * x.pow(3) + 10 * x.pow(2) + 1 * x - 5;
-  ASSERT_EQ("100 * x.pow(3) + 10 * x.pow(2) + x - 5", r.to_string());
+  auto r = 100 * pow(x, 3) + 10 * pow(x, 2) + 1 * x - 5;
+  ASSERT_EQ("100 * pow(x, 3) + 10 * pow(x, 2) + x - 5", to_string(r));
 }
 
 TEST(traced_test, simple2) {
   Traced x = Traced::variable("x", 0);
-  auto r = x.pow(-x);
-  ASSERT_EQ("x.pow(-x)", r.to_string());
+  auto r = pow(x, -x);
+  ASSERT_EQ("pow(x, -x)", to_string(r));
 }
 
 TEST(traced_test, simple3) {
   Traced x = Traced::variable("x", 0);
   auto r = (x + 1) / (x + 2);
-  ASSERT_EQ("(x + 1) / (x + 2)", r.to_string());
+  ASSERT_EQ("(x + 1) / (x + 2)", to_string(r));
 }
 
 TEST(traced_test, simple4) {
   Traced x = Traced::variable("x", 0);
-  auto r = x.exp() + x.log() + x.atan() + x.lgamma() + x.polygamma(5);
+  auto r = exp(x) + log(x) + atan(x) + lgamma(x) + polygamma(5, x);
   ASSERT_EQ(
-      "x.exp() + x.log() + x.atan() + x.lgamma() + x.polygamma(5)",
-      r.to_string());
+      "exp(x) + log(x) + atan(x) + lgamma(x) + polygamma(5, x)", to_string(r));
 }
 
 TEST(traced_test, simple5) {
@@ -43,8 +42,8 @@ TEST(traced_test, simple5) {
   Traced y = Traced::variable("y", 1);
   Traced z = Traced::variable("z", 2);
   Traced w = Traced::variable("w", 3);
-  auto r = x.if_equal(y, z, w);
-  ASSERT_EQ("x.if_equal(y, z, w)", r.to_string());
+  auto r = if_equal(x, y, z, w);
+  ASSERT_EQ("if_equal(x, y, z, w)", to_string(r));
 }
 
 TEST(traced_test, simple6) {
@@ -52,8 +51,8 @@ TEST(traced_test, simple6) {
   Traced y = Traced::variable("y", 1);
   Traced z = Traced::variable("z", 2);
   Traced w = Traced::variable("w", 3);
-  auto r = x.if_less(y, z, w);
-  ASSERT_EQ("x.if_less(y, z, w)", r.to_string());
+  auto r = if_less(x, y, z, w);
+  ASSERT_EQ("if_less(x, y, z, w)", to_string(r));
 }
 
 // Show what happens when the computation graph is a dag instead of a tree.
@@ -66,13 +65,13 @@ TEST(traced_test, dag) {
   auto t3 = t2 + t2;
   // As a small consolation, at least it is minimally parenthesized to preserve
   // order of operations.
-  ASSERT_EQ("x + x + (x + x) + (x + x + (x + x))", t3.to_string());
+  ASSERT_EQ("x + x + (x + x) + (x + x + (x + x))", to_string(t3));
 }
 
 TEST(traced_test, derivative1) {
   Traced tx = Traced::variable("x", 0);
   Num2<Traced> x{tx, 1};
-  auto r = x.pow(2) + 10 * x + 100;
-  auto rp = r.derivative1();
-  ASSERT_EQ("2 * x + 10", rp.to_string());
+  auto r = pow(x, 2) + 10 * x + 100;
+  auto rp = r.derivative1;
+  ASSERT_EQ("2 * x + 10", to_string(rp));
 }

--- a/minibmg/ad/traced.cpp
+++ b/minibmg/ad/traced.cpp
@@ -37,178 +37,178 @@ double Traced::as_double() const {
 // We perform some optimizations during construction.
 // It might be better to do no optimizations at this point and have a tree
 // rewriter that can be reused, but for now this is a simpler approach.
-Traced Traced::operator+(const Traced& other) const {
-  if (this->m_op == Operator::CONSTANT && other.m_op == Operator::CONSTANT) {
-    auto v1 = dynamic_cast<const TracedConstant&>(*this->m_ptr).value;
-    auto v2 = dynamic_cast<const TracedConstant&>(*other.m_ptr).value;
+Traced operator+(const Traced& left, const Traced& right) {
+  if (left.m_op == Operator::CONSTANT && right.m_op == Operator::CONSTANT) {
+    auto v1 = dynamic_cast<const TracedConstant&>(*left.m_ptr).value;
+    auto v2 = dynamic_cast<const TracedConstant&>(*right.m_ptr).value;
     return Traced{Operator::CONSTANT, make_shared<TracedConstant>(v1 + v2)};
-  } else if (this->is_constant(0)) {
-    return other;
-  } else if (other.is_constant(0)) {
-    return *this;
+  } else if (is_constant(left, 0)) {
+    return right;
+  } else if (is_constant(right, 0)) {
+    return left;
   } else {
-    return Traced{Operator::ADD, make_shared<TracedOp>(TracedOp{*this, other})};
-    return Traced{Operator::ADD, make_shared<TracedOp>(TracedOp{*this, other})};
+    return Traced{Operator::ADD, make_shared<TracedOp>(TracedOp{left, right})};
   }
 }
 
-Traced Traced::operator-(const Traced& other) const {
-  if (this->m_op == Operator::CONSTANT && other.m_op == Operator::CONSTANT) {
-    auto v1 = dynamic_cast<const TracedConstant&>(*this->m_ptr).value;
-    auto v2 = dynamic_cast<const TracedConstant&>(*other.m_ptr).value;
+Traced operator-(const Traced& left, const Traced& right) {
+  if (left.m_op == Operator::CONSTANT && right.m_op == Operator::CONSTANT) {
+    auto v1 = dynamic_cast<const TracedConstant&>(*left.m_ptr).value;
+    auto v2 = dynamic_cast<const TracedConstant&>(*right.m_ptr).value;
     return Traced{Operator::CONSTANT, make_shared<TracedConstant>(v1 - v2)};
-  } else if (this->is_constant(0)) {
-    return -other;
-  } else if (other.is_constant(0)) {
-    return *this;
+  } else if (is_constant(left, 0)) {
+    return -right;
+  } else if (is_constant(right, 0)) {
+    return left;
   } else {
     return Traced{
-        Operator::SUBTRACT, make_shared<TracedOp>(TracedOp{*this, other})};
+        Operator::SUBTRACT, make_shared<TracedOp>(TracedOp{left, right})};
   }
 }
 
-Traced Traced::operator-() const {
-  if (this->m_op == Operator::CONSTANT) {
-    auto v1 = dynamic_cast<const TracedConstant&>(*this->m_ptr).value;
+Traced operator-(const Traced& x) {
+  if (x.m_op == Operator::CONSTANT) {
+    auto v1 = dynamic_cast<const TracedConstant&>(*x.m_ptr).value;
     return Traced{Operator::CONSTANT, make_shared<TracedConstant>(-v1)};
   } else {
-    return Traced{Operator::NEGATE, make_shared<TracedOp>(TracedOp{*this})};
+    return Traced{Operator::NEGATE, make_shared<TracedOp>(TracedOp{x})};
   }
 }
 
-Traced Traced::operator*(const Traced& other) const {
-  if (this->m_op == Operator::CONSTANT && other.m_op == Operator::CONSTANT) {
-    auto v1 = dynamic_cast<const TracedConstant&>(*this->m_ptr).value;
-    auto v2 = dynamic_cast<const TracedConstant&>(*other.m_ptr).value;
+Traced operator*(const Traced& left, const Traced& right) {
+  if (left.m_op == Operator::CONSTANT && right.m_op == Operator::CONSTANT) {
+    auto v1 = dynamic_cast<const TracedConstant&>(*left.m_ptr).value;
+    auto v2 = dynamic_cast<const TracedConstant&>(*right.m_ptr).value;
     return Traced{Operator::CONSTANT, make_shared<TracedConstant>(v1 * v2)};
-  } else if (this->is_constant(0) || other.is_constant(1)) {
-    return *this;
-  } else if (other.is_constant(0) || this->is_constant(1)) {
-    return other;
+  } else if (is_constant(left, 0) || is_constant(right, 1)) {
+    return left;
+  } else if (is_constant(right, 0) || is_constant(left, 1)) {
+    return right;
   } else {
     return Traced{
-        Operator::MULTIPLY, make_shared<TracedOp>(TracedOp{*this, other})};
+        Operator::MULTIPLY, make_shared<TracedOp>(TracedOp{left, right})};
   }
 }
 
-Traced Traced::operator/(const Traced& other) const {
-  if (this->m_op == Operator::CONSTANT && other.m_op == Operator::CONSTANT) {
-    auto v1 = dynamic_cast<const TracedConstant&>(*this->m_ptr).value;
-    auto v2 = dynamic_cast<const TracedConstant&>(*other.m_ptr).value;
+Traced operator/(const Traced& left, const Traced& right) {
+  if (left.m_op == Operator::CONSTANT && right.m_op == Operator::CONSTANT) {
+    auto v1 = dynamic_cast<const TracedConstant&>(*left.m_ptr).value;
+    auto v2 = dynamic_cast<const TracedConstant&>(*right.m_ptr).value;
     return Traced{Operator::CONSTANT, make_shared<TracedConstant>(v1 / v2)};
-  } else if (this->is_constant(0) || other.is_constant(1)) {
-    return *this;
+  } else if (is_constant(left, 0) || is_constant(right, 1)) {
+    return left;
   } else {
     return Traced{
-        Operator::DIVIDE, make_shared<TracedOp>(TracedOp{*this, other})};
+        Operator::DIVIDE, make_shared<TracedOp>(TracedOp{left, right})};
   }
 }
 
-Traced Traced::pow(const Traced& other) const {
-  if (this->m_op == Operator::CONSTANT && other.m_op == Operator::CONSTANT) {
-    auto v1 = dynamic_cast<const TracedConstant&>(*this->m_ptr).value;
-    auto v2 = dynamic_cast<const TracedConstant&>(*other.m_ptr).value;
-    return Traced{Operator::CONSTANT, make_shared<TracedConstant>(v1.pow(v2))};
+Traced pow(const Traced& base, const Traced& exponent) {
+  if (base.m_op == Operator::CONSTANT && exponent.m_op == Operator::CONSTANT) {
+    auto v1 = dynamic_cast<const TracedConstant&>(*base.m_ptr).value;
+    auto v2 = dynamic_cast<const TracedConstant&>(*exponent.m_ptr).value;
+    return Traced{Operator::CONSTANT, make_shared<TracedConstant>(pow(v1, v2))};
   }
   double power;
-  if (other.is_constant(power)) {
+  if (is_constant(exponent, power)) {
     if (power == 0) {
       return 1;
     }
     if (power == 1) {
-      return *this;
+      return base;
     }
   }
-  return Traced{Operator::POW, make_shared<TracedOp>(TracedOp{*this, other})};
+  return Traced{Operator::POW, make_shared<TracedOp>(TracedOp{base, exponent})};
 }
 
-Traced Traced::exp() const {
-  if (this->m_op == Operator::CONSTANT) {
-    auto v1 = dynamic_cast<const TracedConstant&>(*this->m_ptr).value;
-    return Traced{Operator::CONSTANT, make_shared<TracedConstant>(v1.exp())};
+Traced exp(const Traced& x) {
+  if (x.m_op == Operator::CONSTANT) {
+    auto v1 = dynamic_cast<const TracedConstant&>(*x.m_ptr).value;
+    return Traced{Operator::CONSTANT, make_shared<TracedConstant>(exp(v1))};
   }
-  return Traced{Operator::EXP, make_shared<TracedOp>(TracedOp{*this})};
+  return Traced{Operator::EXP, make_shared<TracedOp>(TracedOp{x})};
 }
 
-Traced Traced::log() const {
-  if (this->m_op == Operator::CONSTANT) {
-    auto v1 = dynamic_cast<const TracedConstant&>(*this->m_ptr).value;
-    return Traced{Operator::CONSTANT, make_shared<TracedConstant>(v1.log())};
+Traced log(const Traced& x) {
+  if (x.m_op == Operator::CONSTANT) {
+    auto v1 = dynamic_cast<const TracedConstant&>(*x.m_ptr).value;
+    return Traced{Operator::CONSTANT, make_shared<TracedConstant>(log(v1))};
   }
-  return Traced{Operator::LOG, make_shared<TracedOp>(TracedOp{*this})};
+  return Traced{Operator::LOG, make_shared<TracedOp>(TracedOp{x})};
 }
 
-Traced Traced::atan() const {
-  if (this->m_op == Operator::CONSTANT) {
-    auto v1 = dynamic_cast<const TracedConstant&>(*this->m_ptr).value;
-    return Traced{Operator::CONSTANT, make_shared<TracedConstant>(v1.atan())};
+Traced atan(const Traced& x) {
+  if (x.m_op == Operator::CONSTANT) {
+    auto v1 = dynamic_cast<const TracedConstant&>(*x.m_ptr).value;
+    return Traced{Operator::CONSTANT, make_shared<TracedConstant>(atan(v1))};
   }
-  return Traced{Operator::ATAN, make_shared<TracedOp>(TracedOp{*this})};
+  return Traced{Operator::ATAN, make_shared<TracedOp>(TracedOp{x})};
 }
 
-Traced Traced::lgamma() const {
-  if (this->m_op == Operator::CONSTANT) {
-    auto v1 = dynamic_cast<const TracedConstant&>(*this->m_ptr).value;
-    return Traced{Operator::CONSTANT, make_shared<TracedConstant>(v1.lgamma())};
+Traced lgamma(const Traced& x) {
+  if (x.m_op == Operator::CONSTANT) {
+    auto v1 = dynamic_cast<const TracedConstant&>(*x.m_ptr).value;
+    return Traced{Operator::CONSTANT, make_shared<TracedConstant>(lgamma(v1))};
   }
-  return Traced{Operator::LGAMMA, make_shared<TracedOp>(TracedOp{*this})};
+  return Traced{Operator::LGAMMA, make_shared<TracedOp>(TracedOp{x})};
 }
 
-Traced Traced::polygamma(const Traced& other) const {
-  if (this->m_op == Operator::CONSTANT && other.m_op == Operator::CONSTANT) {
-    auto v1 = dynamic_cast<const TracedConstant&>(*this->m_ptr).value;
-    auto v2 = dynamic_cast<const TracedConstant&>(*other.m_ptr).value;
+Traced polygamma(const int n, const Traced& x) {
+  if (x.m_op == Operator::CONSTANT) {
+    auto v1 = dynamic_cast<const TracedConstant&>(*x.m_ptr).value;
     return Traced{
-        Operator::CONSTANT, make_shared<TracedConstant>(v1.polygamma(v2))};
+        Operator::CONSTANT, make_shared<TracedConstant>(polygamma(n, v1))};
   }
-  return Traced{
-      Operator::POLYGAMMA, make_shared<TracedOp>(TracedOp{*this, other})};
+  Traced kn{Operator::CONSTANT, make_shared<TracedConstant>(n)};
+  return Traced{Operator::POLYGAMMA, make_shared<TracedOp>(TracedOp{kn, x})};
 }
 
-Traced Traced::if_equal(
+Traced if_equal(
+    const Traced& value,
     const Traced& comparand,
     const Traced& when_equal,
-    const Traced& when_not_equal) const {
-  if (this->m_op == Operator::CONSTANT &&
+    const Traced& when_not_equal) {
+  if (value.m_op == Operator::CONSTANT &&
       comparand.m_op == Operator::CONSTANT) {
-    auto v1 = dynamic_cast<const TracedConstant&>(*this->m_ptr).value;
+    auto v1 = dynamic_cast<const TracedConstant&>(*value.m_ptr).value;
     auto v2 = dynamic_cast<const TracedConstant&>(*comparand.m_ptr).value;
-    return v1.if_equal(v2, when_equal, when_not_equal);
+    return if_equal(v1, v2, when_equal, when_not_equal);
   }
   return Traced{
       Operator::IF_EQUAL,
       make_shared<TracedOp>(
-          TracedOp{*this, comparand, when_equal, when_not_equal})};
+          TracedOp{value, comparand, when_equal, when_not_equal})};
 }
 
-Traced Traced::if_less(
+Traced if_less(
+    const Traced& value,
     const Traced& comparand,
     const Traced& when_less,
-    const Traced& when_not_less) const {
-  if (this->m_op == Operator::CONSTANT &&
+    const Traced& when_not_less) {
+  if (value.m_op == Operator::CONSTANT &&
       comparand.m_op == Operator::CONSTANT) {
-    auto v1 = dynamic_cast<const TracedConstant&>(*this->m_ptr).value;
+    auto v1 = dynamic_cast<const TracedConstant&>(*value.m_ptr).value;
     auto v2 = dynamic_cast<const TracedConstant&>(*comparand.m_ptr).value;
-    return v1.if_less(v2, when_less, when_not_less);
+    return if_less(v1, v2, when_less, when_not_less);
   }
   return Traced{
       Operator::IF_LESS,
       make_shared<TracedOp>(
-          TracedOp{*this, comparand, when_less, when_not_less})};
+          TracedOp{value, comparand, when_less, when_not_less})};
 }
 
-bool Traced::is_constant(double& value) const {
-  if (this->m_op != Operator::CONSTANT) {
+bool is_constant(const Traced& x, double& value) {
+  if (x.m_op != Operator::CONSTANT) {
     return false;
   }
-  auto k = dynamic_cast<const TracedConstant&>(*this->m_ptr);
+  auto k = dynamic_cast<const TracedConstant&>(*x.m_ptr);
   value = k.value.as_double();
   return true;
 }
 
-bool Traced::is_constant(const double& value) const {
+bool is_constant(const Traced& x, const double& value) {
   double v;
-  return is_constant(v) && v == value;
+  return is_constant(x, v) && v == value;
 }
 
 } // namespace beanmachine::minibmg

--- a/minibmg/ad/traced.h
+++ b/minibmg/ad/traced.h
@@ -27,11 +27,10 @@ An implementation of the Number concept that simply builds an expression tree
 performed.
  */
 class Traced {
- private:
+ public:
   Operator m_op;
   shared_ptr<const TracedBody> m_ptr;
 
- public:
   /* implicit */ Traced(double d);
   static Traced variable(const std::string& name, const uint sequence);
   inline Operator op() const {
@@ -42,32 +41,34 @@ class Traced {
   }
 
   double as_double() const;
-  Traced operator+(const Traced& other) const;
-  Traced operator-(const Traced& other) const;
-  Traced operator-() const;
-  Traced operator*(const Traced& other) const;
-  Traced operator/(const Traced& other) const;
-  Traced pow(const Traced& other) const;
-  Traced exp() const;
-  Traced log() const;
-  Traced atan() const;
-  Traced lgamma() const;
-  Traced polygamma(const Traced& other) const;
-  Traced if_equal(
-      const Traced& comparand,
-      const Traced& when_equal,
-      const Traced& when_not_equal) const;
-  Traced if_less(
-      const Traced& comparand,
-      const Traced& when_less,
-      const Traced& when_not_less) const;
-  bool is_constant(double& value) const;
-  bool is_constant(const double& value) const;
-  std::string to_string() const;
 
- protected:
   Traced(const Operator op, shared_ptr<const TracedBody> p);
 };
+
+Traced operator+(const Traced& left, const Traced& right);
+Traced operator-(const Traced& left, const Traced& right);
+Traced operator-(const Traced& x);
+Traced operator*(const Traced& left, const Traced& right);
+Traced operator/(const Traced& left, const Traced& right);
+Traced pow(const Traced& base, const Traced& exponent);
+Traced exp(const Traced& x);
+Traced log(const Traced& x);
+Traced atan(const Traced& x);
+Traced lgamma(const Traced& x);
+Traced polygamma(int n, const Traced& other);
+Traced if_equal(
+    const Traced& value,
+    const Traced& comparand,
+    const Traced& when_equal,
+    const Traced& when_not_equal);
+Traced if_less(
+    const Traced& value,
+    const Traced& comparand,
+    const Traced& when_less,
+    const Traced& when_not_less);
+bool is_constant(const Traced& x, double& value);
+bool is_constant(const Traced& x, const double& value);
+std::string to_string(const Traced& x);
 
 class TracedBody {
  public:

--- a/minibmg/ad/traced_to_string.cpp
+++ b/minibmg/ad/traced_to_string.cpp
@@ -91,7 +91,7 @@ PrintedForm print(const Traced& traced, std::map<Traced, PrintedForm>& cache) {
           std::static_pointer_cast<const TracedConstant, const TracedBody>(
               traced.ptr())
               .get();
-      return PrintedForm{b->value.to_string(), Precedence::Term};
+      return PrintedForm{to_string(b->value), Precedence::Term};
     }
     case Operator::VARIABLE: {
       const TracedVariable* b =
@@ -142,14 +142,12 @@ PrintedForm print(const Traced& traced, std::map<Traced, PrintedForm>& cache) {
               traced.ptr())
               .get();
       auto left = cache[b->args[0]];
-      auto ls = (left.precedence > Precedence::Term)
-          ? fmt::format("({0})", left.string)
-          : left.string;
+      auto ls = left.string;
       auto right = cache[b->args[1]];
       auto rs = right.string;
       auto this_string = string_for_operator(op);
       return PrintedForm{
-          fmt::format("{0}.{1}({2})", ls, this_string, rs), Precedence::Term};
+          fmt::format("{1}({0}, {2})", ls, this_string, rs), Precedence::Term};
     }
     case Operator::EXP:
     case Operator::LOG:
@@ -161,11 +159,9 @@ PrintedForm print(const Traced& traced, std::map<Traced, PrintedForm>& cache) {
               .get();
       auto this_string = string_for_operator(op);
       auto left = cache[b->args[0]];
-      auto ls = (left.precedence > Precedence::Term)
-          ? fmt::format("({0})", left.string)
-          : left.string;
+      auto ls = left.string;
       return PrintedForm{
-          fmt::format("{0}.{1}()", ls, this_string), Precedence::Term};
+          fmt::format("{1}({0})", ls, this_string), Precedence::Term};
     }
     case Operator::IF_LESS:
     case Operator::IF_EQUAL: {
@@ -175,12 +171,10 @@ PrintedForm print(const Traced& traced, std::map<Traced, PrintedForm>& cache) {
               .get();
       auto this_string = string_for_operator(op);
       auto left = cache[b->args[0]];
-      auto ls = (left.precedence > Precedence::Term)
-          ? fmt::format("({0})", left.string)
-          : left.string;
+      auto ls = left.string;
       return PrintedForm{
           fmt::format(
-              "{0}.{1}({2}, {3}, {4})",
+              "{1}({0}, {2}, {3}, {4})",
               ls,
               this_string,
               cache[b->args[1]].string,
@@ -204,6 +198,9 @@ PrintedForm to_printed_form(
   cache[t] = p;
   return p;
 }
+} // namespace
+
+namespace beanmachine::minibmg {
 
 std::string to_string(const Traced& traced) {
   auto successors = [](const Traced& t) {
@@ -233,9 +230,4 @@ std::string to_string(const Traced& traced) {
   return cache[traced].string;
 }
 
-} // namespace
-
-std::string beanmachine::minibmg::Traced::to_string() const {
-  const Traced& self = *this;
-  return ::to_string(self);
-}
+} // namespace beanmachine::minibmg

--- a/minibmg/distribution/bernoulli.h
+++ b/minibmg/distribution/bernoulli.h
@@ -26,8 +26,8 @@ class Bernoulli : public Distribution<Underlying> {
     auto probability_of_zero = 1 - probability_of_one;
     return value.if_equal(
         1,
-        probability_of_one.log(),
-        value.if_equal(0, probability_of_zero.log(), -INFINITY));
+        log(probability_of_one),
+        value.if_equal(0, log(probability_of_zero), -INFINITY));
   }
 };
 

--- a/minibmg/distribution/beta.h
+++ b/minibmg/distribution/beta.h
@@ -33,8 +33,8 @@ class Beta : public Distribution<Underlying> {
     return p;
   }
   Underlying log_prob(const Underlying& value) const override {
-    return (a - 1) * value.log() + (b - 1) * (1 - value).log() +
-        (a + b).lgamma() - a.lgamma() - b.lgamma();
+    return (a - 1) * log(value) + (b - 1) * log(1 - value) + lgamma(a + b) -
+        lgamma(a) - lgamma(b);
   }
 };
 

--- a/minibmg/distribution/normal.h
+++ b/minibmg/distribution/normal.h
@@ -28,10 +28,10 @@ class Normal : public Distribution<Underlying> {
     // log[PDF[NormalDistribution[m, s], v]]
     // = -(v-m)^2 / 2s^2 - log(s * sqrt(2 * PI))
     // = -(v-m)^2 / 2s^2 - log(s) - log(sqrt(2 * PI))
-    static const auto ls2pi = std::log(std::sqrt(2 * M_PI));
+    static const double ls2pi = std::log(std::sqrt(2 * M_PI));
     auto vmm = value - mean;
     auto t2 = vmm * vmm;
-    return -t2 / (2 * stddev * stddev) - stddev.log() - ls2pi;
+    return -t2 / (2 * stddev * stddev) - log(stddev) - ls2pi;
   }
 };
 

--- a/minibmg/eval.h
+++ b/minibmg/eval.h
@@ -37,18 +37,18 @@ eval_operator(Operator op, std::function<N(uint)> get_value) {
     case Operator::DIVIDE:
       return get_value(0) / get_value(1);
     case Operator::POW:
-      return get_value(0).pow(get_value(1));
+      return pow(get_value(0), get_value(1));
     case Operator::EXP:
-      return get_value(0).exp();
+      return exp(get_value(0));
     case Operator::LOG:
-      return get_value(0).log();
+      return log(get_value(0));
     case Operator::ATAN:
-      return get_value(0).atan();
+      return atan(get_value(0));
     case Operator::LGAMMA:
-      return get_value(0).lgamma();
+      return lgamma(get_value(0));
     case Operator::POLYGAMMA: {
       // Note that we discard the gradients of n and require it be a constant.
-      return get_value(0).polygamma(get_value(1).as_double());
+      return polygamma((int)get_value(0).as_double(), get_value(1));
     }
     default:
       throw EvalError(

--- a/minibmg/tests/eval_test.cpp
+++ b/minibmg/tests/eval_test.cpp
@@ -77,7 +77,7 @@ TEST(eval_test, sample1) {
 // the function f
 template <class T>
 requires Number<T> T f(T x) {
-  return 1.1 * x.pow(2);
+  return 1.1 * pow(x, 2);
 }
 
 // f's first derivative
@@ -119,9 +119,8 @@ TEST(eval_test, derivative_dual) {
     data.clear();
     data.assign(graph_size, 0);
     eval_graph<Dual>(graph, gen, read_variable, data);
-    EXPECT_CLOSE(f<Real>(input).as_double(), data[s].primal().as_double());
-    EXPECT_CLOSE(
-        fp<Real>(input).as_double(), data[s].derivative1().as_double());
+    EXPECT_CLOSE(f<Real>(input).as_double(), data[s].primal.as_double());
+    EXPECT_CLOSE(fp<Real>(input).as_double(), data[s].derivative1.as_double());
   }
 }
 
@@ -152,10 +151,8 @@ TEST(eval_test, derivatives_triune) {
     data.clear();
     data.assign(graph_size, 0);
     eval_graph<Triune>(graph, gen, read_variable, data);
-    EXPECT_CLOSE(f<Real>(input).as_double(), data[s].primal().as_double());
-    EXPECT_CLOSE(
-        fp<Real>(input).as_double(), data[s].derivative1().as_double());
-    EXPECT_CLOSE(
-        fpp<Real>(input).as_double(), data[s].derivative2().as_double());
+    EXPECT_CLOSE(f<Real>(input).as_double(), data[s].primal.as_double());
+    EXPECT_CLOSE(fp<Real>(input).as_double(), data[s].derivative1.as_double());
+    EXPECT_CLOSE(fpp<Real>(input).as_double(), data[s].derivative2.as_double());
   }
 }

--- a/minibmg/tests/log_prob_test.cpp
+++ b/minibmg/tests/log_prob_test.cpp
@@ -43,7 +43,7 @@ TEST(log_prob, normal_dual) {
   // ReplaceAll[D[log(PDF[NormalDistribution[4.223, 6.221], x]), {x, 1}], {x
   // -> 1.234}]
   double expected_derivative1 = 0.0772335;
-  EXPECT_CLOSE(expected_derivative1, result.derivative1().as_double());
+  EXPECT_CLOSE(expected_derivative1, result.derivative1.as_double());
 }
 
 using Triune = Num3<Real>;
@@ -56,9 +56,9 @@ TEST(log_prob, normal_triune) {
   auto result = Normal<Triune>{mean, stdev}.log_prob(v);
   EXPECT_CLOSE(expected, result.as_double());
   double expected_derivative1 = 0.0772335;
-  EXPECT_CLOSE(expected_derivative1, result.derivative1().as_double());
+  EXPECT_CLOSE(expected_derivative1, result.derivative1.as_double());
   // ReplaceAll[D[log(PDF[NormalDistribution[4.223, 6.221], x]), {x, 2}], {x
   // -> 1.234}]
   double expected_derivative2 = -0.0258392;
-  EXPECT_CLOSE(expected_derivative2, result.derivative2().as_double());
+  EXPECT_CLOSE(expected_derivative2, result.derivative2.as_double());
 }


### PR DESCRIPTION
Summary:
Previously, operators such as `operator+` were defined as members of the class on which they operate.  This moves them to the namespace scope, as recommended by many writers about proper C++ usage.  In addition, the order of the parameters of polygamma was changed.  It used to be `x.polygamma(n)`.  Now it is `polygamma(n, x)`.

I'm sorry for giving such a large diff, but it is all systematic refactoring with no change of behavior intended.

Reviewed By: feynmanliang

Differential Revision: D39173709

