### PR TITLE
bmg MATRIX_LOG1MEXP

### DIFF
--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -350,6 +350,7 @@ enum class OperatorType {
   MATRIX_LOG,
   LOG1P,
   MATRIX_LOG1P,
+  MATRIX_LOG1MEXP,
 };
 
 enum class DistributionType {

--- a/src/beanmachine/graph/operator/backward.cpp
+++ b/src/beanmachine/graph/operator/backward.cpp
@@ -393,5 +393,15 @@ void MatrixLog1p::backward() {
   }
 }
 
+// g(x) = log (1 - exp(x))
+// g'(x) = -exp(x) / (1 - exp(x)) = 1 - exp(-g)
+void MatrixLog1mexp::backward() {
+  assert(in_nodes.size() == 1);
+  if (in_nodes[0]->needs_gradient()) {
+    auto value = this->value._matrix.array();
+    in_nodes[0]->back_grad1 = back_grad1.array() * (1.0 - (-value).exp());
+  }
+}
+
 } // namespace oper
 } // namespace beanmachine

--- a/src/beanmachine/graph/operator/gradient.cpp
+++ b/src/beanmachine/graph/operator/gradient.cpp
@@ -110,6 +110,7 @@ void Log1pExp::compute_gradients() {
 
 void Log1mExp::compute_gradients() {
   assert(in_nodes.size() == 1);
+  // [Assuming x <= 0...]
   // f(x) = log (1 - exp(x))
   // f'(x) = -exp(x) / (1 - exp(x)) = 1 - exp(-f)
   // f''(x) = -exp(x) / (1 - exp(x))^2 = f' * (1 - f')
@@ -631,6 +632,20 @@ void MatrixLog1p::compute_gradients() {
   Grad1 = g1.cwiseQuotient(gp1);
   Grad2 = (gp1.cwiseProduct(g2) - g1.cwiseProduct(g1))
               .cwiseQuotient(gp1.cwiseProduct(gp1));
+}
+
+void MatrixLog1mexp::compute_gradients() {
+  assert(in_nodes.size() == 1);
+  // f(x) = log (1 - exp(x))
+  // f'(x) = -exp(x) / (1 - exp(x)) = 1 - exp(-f)
+  // f''(x) = -exp(x) / (1 - exp(x))^2 = f' * (1 - f')
+  auto g1 = in_nodes[0]->Grad1.array();
+  auto g2 = in_nodes[0]->Grad2.array();
+  auto f = value._matrix.array();
+  auto f1 = 1.0 - (-f).exp();
+  auto f2 = f1 * (1.0 - f1);
+  Grad1 = f1 * g1;
+  Grad2 = f2 * g1 * g1 + f1 * g2;
 }
 
 } // namespace oper

--- a/src/beanmachine/graph/operator/linalgop.cpp
+++ b/src/beanmachine/graph/operator/linalgop.cpp
@@ -9,6 +9,7 @@
 #include <beanmachine/graph/graph.h>
 #include <stdexcept>
 #include "beanmachine/graph/graph.h"
+#include "beanmachine/graph/util.h"
 
 /*
 A MACRO that checks the atomic_type of a node to make sure the underlying
@@ -567,6 +568,32 @@ MatrixLog1p::MatrixLog1p(const std::vector<graph::Node*>& in_nodes)
 void MatrixLog1p::eval(std::mt19937& /* gen */) {
   assert(in_nodes.size() == 1);
   value._matrix = Eigen::log1p(in_nodes[0]->value._matrix.array());
+}
+
+MatrixLog1mexp::MatrixLog1mexp(const std::vector<graph::Node*>& in_nodes)
+    : Operator(graph::OperatorType::MATRIX_LOG1MEXP) {
+  if (in_nodes.size() != 1) {
+    throw std::invalid_argument("MATRIX_LOG1MEXP requires one parent node");
+  }
+  auto type = in_nodes[0]->value.type;
+  if (type.variable_type != graph::VariableType::BROADCAST_MATRIX) {
+    throw std::invalid_argument(
+        "the parent of MATRIX_LOG1MEXP must be a BROADCAST_MATRIX");
+  }
+  if (type.atomic_type != graph::AtomicType::NEG_REAL) {
+    throw std::invalid_argument(
+        "operator MATRIX_LOG1MEXP requires a neg_real parent");
+  }
+  value = graph::NodeValue(graph::ValueType(
+      graph::VariableType::BROADCAST_MATRIX,
+      graph::AtomicType::NEG_REAL,
+      type.rows,
+      type.cols));
+}
+
+void MatrixLog1mexp::eval(std::mt19937& /* gen */) {
+  assert(in_nodes.size() == 1);
+  value._matrix = util::log1mexp(in_nodes[0]->value._matrix);
 }
 
 } // namespace oper

