### PR TITLE
Moving compute_mean_at_index to util

### DIFF
--- a/src/beanmachine/graph/cavi.cpp
+++ b/src/beanmachine/graph/cavi.cpp
@@ -5,10 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#define _USE_MATH_DEFINES
+#include <cmath>
+
 #include <beanmachine/graph/distribution/distribution.h>
 #include <beanmachine/graph/graph.h>
 #include <beanmachine/graph/util.h>
-#include <cmath>
 #include <unordered_set>
 
 namespace beanmachine {

--- a/src/beanmachine/graph/distribution/bernoulli.cpp
+++ b/src/beanmachine/graph/distribution/bernoulli.cpp
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#define _USE_MATH_DEFINES
 #include <cmath>
 
 #include "beanmachine/graph/distribution/bernoulli.h"

--- a/src/beanmachine/graph/distribution/bernoulli_logit.cpp
+++ b/src/beanmachine/graph/distribution/bernoulli_logit.cpp
@@ -5,7 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#define _USE_MATH_DEFINES
 #include <cmath>
+
 #include <random>
 #include <string>
 

--- a/src/beanmachine/graph/distribution/bernoulli_noisy_or.cpp
+++ b/src/beanmachine/graph/distribution/bernoulli_noisy_or.cpp
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#define _USE_MATH_DEFINES
 #include <cmath>
 
 #include "beanmachine/graph/distribution/bernoulli_noisy_or.h"

--- a/src/beanmachine/graph/distribution/beta.cpp
+++ b/src/beanmachine/graph/distribution/beta.cpp
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#define _USE_MATH_DEFINES
 #include <cmath>
 
 #include "beanmachine/graph/distribution/beta.h"

--- a/src/beanmachine/graph/distribution/bimixture.cpp
+++ b/src/beanmachine/graph/distribution/bimixture.cpp
@@ -5,7 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#define _USE_MATH_DEFINES
 #include <cmath>
+
 #include <random>
 #include <string>
 

--- a/src/beanmachine/graph/distribution/binomial.cpp
+++ b/src/beanmachine/graph/distribution/binomial.cpp
@@ -5,7 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#define _USE_MATH_DEFINES
 #include <cmath>
+
 #include <unsupported/Eigen/SpecialFunctions>
 
 #include "beanmachine/graph/distribution/binomial.h"

--- a/src/beanmachine/graph/distribution/categorical.cpp
+++ b/src/beanmachine/graph/distribution/categorical.cpp
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#define _USE_MATH_DEFINES
 #include <cmath>
 
 #include "beanmachine/graph/distribution/categorical.h"

--- a/src/beanmachine/graph/distribution/dirichlet.cpp
+++ b/src/beanmachine/graph/distribution/dirichlet.cpp
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#define _USE_MATH_DEFINES
 #include <cmath>
 
 #include "beanmachine/graph/distribution/dirichlet.h"

--- a/src/beanmachine/graph/distribution/dummy_marginal.cpp
+++ b/src/beanmachine/graph/distribution/dummy_marginal.cpp
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#define _USE_MATH_DEFINES
 #include <cmath>
 
 #include "beanmachine/graph/distribution/dummy_marginal.h"

--- a/src/beanmachine/graph/distribution/gamma.cpp
+++ b/src/beanmachine/graph/distribution/gamma.cpp
@@ -5,7 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#define _USE_MATH_DEFINES
 #include <cmath>
+
 #include <random>
 #include <string>
 

--- a/src/beanmachine/graph/distribution/geometric.cpp
+++ b/src/beanmachine/graph/distribution/geometric.cpp
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#define _USE_MATH_DEFINES
 #include <cmath>
 
 #include "beanmachine/graph/distribution/geometric.h"

--- a/src/beanmachine/graph/distribution/half_cauchy.cpp
+++ b/src/beanmachine/graph/distribution/half_cauchy.cpp
@@ -7,6 +7,7 @@
 
 #define _USE_MATH_DEFINES
 #include <cmath>
+
 #include <random>
 #include <string>
 

--- a/src/beanmachine/graph/distribution/half_normal.cpp
+++ b/src/beanmachine/graph/distribution/half_normal.cpp
@@ -7,6 +7,7 @@
 
 #define _USE_MATH_DEFINES
 #include <cmath>
+
 #include <random>
 #include <string>
 

--- a/src/beanmachine/graph/distribution/lkj_cholesky.cpp
+++ b/src/beanmachine/graph/distribution/lkj_cholesky.cpp
@@ -6,8 +6,9 @@
  */
 
 #define _USE_MATH_DEFINES
-#include "beanmachine/graph/distribution/lkj_cholesky.h"
 #include <cmath>
+
+#include "beanmachine/graph/distribution/lkj_cholesky.h"
 #include "beanmachine/graph/util.h"
 
 namespace beanmachine {

--- a/src/beanmachine/graph/distribution/log_normal.cpp
+++ b/src/beanmachine/graph/distribution/log_normal.cpp
@@ -6,8 +6,9 @@
  */
 
 #define _USE_MATH_DEFINES
-#include <Eigen/Core>
 #include <cmath>
+
+#include <Eigen/Core>
 #include <random>
 
 #include "beanmachine/graph/distribution/log_normal.h"

--- a/src/beanmachine/graph/distribution/multivariate_normal.cpp
+++ b/src/beanmachine/graph/distribution/multivariate_normal.cpp
@@ -6,9 +6,10 @@
  */
 
 #define _USE_MATH_DEFINES
-#include "beanmachine/graph/distribution/multivariate_normal.h"
-#include <beanmachine/graph/graph.h>
 #include <cmath>
+
+#include <beanmachine/graph/distribution/multivariate_normal.h>
+#include <beanmachine/graph/graph.h>
 
 namespace beanmachine {
 namespace distribution {

--- a/src/beanmachine/graph/distribution/normal.cpp
+++ b/src/beanmachine/graph/distribution/normal.cpp
@@ -7,10 +7,12 @@
 
 #define _USE_MATH_DEFINES
 #include <cmath>
+
 #include <random>
 #include <string>
 
 #include "beanmachine/graph/distribution/normal.h"
+#include "beanmachine/graph/util.h"
 
 namespace beanmachine {
 namespace distribution {
@@ -74,8 +76,7 @@ double Normal::log_prob(const NodeValue& value) const {
     throw std::runtime_error(
         "Normal::log_prob applied to invalid variable type");
   }
-  result = (-std::log(s) - 0.5 * std::log(2 * M_PI)) * size -
-      0.5 * (sum_xsq - 2 * m * sum_x + m * m * size) / (s * s);
+  result = util::log_normal_density(sum_x, sum_xsq, m, s, size);
   return result;
 }
 

--- a/src/beanmachine/graph/distribution/poisson.cpp
+++ b/src/beanmachine/graph/distribution/poisson.cpp
@@ -5,10 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#define _USE_MATH_DEFINES
 #include <cmath>
+
 #include <unsupported/Eigen/SpecialFunctions>
 
 #include "beanmachine/graph/distribution/poisson.h"
+#include "beanmachine/graph/util.h"
 
 namespace beanmachine {
 namespace distribution {
@@ -52,8 +55,7 @@ double Poisson::log_prob(const graph::NodeValue& value) const {
     if (k < 0) {
       return -std::numeric_limits<double>::infinity();
     }
-
-    ret_val += k * log(lambda) - lambda - std::lgamma(k + 1);
+    ret_val += util::log_poisson_probability(static_cast<unsigned>(k), lambda);
   } else if (
       value.type.variable_type == graph::VariableType::BROADCAST_MATRIX) {
     if ((value._nmatrix.array() < 0).any()) {

--- a/src/beanmachine/graph/distribution/student_t.cpp
+++ b/src/beanmachine/graph/distribution/student_t.cpp
@@ -7,6 +7,7 @@
 
 #define _USE_MATH_DEFINES
 #include <cmath>
+
 #include <random>
 #include <string>
 

--- a/src/beanmachine/graph/distribution/tabular.cpp
+++ b/src/beanmachine/graph/distribution/tabular.cpp
@@ -5,7 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#define _USE_MATH_DEFINES
 #include <cmath>
+
 #include <random>
 
 #include "beanmachine/graph/distribution/tabular.h"

--- a/src/beanmachine/graph/distribution/tests/cauchy_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/cauchy_test.cpp
@@ -5,8 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <gtest/gtest.h>
+#define _USE_MATH_DEFINES
 #include <cmath>
+
+#include <gtest/gtest.h>
 
 #include <beanmachine/graph/operator/stochasticop.h>
 #include "beanmachine/graph/distribution/distribution.h"

--- a/src/beanmachine/graph/distribution/tests/half_cauchy_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/half_cauchy_test.cpp
@@ -5,8 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <gtest/gtest.h>
+#define _USE_MATH_DEFINES
 #include <cmath>
+
+#include <gtest/gtest.h>
 
 #include "beanmachine/graph/graph.h"
 #include "beanmachine/graph/util.h"

--- a/src/beanmachine/graph/distribution/tests/lkj_cholesky_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/lkj_cholesky_test.cpp
@@ -5,9 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#define _USE_MATH_DEFINES
+#include <cmath>
+
 #include <gtest/gtest.h>
 #include <Eigen/Core>
-#include <cmath>
 
 #include "beanmachine/graph/distribution/distribution.h"
 #include "beanmachine/graph/distribution/lkj_cholesky.h"

--- a/src/beanmachine/graph/distribution/tests/log_normal_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/log_normal_test.cpp
@@ -6,9 +6,10 @@
  */
 
 #define _USE_MATH_DEFINES
+#include <cmath>
+
 #include <gtest/gtest.h>
 #include <Eigen/Core>
-#include <cmath>
 
 #include "beanmachine/graph/graph.h"
 

--- a/src/beanmachine/graph/factor/exp_product.cpp
+++ b/src/beanmachine/graph/factor/exp_product.cpp
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#define _USE_MATH_DEFINES
 #include <cmath>
 
 #include "beanmachine/graph/factor/exp_product.h"

--- a/src/beanmachine/graph/gibbs.cpp
+++ b/src/beanmachine/graph/gibbs.cpp
@@ -5,8 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <algorithm>
+#define _USE_MATH_DEFINES
 #include <cmath>
+
+#include <algorithm>
 #include <random>
 #include <vector>
 

--- a/src/beanmachine/graph/global/global_state.cpp
+++ b/src/beanmachine/graph/global/global_state.cpp
@@ -5,8 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <algorithm>
+#define _USE_MATH_DEFINES
 #include <cmath>
+
+#include <algorithm>
 #include <random>
 #include <vector>
 

--- a/src/beanmachine/graph/global/tests/conjugate_util_test.cpp
+++ b/src/beanmachine/graph/global/tests/conjugate_util_test.cpp
@@ -8,20 +8,10 @@
 #include "beanmachine/graph/global/tests/conjugate_util_test.h"
 #include <gtest/gtest.h>
 #include "beanmachine/graph/graph.h"
+#include "beanmachine/graph/util.h"
 
 namespace beanmachine {
 namespace graph {
-
-double _compute_mean_at_index(
-    std::vector<std::vector<NodeValue>> samples,
-    int index) {
-  double mean = 0;
-  for (int i = 0; i < samples.size(); i++) {
-    mean += samples[i][index]._double;
-  }
-  mean /= samples.size();
-  return mean;
-}
 
 void add_gamma_gamma_conjugate_(
     Graph& g,
@@ -386,7 +376,8 @@ void test_conjugate_model_moments(
       mh.infer(num_samples, seed, num_warmup_samples);
   EXPECT_EQ(samples.size(), num_samples);
   for (uint i = 0; i < expected_moments.size(); i++) {
-    EXPECT_NEAR(_compute_mean_at_index(samples, i), expected_moments[i], delta);
+    EXPECT_NEAR(
+        util::compute_mean_at_index(samples, i), expected_moments[i], delta);
   }
 }
 

--- a/src/beanmachine/graph/graph.cpp
+++ b/src/beanmachine/graph/graph.cpp
@@ -5,6 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#define _USE_MATH_DEFINES
+#include <cmath>
+// We must include cmath first thing with macro _USE_MATH_DEFINES
+// to ensure the definition of math constants in Windows,
+// before any other header files have the chance of including cmath
+// without the macro.
+
 #include <algorithm>
 #include <iomanip>
 #include <random>

--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -6,6 +6,9 @@
  */
 
 #pragma once
+#define _USE_MATH_DEFINES
+#include <cmath>
+
 #include <Eigen/Dense>
 #include <algorithm>
 #include <list>

--- a/src/beanmachine/graph/mh.cpp
+++ b/src/beanmachine/graph/mh.cpp
@@ -5,9 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#define _USE_MATH_DEFINES
+#include <cmath>
+
 #include <boost/iostreams/stream.hpp>
 #include <boost/progress.hpp>
-#include <cmath>
 #include <random>
 #include <string>
 #include <vector>

--- a/src/beanmachine/graph/nmc.cpp
+++ b/src/beanmachine/graph/nmc.cpp
@@ -5,8 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <algorithm>
+#define _USE_MATH_DEFINES
 #include <cmath>
+
+#include <algorithm>
 #include <random>
 #include <string>
 #include <vector>

--- a/src/beanmachine/graph/nmc_stepper.h
+++ b/src/beanmachine/graph/nmc_stepper.h
@@ -5,8 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <algorithm>
+#define _USE_MATH_DEFINES
 #include <cmath>
+
+#include <algorithm>
 #include <random>
 #include <string>
 #include <vector>

--- a/src/beanmachine/graph/operator/multiaryop.cpp
+++ b/src/beanmachine/graph/operator/multiaryop.cpp
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#define _USE_MATH_DEFINES
 #include <cmath>
 
 #include <beanmachine/graph/graph.h>

--- a/src/beanmachine/graph/operator/unaryop.cpp
+++ b/src/beanmachine/graph/operator/unaryop.cpp
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#define _USE_MATH_DEFINES
 #include <cmath>
 
 #include "beanmachine/graph/graph.h"

--- a/src/beanmachine/graph/proposer/beta.cpp
+++ b/src/beanmachine/graph/proposer/beta.cpp
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#define _USE_MATH_DEFINES
 #include <cmath>
 
 #include "beanmachine/graph/proposer/beta.h"

--- a/src/beanmachine/graph/proposer/gamma.cpp
+++ b/src/beanmachine/graph/proposer/gamma.cpp
@@ -5,7 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#define _USE_MATH_DEFINES
 #include <cmath>
+
 #include <random>
 
 #include "beanmachine/graph/proposer/gamma.h"

--- a/src/beanmachine/graph/proposer/mixture.cpp
+++ b/src/beanmachine/graph/proposer/mixture.cpp
@@ -5,7 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#define _USE_MATH_DEFINES
 #include <cmath>
+
 #include <random>
 
 #include "beanmachine/graph/proposer/mixture.h"

--- a/src/beanmachine/graph/proposer/normal.cpp
+++ b/src/beanmachine/graph/proposer/normal.cpp
@@ -7,9 +7,11 @@
 
 #define _USE_MATH_DEFINES
 #include <cmath>
+
 #include <random>
 
 #include "beanmachine/graph/proposer/normal.h"
+#include "beanmachine/graph/util.h"
 
 namespace beanmachine {
 namespace proposer {
@@ -20,8 +22,7 @@ graph::NodeValue Normal::sample(std::mt19937& gen) const {
 }
 
 double Normal::log_prob(graph::NodeValue& value) const {
-  return -std::log(sigma) - 0.5 * std::log(2 * M_PI) -
-      0.5 * (value._double - mu) * (value._double - mu) / (sigma * sigma);
+  return util::log_normal_density(value._double, mu, sigma);
 }
 
 } // namespace proposer

--- a/src/beanmachine/graph/proposer/trunc_cauchy.cpp
+++ b/src/beanmachine/graph/proposer/trunc_cauchy.cpp
@@ -7,6 +7,7 @@
 
 #define _USE_MATH_DEFINES
 #include <cmath>
+
 #include <random>
 
 #include "beanmachine/graph/proposer/trunc_cauchy.h"

--- a/src/beanmachine/graph/stepper/single_site/default_single_site_stepping_method.cpp
+++ b/src/beanmachine/graph/stepper/single_site/default_single_site_stepping_method.cpp
@@ -5,8 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <algorithm>
+#define _USE_MATH_DEFINES
 #include <cmath>
+
+#include <algorithm>
 #include <random>
 #include <string>
 #include <vector>

--- a/src/beanmachine/graph/stepper/single_site/nmc_dirichlet_beta_single_site_stepping_method.cpp
+++ b/src/beanmachine/graph/stepper/single_site/nmc_dirichlet_beta_single_site_stepping_method.cpp
@@ -5,8 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <algorithm>
+#define _USE_MATH_DEFINES
 #include <cmath>
+
+#include <algorithm>
 #include <random>
 #include <string>
 #include <vector>

--- a/src/beanmachine/graph/stepper/single_site/nmc_dirichlet_gamma_single_site_stepping_method.cpp
+++ b/src/beanmachine/graph/stepper/single_site/nmc_dirichlet_gamma_single_site_stepping_method.cpp
@@ -5,8 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <algorithm>
+#define _USE_MATH_DEFINES
 #include <cmath>
+
+#include <algorithm>
 #include <random>
 #include <string>
 #include <vector>

--- a/src/beanmachine/graph/stepper/single_site/nmc_scalar_single_site_stepping_method.cpp
+++ b/src/beanmachine/graph/stepper/single_site/nmc_scalar_single_site_stepping_method.cpp
@@ -5,8 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <algorithm>
+#define _USE_MATH_DEFINES
 #include <cmath>
+
+#include <algorithm>
 #include <random>
 #include <string>
 #include <vector>

--- a/src/beanmachine/graph/tests/cavi_test.cpp
+++ b/src/beanmachine/graph/tests/cavi_test.cpp
@@ -5,8 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <array>
+#define _USE_MATH_DEFINES
 #include <cmath>
+
+#include <array>
 #include <tuple>
 
 #include <gtest/gtest.h>

--- a/src/beanmachine/graph/tests/graph_stat_test.cpp
+++ b/src/beanmachine/graph/tests/graph_stat_test.cpp
@@ -5,10 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#define _USE_MATH_DEFINES
+#include <cmath>
+
 #include <gtest/gtest.h>
 #include <math.h>
 #include <mcheck.h>
-#include <cmath>
 #include <vector>
 
 #include "beanmachine/graph/graph.h"

--- a/src/beanmachine/graph/util.cpp
+++ b/src/beanmachine/graph/util.cpp
@@ -142,4 +142,30 @@ Eigen::MatrixXd log1mexp(const Eigen::MatrixXd& x) {
   return x.unaryExpr([](double x) { return log1mexp(x); });
 }
 
+double compute_mean_at_index(
+    std::vector<std::vector<graph::NodeValue>> samples,
+    std::size_t index) {
+  double mean = 0;
+  for (size_t i = 0; i < samples.size(); i++) {
+    assert(samples[i].size() > index);
+    // NOLINTNEXTLINE(facebook-hte-ParameterUncheckedArrayBounds)
+    mean += samples[i][index]._double;
+  }
+  mean /= samples.size();
+  return mean;
+}
+
+std::vector<double> compute_means(
+    std::vector<std::vector<graph::NodeValue>> samples) {
+  if (samples.empty()) {
+    return std::vector<double>();
+  }
+  auto num_dims = samples[0].size();
+  auto means = std::vector<double>(num_dims);
+  for (size_t i = 0; i != num_dims; i++) {
+    means[i] = compute_mean_at_index(samples, i);
+  }
+  return means;
+}
+
 } // namespace beanmachine::util

--- a/src/beanmachine/graph/util.cpp
+++ b/src/beanmachine/graph/util.cpp
@@ -6,11 +6,12 @@
  */
 
 #define _USE_MATH_DEFINES
-#include "beanmachine/graph/util.h"
+#include <cmath>
+
 #include <boost/math/special_functions/polygamma.hpp>
 #include <Eigen/Core>
-#include <cmath>
 #include "beanmachine/graph/graph.h"
+#include "beanmachine/graph/util.h"
 
 namespace beanmachine::util {
 

--- a/src/beanmachine/graph/util.h
+++ b/src/beanmachine/graph/util.h
@@ -13,6 +13,7 @@
 #include <Eigen/Dense>
 #include <algorithm>
 #include <random>
+#include "beanmachine/graph/graph.h"
 
 namespace beanmachine {
 namespace util {
@@ -183,6 +184,19 @@ as well as lambda (rate).
 inline auto log_poisson_probability(unsigned k, double lambda) {
   return k * std::log(lambda) - lambda - std::lgamma(k + 1);
 }
+
+/*
+Returns the mean of the index-th dimension in samples.
+*/
+double compute_mean_at_index(
+    std::vector<std::vector<graph::NodeValue>> samples,
+    std::size_t index);
+
+/*
+Returns the means of samples.
+*/
+std::vector<double> compute_means(
+    std::vector<std::vector<graph::NodeValue>> samples);
 
 } // namespace util
 } // namespace beanmachine

--- a/src/beanmachine/graph/util.h
+++ b/src/beanmachine/graph/util.h
@@ -6,6 +6,10 @@
  */
 
 #pragma once
+
+#define _USE_MATH_DEFINES
+#include <cmath>
+
 #include <Eigen/Dense>
 #include <algorithm>
 #include <random>
@@ -144,6 +148,40 @@ std::vector<T> make_reserved_vector(size_t n) {
   std::vector<T> result;
   result.reserve(n);
   return result;
+}
+
+/*
+Computes the log normal density for n idd samples.
+Takes the sum of samples as well as the sum of sample squares,
+as well as mu (mean) and sigma (standard deviation).
+*/
+inline double log_normal_density(
+    double sum_x,
+    double sum_xsq,
+    double mu,
+    double sigma,
+    unsigned n) {
+  static const double half_of_log_2_pi = 0.5 * std::log(2 * M_PI);
+  return (-std::log(sigma) - half_of_log_2_pi) * n -
+      0.5 * (sum_xsq - 2 * mu * sum_x + mu * mu * n) / (sigma * sigma);
+}
+
+/*
+Computes the log normal density for a sample.
+Takes the sampled value
+as well as mu (mean) and sigma (standard deviation).
+*/
+inline double log_normal_density(double x, double mu, double sigma) {
+  return log_normal_density(x, x * x, mu, sigma, 1);
+}
+
+/*
+Computes the log poisson probability for a sample.
+Takes the sampled value k
+as well as lambda (rate).
+*/
+inline auto log_poisson_probability(unsigned k, double lambda) {
+  return k * std::log(lambda) - lambda - std::lgamma(k + 1);
 }
 
 } // namespace util


### PR DESCRIPTION
Summary: Moving function for computing sample means from conjugate_util_test to util for more general reusability.

Reviewed By: gafter

Differential Revision: D39218552

