### PR TITLE
Make RVIdentifier sortable (for now)

### DIFF
--- a/src/beanmachine/ppl/inference/proposer/nnc/utils.py
+++ b/src/beanmachine/ppl/inference/proposer/nnc/utils.py
@@ -7,7 +7,6 @@ import warnings
 
 import torch
 import torch.jit
-import torch.utils._pytree as pytree
 from functorch.compile import nnc_jit
 
 
@@ -22,18 +21,5 @@ warnings.warn(
 # pyre-fixme[16]: Module `_C` has no attribute `_jit_set_texpr_reductions_enabled`.
 torch._C._jit_set_texpr_reductions_enabled(True)
 
-
-# override default dict flatten (which requires keys to be sortable)
-def _dict_flatten(d):
-    keys = list(d.keys())
-    values = [d[key] for key in keys]
-    return values, keys
-
-
-def _dict_unflatten(values, context):
-    return {key: value for key, value in zip(context, values)}
-
-
-pytree._register_pytree_node(dict, _dict_flatten, _dict_unflatten)
 
 __all__ = ["nnc_jit"]

--- a/src/beanmachine/ppl/model/rv_identifier.py
+++ b/src/beanmachine/ppl/model/rv_identifier.py
@@ -5,7 +5,7 @@
 
 import warnings
 from dataclasses import dataclass
-from typing import Callable, Tuple
+from typing import Any, Callable, Tuple
 
 import torch
 
@@ -31,6 +31,14 @@ class RVIdentifier:
 
     def __str__(self):
         return str(self.function.__name__) + str(self.arguments)
+
+    def __lt__(self, other: Any) -> bool:
+        # define comparison so that functorch doesn't raise when it tries to
+        # sort dictionary keys (https://fburl.com/0gomiv80). This can be
+        # removed with the v0.2.1+ release of functorch.
+        if isinstance(other, RVIdentifier):
+            return str(self) < str(other)
+        return NotImplemented
 
     @property
     def function(self):

--- a/src/beanmachine/ppl/model/tests/rv_identifier_test.py
+++ b/src/beanmachine/ppl/model/tests/rv_identifier_test.py
@@ -10,6 +10,7 @@ import warnings
 import beanmachine.ppl as bm
 import torch
 import torch.distributions as dist
+import torch.utils._pytree as pytree
 
 
 @bm.random_variable
@@ -151,3 +152,14 @@ class RVIdentifierTest(unittest.TestCase):
         self.assertIn(model2.baz(), rv_set)
         self.assertNotIn(model1.bar(1.5), rv_set)
         self.assertIn(model2.bar(1.5), rv_set)
+
+    def test_sorting_rv_identifier(self):
+        model = self.SampleModel()
+        observations = {
+            model.foo(): torch.tensor(1.0),
+            model.bar(0.5): torch.tensor(1.0),
+            model.baz(): torch.tensor(1.0),
+        }
+        # make sure the following doesn't raise
+        sorted(observations.keys())
+        pytree.tree_flatten(observations)


### PR DESCRIPTION
Summary:
As reported in [#1665](https://github.com/facebookresearch/beanmachine/issues/1665), when trying to compile with NNC, functorch (v2.1.0) will attempt to sort [the keys of a dictionary before flattening it](https://github.com/pytorch/functorch/blob/v0.2.1/functorch/_src/aot_autograd.py#L42), where it will raise an exception because Bean Machine's RVIdentifier type is not sortable.

This sorting of dictionary keys is removed in the latest functorch, though until then, as a workaround, we can make `RVIdentifier` sortable for now by defining a `__lt__` operator for it.

Differential Revision: D39486353

