### PR TITLE
Add flag to discard burn in samples in beanstalk

### DIFF
--- a/src/beanmachine/ppl/compiler/tests/bmg_infer_interface_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_infer_interface_test.py
@@ -135,6 +135,25 @@ tensor([[[ 1.5000, -2.5000]],
         f4 = samples[flip4()]
         self.assertEqual(str(f3), str(f4))
 
+    def test_infer_interface_burn_in(self) -> None:
+        # Check default case when num_adaptive_samples = 0
+        num_samples = 25
+        num_adaptive_samples = 0
+        samples = BMGInference().infer([c(), c2()], {}, num_samples, 1)
+        observed = len(samples[c()][0])
+        expected = num_samples - num_adaptive_samples
+        self.assertEqual(expected, observed)
+
+        # Check case when num_adaptive_samples = 10
+        num_samples = 25
+        num_adaptive_samples = 10
+        samples = BMGInference().infer(
+            [c(), c2()], {}, num_samples, 1, num_adaptive_samples=num_adaptive_samples
+        )
+        observed = len(samples[c()][0])
+        expected = num_samples - num_adaptive_samples
+        self.assertEqual(expected, observed)
+
     class SampleModel:
         @bm.random_variable
         def a(self):

--- a/src/beanmachine/ppl/compiler/tests/dirichlet_test.py
+++ b/src/beanmachine/ppl/compiler/tests/dirichlet_test.py
@@ -438,7 +438,9 @@ digraph "graph" {
         observations = {}
         num_samples = 10
 
-        results = BMGInference().infer(queries, observations, num_samples, 1, nmc)
+        results = BMGInference().infer(
+            queries, observations, num_samples, 1, inference_type=nmc
+        )
         samples = results[d2a()]
         self.assertEqual(Size([1, num_samples, 2]), samples.size())
 
@@ -456,7 +458,9 @@ digraph "graph" {
         observations = {}
         num_samples = 20
 
-        results = BMGInference().infer(queries, observations, num_samples, 1, rejection)
+        results = BMGInference().infer(
+            queries, observations, num_samples, 1, inference_type=rejection
+        )
         samples = results[d3()]
         self.assertEqual(Size([1, num_samples, 3]), samples.size())
 
@@ -467,7 +471,9 @@ digraph "graph" {
         observations = {d3(): tensor([0.5, 0.25, 0.25])}
         num_samples = 1
 
-        results = BMGInference().infer(queries, observations, num_samples, 1, nmc)
+        results = BMGInference().infer(
+            queries, observations, num_samples, 1, inference_type=nmc
+        )
         samples = results[d3()]
         expected = "tensor([[[0.5000, 0.2500, 0.2500]]], dtype=torch.float64)"
         self.assertEqual(expected, str(samples))

--- a/src/beanmachine/ppl/inference/bmg_inference.py
+++ b/src/beanmachine/ppl/inference/bmg_inference.py
@@ -143,7 +143,13 @@ class BMGInference:
         return samples
 
     def _build_mcsamples(
-        self, rv_to_query, samples, query_to_query_id, num_samples: int, num_chains: int
+        self,
+        rv_to_query,
+        samples,
+        query_to_query_id,
+        num_samples: int,
+        num_chains: int,
+        num_adaptive_samples: int,
     ) -> MonteCarloSamples:
         self._begin(prof.build_mcsamples)
 
@@ -162,9 +168,13 @@ class BMGInference:
         # we had to tweak it to support the right operator for merging
         # saumple values when num_chains!=1.
         if num_chains == 1:
-            mcsamples = MonteCarloSamples(results[0], 0, stack_not_cat=True)
+            mcsamples = MonteCarloSamples(
+                results[0], num_adaptive_samples, stack_not_cat=True
+            )
         else:
-            mcsamples = MonteCarloSamples(results, 0, stack_not_cat=False)
+            mcsamples = MonteCarloSamples(
+                results, num_adaptive_samples, stack_not_cat=False
+            )
 
         self._finish(prof.build_mcsamples)
 
@@ -176,6 +186,7 @@ class BMGInference:
         observations: Dict[RVIdentifier, torch.Tensor],
         num_samples: int,
         num_chains: int = 1,
+        num_adaptive_samples: int = 0,
         inference_type: InferenceType = InferenceType.NMC,
         produce_report: bool = True,
         skip_optimizations: Set[str] = default_skip_optimizations,
@@ -231,6 +242,7 @@ class BMGInference:
             query_to_query_id,
             num_samples,
             num_chains,
+            num_adaptive_samples,
         )
 
         self._finish(prof.infer)
@@ -246,6 +258,7 @@ class BMGInference:
         observations: Dict[RVIdentifier, torch.Tensor],
         num_samples: int,
         num_chains: int = 4,
+        num_adaptive_samples: int = 0,
         inference_type: InferenceType = InferenceType.NMC,
         skip_optimizations: Set[str] = default_skip_optimizations,
     ) -> MonteCarloSamples:
@@ -259,6 +272,7 @@ class BMGInference:
             observations: observations dict
             num_samples: number of samples in each chain
             num_chains: number of chains generated
+            num_adaptive_samples: number of burn in samples to discard
             inference_type: inference method, currently only NMC is supported
             skip_optimizations: list of optimization to disable in this call
 
@@ -272,6 +286,7 @@ class BMGInference:
             observations,
             num_samples,
             num_chains,
+            num_adaptive_samples,
             inference_type,
             False,
             skip_optimizations,


### PR DESCRIPTION
Summary:
In some cases, it is useful to discard the first few samples of inference to get better chain mixing, therefore improved `r_hat` and `ess` metrics.
`MonteCarloSamples` already has logic implemented to discard the specified number of samples using the optional `num_adaptive_samples` parameter.
In this diff, I expose this parameter one level up in `BMGInference.infer()`.
Added a test case to ensure that it works correctly in the default and non-default case.

Differential Revision: D39565178

