### PR TITLE
Add MATRIX_PHI to BMG

### DIFF
--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -350,6 +350,7 @@ enum class OperatorType {
   MATRIX_LOG,
   LOG1P,
   MATRIX_LOG1P,
+  MATRIX_PHI,
 };
 
 enum class DistributionType {

--- a/src/beanmachine/graph/operator/backward.cpp
+++ b/src/beanmachine/graph/operator/backward.cpp
@@ -393,5 +393,23 @@ void MatrixLog1p::backward() {
   }
 }
 
+void MatrixPhi::backward() {
+  // phi(x) is defined as the CDF of the standard normal:
+  //
+  //             1        /  x               2
+  // phi(x) =  --------   |      exp(-0.5 * t ) dt
+  //          sqrt(2pi)   / -inf
+  //
+  // so doing the derivative is easy; its just
+  //
+  // phi'(x) = exp(-0.5 x^2)/sqrt(2pi)
+  assert(in_nodes.size() == 1);
+  if (in_nodes[0]->needs_gradient()) {
+    auto x = in_nodes[0]->value._matrix.array();
+    auto phi1 = _1_SQRT2PI * (-0.5 * x * x).exp();
+    in_nodes[0]->back_grad1 += back_grad1.array() * phi1;
+  }
+}
+
 } // namespace oper
 } // namespace beanmachine

--- a/src/beanmachine/graph/operator/gradient.cpp
+++ b/src/beanmachine/graph/operator/gradient.cpp
@@ -633,5 +633,28 @@ void MatrixLog1p::compute_gradients() {
               .cwiseQuotient(gp1.cwiseProduct(gp1));
 }
 
+void MatrixPhi::compute_gradients() {
+  assert(in_nodes.size() == 1);
+  // phi is defined as the CDF of the standard normal:
+  //
+  //             1        /g(x)             2
+  // f(x) =    --------   |     exp(-0.5 * t ) dt
+  //          sqrt(2pi)   /-inf
+  //
+  // define helper function h(x) as:
+  //
+  // h(x)   = exp(-0.5 g(x)^2) / sqrt(2pi)
+  // h'(x)  = -g'(x) g(x) h(x)
+  // f'(x)  = g'(x) h(x)
+  // f''(x) = g''(x) h(x) + g'(x) h'(x)
+  auto g = in_nodes[0]->value._matrix.array();
+  auto g1 = in_nodes[0]->Grad1.array();
+  auto g2 = in_nodes[0]->Grad2.array();
+  auto h = _1_SQRT2PI * (-0.5 * g * g).exp();
+  auto h1 = -g1 * g * h;
+  Grad1 = g1 * h;
+  Grad2 = g2 * h + g1 * h1;
+}
+
 } // namespace oper
 } // namespace beanmachine

--- a/src/beanmachine/graph/operator/linalgop.cpp
+++ b/src/beanmachine/graph/operator/linalgop.cpp
@@ -5,9 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#define _USE_MATH_DEFINES
 #include "beanmachine/graph/operator/linalgop.h"
-#include <beanmachine/graph/graph.h>
+#include <cmath>
 #include <stdexcept>
