### PR TITLE
Separate computation of deterministic and stochastic ancestors from Graph implementation.

### DIFF
--- a/src/beanmachine/graph/graph.cpp
+++ b/src/beanmachine/graph/graph.cpp
@@ -570,26 +570,12 @@ std::vector<Node*> Graph::convert_parent_ids(
 }
 
 uint Graph::add_node(std::unique_ptr<Node> node, std::vector<uint> parents) {
-  // for each parent collect their deterministic/stochastic ancestors
-  // also maintain the in/out nodes of this node and its parents
-  std::set<uint> det_set;
-  std::set<uint> sto_set;
+  // Maintain the in/out nodes of this node and its parents
   for (uint paridx : parents) {
     Node* parent = nodes[paridx].get();
     parent->out_nodes.push_back(node.get());
     node->in_nodes.push_back(parent);
-    if (parent->is_stochastic()) {
-      sto_set.insert(parent->index);
-    } else {
-      det_set.insert(parent->det_anc.begin(), parent->det_anc.end());
-      if (parent->node_type == NodeType::OPERATOR) {
-        det_set.insert(parent->index);
-      }
-      sto_set.insert(parent->sto_anc.begin(), parent->sto_anc.end());
-    }
   }
-  node->det_anc.insert(node->det_anc.end(), det_set.begin(), det_set.end());
-  node->sto_anc.insert(node->sto_anc.end(), sto_set.begin(), sto_set.end());
   uint index = node->index = static_cast<uint>(nodes.size());
   nodes.push_back(std::move(node));
   return index;

--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -443,8 +443,6 @@ class Node {
   uint index; // index in Graph::nodes
   std::vector<Node*> in_nodes;
   std::vector<Node*> out_nodes;
-  std::vector<uint> det_anc; // deterministic (operator) ancestors
-  std::vector<uint> sto_anc; // stochastic ancestors
   NodeValue value;
   double grad1;
   double grad2;
@@ -802,9 +800,6 @@ struct Graph {
       const std::set<uint>& ordered_support_node_ids,
       bool affected_only,
       bool include_root_node);
-
-  std::tuple<std::vector<uint>, std::vector<uint>> compute_ancestors(
-      uint node_id);
 
   void eval_and_update_backgrad(std::vector<Node*>& ordered_supp);
   /*

--- a/src/beanmachine/graph/support.cpp
+++ b/src/beanmachine/graph/support.cpp
@@ -9,9 +9,12 @@
 
 #include "beanmachine/graph/graph.h"
 #include "beanmachine/graph/operator/operator.h"
+#include "beanmachine/graph/support.h"
 
 namespace beanmachine {
 namespace graph {
+
+using namespace std;
 
 // the support of a graph is the set of operator and factor nodes that are
 // needed to determine the value of query and observed variables.
@@ -153,21 +156,33 @@ Graph::_compute_nodes_until_stochastic(
   return std::make_tuple(det_desc, sto_desc);
 }
 
-// compute the ancestors of the current node
-// returns vector of deterministic nodes and vector of stochastic nodes
-// that are operators and ancestors of the current node
-// NOTE: we don't return ancestors of stochastic ancestors
-// NOTE: current node is not returned
-std::tuple<std::vector<uint>, std::vector<uint>> Graph::compute_ancestors(
-    uint root_id) {
-  // check for the validity of root_id since this method is not private
-  if (root_id >= nodes.size()) {
-    throw std::out_of_range(
-        "node_id (" + std::to_string(root_id) + ") must be less than " +
-        std::to_string(nodes.size()));
+std::tuple<DeterministicAncestors, StochasticAncestors>
+collect_deterministic_and_stochastic_ancestors(Graph& graph) {
+  graph.ensure_evaluation_and_inference_readiness();
+  std::vector<std::vector<uint>> det_anc(graph.node_ptrs.size());
+  std::vector<std::vector<uint>> sto_anc(graph.node_ptrs.size());
+  for (Node* node : graph.node_ptrs) {
+    std::set<uint> det_set;
+    std::set<uint> sto_set;
+    for (Node* parent : node->in_nodes) {
+      if (parent->is_stochastic()) {
+        sto_set.insert(parent->index);
+      } else {
+        auto parent_det_anc = det_anc[parent->index]; // NOLINT
+        det_set.insert(parent_det_anc.begin(), parent_det_anc.end());
+        if (parent->node_type == NodeType::OPERATOR) {
+          det_set.insert(parent->index);
+        }
+        auto parent_sto_anc = sto_anc[parent->index]; // NOLINT
+        sto_set.insert(parent_sto_anc.begin(), parent_sto_anc.end());
+      }
+    }
+    std::vector<uint>& node_det_anc = det_anc[node->index]; // NOLINT
+    std::vector<uint>& node_sto_anc = sto_anc[node->index]; // NOLINT
+    node_det_anc.insert(node_det_anc.end(), det_set.begin(), det_set.end());
+    node_sto_anc.insert(node_sto_anc.end(), sto_set.begin(), sto_set.end());
   }
-  const Node* root = nodes[root_id].get();
-  return std::make_tuple(root->det_anc, root->sto_anc);
+  return std::tie(det_anc, sto_anc);
 }
 
 } // namespace graph

--- a/src/beanmachine/graph/support.h
+++ b/src/beanmachine/graph/support.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <beanmachine/graph/graph.h>
+
+namespace beanmachine {
+namespace graph {
+
+using DeterministicAncestors = std::vector<std::vector<uint>>;
+using StochasticAncestors = std::vector<std::vector<uint>>;
+
+/*
+Returns two vectors of vectors of node ids.
+The first vector contains, for each node in topological order,
+the indices of deterministic ancestors of that node.
+The second vector analogously contains stochastic ancestors.
+*/
+std::tuple<DeterministicAncestors, StochasticAncestors>
+collect_deterministic_and_stochastic_ancestors(Graph& graph);
+
+} // namespace graph
+} // namespace beanmachine

