### PR TITLE
Added numpy import statement to Bayesian_NNs_with_ADVI

### DIFF
--- a/tutorials/Bayesian_NNs_with_ADVI.ipynb
+++ b/tutorials/Bayesian_NNs_with_ADVI.ipynb
@@ -1824,6 +1824,8 @@
     }
    ],
    "source": [
+    "import numpy as np\n",
+    "\n",
     "x_points = 100\n",
     "y_points = 100\n",
     "\n",


### PR DESCRIPTION
Summary:
Sandcastle (and Skycastle) build for bayesian_nns_with_advi is failing
- numpy is never imported in

Reviewed By: horizon-blue

Differential Revision: D39475218