--- a/src/beanmachine/graph/operator/linalgop.h
+++ b/src/beanmachine/graph/operator/linalgop.h
@@ -228,5 +228,20 @@ class MatrixLog1p : public Operator {
   }
 };
 
+class MatrixLog1mexp : public Operator {
+ public:
+  explicit MatrixLog1mexp(const std::vector<graph::Node*>& in_nodes);
+  ~MatrixLog1mexp() override {}
+
+  void eval(std::mt19937& gen) override;
+  void backward() override;
+  void compute_gradients() override;
+
+  static std::unique_ptr<Operator> new_op(
+      const std::vector<graph::Node*>& in_nodes) {
+    return std::make_unique<MatrixLog1mexp>(in_nodes);
+  }
+};
+
 } // namespace oper
 } // namespace beanmachine

--- a/src/beanmachine/graph/operator/register.cpp
+++ b/src/beanmachine/graph/operator/register.cpp
@@ -178,4 +178,8 @@ bool ::beanmachine::oper::OperatorFactory::factories_are_registered =
 
     OperatorFactory::register_op(
         graph::OperatorType::MATRIX_SUM,
-        &(MatrixSum::new_op));
+        &(MatrixSum::new_op)) &&
+
+    OperatorFactory::register_op(
+        graph::OperatorType::MATRIX_LOG1MEXP,
+        &(MatrixLog1mexp::new_op));

--- a/src/beanmachine/graph/pybindings.cpp
+++ b/src/beanmachine/graph/pybindings.cpp
@@ -94,7 +94,8 @@ PYBIND11_MODULE(graph, module) {
       .value("MATRIX_EXP", OperatorType::MATRIX_EXP)
       .value("MATRIX_SUM", OperatorType::MATRIX_SUM)
       .value("MATRIX_LOG", OperatorType::MATRIX_LOG)
-      .value("MATRIX_LOG1P", OperatorType::MATRIX_LOG1P);
+      .value("MATRIX_LOG1P", OperatorType::MATRIX_LOG1P)
+      .value("MATRIX_LOG1MEXP", OperatorType::MATRIX_LOG1MEXP);
 
   py::enum_<DistributionType>(module, "DistributionType")
       .value("TABULAR", DistributionType::TABULAR)

--- a/src/beanmachine/graph/to_dot.cpp
+++ b/src/beanmachine/graph/to_dot.cpp
@@ -209,6 +209,8 @@ class DOT {
         return "MatrixLog";
       case OperatorType::MATRIX_LOG1P:
         return "MatrixLog1p";
+      case OperatorType::MATRIX_LOG1MEXP:
+        return "MatrixLog1mexp";
       default:
         throw std::invalid_argument(
             "internal error: missing case for OperatorType");

--- a/src/beanmachine/graph/util.cpp
+++ b/src/beanmachine/graph/util.cpp
@@ -137,4 +137,8 @@ double log1mexp(double x) {
   }
 }
 
+Eigen::MatrixXd log1mexp(const Eigen::MatrixXd& x) {
+  return x.unaryExpr([](double x) { return log1mexp(x); });
+}
+
 } // namespace beanmachine::util

--- a/src/beanmachine/graph/util.h
+++ b/src/beanmachine/graph/util.h
@@ -137,6 +137,8 @@ See: https://cran.r-project.org/web/packages/Rmpfr/vignettes/log1mexp-note.pdf
 */
 double log1mexp(double x);
 
+Eigen::MatrixXd log1mexp(const Eigen::MatrixXd& x);
+
 template <typename T>
 std::vector<T> make_reserved_vector(size_t n) {
   std::vector<T> result;


### PR DESCRIPTION
Summary:
See also https://www.tensorflow.org/probability/api_docs/python/tfp/math/log1mexp
and https://www.wolframalpha.com/input?i=D%5BLog%5B1+-+E%5Eabs%28x%29%5D%2C+x%5D

Like the scalar version of this operator, the argument is required to be negative and the result is negative.

Reviewed By: rodrigodesalvobraz

Differential Revision: D39228004