--- a/src/beanmachine/graph/tests/support_test.cpp
+++ b/src/beanmachine/graph/tests/support_test.cpp
@@ -10,6 +10,7 @@
 #include <gtest/gtest.h>
 
 #include <beanmachine/graph/graph.h>
+#include <beanmachine/graph/support.h>
 
 using namespace beanmachine;
 using namespace graph;
@@ -73,21 +74,30 @@ TEST(testgraph, support) {
   EXPECT_EQ(det_nodes.front(), o3);
   EXPECT_EQ(sto_nodes.size(), 1);
   EXPECT_EQ(sto_nodes.front(), o4);
-  std::vector<uint> det_anc;
-  std::vector<uint> sto_anc;
-  std::tie(det_anc, sto_anc) = g.compute_ancestors(o4);
+
+  DeterministicAncestors det_anc;
+  StochasticAncestors sto_anc;
+  std::tie(det_anc, sto_anc) =
+      collect_deterministic_and_stochastic_ancestors(g);
   // o4 -ancestors-> det: c3, c4, o3, d2 sto:
   // restricting to operators: det: o3 sto:
-  EXPECT_EQ(det_anc.size(), 1);
-  EXPECT_EQ(det_anc.front(), o3);
-  EXPECT_EQ(sto_anc.size(), 0);
-  std::tie(det_anc, sto_anc) = g.compute_ancestors(o8);
+  EXPECT_EQ(det_anc[o4].size(), 1);
+  EXPECT_EQ(det_anc[o4].front(), o3);
+  EXPECT_EQ(sto_anc[o4].size(), 0);
   // restricting to operators, ancestors(o8) = det: o3, o7 sto: o6
-  EXPECT_EQ(det_anc.size(), 2);
-  EXPECT_EQ(det_anc.front(), o3);
-  EXPECT_EQ(det_anc.back(), o7);
-  EXPECT_EQ(sto_anc.size(), 1);
-  EXPECT_EQ(sto_anc.front(), o6);
+  EXPECT_EQ(det_anc[o8].size(), 2);
+  EXPECT_EQ(det_anc[o8].front(), o3);
+  EXPECT_EQ(det_anc[o8].back(), o7);
+  EXPECT_EQ(sto_anc[o8].size(), 1);
+  EXPECT_EQ(sto_anc[o8].front(), o6);
+  // ancestors(o5) = det: ro2, ro4, sto: o2 o4
+  EXPECT_EQ(det_anc[o5].size(), 2);
+  EXPECT_EQ(det_anc[o5].front(), ro2);
+  EXPECT_EQ(det_anc[o5].back(), ro4);
+  EXPECT_EQ(sto_anc[o5].size(), 2);
+  EXPECT_EQ(sto_anc[o5].front(), o2);
+  EXPECT_EQ(sto_anc[o5].back(), o4);
+
   // query o5 so support is now 13 nodes:
   //   c1, c2, o1, d1, o2, ro2, c3, c4, o3, d2, o4, ro5, o5
   // but we only include operators o1, o2, ro2, o3, o4, ro4, and o5
@@ -106,14 +116,6 @@ TEST(testgraph, support) {
   EXPECT_EQ(det_nodes.back(), o5);
   EXPECT_EQ(sto_nodes.size(), 1);
   EXPECT_EQ(sto_nodes.front(), o4);
-  std::tie(det_anc, sto_anc) = g.compute_ancestors(o5);
-  // ancestors(o5) = det: ro2, ro4, sto: o2 o4
-  EXPECT_EQ(det_anc.size(), 2);
-  EXPECT_EQ(det_anc.front(), ro2);
-  EXPECT_EQ(det_anc.back(), ro4);
-  EXPECT_EQ(sto_anc.size(), 2);
-  EXPECT_EQ(sto_anc.front(), o2);
-  EXPECT_EQ(sto_anc.back(), o4);
 }
 
 TEST(testgraph, full_support) {


### PR DESCRIPTION
Summary:
Class Graph was keeping track of "deterministic and stochastic ancestors" as fields, complicating the class and especially the `add_node` method. This was unnecessary especially since this data is only currently being used by the experimental (not used?) CAVI inference method.
This functionality is now separate from class Graph and implemented as a regular function in `support.cpp`. This greatly simplifies `Graph::add_node`, which in turn will make it easier to implement a new method `Graph::remove_node`, the original motivation for this diff.

Differential Revision: D39449301

