### PR TITLE
Throw a meaningful error when user tries to query a discrete random variable with HMC/NUTS

### DIFF
--- a/src/beanmachine/ppl/inference/proposer/hmc_utils.py
+++ b/src/beanmachine/ppl/inference/proposer/hmc_utils.py
@@ -255,7 +255,10 @@ class RealSpaceTransform(DictTransform):
     def __init__(self, world: World, target_rvs: Set[RVIdentifier]):
         transforms = {}
         for node in target_rvs:
-            transforms[node] = get_default_transforms(
-                world.get_variable(node).distribution
-            )
+            node_distribution = world.get_variable(node).distribution
+            if node_distribution.support.is_discrete:
+                raise TypeError(
+                    f"HMC can perform inference only on continuous latent random variables, but node {node} is discrete."
+                )
+            transforms[node] = get_default_transforms(node_distribution)
         super().__init__(transforms)

--- a/src/beanmachine/ppl/inference/proposer/tests/hmc_utils_test.py
+++ b/src/beanmachine/ppl/inference/proposer/tests/hmc_utils_test.py
@@ -30,6 +30,12 @@ class SampleModel:
         return dist.Normal(self.foo(), 1.0)
 
 
+class DiscreteModel:
+    @bm.random_variable
+    def baz(self):
+        return dist.Poisson(5.0)
+
+
 def test_dual_average_adapter():
     adapter = DualAverageAdapter(torch.tensor(0.1))
     epsilon1 = adapter.step(torch.tensor(1.0))
@@ -149,3 +155,11 @@ def test_welford_exception():
     welford.step(torch.rand(5))
     with pytest.raises(RuntimeError):  # number of samples is too small
         welford.finalize()
+
+
+def test_discrete_rv_exception():
+    model = DiscreteModel()
+    world = World()
+    world.call(model.baz())
+    with pytest.raises(TypeError):
+        RealSpaceTransform(world, world.latent_nodes)(dict(world))


### PR DESCRIPTION
Summary:
HMC algorithms (including its variants NUTS) can only perform inference on continuous latent random variable, and should raise an error if user try to query a discrete latent random variable. Currently, Bean Machine doesn't perform an explicit check for the support of the distribution, and may either throw an obscured error message during part of inference (e.g. LongTensor doesn't support gradient) or silently return an incorrect inference result (e.g. when a model contains a Poisson distribution).

In this diff, I check whether a discrete latent random variable is present in the initialization of `RealSpaceTransform` and raise an error if it is the case. Added a test case in `hmc_utils_test.py` to test this new addition.

Differential Revision: D39314722

