### PR TITLE
Automate generation of Graph's cached structural information.

### DIFF
--- a/src/beanmachine/graph/distribution/tests/product_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/product_test.cpp
@@ -96,20 +96,18 @@ TEST(testdistrib, product_construction_and_log_prob) {
       AtomicType::NATURAL,
       std::vector<uint>{poisson_dist1, poisson_dist2});
 
-  g.ensure_evaluation_and_inference_readiness();
-
-  auto dist_obj1 = static_cast<Distribution*>(g.node_ptrs[product_dist1]);
+  auto dist_obj1 = static_cast<Distribution*>(g.node_ptrs()[product_dist1]);
   auto x = MEAN1;
   auto expected = log_normal_density(x, MEAN1, STD1);
   EXPECT_NEAR(dist_obj1->log_prob(NodeValue(x)), expected, 1e-6);
 
-  auto dist_obj2 = static_cast<Distribution*>(g.node_ptrs[product_dist2]);
+  auto dist_obj2 = static_cast<Distribution*>(g.node_ptrs()[product_dist2]);
   x = MEAN1;
   expected =
       log_normal_density(x, MEAN1, STD1) + log_normal_density(x, MEAN2, STD2);
   EXPECT_NEAR(dist_obj2->log_prob(NodeValue(x)), expected, 1e-6);
 
-  auto dist_obj3 = static_cast<Distribution*>(g.node_ptrs[product_dist3]);
+  auto dist_obj3 = static_cast<Distribution*>(g.node_ptrs()[product_dist3]);
   natural_t k = 4;
   expected =
       log_poisson_probability(k, RATE1) + log_poisson_probability(k, RATE2);

