### PR TITLE
Fix nightly Hierarchical Modeling tutorial test

### DIFF
--- a/src/beanmachine/tutorials/utils/__init__.py
+++ b/src/beanmachine/tutorials/utils/__init__.py
@@ -3,5 +3,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-# flake8: noqa
 from beanmachine.tutorials.utils import etl, plots
+
+__all__ = ["etl", "plots"]

--- a/src/beanmachine/tutorials/utils/baseball.py
+++ b/src/beanmachine/tutorials/utils/baseball.py
@@ -313,7 +313,7 @@ def plot_no_pooling_diagnostics(
     names = df["Name"].values
     keys = [f"θ[{name}]" for name in names]
     values = np.dsplit(samples.get(query).numpy(), 18)
-    values = [value.reshape(4, 5000) for value in values]
+    values = [value.reshape(samples.num_chains, -1) for value in values]
     diagnostics_data = dict(zip(keys, values))
 
     # Cycle through each query and create the diagnostics plots using arviz.
@@ -419,7 +419,7 @@ def plot_no_pooling_model(
     names = df["Name"].values
     keys = [f"θ[{name}]" for name in names]
     values = np.dsplit(samples.get(query).numpy(), 18)
-    values = [value.reshape(4, 5000) for value in values]
+    values = [value.reshape(samples.num_chains, -1) for value in values]
     data = dict(zip(keys, values))
 
     hdi_df = az.hdi(data, hdi_prob=0.89).to_dataframe()


### PR DESCRIPTION
Summary: The nightly test for the Hierarchical Modeling tutorial [has been failing because we hard-coded the reshape dimension to `(4, 5000)` in tutorial utils](https://www.internalfb.com/intern/sandcastle/job/13510799651396224/), which does't match the dimension of the samples we get from running smoke test. This can be fixed by updating the utils to determine the shape by checking the `MonteCarloSamples` object.

Differential Revision: D39495458