+#include <unsupported/Eigen/SpecialFunctions>
 #include "beanmachine/graph/graph.h"
 
 /*
@@ -567,6 +569,34 @@ MatrixLog1p::MatrixLog1p(const std::vector<graph::Node*>& in_nodes)
 void MatrixLog1p::eval(std::mt19937& /* gen */) {
   assert(in_nodes.size() == 1);
   value._matrix = Eigen::log1p(in_nodes[0]->value._matrix.array());
+}
+
+MatrixPhi::MatrixPhi(const std::vector<graph::Node*>& in_nodes)
+    : Operator(graph::OperatorType::MATRIX_PHI) {
+  if (in_nodes.size() != 1) {
+    throw std::invalid_argument("MATRIX_PHI requires one parent node");
+  }
+  auto type = in_nodes[0]->value.type;
+  if (type.variable_type != graph::VariableType::BROADCAST_MATRIX) {
+    throw std::invalid_argument(
+        "the parent of MATRIX_PHI must be a BROADCAST_MATRIX");
+  }
+  if (type.atomic_type != graph::AtomicType::REAL) {
+    throw std::invalid_argument("operator MATRIX_PHI requires a real parent");
+  }
+  value = graph::NodeValue(graph::ValueType(
+      graph::VariableType::BROADCAST_MATRIX,
+      graph::AtomicType::PROBABILITY,
+      type.rows,
+      type.cols));
+}
+
+void MatrixPhi::eval(std::mt19937& /* gen */) {
+  assert(in_nodes.size() == 1);
+  // Eigen does not implement a phi function, but we have
+  // this handy identity relating erf and phi:
+  auto x = in_nodes[0]->value._matrix.array();
+  value._matrix = (1.0 + (x * M_SQRT1_2).erf()) / 2.0;
 }
 
 } // namespace oper

--- a/src/beanmachine/graph/operator/linalgop.h
+++ b/src/beanmachine/graph/operator/linalgop.h
@@ -228,5 +228,22 @@ class MatrixLog1p : public Operator {
   }
 };
 
+class MatrixPhi : public Operator {
+ public:
+  explicit MatrixPhi(const std::vector<graph::Node*>& in_nodes);
+  ~MatrixPhi() override {}
+
+  void eval(std::mt19937& gen) override;
+  void backward() override;
+  void compute_gradients() override;
+
+  static std::unique_ptr<Operator> new_op(
+      const std::vector<graph::Node*>& in_nodes) {
+    return std::make_unique<MatrixPhi>(in_nodes);
+  }
+};
+
+const double _1_SQRT2PI = 0.39894228040143267;
+
 } // namespace oper
 } // namespace beanmachine

--- a/src/beanmachine/graph/operator/register.cpp
+++ b/src/beanmachine/graph/operator/register.cpp
@@ -152,6 +152,10 @@ bool ::beanmachine::oper::OperatorFactory::factories_are_registered =
         graph::OperatorType::MATRIX_LOG1P,
         &(MatrixLog1p::new_op)) &&
 
+    OperatorFactory::register_op(
+        graph::OperatorType::MATRIX_PHI,
+        &(MatrixPhi::new_op)) &&
+
     // matrix index
     OperatorFactory::register_op(
         graph::OperatorType::INDEX,

--- a/src/beanmachine/graph/pybindings.cpp
+++ b/src/beanmachine/graph/pybindings.cpp
@@ -94,7 +94,8 @@ PYBIND11_MODULE(graph, module) {
       .value("MATRIX_EXP", OperatorType::MATRIX_EXP)
       .value("MATRIX_SUM", OperatorType::MATRIX_SUM)
       .value("MATRIX_LOG", OperatorType::MATRIX_LOG)
-      .value("MATRIX_LOG1P", OperatorType::MATRIX_LOG1P);
+      .value("MATRIX_LOG1P", OperatorType::MATRIX_LOG1P)
+      .value("MATRIX_PHI", OperatorType::MATRIX_PHI);
 
   py::enum_<DistributionType>(module, "DistributionType")
       .value("TABULAR", DistributionType::TABULAR)

--- a/src/beanmachine/graph/to_dot.cpp
+++ b/src/beanmachine/graph/to_dot.cpp
@@ -209,6 +209,8 @@ class DOT {
         return "MatrixLog";
       case OperatorType::MATRIX_LOG1P:
         return "MatrixLog1p";
+      case OperatorType::MATRIX_PHI:
+        return "MatrixPhi";
       default:
         throw std::invalid_argument(
             "internal error: missing case for OperatorType");


### PR DESCRIPTION
Summary:
I've added an implementation of MATRIX_PHI to BMG.

We likely will change the name of this to something like ARRAY_PHI or BATCH_PHI or some such, but we can do that in a later diff once we've sorted out the correct nomenclature.

Differential Revision: D39278315