--- a/src/beanmachine/graph/global/global_state.cpp
+++ b/src/beanmachine/graph/global/global_state.cpp
@@ -22,11 +22,10 @@ namespace graph {
 
 GlobalState::GlobalState(Graph& g) : graph(g) {
   flat_size = 0;
-  graph.ensure_evaluation_and_inference_readiness();
 
   // initialize unconstrained value types
   // TODO: rename to initialize_unconstrained_value_types
-  for (auto node : graph.supp) {
+  for (auto node : graph.supp()) {
     if (node->is_stochastic() and node->node_type == NodeType::OPERATOR) {
       auto sto_node = static_cast<oper::StochasticOperator*>(node);
       sto_node->get_unconstrained_value(true);
@@ -34,7 +33,7 @@ GlobalState::GlobalState(Graph& g) : graph(g) {
   }
 
   // save stochastic and deterministic nodes
-  for (auto node : graph.supp) {
+  for (auto node : graph.supp()) {
     if (node->is_stochastic() and !node->is_observed) {
       stochastic_nodes.push_back(node);
       // initialize vals_backup and grads_backup to correct size
@@ -217,7 +216,7 @@ void GlobalState::update_log_prob() {
 }
 
 void GlobalState::update_backgrad() {
-  graph.eval_and_update_backgrad(graph.supp);
+  graph.eval_and_update_backgrad(graph.supp());
 }
 
 } // namespace graph

--- a/src/beanmachine/graph/mh.cpp
+++ b/src/beanmachine/graph/mh.cpp
@@ -39,13 +39,12 @@ void MH::infer(uint num_samples, InferConfig infer_config) {
 // need during inference, and verifies that the MH algorithm can
 // compute gradients of every node we need to.
 void MH::initialize() {
-  graph->ensure_evaluation_and_inference_readiness();
   ensure_all_nodes_are_supported();
   compute_initial_values();
 }
 
 void MH::ensure_all_nodes_are_supported() {
-  for (Node* node : graph->unobserved_sto_supp) {
+  for (Node* node : graph->unobserved_sto_supp()) {
     std::string error_message = is_not_supported(node);
     if (error_message != "") {
       throw std::runtime_error(error_message);
@@ -58,10 +57,10 @@ void MH::ensure_all_nodes_are_supported() {
 // Unobserved stochastic nodes are assigned a value by the uniform
 // initializer. Deterministic nodes are computed from their inputs.
 // Note that we only need a single pass because parent nodes always have
-// indices less than those of their children, and unobserved_supp
+// indices less than those of their children, and unobserved_supp()
 // respects index order.
 void MH::compute_initial_values() {
-  for (Node* unobs_node : graph->unobserved_supp) {
+  for (Node* unobs_node : graph->unobserved_supp()) {
     if (unobs_node->is_stochastic()) {
       proposer::default_initializer(gen, unobs_node);
     } else { // non-stochastic operator node, so just evaluate

--- a/src/beanmachine/graph/operator/multiaryop.h
+++ b/src/beanmachine/graph/operator/multiaryop.h
@@ -8,6 +8,7 @@
 #pragma once
 #include "beanmachine/graph/graph.h"
 #include "beanmachine/graph/operator/operator.h"
+#include "beanmachine/graph/third-party/nameof.h"
 
 namespace beanmachine {
 namespace oper {
@@ -28,8 +29,7 @@ class MultiaryOperator : public Operator {
     for (const graph::Node* node : in_nodes) {
       if (node->value.type.atomic_type != type0) {
         throw std::invalid_argument(
-            "all parents of operator " +
-            std::to_string(static_cast<int>(op_type)) +
+            "all parents of operator " + std::string(NAMEOF_ENUM(op_type)) +
             " should have the same atomic type");
       }
     }

--- a/src/beanmachine/graph/operator/unaryop.h
+++ b/src/beanmachine/graph/operator/unaryop.h
@@ -8,6 +8,7 @@
 #pragma once
 #include "beanmachine/graph/graph.h"
 #include "beanmachine/graph/operator/operator.h"
+#include "beanmachine/graph/third-party/nameof.h"
 
 namespace beanmachine {
 namespace oper {
@@ -21,7 +22,7 @@ class UnaryOperator : public Operator {
     if (in_nodes.size() != 1) {
       throw std::invalid_argument(
           "expecting exactly a single parent for unary operator " +
-          std::to_string(static_cast<int>(op_type)));
+          std::string(NAMEOF_ENUM(op_type)));
     }
     // if the parent node's value type has not been initialized then we
     // can't define an operator here

--- a/src/beanmachine/graph/stepper/single_site/nmc_scalar_single_site_stepping_method.cpp
+++ b/src/beanmachine/graph/stepper/single_site/nmc_scalar_single_site_stepping_method.cpp
@@ -37,8 +37,6 @@ ProfilerEvent NMCScalarSingleSiteSteppingMethod::get_step_profiler_event() {
 
 // Returns the NMC proposal distribution conditioned on the
 // target node's current value.
-// NOTE: assumes that det_affected_nodes's values are already
-// evaluated according to the target node's value.
 std::unique_ptr<proposer::Proposer>
 NMCScalarSingleSiteSteppingMethod::get_proposal_distribution(Node* tgt_node) {
   auto graph = mh->graph;

--- a/src/beanmachine/graph/stepper/single_site/sequential_single_site_stepper.cpp
+++ b/src/beanmachine/graph/stepper/single_site/sequential_single_site_stepper.cpp
@@ -39,7 +39,7 @@ std::vector<Stepper*>& SequentialSingleSiteStepper::get_steppers() {
 }
 
 void SequentialSingleSiteStepper::make_steppers() {
-  for (auto tgt_node : mh->graph->unobserved_sto_supp) {
+  for (auto tgt_node : mh->graph->unobserved_sto_supp()) {
     auto single_site_stepping_method =
         find_applicable_single_site_stepping_method(tgt_node);
     steppers.push_back(

--- a/src/beanmachine/graph/support.cpp
+++ b/src/beanmachine/graph/support.cpp
@@ -158,10 +158,9 @@ Graph::_compute_nodes_until_stochastic(
 
 std::tuple<DeterministicAncestors, StochasticAncestors>
 collect_deterministic_and_stochastic_ancestors(Graph& graph) {
-  graph.ensure_evaluation_and_inference_readiness();
-  std::vector<std::vector<uint>> det_anc(graph.node_ptrs.size());
-  std::vector<std::vector<uint>> sto_anc(graph.node_ptrs.size());
-  for (Node* node : graph.node_ptrs) {
+  std::vector<std::vector<uint>> det_anc(graph.node_ptrs().size());
+  std::vector<std::vector<uint>> sto_anc(graph.node_ptrs().size());
+  for (Node* node : graph.node_ptrs()) {
     std::set<uint> det_set;
     std::set<uint> sto_set;
     for (Node* parent : node->in_nodes) {

--- a/src/beanmachine/graph/tests/graph_test.cpp
+++ b/src/beanmachine/graph/tests/graph_test.cpp
@@ -578,8 +578,7 @@ TEST(testgraph, eval_and_update_backgrad) {
       g.add_operator(graph::OperatorType::SAMPLE, std::vector<uint>{dist1});
   g.observe(y, 100.0);
   g.query(x_sq);
-  g.ensure_evaluation_and_inference_readiness();
   g.nodes[x]->value._double = 2.0;
-  g.eval_and_update_backgrad(g.supp);
+  g.eval_and_update_backgrad(g.supp());
   EXPECT_NEAR(g.nodes[x]->back_grad1, 3.76, 1e-5);
 }

--- a/src/beanmachine/graph/util.h
+++ b/src/beanmachine/graph/util.h
@@ -323,5 +323,10 @@ inline bool atomic_type_unknown_or_equal_to(
   return a == graph::AtomicType::UNKNOWN or graph::ValueType(a) == v;
 }
 
+template <typename T>
+void erase_position(std::vector<T>& vector, std::size_t index) {
+  vector.erase(vector.begin() + index);
+}
+
 } // namespace util
 } // namespace beanmachine


### PR DESCRIPTION
Summary:
Graph has a number of auxiliary structures: which nodes are stochastic, which ones affect which others, and so on.
Previously, client code that to explicit ask these to be computed, which is error-prone.
This diff makes this data obtained through getters only, which calculate them as needed if they have not been calculated yet. Client code no longer needs to be concerned about that (see for example changes in `mh.cpp` and `global_state.cpp`).
This change was further prompted by the fact that now one can remove nodes from the graph. This invalidates the auxiliary data structures. Instead of hoping for the user to realize that and request their recalculation, it is better to invalidate the cache and have it automatically computed if need be.
For good measure, `add_node` now likewise invalidates the cache, since it also renders the information obsolete.

Differential Revision: D39515797

