### PR TITLE
bmg MATRIX_COMPLEMENT

### DIFF
--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -351,6 +351,7 @@ enum class OperatorType {
   LOG1P,
   MATRIX_LOG1P,
   MATRIX_LOG1MEXP,
+  MATRIX_COMPLEMENT,
 };
 
 enum class DistributionType {

--- a/src/beanmachine/graph/operator/backward.cpp
+++ b/src/beanmachine/graph/operator/backward.cpp
@@ -403,5 +403,14 @@ void MatrixLog1mexp::backward() {
   }
 }
 
+// g(x) = 1 - x
+// g'(x) = -1
+void MatrixComplement::backward() {
+  assert(in_nodes.size() == 1);
+  if (in_nodes[0]->needs_gradient()) {
+    in_nodes[0]->back_grad1 = -back_grad1.array();
+  }
+}
+
 } // namespace oper
 } // namespace beanmachine

--- a/src/beanmachine/graph/operator/gradient.cpp
+++ b/src/beanmachine/graph/operator/gradient.cpp
@@ -648,5 +648,11 @@ void MatrixLog1mexp::compute_gradients() {
   Grad2 = f2 * g1 * g1 + f1 * g2;
 }
 
+void MatrixComplement::compute_gradients() {
+  assert(in_nodes.size() == 1);
+  Grad1 = -in_nodes[0]->Grad1.array();
+  Grad2 = -in_nodes[0]->Grad2.array();
+}
+
 } // namespace oper
 } // namespace beanmachine

--- a/src/beanmachine/graph/operator/linalgop.h
+++ b/src/beanmachine/graph/operator/linalgop.h
@@ -243,5 +243,20 @@ class MatrixLog1mexp : public Operator {
   }
 };
 
+class MatrixComplement : public Operator {
+ public:
+  explicit MatrixComplement(const std::vector<graph::Node*>& in_nodes);
+  ~MatrixComplement() override {}
+
+  void eval(std::mt19937& gen) override;
+  void backward() override;
+  void compute_gradients() override;
+
+  static std::unique_ptr<Operator> new_op(
+      const std::vector<graph::Node*>& in_nodes) {
+    return std::make_unique<MatrixComplement>(in_nodes);
+  }
+};
+
 } // namespace oper
 } // namespace beanmachine

--- a/src/beanmachine/graph/operator/register.cpp
+++ b/src/beanmachine/graph/operator/register.cpp
@@ -182,4 +182,8 @@ bool ::beanmachine::oper::OperatorFactory::factories_are_registered =
 
     OperatorFactory::register_op(
         graph::OperatorType::MATRIX_LOG1MEXP,
-        &(MatrixLog1mexp::new_op));
+        &(MatrixLog1mexp::new_op)) &&
+
+    OperatorFactory::register_op(
+        graph::OperatorType::MATRIX_COMPLEMENT,
+        &(MatrixComplement::new_op));

--- a/src/beanmachine/graph/pybindings.cpp
+++ b/src/beanmachine/graph/pybindings.cpp
@@ -95,7 +95,8 @@ PYBIND11_MODULE(graph, module) {
       .value("MATRIX_SUM", OperatorType::MATRIX_SUM)
       .value("MATRIX_LOG", OperatorType::MATRIX_LOG)
       .value("MATRIX_LOG1P", OperatorType::MATRIX_LOG1P)
-      .value("MATRIX_LOG1MEXP", OperatorType::MATRIX_LOG1MEXP);
+      .value("MATRIX_LOG1MEXP", OperatorType::MATRIX_LOG1MEXP)
+      .value("MATRIX_COMPLEMENT", OperatorType::MATRIX_COMPLEMENT);
 
   py::enum_<DistributionType>(module, "DistributionType")
       .value("TABULAR", DistributionType::TABULAR)

--- a/src/beanmachine/graph/to_dot.cpp
+++ b/src/beanmachine/graph/to_dot.cpp
@@ -211,6 +211,8 @@ class DOT {
         return "MatrixLog1p";
       case OperatorType::MATRIX_LOG1MEXP:
         return "MatrixLog1mexp";
+      case OperatorType::MATRIX_COMPLEMENT:
+        return "MatrixComplement";
       default:
         throw std::invalid_argument(
             "internal error: missing case for OperatorType");

--- a/src/beanmachine/graph/util.h
+++ b/src/beanmachine/graph/util.h
@@ -130,7 +130,7 @@ double log1pexp(double x);
 Eigen::MatrixXd log1pexp(const Eigen::MatrixXd& x);
 
 /*
-Compute `log(1 - exp(x))` with numerical stability.
+Compute `log(1 - exp(x))` with numerical stability for negative x values.
 See: https://cran.r-project.org/web/packages/Rmpfr/vignettes/log1mexp-note.pdf
 :param x:
 :returns: log(1 - exp(x))


### PR DESCRIPTION
Summary:
Implement the matrix version of the complement operator (not to be confused with the C ~ operator).

For booleans, it inverts the sense of the value.

For probabilities, it returns *(1 - p)*.

(By contrast, the C ~ operator computes `-(p + 1)` for integers)

Differential Revision: D39359519

