### PR TITLE
Add consistently named methods for adding constants to BMG.

### DIFF
--- a/src/beanmachine/graph/distribution/tests/bernoulli_logit_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/bernoulli_logit_test.cpp
@@ -14,7 +14,7 @@ using namespace beanmachine::graph;
 TEST(testdistrib, bernoulli_logit) {
   Graph g;
   const double LOGIT = -1.5;
-  auto logit = g.add_constant(LOGIT);
+  auto logit = g.add_constant_real(LOGIT);
   auto pos1 = g.add_constant_pos_real(1.0);
   // negative tests: BernoulliLogit has one parent
   EXPECT_THROW(
@@ -106,7 +106,7 @@ TEST(testdistrib, bernoulli_logit) {
   EXPECT_EQ(grad.size(), 5);
   EXPECT_NEAR((*grad[2]), -3.0420, 1e-3);
 
-  auto two = g.add_constant((natural_t)2);
+  auto two = g.add_constant_natural(2);
   auto var3 = g.add_operator(
       OperatorType::IID_SAMPLE, std::vector<uint>{dist2, two, two});
   Eigen::MatrixXb m1(2, 2);
@@ -119,7 +119,7 @@ TEST(testdistrib, bernoulli_logit) {
 
   // mixture of Bernoulli-Logit
   Graph g2;
-  auto size = g2.add_constant((natural_t)2);
+  auto size = g2.add_constant_natural(2);
   auto flat_real = g2.add_distribution(
       DistributionType::FLAT, AtomicType::REAL, std::vector<uint>{});
   auto flat_prob = g2.add_distribution(

--- a/src/beanmachine/graph/distribution/tests/bernoulli_noisy_or_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/bernoulli_noisy_or_test.cpp
@@ -14,7 +14,7 @@ using namespace beanmachine::graph;
 TEST(testdistrib, backward_bernoulli_noisy_or) {
   Graph g;
 
-  uint two = g.add_constant((natural_t)2);
+  uint two = g.add_constant_natural(2);
   uint flat_pos = g.add_distribution(
       DistributionType::FLAT, AtomicType::POS_REAL, std::vector<uint>{});
   uint y = g.add_operator(OperatorType::SAMPLE, std::vector<uint>{flat_pos});
@@ -56,7 +56,7 @@ TEST(testdistrib, backward_bernoulli_noisy_or) {
   uint y1 = g2.add_operator(OperatorType::SAMPLE, std::vector<uint>{flat_pos});
   uint y2 = g2.add_operator(OperatorType::SAMPLE, std::vector<uint>{flat_pos});
 
-  two = g2.add_constant((natural_t)2);
+  two = g2.add_constant_natural(2);
   uint d1 = g2.add_distribution(
       DistributionType::BERNOULLI_NOISY_OR,
       AtomicType::BOOLEAN,

--- a/src/beanmachine/graph/distribution/tests/beta_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/beta_test.cpp
@@ -19,7 +19,7 @@ TEST(testdistrib, beta1) {
   const double C = -1.5;
   auto pos1 = g1.add_constant_pos_real(A);
   auto pos2 = g1.add_constant_pos_real(B);
-  auto neg1 = g1.add_constant(C);
+  auto neg1 = g1.add_constant_real(C);
   // negative test the sample_type must be probability.
   EXPECT_THROW(
       g1.add_distribution(
@@ -147,7 +147,7 @@ TEST(testdistrib, beta2) {
   const double B = 5.0;
   auto pos1 = g1.add_constant_pos_real(A);
   auto pos2 = g1.add_constant_pos_real(B);
-  auto two = g1.add_constant((natural_t)2);
+  auto two = g1.add_constant_natural(2);
 
   auto beta_dist = g1.add_distribution(
       DistributionType::BETA,
@@ -167,7 +167,7 @@ TEST(testdistrib, beta2) {
   // b ~ FLAT
   // y = (y1, y2) ~ Beta(a^2, b^2)
   Graph g2;
-  auto nat_node = g2.add_constant((natural_t)2);
+  auto nat_node = g2.add_constant_natural(2);
   auto a = g2.add_operator(
       OperatorType::SAMPLE,
       std::vector<uint>{g2.add_distribution(
@@ -207,7 +207,7 @@ TEST(testdistrib, beta2) {
 
   // test sample/iid_sample from a mixture of betas
   Graph g3;
-  auto size = g3.add_constant((natural_t)2);
+  auto size = g3.add_constant_natural(2);
   auto flat_pos = g3.add_distribution(
       DistributionType::FLAT, AtomicType::POS_REAL, std::vector<uint>{});
   auto flat_prob = g3.add_distribution(

--- a/src/beanmachine/graph/distribution/tests/bimixture_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/bimixture_test.cpp
@@ -13,8 +13,8 @@ using namespace beanmachine::graph;
 
 TEST(testdistrib, bimixture) {
   Graph g1;
-  auto real1 = g1.add_constant(-0.5);
-  auto real2 = g1.add_constant(0.5);
+  auto real1 = g1.add_constant_real(-0.5);
+  auto real2 = g1.add_constant_real(0.5);
   auto pos1 = g1.add_constant_pos_real(1.5);
   auto pos2 = g1.add_constant_pos_real(2.5);
   auto prob1 = g1.add_constant_probability(0.3);
@@ -123,7 +123,7 @@ TEST(testdistrib, bimixture) {
       g2.add_operator(OperatorType::SAMPLE, std::vector<uint>{flat_pos_real});
   auto p = g2.add_operator(OperatorType::LOGISTIC, std::vector<uint>{a});
   g2.observe(a, -1.5);
-  auto zero = g2.add_constant(0.0);
+  auto zero = g2.add_constant_real(0.0);
   auto b_sq = g2.add_operator(OperatorType::MULTIPLY, std::vector<uint>{b, b});
   g2.observe(b, 1.8);
   auto c_sq = g2.add_operator(OperatorType::MULTIPLY, std::vector<uint>{c, c});
@@ -193,7 +193,7 @@ TEST(testdistrib, bimixture) {
 TEST(testdistrib, bimixture_of_mixture) {
   // mixture of normals
   Graph g;
-  auto size = g.add_constant((natural_t)2);
+  auto size = g.add_constant_natural(2);
   auto flat_real = g.add_distribution(
       DistributionType::FLAT, AtomicType::REAL, std::vector<uint>{});
   auto flat_pos = g.add_distribution(

--- a/src/beanmachine/graph/distribution/tests/binomial_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/binomial_test.cpp
@@ -13,8 +13,8 @@ using namespace beanmachine::graph;
 
 TEST(testdistrib, backward_binomial) {
   Graph g;
-  uint two = g.add_constant((natural_t)2);
-  uint ten = g.add_constant((natural_t)10);
+  uint two = g.add_constant_natural(2);
+  uint ten = g.add_constant_natural(10);
 
   uint flat_dist = g.add_distribution(
       DistributionType::FLAT, AtomicType::PROBABILITY, std::vector<uint>{});
@@ -73,8 +73,8 @@ TEST(testdistrib, backward_binomial) {
   uint prob2 =
       g2.add_operator(OperatorType::SAMPLE, std::vector<uint>{flat_prob});
 
-  two = g2.add_constant((natural_t)2);
-  ten = g2.add_constant((natural_t)10);
+  two = g2.add_constant_natural(2);
+  ten = g2.add_constant_natural(10);
   uint d1 = g2.add_distribution(
       DistributionType::BINOMIAL,
       AtomicType::NATURAL,

--- a/src/beanmachine/graph/distribution/tests/categorical_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/categorical_test.cpp
@@ -22,7 +22,7 @@ TEST(testdistrib, categorical) {
   Eigen::MatrixXd matrix2(4, 2);
   matrix2 << 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25;
 
-  uint c0 = g.add_constant(0.0);
+  uint c0 = g.add_constant_real(0.0);
   uint c1 = g.add_constant_col_simplex_matrix(matrix);
   uint c2 = g.add_constant_col_simplex_matrix(matrix2);
 

--- a/src/beanmachine/graph/distribution/tests/cauchy_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/cauchy_test.cpp
@@ -24,9 +24,9 @@ TEST(testdistrib, cauchy) {
   const double SCALE = 3.5;
   const double X0 = 1.2;
   auto scale_pos = g.add_constant_pos_real(SCALE);
-  auto x0_real = g.add_constant(X0);
+  auto x0_real = g.add_constant_real(X0);
   auto pos1 = g.add_constant_pos_real(SCALE);
-  auto real1 = g.add_constant(SCALE);
+  auto real1 = g.add_constant_real(SCALE);
   // negative tests: cauchy has two parents which are real and positive
   EXPECT_THROW(
       g.add_distribution(
@@ -60,7 +60,7 @@ TEST(testdistrib, cauchy) {
 
   // test creation of a distribution
 
-  auto zero = g.add_constant(0.0);
+  auto zero = g.add_constant_real(0.0);
   auto pos_zero = g.add_constant_pos_real(0.0);
   auto loc =
       g.add_operator(OperatorType::ADD, std::vector<uint>{zero, x0_real});

--- a/src/beanmachine/graph/distribution/tests/dirichlet_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/dirichlet_test.cpp
@@ -19,7 +19,7 @@ TEST(testdistrib, dirichlet_negative) {
   Eigen::MatrixXd m1(3, 1);
   m1 << 1.5, 1.0, 2.0;
   uint cm1 = g.add_constant_pos_matrix(m1);
-  uint two = g.add_constant((natural_t)2);
+  uint two = g.add_constant_natural(2);
 
   // negative initialization tests
   EXPECT_THROW(

--- a/src/beanmachine/graph/distribution/tests/distribution_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/distribution_test.cpp
@@ -53,7 +53,7 @@ TEST(testdistrib, bernoulli) {
       std::invalid_argument);
 
   graph::Graph g;
-  auto two = g.add_constant((graph::natural_t)2);
+  auto two = g.add_constant_natural(2);
   auto flat_dist = g.add_distribution(
       graph::DistributionType::FLAT,
       graph::AtomicType::PROBABILITY,
@@ -88,7 +88,7 @@ TEST(testdistrib, bernoulli) {
 
   // mixture of Bernoulli-Logit
   graph::Graph g2;
-  auto size = g2.add_constant((graph::natural_t)2);
+  auto size = g2.add_constant_natural(2);
   auto flat_prob = g2.add_distribution(
       graph::DistributionType::FLAT,
       graph::AtomicType::PROBABILITY,

--- a/src/beanmachine/graph/distribution/tests/flat_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/flat_test.cpp
@@ -13,7 +13,7 @@ using namespace beanmachine::graph;
 
 TEST(testdistrib, flat) {
   Graph g;
-  auto real1 = g.add_constant(3.0);
+  auto real1 = g.add_constant_real(3.0);
   // negative test: flat has no parent
   EXPECT_THROW(
       g.add_distribution(

--- a/src/beanmachine/graph/distribution/tests/gamma_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/gamma_test.cpp
@@ -18,7 +18,7 @@ TEST(testdistrib, gamma) {
   const double C = -1.0;
   auto pos1 = g.add_constant_pos_real(A);
   auto pos2 = g.add_constant_pos_real(B);
-  auto neg1 = g.add_constant(C);
+  auto neg1 = g.add_constant_real(C);
   // negative test the sample_type must be positive real.
   EXPECT_THROW(
       g.add_distribution(
@@ -123,7 +123,7 @@ TEST(testdistrib, gamma) {
   EXPECT_NEAR(grad2, -15.7778, 0.001);
   // test test backward_param, backward_value, backward_param_iid,
   // backward_value_iid
-  auto two = g.add_constant((natural_t)2);
+  auto two = g.add_constant_natural(2);
   auto y2 = g.add_operator(
       OperatorType::IID_SAMPLE, std::vector<uint>{y_dist, two, two});
   Eigen::MatrixXd m_y(2, 2);
@@ -142,7 +142,7 @@ TEST(testdistrib, gamma) {
 
   // test sample/iid_sample from a mixture of gammas
   Graph g2;
-  auto size = g2.add_constant((natural_t)2);
+  auto size = g2.add_constant_natural(2);
   auto flat_pos = g2.add_distribution(
       DistributionType::FLAT, AtomicType::POS_REAL, std::vector<uint>{});
   auto flat_prob = g2.add_distribution(

--- a/src/beanmachine/graph/distribution/tests/geometric_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/geometric_test.cpp
@@ -100,7 +100,7 @@ TEST(testdistrib, geometric) {
   EXPECT_NEAR(grad2, -22.3639, 0.001);
   // test backward_param, backward_value
   // test backward_param_iid, backward_param_iid
-  auto two = g.add_constant((natural_t)2);
+  auto two = g.add_constant_natural(2);
   auto y2 = g.add_operator(
       OperatorType::IID_SAMPLE, std::vector<uint>{y_dist, two, two});
   Eigen::MatrixXn m_y(2, 2);

--- a/src/beanmachine/graph/distribution/tests/half_cauchy_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/half_cauchy_test.cpp
@@ -18,7 +18,7 @@ using namespace beanmachine::graph;
 
 TEST(testdistrib, half_cauchy) {
   Graph g;
-  auto real1 = g.add_constant(4.5);
+  auto real1 = g.add_constant_real(4.5);
   const double SCALE = 3.5;
   auto pos1 = g.add_constant_pos_real(SCALE);
   // negative tests: half cauchy has one parent which is positive real
@@ -109,7 +109,7 @@ TEST(testdistrib, half_cauchy) {
   // torch.autograd.grad(log_p, X) -> -4.8711
   // torch.autograd.grad(log_p, Y) -> [[-0.3077, -0.5882], [-0.8219, -1.0000]]
   Graph g2;
-  auto two = g2.add_constant((natural_t)2);
+  auto two = g2.add_constant_natural(2);
   auto pos2 = g2.add_constant_pos_real(1.1);
   auto hc_dist = g2.add_distribution(
       DistributionType::HALF_CAUCHY,
@@ -139,7 +139,7 @@ TEST(testdistrib, half_cauchy) {
 
   // mixture of half_cauchy
   Graph g3;
-  auto size = g3.add_constant((natural_t)2);
+  auto size = g3.add_constant_natural(2);
   auto flat_pos = g3.add_distribution(
       DistributionType::FLAT, AtomicType::POS_REAL, std::vector<uint>{});
   auto flat_prob = g3.add_distribution(

--- a/src/beanmachine/graph/distribution/tests/half_normal_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/half_normal_test.cpp
@@ -19,7 +19,7 @@ TEST(testdistrib, half_normal) {
   // TODO[Walid]: Move declarations and graph additions closer to use
   const double MEAN = 0; // Half-normal assumes 0
   const double STD = 3.0;
-  auto real1 = g.add_constant(MEAN);
+  auto real1 = g.add_constant_real(MEAN);
   auto pos1 = g.add_constant_pos_real(STD);
   // Test that g.add_distribution checks arguments to HALF_NORMAL correctly
   // negative tests half_normal has one parent
@@ -222,9 +222,9 @@ TEST(testdistrib, half_normal) {
 // Tests with aggregate samples
 TEST(testdistrib, backward_half_normal_half_normal) {
   Graph g;
-  uint zero = g.add_constant(0.0);
+  uint zero = g.add_constant_real(0.0);
   uint pos_one = g.add_constant_pos_real(1.0);
-  uint two = g.add_constant((natural_t)2);
+  uint two = g.add_constant_natural(2);
 
   uint half_normal_dist = g.add_distribution(
       DistributionType::HALF_NORMAL,
@@ -298,7 +298,7 @@ TEST(testdistrib, backward_half_normal_half_normal) {
   // back gradient calculations with respect to several
   // sampled variables, and through a composition of distributions.
   Graph g2;
-  auto size = g2.add_constant((natural_t)2);
+  auto size = g2.add_constant_natural(2);
   auto flat_real = g2.add_distribution(
       DistributionType::FLAT, AtomicType::REAL, std::vector<uint>{});
   auto flat_pos = g2.add_distribution(

--- a/src/beanmachine/graph/distribution/tests/lkj_cholesky_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/lkj_cholesky_test.cpp
@@ -21,7 +21,7 @@ TEST(testdistrib, lkj_cholesky) {
   Graph g;
   const double ETA = 3.0;
   auto pos1 = g.add_constant_pos_real(ETA);
-  auto nat1 = g.add_constant((natural_t)1);
+  auto nat1 = g.add_constant_natural(1);
 
   // negative tests that LKJ Cholesky has one positive real parent
   EXPECT_THROW(

--- a/src/beanmachine/graph/distribution/tests/log_normal_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/log_normal_test.cpp
@@ -23,7 +23,7 @@ TEST(testdistrib, lognormal) {
   const double LOG_STD = 3.0;
   const double LOG_STD_SQ = 9.0;
   const double MEAN = std::exp(LOG_MEAN + LOG_STD * LOG_STD / 2);
-  auto real1 = g.add_constant(LOG_MEAN);
+  auto real1 = g.add_constant_real(LOG_MEAN);
   auto pos1 = g.add_constant_pos_real(LOG_STD);
 
   // negative tests that log normal has two parents
@@ -117,9 +117,9 @@ TEST(testdistrib, lognormal) {
 
 TEST(testdistrib, backward_lognormal_lognormal) {
   Graph g;
-  uint zero = g.add_constant(0.0);
+  uint zero = g.add_constant_real(0.0);
   uint pos_one = g.add_constant_pos_real(1.0);
-  uint two = g.add_constant((natural_t)2);
+  uint two = g.add_constant_natural(2);
 
   uint lognormal_dist = g.add_distribution(
       DistributionType::LOG_NORMAL,

--- a/src/beanmachine/graph/distribution/tests/normal_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/normal_test.cpp
@@ -15,7 +15,7 @@ TEST(testdistrib, normal) {
   Graph g;
   const double MEAN = -11.0;
   const double STD = 3.0;
-  auto real1 = g.add_constant(MEAN);
+  auto real1 = g.add_constant_real(MEAN);
   auto pos1 = g.add_constant_pos_real(STD);
   // negative tests normal has two parents
   EXPECT_THROW(
@@ -106,9 +106,9 @@ TEST(testdistrib, normal) {
 
 TEST(testdistrib, backward_normal_normal) {
   Graph g;
-  uint zero = g.add_constant(0.0);
+  uint zero = g.add_constant_real(0.0);
   uint pos_one = g.add_constant_pos_real(1.0);
-  uint two = g.add_constant((natural_t)2);
+  uint two = g.add_constant_natural(2);
 
   uint normal_dist = g.add_distribution(
       DistributionType::NORMAL,
@@ -151,7 +151,7 @@ TEST(testdistrib, backward_normal_normal) {
 
   // mixture of normals
   Graph g2;
-  auto size = g2.add_constant((natural_t)2);
+  auto size = g2.add_constant_natural(2);
   auto flat_real = g2.add_distribution(
       DistributionType::FLAT, AtomicType::REAL, std::vector<uint>{});
   auto flat_pos = g2.add_distribution(

--- a/src/beanmachine/graph/distribution/tests/poisson_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/poisson_test.cpp
@@ -84,7 +84,7 @@ TEST(testdistrib, poisson) {
   EXPECT_NEAR(grad2, -2.6667, 0.001);
   // test backward_param, backward_value
   // test backward_param_iid, backward_param_iid
-  auto two = g.add_constant((natural_t)2);
+  auto two = g.add_constant_natural(2);
   auto y2 = g.add_operator(
       OperatorType::IID_SAMPLE, std::vector<uint>{y_dist, two, two});
   Eigen::MatrixXn m_y(2, 2);

--- a/src/beanmachine/graph/distribution/tests/product_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/product_test.cpp
@@ -35,7 +35,7 @@ TEST(testdistrib, product_construction_and_log_prob) {
 
   const double MEAN1 = -11.0;
   const double STD1 = 3.0;
-  auto real1 = g.add_constant(MEAN1);
+  auto real1 = g.add_constant_real(MEAN1);
   auto pos1 = g.add_constant_pos_real(STD1);
 
   auto normal_dist1 = g.add_distribution(
@@ -45,7 +45,7 @@ TEST(testdistrib, product_construction_and_log_prob) {
 
   const double MEAN2 = 0.0;
   const double STD2 = 2.0;
-  auto real2 = g.add_constant(MEAN2);
+  auto real2 = g.add_constant_real(MEAN2);
   auto pos2 = g.add_constant_pos_real(STD2);
 
   auto normal_dist2 = g.add_distribution(
@@ -141,7 +141,7 @@ TEST(testdistrib, product_inference_downstream) {
 
   const double MEAN1 = -5.0;
   const double STD1 = 2.0;
-  auto real1 = g.add_constant(MEAN1);
+  auto real1 = g.add_constant_real(MEAN1);
   auto pos1 = g.add_constant_pos_real(STD1);
 
   auto normal_dist1 = g.add_distribution(
@@ -151,7 +151,7 @@ TEST(testdistrib, product_inference_downstream) {
 
   const double MEAN2 = 5.0;
   const double STD2 = 2.0;
-  auto real2 = g.add_constant(MEAN2);
+  auto real2 = g.add_constant_real(MEAN2);
   auto pos2 = g.add_constant_pos_real(STD2);
 
   auto normal_dist2 = g.add_distribution(
@@ -179,7 +179,7 @@ TEST(testdistrib, product_inference_upstream) {
 
   const double MEAN0 = -5.0;
   const double STD0 = 1.0;
-  auto real0 = g.add_constant(MEAN0);
+  auto real0 = g.add_constant_real(MEAN0);
   auto pos0 = g.add_constant_pos_real(STD0);
 
   auto normal_dist0 = g.add_distribution(
@@ -200,7 +200,7 @@ TEST(testdistrib, product_inference_upstream) {
 
   const double MEAN2 = 5.0;
   const double STD2 = 2.0;
-  auto real2 = g.add_constant(MEAN2);
+  auto real2 = g.add_constant_real(MEAN2);
   auto pos2 = g.add_constant_pos_real(STD2);
 
   auto normal_dist2 = g.add_distribution(
@@ -240,7 +240,7 @@ TEST(testdistrib, product_inference_upstream_iid) {
 
   const double MEAN0 = -5.0;
   const double STD0 = 1.0;
-  auto real0 = g.add_constant(MEAN0);
+  auto real0 = g.add_constant_real(MEAN0);
   auto pos0 = g.add_constant_pos_real(STD0);
 
   auto normal_dist0 = g.add_distribution(
@@ -261,7 +261,7 @@ TEST(testdistrib, product_inference_upstream_iid) {
 
   const double MEAN2 = 5.0;
   const double STD2 = 2.0;
-  auto real2 = g.add_constant(MEAN2);
+  auto real2 = g.add_constant_real(MEAN2);
   auto pos2 = g.add_constant_pos_real(STD2);
 
   auto normal_dist2 = g.add_distribution(
@@ -275,7 +275,7 @@ TEST(testdistrib, product_inference_upstream_iid) {
       std::vector<uint>{normal_dist1, normal_dist2});
 
   natural_t sample_size = 3;
-  auto sample_size_node = g.add_constant((natural_t)sample_size);
+  auto sample_size_node = g.add_constant_natural((natural_t)sample_size);
   auto product_sample_idd = g.add_operator(
       OperatorType::IID_SAMPLE,
       std::vector<uint>{product_dist1, sample_size_node});
@@ -315,7 +315,7 @@ TEST(testdistrib, product_inference_upstream_larger) {
 
   const double MEAN0 = -5.0;
   const double STD0 = 1.0;
-  auto real0 = g.add_constant(MEAN0);
+  auto real0 = g.add_constant_real(MEAN0);
   auto pos0 = g.add_constant_pos_real(STD0);
 
   auto normal_dist0 = g.add_distribution(
@@ -336,7 +336,7 @@ TEST(testdistrib, product_inference_upstream_larger) {
 
   const double MEAN2 = 5.0;
   const double STD2 = 2.0;
-  auto real2 = g.add_constant(MEAN2);
+  auto real2 = g.add_constant_real(MEAN2);
   auto pos2 = g.add_constant_pos_real(STD2);
 
   auto normal_dist2 = g.add_distribution(
@@ -353,7 +353,7 @@ TEST(testdistrib, product_inference_upstream_larger) {
       g.add_operator(OperatorType::SAMPLE, std::vector<uint>{product_dist1});
 
   const double STD3 = 3.0;
-  auto two = g.add_constant(2.0);
+  auto two = g.add_constant_real(2.0);
   auto mean3 =
       g.add_operator(OperatorType::ADD, std::vector<uint>{product_sample, two});
   auto pos3 = g.add_constant_pos_real(STD3);

--- a/src/beanmachine/graph/distribution/tests/student_t_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/student_t_test.cpp
@@ -17,7 +17,7 @@ TEST(testdistrib, student_t) {
   const double LOC = -11.0;
   const double SCALE = 4.0;
   auto dof = g.add_constant_pos_real(DOF);
-  auto loc = g.add_constant(LOC);
+  auto loc = g.add_constant_real(LOC);
   auto scale = g.add_constant_pos_real(SCALE);
   // negative tests: student-t has three parents
   EXPECT_THROW(
@@ -158,7 +158,7 @@ TEST(testdistrib, student_t) {
   EXPECT_NEAR((*grad[3]), 0.6213, 1e-3); // scale
 
   // test log_prob, backward_param_iid, backward_value_iid:
-  auto two = g.add_constant((natural_t)2);
+  auto two = g.add_constant_natural(2);
   auto y = g.add_operator(
       OperatorType::IID_SAMPLE, std::vector<uint>{x_dist, two, two});
   Eigen::MatrixXd m(2, 2);
@@ -178,7 +178,7 @@ TEST(testdistrib, student_t) {
 
   // test sample/iid_sample from a mixture of t-dist
   Graph g2;
-  auto size = g2.add_constant((natural_t)2);
+  auto size = g2.add_constant_natural(2);
   auto flat_real = g2.add_distribution(
       DistributionType::FLAT, AtomicType::REAL, std::vector<uint>{});
   auto flat_pos = g2.add_distribution(

--- a/src/beanmachine/graph/factor/tests/exp_product_test.cpp
+++ b/src/beanmachine/graph/factor/tests/exp_product_test.cpp
@@ -18,13 +18,13 @@ TEST(testfactor, exp_product) {
       g.add_factor(FactorType::EXP_PRODUCT, std::vector<uint>{}),
       std::invalid_argument);
   // negative test, booleans can't be the parent of an exp_product
-  uint bool1 = g.add_constant(true);
+  uint bool1 = g.add_constant_bool(true);
   EXPECT_THROW(
       g.add_factor(FactorType::EXP_PRODUCT, std::vector<uint>{bool1}),
       std::invalid_argument);
   // positive test, mixed product types are allowed
   uint pos1 = g.add_constant_pos_real(2.0);
-  uint real1 = g.add_constant(3.0);
+  uint real1 = g.add_constant_real(3.0);
   uint prob1 = g.add_constant_probability(0.4);
   uint neg1 = g.add_constant_neg_real(-1.0);
   g.add_factor(

--- a/src/beanmachine/graph/global/tests/conjugate_util_test.cpp
+++ b/src/beanmachine/graph/global/tests/conjugate_util_test.cpp
@@ -124,7 +124,7 @@ void add_normal_normal_conjugate_(
   x ~ Normal(mu, sigma)
   x is observed
   */
-  uint mu_0_node = g.add_constant(mu_0);
+  uint mu_0_node = g.add_constant_real(mu_0);
   uint sigma_0_node = g.add_constant_pos_real(sigma_0);
   uint sigma_node = g.add_constant_pos_real(sigma);
 
@@ -235,15 +235,15 @@ void add_gamma_normal_conjugate_(
   uint sample = g.add_operator(OperatorType::SAMPLE, {gamma_dist});
 
   // 1 / sqrt(sample)
-  uint point_five = g.add_constant(0.5);
+  uint point_five = g.add_constant_real(0.5);
   uint sqrt_sample = g.add_operator(OperatorType::POW, {sample, point_five});
-  uint neg_one = g.add_constant(-1.0);
+  uint neg_one = g.add_constant_real(-1.0);
   uint inv_sqrt_sample =
       g.add_operator(OperatorType::POW, {sqrt_sample, neg_one});
   inv_sqrt_sample =
       g.add_operator(OperatorType::TO_POS_REAL, {inv_sqrt_sample});
 
-  uint mu_node = g.add_constant(mu);
+  uint mu_node = g.add_constant_real(mu);
   uint gamma_norm_dist = g.add_distribution(
       DistributionType::NORMAL, AtomicType::REAL, {mu_node, inv_sqrt_sample});
   for (uint i = 0; i < x_observed.size(); i++) {
@@ -311,7 +311,7 @@ void add_beta_binomial_model_(
       DistributionType::BETA, AtomicType::PROBABILITY, {alpha_node, beta_node});
   uint p = g.add_operator(OperatorType::SAMPLE, {beta_dist});
 
-  uint n_node = g.add_constant((natural_t)n);
+  uint n_node = g.add_constant_natural(n);
   uint beta_binomial_dist = g.add_distribution(
       DistributionType::BINOMIAL, AtomicType::NATURAL, {n_node, p});
   uint obs = g.add_operator(OperatorType::SAMPLE, {beta_binomial_dist});

--- a/src/beanmachine/graph/global/tests/global_state_test.cpp
+++ b/src/beanmachine/graph/global/tests/global_state_test.cpp
@@ -23,10 +23,10 @@ TEST(testglobal, global_state_no_transform) {
   // incrementing global values, and calculating gradients
   Graph g = Graph();
 
-  uint zero = g.add_constant(0.0);
+  uint zero = g.add_constant_real(0.0);
   uint one = g.add_constant_pos_real(1.0);
-  uint two = g.add_constant((natural_t)2);
-  uint three = g.add_constant(3.0);
+  uint two = g.add_constant_natural(2);
+  uint three = g.add_constant_real(3.0);
 
   uint norm_dist = g.add_distribution(
       DistributionType::NORMAL, AtomicType::REAL, {zero, one});
@@ -144,7 +144,7 @@ TEST(testglobal, global_state_no_transform) {
 TEST(testglobal, global_state_transform) {
   Graph g;
   uint one = g.add_constant_pos_real(1.0);
-  uint three_nat = g.add_constant((natural_t)3);
+  uint three_nat = g.add_constant_natural(3);
   uint three = g.add_constant_pos_real(3.0);
 
   uint dist = g.add_distribution(
@@ -288,9 +288,9 @@ TEST(testglobal, global_state_gamma_transform) {
 TEST(testglobal, global_state_initialization) {
   /* Test initialization in real space */
   Graph g;
-  uint hundred = g.add_constant(100.0);
+  uint hundred = g.add_constant_real(100.0);
   uint one = g.add_constant_pos_real(1.0);
-  uint thousand = g.add_constant((natural_t)1000);
+  uint thousand = g.add_constant_natural(1000);
 
   uint normal_dist = g.add_distribution(
       DistributionType::NORMAL,
@@ -333,7 +333,7 @@ TEST(testglobal, global_state_transform_initialization) {
   Graph g;
   uint twohundred = g.add_constant_pos_real(200.0);
   uint hundred = g.add_constant_pos_real(100.0);
-  uint thousand = g.add_constant((natural_t)1000);
+  uint thousand = g.add_constant_natural(1000);
 
   uint normal_dist = g.add_distribution(
       DistributionType::GAMMA,

--- a/src/beanmachine/graph/global/tests/random_walk_test.cpp
+++ b/src/beanmachine/graph/global/tests/random_walk_test.cpp
@@ -22,7 +22,7 @@ TEST(testglobal, rw_normal_normal) {
   posterior is Normal(0.25, 0.5)
   */
   Graph g;
-  uint zero = g.add_constant(0.0);
+  uint zero = g.add_constant_real(0.0);
   uint one = g.add_constant_pos_real(1.0);
 
   uint norm_dist = g.add_distribution(
@@ -57,7 +57,7 @@ TEST(testglobal, rw_distant_normal_normal) {
   posterior is Normal(50.5, 0.5)
   */
   Graph g;
-  uint hundred = g.add_constant(100.0);
+  uint hundred = g.add_constant_real(100.0);
   uint one = g.add_constant_pos_real(1.0);
 
   uint norm_dist = g.add_distribution(

--- a/src/beanmachine/graph/graph.cpp
+++ b/src/beanmachine/graph/graph.cpp
@@ -698,11 +698,23 @@ uint Graph::add_constant(bool value) {
   return add_constant(NodeValue(value));
 }
 
+uint Graph::add_constant_bool(bool value) {
+  return add_constant(NodeValue(value));
+}
+
 uint Graph::add_constant(double value) {
   return add_constant(NodeValue(value));
 }
 
+uint Graph::add_constant_real(double value) {
+  return add_constant(NodeValue(value));
+}
+
 uint Graph::add_constant(natural_t value) {
+  return add_constant(NodeValue(value));
+}
+
+uint Graph::add_constant_natural(natural_t value) {
   return add_constant(NodeValue(value));
 }
 

--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -581,6 +581,9 @@ struct Graph {
   uint add_constant(double value);
   uint add_constant(natural_t value);
   uint add_constant(NodeValue value);
+  uint add_constant_bool(bool value);
+  uint add_constant_real(double value);
+  uint add_constant_natural(natural_t value);
   uint add_constant_probability(double value);
   uint add_constant_pos_real(double value);
   uint add_constant_neg_real(double value);

--- a/src/beanmachine/graph/marginalization/marginalized_graph_test.cpp
+++ b/src/beanmachine/graph/marginalization/marginalized_graph_test.cpp
@@ -232,7 +232,7 @@ TEST(testmarginals, DISABLED_parent_and_children) {
 }
   */
   Graph g;
-  uint binomial_n = g.add_constant((natural_t)10);
+  uint binomial_n = g.add_constant_natural(10);
   uint p = g.add_constant_probability(0.3);
   uint binomial = g.add_distribution(
       DistributionType::BINOMIAL, AtomicType::NATURAL, {binomial_n, p});
@@ -245,7 +245,7 @@ TEST(testmarginals, DISABLED_parent_and_children) {
   uint n1 = g.add_operator(OperatorType::SAMPLE, {normal_1});
   g.query(n1);
 
-  uint five = g.add_constant(5.0);
+  uint five = g.add_constant_real(5.0);
   uint binomial_plus_five =
       g.add_operator(OperatorType::ADD, {binomial_real, five});
   uint normal_2 = g.add_distribution(

--- a/src/beanmachine/graph/operator/tests/gradient_test.cpp
+++ b/src/beanmachine/graph/operator/tests/gradient_test.cpp
@@ -30,8 +30,8 @@ TEST(testgradient, operators) {
   double grad1;
   double grad2;
   // test operators on real numbers
-  auto a = g.add_constant(3.0);
-  auto b = g.add_constant(10.0);
+  auto a = g.add_constant_real(3.0);
+  auto b = g.add_constant_real(10.0);
   auto c = g.add_operator(OperatorType::MULTIPLY, std::vector<uint>({a, b}));
   auto d = g.add_operator(OperatorType::ADD, std::vector<uint>({a, a, c}));
   auto e =
@@ -180,7 +180,7 @@ TEST(testgradient, beta_binomial) {
   Graph g;
   uint a = g.add_constant_pos_real(5.0);
   uint b = g.add_constant_pos_real(3.0);
-  uint n = g.add_constant((natural_t)3);
+  uint n = g.add_constant_natural(3);
   uint beta = g.add_distribution(
       DistributionType::BETA,
       AtomicType::PROBABILITY,
@@ -238,7 +238,7 @@ TEST(testgradient, backward_scalar_linearmodel) {
   // prior: coeff_x, intercept ~ Normal(0, 1)
   // likelihood: y_i ~ Normal(x_i * coeff_x + intercept, 1)
   Graph g;
-  uint zero = g.add_constant(0.0);
+  uint zero = g.add_constant_real(0.0);
   uint pos_one = g.add_constant_pos_real(1.0);
 
   uint normal_dist = g.add_distribution(
@@ -252,7 +252,7 @@ TEST(testgradient, backward_scalar_linearmodel) {
 
   std::vector<double> X{0.5, -1.5, 2.1};
   for (double x : X) {
-    uint x_i = g.add_constant(x);
+    uint x_i = g.add_constant_real(x);
     uint xb_i =
         g.add_operator(OperatorType::MULTIPLY, std::vector<uint>{x_i, coeff_x});
     uint mu_i =
@@ -291,9 +291,9 @@ TEST(testgradient, backward_vector_linearmodel) {
   // prior vector(2 by 1): betas ~ iid Normal(0, 1)
   // likelihood: y_i ~ Normal((X @ betas)[i], 1)
   Graph g;
-  uint zero = g.add_constant(0.0);
+  uint zero = g.add_constant_real(0.0);
   uint pos_one = g.add_constant_pos_real(1.0);
-  uint two = g.add_constant((natural_t)2);
+  uint two = g.add_constant_natural(2);
 
   uint normal_dist = g.add_distribution(
       DistributionType::NORMAL,
@@ -388,7 +388,7 @@ TEST(testgradient, backward_matrix_index) {
   Eigen::MatrixXd m1(3, 1);
   m1 << 2.0, 0.5, 3.0;
   uint cm1 = g.add_constant_pos_matrix(m1);
-  uint one = g.add_constant((natural_t)1);
+  uint one = g.add_constant_natural(1);
   uint half = g.add_constant_probability(0.5);
 
   uint diri_dist = g.add_distribution(
@@ -435,11 +435,11 @@ TEST(testgradient, backward_column_index) {
   Eigen::MatrixXd m1(3, 2);
   m1 << 2.0, 1.0, 0.5, 3.0, 3.0, 2.0;
   uint cm1 = g.add_constant_pos_matrix(m1);
-  uint zero = g.add_constant((natural_t)0);
+  uint zero = g.add_constant_natural(0);
 
   uint first_column = g.add_operator(OperatorType::COLUMN_INDEX, {cm1, zero});
 
-  uint one = g.add_constant((natural_t)1);
+  uint one = g.add_constant_natural(1);
   uint half = g.add_constant_probability(0.5);
 
   uint diri_dist = g.add_distribution(
@@ -482,12 +482,12 @@ TEST(testgradient, backward_column_index) {
 
 TEST(testgradient, forward_to_matrix) {
   Graph g;
-  uint zero = g.add_constant(0.0);
+  uint zero = g.add_constant_real(0.0);
   uint one = g.add_constant_pos_real(1.0);
   uint two = g.add_constant_pos_real(2.0);
   uint five = g.add_constant_pos_real(5.0);
-  uint nat_one = g.add_constant((natural_t)1);
-  uint nat_two = g.add_constant((natural_t)2);
+  uint nat_one = g.add_constant_natural(1);
+  uint nat_two = g.add_constant_natural(2);
 
   uint norm_dist = g.add_distribution(
       DistributionType::NORMAL, AtomicType::REAL, {zero, one});
@@ -501,7 +501,7 @@ TEST(testgradient, forward_to_matrix) {
   uint sample_matrix = g.add_operator(
       OperatorType::TO_MATRIX, {nat_two, nat_one, norm_sample, stu_sample});
 
-  uint zero_nat = g.add_constant((natural_t)0);
+  uint zero_nat = g.add_constant_natural(0);
   uint sample_index =
       g.add_operator(OperatorType::INDEX, {sample_matrix, zero_nat});
   uint new_norm_dist = g.add_distribution(
@@ -525,12 +525,12 @@ TEST(testgradient, forward_to_matrix) {
 
 TEST(testgradient, backward_to_matrix) {
   Graph g;
-  uint zero = g.add_constant(0.0);
+  uint zero = g.add_constant_real(0.0);
   uint one = g.add_constant_pos_real(1.0);
   uint two = g.add_constant_pos_real(2.0);
   uint five = g.add_constant_pos_real(5.0);
-  uint nat_two = g.add_constant((natural_t)2);
-  uint nat_one = g.add_constant((natural_t)1);
+  uint nat_two = g.add_constant_natural(2);
+  uint nat_one = g.add_constant_natural(1);
 
   uint norm_dist = g.add_distribution(
       DistributionType::NORMAL, AtomicType::REAL, {zero, one});
@@ -545,7 +545,7 @@ TEST(testgradient, backward_to_matrix) {
   uint sample_matrix = g.add_operator(
       OperatorType::TO_MATRIX, {nat_two, nat_one, norm_sample, stu_sample});
 
-  uint zero_nat = g.add_constant((natural_t)0);
+  uint zero_nat = g.add_constant_natural(0);
   uint sample_index =
       g.add_operator(OperatorType::INDEX, {sample_matrix, zero_nat});
   uint new_norm_dist = g.add_distribution(
@@ -588,7 +588,7 @@ TEST(testgradient, forward_matrix_scale) {
   double s0 = uniform(gen);
   double s1 = uniform(gen);
   double s2 = uniform(gen);
-  auto s = g.add_constant(s0);
+  auto s = g.add_constant_real(s0);
   g.get_node(s)->grad1 = s1;
   g.get_node(s)->grad2 = s2;
 
@@ -612,14 +612,14 @@ TEST(testgradient, forward_matrix_scale) {
 
 TEST(testgradient, forward_broadcast_add) {
   Graph g;
-  auto zero = g.add_constant(0.0);
+  auto zero = g.add_constant_real(0.0);
   auto one = g.add_constant_pos_real(1.0);
   auto norm_dist = g.add_distribution(
       DistributionType::NORMAL, AtomicType::REAL, {zero, one});
   auto norm_sample = g.add_operator(OperatorType::SAMPLE, {norm_dist});
 
-  auto nat_zero = g.add_constant((natural_t)0);
-  auto nat_one = g.add_constant((natural_t)1);
+  auto nat_zero = g.add_constant_natural(0);
+  auto nat_one = g.add_constant_natural(1);
   Eigen::MatrixXd m(2, 1);
   m << 1.0, 2.0;
   auto matrix = g.add_constant_real_matrix(m);
@@ -654,7 +654,7 @@ TEST(testgradient, forward_broadcast_add) {
 
 TEST(testgradient, backward_broadcast_add) {
   Graph g;
-  auto zero = g.add_constant(0.0);
+  auto zero = g.add_constant_real(0.0);
   auto one = g.add_constant_pos_real(1.0);
   auto two = g.add_constant_pos_real(2.0);
   auto five = g.add_constant_pos_real(5.0);
@@ -669,8 +669,8 @@ TEST(testgradient, backward_broadcast_add) {
   auto matrix = g.add_constant_real_matrix(m);
   auto sum_matrix =
       g.add_operator(OperatorType::BROADCAST_ADD, {stu_sample, matrix});
-  auto nat_zero = g.add_constant((natural_t)0);
-  auto nat_one = g.add_constant((natural_t)1);
+  auto nat_zero = g.add_constant_natural(0);
+  auto nat_one = g.add_constant_natural(1);
   auto first_entry =
       g.add_operator(OperatorType::INDEX, {sum_matrix, nat_zero});
   auto second_entry =
@@ -733,7 +733,7 @@ TEST(testgradient, matrix_add_grad) {
 
   // test where constant matrices don't have gradient initialized
   Graph g1;
-  auto zero = g1.add_constant(0.0);
+  auto zero = g1.add_constant_real(0.0);
   auto one = g1.add_constant_pos_real(1.0);
   Eigen::MatrixXd constant(2, 1);
   constant << -2.0, 1.0;
@@ -741,7 +741,7 @@ TEST(testgradient, matrix_add_grad) {
 
   auto normal_dist = g1.add_distribution(
       DistributionType::NORMAL, AtomicType::REAL, {zero, one});
-  auto two_natural = g1.add_constant((natural_t)2);
+  auto two_natural = g1.add_constant_natural(2);
   auto sample = g1.add_operator(
       OperatorType::IID_SAMPLE, std::vector<uint>{normal_dist, two_natural});
   auto add = g1.add_operator(OperatorType::MATRIX_ADD, {cm, sample});
@@ -954,10 +954,10 @@ TEST(testgradient, backward_cholesky) {
     autograd.grad(log_p, x)
   */
   Graph g;
-  auto zero = g.add_constant(0.0);
+  auto zero = g.add_constant_real(0.0);
   auto pos1 = g.add_constant_pos_real(1.0);
-  auto one = g.add_constant((natural_t)1);
-  auto three = g.add_constant((natural_t)3);
+  auto one = g.add_constant_natural(1);
+  auto three = g.add_constant_natural(3);
   auto normal_dist = g.add_distribution(
       DistributionType::NORMAL,
       AtomicType::REAL,
@@ -1014,7 +1014,7 @@ TEST(testgradient, matrix_exp_grad) {
   m1 << -2., -3.0;
   auto cm1 = g.add_constant_real_matrix(m1);
 
-  auto c = g.add_constant(2.0);
+  auto c = g.add_constant_real(2.0);
   auto cm = g.add_operator(OperatorType::MATRIX_SCALE, {c, cm1});
   auto exp = g.add_operator(OperatorType::MATRIX_EXP, {cm});
 
@@ -1041,11 +1041,11 @@ TEST(testgradient, matrix_exp_grad) {
 
   // test backward
   Graph g1;
-  auto zero = g1.add_constant(0.0);
+  auto zero = g1.add_constant_real(0.0);
   auto one = g1.add_constant_pos_real(1.0);
   auto x_dist = g1.add_distribution(
       DistributionType::NORMAL, AtomicType::REAL, {zero, one});
-  auto two = g1.add_constant((natural_t)2);
+  auto two = g1.add_constant_natural(2);
   auto x_sample =
       g1.add_operator(OperatorType::IID_SAMPLE, std::vector<uint>{x_dist, two});
   Eigen::MatrixXd x_value(2, 1);
@@ -1054,7 +1054,7 @@ TEST(testgradient, matrix_exp_grad) {
   auto exp_x_pos = g1.add_operator(OperatorType::MATRIX_EXP, {x_sample});
   auto exp_x = g1.add_operator(OperatorType::TO_REAL_MATRIX, {exp_x_pos});
 
-  auto index_zero = g1.add_constant((natural_t)0);
+  auto index_zero = g1.add_constant_natural(0);
   auto exp_x1 = g1.add_operator(OperatorType::INDEX, {exp_x, index_zero});
   auto y1_dist = g1.add_distribution(
       DistributionType::NORMAL, AtomicType::REAL, {exp_x1, one});
@@ -1062,7 +1062,7 @@ TEST(testgradient, matrix_exp_grad) {
       g1.add_operator(OperatorType::SAMPLE, std::vector<uint>{y1_dist});
   g1.observe(y1_sample, 2.5);
 
-  auto index_one = g1.add_constant((natural_t)1);
+  auto index_one = g1.add_constant_natural(1);
   auto exp_x2 = g1.add_operator(OperatorType::INDEX, {exp_x, index_one});
   auto y2_dist = g1.add_distribution(
       DistributionType::NORMAL, AtomicType::REAL, {exp_x2, one});
@@ -1170,7 +1170,7 @@ torch.autograd.grad(log_prob, sn1, retain_graph=True) # -2.1931
   auto one = g.add_constant_pos_real(1.0);
   auto hn = g.add_distribution(
       DistributionType::HALF_NORMAL, AtomicType::POS_REAL, {one});
-  auto two = g.add_constant((natural_t)2);
+  auto two = g.add_constant_natural(2);
   auto hn_sample =
       g.add_operator(OperatorType::IID_SAMPLE, std::vector<uint>{hn, two});
   Eigen::MatrixXd hn_observed(2, 1);
@@ -1179,9 +1179,9 @@ torch.autograd.grad(log_prob, sn1, retain_graph=True) # -2.1931
 
   auto mlog_pos = g.add_operator(OperatorType::MATRIX_LOG, {hn_sample});
   auto mlog = g.add_operator(OperatorType::TO_REAL_MATRIX, {mlog_pos});
-  auto index_zero = g.add_constant((natural_t)0);
+  auto index_zero = g.add_constant_natural(0);
   auto mlog0 = g.add_operator(OperatorType::INDEX, {mlog, index_zero});
-  auto index_one = g.add_constant((natural_t)1);
+  auto index_one = g.add_constant_natural(1);
   auto mlog1 = g.add_operator(OperatorType::INDEX, {mlog, index_one});
 
   auto n0 = g.add_distribution(
@@ -1211,7 +1211,7 @@ TEST(testgradient, matrix_phi_grad_forward) {
   Eigen::MatrixXd m1(1, 2);
   m1 << 2.0, 3.0;
   auto cm1 = g.add_constant_real_matrix(m1);
-  auto c = g.add_constant(2.0);
+  auto c = g.add_constant_real(2.0);
   auto cm = g.add_operator(OperatorType::MATRIX_SCALE, {c, cm1});
   auto mphi = g.add_operator(OperatorType::MATRIX_PHI, {cm});
   // f(x) = phi(2 * g(x))
@@ -1311,7 +1311,7 @@ torch.autograd.grad(log_prob, sn1, retain_graph=True) # -0.8085
   auto one = g.add_constant_pos_real(1.0);
   auto hn = g.add_distribution(
       DistributionType::HALF_NORMAL, AtomicType::POS_REAL, {one});
-  auto two = g.add_constant((natural_t)2);
+  auto two = g.add_constant_natural(2);
   auto hn_sample =
       g.add_operator(OperatorType::IID_SAMPLE, std::vector<uint>{hn, two});
   Eigen::MatrixXd hn_observed(2, 1);
@@ -1321,9 +1321,9 @@ torch.autograd.grad(log_prob, sn1, retain_graph=True) # -0.8085
   auto to_real = g.add_operator(OperatorType::TO_REAL_MATRIX, {hn_sample});
   auto mlog_pos = g.add_operator(OperatorType::MATRIX_PHI, {to_real});
   auto mlog = g.add_operator(OperatorType::TO_REAL_MATRIX, {mlog_pos});
-  auto index_zero = g.add_constant((natural_t)0);
+  auto index_zero = g.add_constant_natural(0);
   auto mlog0 = g.add_operator(OperatorType::INDEX, {mlog, index_zero});
-  auto index_one = g.add_constant((natural_t)1);
+  auto index_one = g.add_constant_natural(1);
   auto mlog1 = g.add_operator(OperatorType::INDEX, {mlog, index_one});
 
   auto n0 = g.add_distribution(
@@ -1347,15 +1347,15 @@ torch.autograd.grad(log_prob, sn1, retain_graph=True) # -0.8085
 
 TEST(testgradient, matrix_elementwise_mult_backward) {
   Graph g;
-  auto zero = g.add_constant(0.0);
+  auto zero = g.add_constant_real(0.0);
   auto pos1 = g.add_constant_pos_real(1.0);
   auto normal_dist = g.add_distribution(
       DistributionType::NORMAL,
       AtomicType::REAL,
       std::vector<uint>{zero, pos1});
-  auto one = g.add_constant((natural_t)1);
-  auto two = g.add_constant((natural_t)2);
-  auto three = g.add_constant((natural_t)3);
+  auto one = g.add_constant_natural(1);
+  auto two = g.add_constant_natural(2);
+  auto three = g.add_constant_natural(3);
 
   Eigen::MatrixXd m1(3, 2);
   Eigen::MatrixXd m2(3, 2);
@@ -1502,11 +1502,11 @@ TEST(testgradient, log_prob) {
   std::mt19937 gen;
   Graph g;
   double epsilon = 0.0000001;
-  auto zero = g.add_constant(0.0);
+  auto zero = g.add_constant_real(0.0);
   auto pos_zero = g.add_constant_pos_real(0.0);
 
   auto makeConst = [&](double value) {
-    auto v = g.add_constant(value);
+    auto v = g.add_constant_real(value);
     auto plus = g.add_operator(OperatorType::ADD, {zero, v});
     g.get_node(plus)->eval(gen);
     return plus;
@@ -1675,7 +1675,7 @@ TEST(testgradient, matrix_sum) {
   // grad(log_p, y) -> -1.25
 
   Graph g1;
-  auto zero = g1.add_constant(0.0);
+  auto zero = g1.add_constant_real(0.0);
   auto pos_one = g1.add_constant_pos_real(1.0);
   auto x_dist = g1.add_distribution(
       DistributionType::NORMAL,
@@ -1684,8 +1684,8 @@ TEST(testgradient, matrix_sum) {
   auto x = g1.add_operator(OperatorType::SAMPLE, {x_dist});
   g1.observe(x, 0.5);
   auto x_squared = g1.add_operator(OperatorType::MULTIPLY, {x, x});
-  auto one = g1.add_constant((natural_t)1);
-  auto two = g1.add_constant((natural_t)2);
+  auto one = g1.add_constant_natural(1);
+  auto two = g1.add_constant_natural(2);
   auto x_matrix =
       g1.add_operator(OperatorType::TO_MATRIX, {two, one, x, x_squared});
   auto x_sum = g1.add_operator(OperatorType::MATRIX_SUM, {x_matrix});
@@ -1790,7 +1790,7 @@ print(torch.autograd.grad(log_prob, sn1, retain_graph=True)) # -1.0945
   auto one = g.add_constant_pos_real(1.0);
   auto hn = g.add_distribution(
       DistributionType::HALF_NORMAL, AtomicType::POS_REAL, {one});
-  auto two = g.add_constant((natural_t)2);
+  auto two = g.add_constant_natural(2);
   auto hn_sample =
       g.add_operator(OperatorType::IID_SAMPLE, std::vector<uint>{hn, two});
   Eigen::MatrixXd hn_observed(2, 1);
@@ -1799,9 +1799,9 @@ print(torch.autograd.grad(log_prob, sn1, retain_graph=True)) # -1.0945
 
   auto mlog_pos = g.add_operator(OperatorType::MATRIX_LOG1P, {hn_sample});
   auto mlog = g.add_operator(OperatorType::TO_REAL_MATRIX, {mlog_pos});
-  auto index_zero = g.add_constant((natural_t)0);
+  auto index_zero = g.add_constant_natural(0);
   auto mlog0 = g.add_operator(OperatorType::INDEX, {mlog, index_zero});
-  auto index_one = g.add_constant((natural_t)1);
+  auto index_one = g.add_constant_natural(1);
   auto mlog1 = g.add_operator(OperatorType::INDEX, {mlog, index_one});
 
   auto n0 = g.add_distribution(
@@ -1920,7 +1920,7 @@ print(torch.autograd.grad(log_prob, ns, retain_graph=True))
   auto one = g.add_constant_pos_real(1.0);
   auto hn = g.add_distribution(
       DistributionType::HALF_NORMAL, AtomicType::POS_REAL, {one});
-  auto two = g.add_constant((natural_t)2);
+  auto two = g.add_constant_natural(2);
   // sample 0
   auto hn_sample =
       g.add_operator(OperatorType::IID_SAMPLE, std::vector<uint>{hn, two});
@@ -1934,7 +1934,7 @@ print(torch.autograd.grad(log_prob, ns, retain_graph=True))
       g.add_operator(OperatorType::MATRIX_LOG1MEXP, {hn_sample_neg});
   auto mlog = g.add_operator(OperatorType::TO_REAL_MATRIX, {mlog_neg});
 
-  auto index_zero = g.add_constant((natural_t)0);
+  auto index_zero = g.add_constant_natural(0);
   auto mlog0 = g.add_operator(OperatorType::INDEX, {mlog, index_zero});
   auto n0 = g.add_distribution(
       DistributionType::NORMAL, AtomicType::REAL, {mlog0, one});
@@ -1942,7 +1942,7 @@ print(torch.autograd.grad(log_prob, ns, retain_graph=True))
   auto ns0 = g.add_operator(OperatorType::SAMPLE, std::vector<uint>{n0});
   g.observe(ns0, 2.5);
 
-  auto index_one = g.add_constant((natural_t)1);
+  auto index_one = g.add_constant_natural(1);
   auto mlog1 = g.add_operator(OperatorType::INDEX, {mlog, index_one});
   auto n1 = g.add_distribution(
       DistributionType::NORMAL, AtomicType::REAL, {mlog1, one});
@@ -2033,7 +2033,7 @@ print(torch.autograd.grad(log_prob, ns, retain_graph=True))
   // sample 0
   auto beta_sample = g.add_operator(
       OperatorType::IID_SAMPLE,
-      std::vector<uint>{beta, g.add_constant((natural_t)2)});
+      std::vector<uint>{beta, g.add_constant_natural(2)});
   Eigen::MatrixXd beta_observed(2, 1);
   beta_observed << 0.1, 0.7;
   g.observe(beta_sample, beta_observed);
@@ -2044,7 +2044,7 @@ print(torch.autograd.grad(log_prob, ns, retain_graph=True))
   // COMPLEMENT takes probability values and returns probability values.
   auto comp = g.add_operator(OperatorType::TO_REAL_MATRIX, {complement});
 
-  auto index_zero = g.add_constant((natural_t)0);
+  auto index_zero = g.add_constant_natural(0);
   auto comp0 = g.add_operator(OperatorType::INDEX, {comp, index_zero});
   auto n0 = g.add_distribution(
       DistributionType::NORMAL, AtomicType::REAL, {comp0, one});
@@ -2052,7 +2052,7 @@ print(torch.autograd.grad(log_prob, ns, retain_graph=True))
   auto ns0 = g.add_operator(OperatorType::SAMPLE, std::vector<uint>{n0});
   g.observe(ns0, 1.1);
 
-  auto index_one = g.add_constant((natural_t)1);
+  auto index_one = g.add_constant_natural(1);
   auto comp1 = g.add_operator(OperatorType::INDEX, {comp, index_one});
   auto n1 = g.add_distribution(
       DistributionType::NORMAL, AtomicType::REAL, {comp1, one});

--- a/src/beanmachine/graph/operator/tests/operator_test.cpp
+++ b/src/beanmachine/graph/operator/tests/operator_test.cpp
@@ -63,7 +63,7 @@ TEST(testoperator, multiply) {
   EXPECT_THROW(
       g.add_operator(OperatorType::MULTIPLY, std::vector<uint>{pos1}),
       std::invalid_argument);
-  auto real1 = g.add_constant(0.0);
+  auto real1 = g.add_constant_real(0.0);
   EXPECT_THROW(
       g.add_operator(OperatorType::MULTIPLY, std::vector<uint>{real1, pos1}),
       std::invalid_argument);
@@ -140,7 +140,7 @@ TEST(testoperator, phi) {
   EXPECT_THROW(
       g.add_operator(OperatorType::PHI, std::vector<uint>{pos1}),
       std::invalid_argument);
-  auto real1 = g.add_constant(0.0);
+  auto real1 = g.add_constant_real(0.0);
   EXPECT_THROW(
       g.add_operator(OperatorType::PHI, std::vector<uint>{real1, real1}),
       std::invalid_argument);
@@ -189,7 +189,7 @@ TEST(testoperator, logistic) {
   EXPECT_THROW(
       g.add_operator(OperatorType::LOGISTIC, std::vector<uint>{pos1}),
       std::invalid_argument);
-  auto real1 = g.add_constant(0.0);
+  auto real1 = g.add_constant_real(0.0);
   EXPECT_THROW(
       g.add_operator(OperatorType::LOGISTIC, std::vector<uint>{real1, real1}),
       std::invalid_argument);
@@ -231,9 +231,9 @@ TEST(testoperator, logistic) {
 
 TEST(testoperator, if_then_else) {
   Graph g;
-  auto bool1 = g.add_constant(true);
-  auto real1 = g.add_constant(10.0);
-  auto real2 = g.add_constant(100.0);
+  auto bool1 = g.add_constant_bool(true);
+  auto real1 = g.add_constant_real(10.0);
+  auto real2 = g.add_constant_real(100.0);
   // negative tests: arg1.type==bool, arg2.type == arg3.type
   EXPECT_THROW(
       g.add_operator(OperatorType::IF_THEN_ELSE, std::vector<uint>{}),
@@ -274,7 +274,7 @@ TEST(testoperator, if_then_else) {
       g.add_operator(OperatorType::MULTIPLY, std::vector<uint>{x, x, x});
   auto y = g.add_operator(
       OperatorType::IF_THEN_ELSE, std::vector<uint>{bool1, x_sq, x_cube});
-  auto bool3 = g.add_constant(false);
+  auto bool3 = g.add_constant_bool(false);
   auto z = g.add_operator(
       OperatorType::IF_THEN_ELSE, std::vector<uint>{bool3, x_sq, x_cube});
   g.add_factor(FactorType::EXP_PRODUCT, std::vector<uint>{real1, y});
@@ -303,10 +303,10 @@ TEST(testoperator, choice) {
       std::vector<uint>{simplex});
   auto natural = g.add_operator(OperatorType::SAMPLE, std::vector<uint>{cat});
 
-  auto boolean = g.add_constant(true);
-  auto real1 = g.add_constant(10.0);
-  auto real2 = g.add_constant(20.0);
-  auto real3 = g.add_constant(30.0);
+  auto boolean = g.add_constant_bool(true);
+  auto real1 = g.add_constant_real(10.0);
+  auto real2 = g.add_constant_real(20.0);
+  auto real3 = g.add_constant_real(30.0);
 
   // We need at least two parents:
   EXPECT_THROW(
@@ -400,7 +400,7 @@ TEST(testoperator, log1mexp) {
   EXPECT_THROW(
       g.add_operator(OperatorType::LOG1MEXP, std::vector<uint>{}),
       std::invalid_argument);
-  auto real1 = g.add_constant(0.5);
+  auto real1 = g.add_constant_real(0.5);
   EXPECT_THROW(
       g.add_operator(OperatorType::LOG1MEXP, std::vector<uint>{real1}),
       std::invalid_argument);
@@ -543,8 +543,8 @@ TEST(testoperator, logsumexp_vector) {
           OperatorType::LOGSUMEXP_VECTOR, std::vector<uint>{prob1, prob1}),
       std::invalid_argument);
   auto neg1 = g.add_constant_neg_real(-1.0);
-  auto two = g.add_constant((natural_t)2);
-  auto one = g.add_constant((natural_t)1);
+  auto two = g.add_constant_natural(2);
+  auto one = g.add_constant_natural(1);
   auto pospos = g.add_operator(OperatorType::TO_MATRIX, {two, one, pos1, pos1});
   auto negneg = g.add_operator(OperatorType::TO_MATRIX, {two, one, neg1, neg1});
   g.add_operator(OperatorType::LOGSUMEXP_VECTOR, std::vector<uint>{pospos});
@@ -605,7 +605,7 @@ TEST(testoperator, log) {
       std::invalid_argument);
   auto prob1 = g.add_constant_probability(0.5);
   g.add_operator(OperatorType::LOG, std::vector<uint>{prob1});
-  auto real1 = g.add_constant(-0.5);
+  auto real1 = g.add_constant_real(-0.5);
   EXPECT_THROW(
       g.add_operator(OperatorType::LOG, std::vector<uint>{real1}),
       std::invalid_argument);
@@ -729,7 +729,7 @@ TEST(testoperator, pow) {
   // f1x -> 0.25 and f2x -> -1.5
   Graph g1;
   uint one = g1.add_constant_pos_real(1.0);
-  y = g1.add_constant(2.0);
+  y = g1.add_constant_real(2.0);
   uint flat_dist =
       g1.add_distribution(DistributionType::FLAT, AtomicType::REAL, {});
   x = g1.add_operator(OperatorType::SAMPLE, {flat_dist});
@@ -756,8 +756,8 @@ TEST(testoperator, pow) {
   // f1x -> nan and f2x -> nan
   Graph g2;
   one = g2.add_constant_pos_real(1.0);
-  uint two = g2.add_constant(2.0);
-  y = g1.add_constant(2.0);
+  uint two = g2.add_constant_real(2.0);
+  y = g1.add_constant_real(2.0);
   flat_dist = g2.add_distribution(DistributionType::FLAT, AtomicType::REAL, {});
   x = g2.add_operator(OperatorType::SAMPLE, {flat_dist});
   y = g2.add_operator(OperatorType::MULTIPLY, {x, two});
@@ -896,7 +896,7 @@ TEST(testoperator, matrix_multiply) {
       g.add_operator(OperatorType::MATRIX_MULTIPLY, std::vector<uint>{cm0}),
       std::invalid_argument);
   // requires matrix parents
-  auto c1 = g.add_constant(1.5);
+  auto c1 = g.add_constant_real(1.5);
   EXPECT_THROW(
       g.add_operator(OperatorType::MATRIX_MULTIPLY, std::vector<uint>{c1, c1}),
       std::invalid_argument);
@@ -923,15 +923,15 @@ TEST(testoperator, matrix_multiply) {
       std::invalid_argument);
 
   // test eval()
-  auto zero = g.add_constant(0.0);
+  auto zero = g.add_constant_real(0.0);
   auto pos1 = g.add_constant_pos_real(1.0);
   auto normal_dist = g.add_distribution(
       DistributionType::NORMAL,
       AtomicType::REAL,
       std::vector<uint>{zero, pos1});
-  auto one = g.add_constant((natural_t)1);
-  auto two = g.add_constant((natural_t)2);
-  auto three = g.add_constant((natural_t)3);
+  auto one = g.add_constant_natural(1);
+  auto two = g.add_constant_natural(2);
+  auto three = g.add_constant_natural(3);
 
   auto x = g.add_operator(
       OperatorType::IID_SAMPLE, std::vector<uint>{normal_dist, one, three});
@@ -1048,7 +1048,7 @@ TEST(testoperator, matrix_elementwise_mult) {
           OperatorType::ELEMENTWISE_MULTIPLY, std::vector<uint>{cm0}),
       std::invalid_argument);
   // requires matrix parents
-  auto c1 = g.add_constant(1.5);
+  auto c1 = g.add_constant_real(1.5);
   EXPECT_THROW(
       g.add_operator(
           OperatorType::ELEMENTWISE_MULTIPLY, std::vector<uint>{c1, c1}),
@@ -1081,14 +1081,14 @@ TEST(testoperator, matrix_elementwise_mult) {
       std::invalid_argument);
 
   // test eval()
-  auto zero = g.add_constant(0.0);
+  auto zero = g.add_constant_real(0.0);
   auto pos1 = g.add_constant_pos_real(1.0);
   auto normal_dist = g.add_distribution(
       DistributionType::NORMAL,
       AtomicType::REAL,
       std::vector<uint>{zero, pos1});
-  auto two = g.add_constant((natural_t)2);
-  auto three = g.add_constant((natural_t)3);
+  auto two = g.add_constant_natural(2);
+  auto three = g.add_constant_natural(3);
 
   auto x = g.add_operator(
       OperatorType::IID_SAMPLE, std::vector<uint>{normal_dist, three, two});
@@ -1122,7 +1122,7 @@ TEST(testoperator, matrix_scale) {
   EXPECT_THROW(
       g.add_operator(OperatorType::MATRIX_SCALE, std::vector<uint>{}),
       std::invalid_argument);
-  auto c1 = g.add_constant(1.5);
+  auto c1 = g.add_constant_real(1.5);
   EXPECT_THROW(
       g.add_operator(OperatorType::MATRIX_SCALE, std::vector<uint>{c1}),
       std::invalid_argument);
@@ -1149,7 +1149,7 @@ TEST(testoperator, matrix_scale) {
       g.add_operator(OperatorType::MATRIX_SCALE, std::vector<uint>{c1, cmp1}),
       std::invalid_argument);
   // requires real/pos_real/probability types
-  auto cb2 = g.add_constant(false);
+  auto cb2 = g.add_constant_bool(false);
   Eigen::MatrixXb m2 = Eigen::MatrixXb::Random(1, 2);
   auto cmb2 = g.add_constant_bool_matrix(m2);
   EXPECT_THROW(
@@ -1157,15 +1157,15 @@ TEST(testoperator, matrix_scale) {
       std::invalid_argument);
 
   // test eval()
-  auto zero = g.add_constant(0.0);
+  auto zero = g.add_constant_real(0.0);
   auto pos1 = g.add_constant_pos_real(1.0);
   auto normal_dist = g.add_distribution(
       DistributionType::NORMAL,
       AtomicType::REAL,
       std::vector<uint>{zero, pos1});
-  auto one = g.add_constant((natural_t)1);
-  auto two = g.add_constant((natural_t)2);
-  auto three = g.add_constant((natural_t)3);
+  auto one = g.add_constant_natural(1);
+  auto two = g.add_constant_natural(2);
+  auto three = g.add_constant_natural(3);
 
   auto x = g.add_operator(OperatorType::SAMPLE, std::vector<uint>{normal_dist});
   auto y = g.add_operator(
@@ -1317,7 +1317,7 @@ TEST(testoperator, matrix_add) {
       g.add_operator(OperatorType::MATRIX_ADD, std::vector<uint>{cm1}),
       std::invalid_argument);
   // requires two matrices matrix parent
-  auto c1 = g.add_constant(1.5);
+  auto c1 = g.add_constant_real(1.5);
   EXPECT_THROW(
       g.add_operator(OperatorType::MATRIX_ADD, std::vector<uint>{c1, c1}),
       std::invalid_argument);
@@ -1369,7 +1369,7 @@ TEST(testoperator, matrix_negate) {
   EXPECT_THROW(
       g.add_operator(OperatorType::MATRIX_NEGATE, std::vector<uint>{cm1, cm2}),
       std::invalid_argument);
-  auto c1 = g.add_constant(1.5);
+  auto c1 = g.add_constant_real(1.5);
   EXPECT_THROW(
       g.add_operator(OperatorType::MATRIX_NEGATE, std::vector<uint>{c1}),
       std::invalid_argument);
@@ -1399,7 +1399,7 @@ TEST(testoperator, transpose) {
       g.add_operator(OperatorType::TRANSPOSE, std::vector<uint>{}),
       std::invalid_argument);
   // incorrect types
-  auto b1 = g.add_constant(true);
+  auto b1 = g.add_constant_bool(true);
   EXPECT_THROW(
       g.add_operator(OperatorType::TRANSPOSE, std::vector<uint>{b1}),
       std::invalid_argument);
@@ -1439,17 +1439,17 @@ TEST(testoperator, index) {
       g.add_operator(OperatorType::INDEX, std::vector<uint>{cm1}),
       std::invalid_argument);
   // requires matrix and natural number
-  uint real = g.add_constant(0.5);
+  uint real = g.add_constant_real(0.5);
   EXPECT_THROW(
       g.add_operator(OperatorType::INDEX, std::vector<uint>{cm1, real}),
       std::invalid_argument);
 
-  uint zero = g.add_constant((natural_t)0);
+  uint zero = g.add_constant_natural(0);
   uint first_element =
       g.add_operator(OperatorType::INDEX, std::vector<uint>{cm1, zero});
   g.query(first_element);
 
-  uint real_three = g.add_constant(3.0);
+  uint real_three = g.add_constant_real(3.0);
   uint times_three = g.add_operator(
       OperatorType::MULTIPLY, std::vector<uint>{first_element, real_three});
   g.query(times_three);
@@ -1472,7 +1472,7 @@ TEST(testoperator, column_index) {
       g.add_operator(OperatorType::COLUMN_INDEX, std::vector<uint>{cm1}),
       std::invalid_argument);
   // requires matrix and natural number
-  uint real = g.add_constant(0.5);
+  uint real = g.add_constant_real(0.5);
   EXPECT_THROW(
       g.add_operator(OperatorType::COLUMN_INDEX, std::vector<uint>{cm1, real}),
       std::invalid_argument);
@@ -1480,7 +1480,7 @@ TEST(testoperator, column_index) {
   Eigen::MatrixXd m2(2, 2);
   m2 << 1.0, 2.0, 3.0, 4.0;
   uint cm2 = g.add_constant_real_matrix(m2);
-  uint zero = g.add_constant((natural_t)0);
+  uint zero = g.add_constant_natural(0);
   uint first_column =
       g.add_operator(OperatorType::COLUMN_INDEX, std::vector<uint>{cm2, zero});
   g.query(first_column);
@@ -1512,7 +1512,7 @@ TEST(testoperator, to_real_matrix) {
   uint b2 = g.add_operator(OperatorType::SAMPLE, std::vector<uint>{beta});
   uint b3 = g.add_operator(OperatorType::SAMPLE, std::vector<uint>{beta});
   uint b4 = g.add_operator(OperatorType::SAMPLE, std::vector<uint>{beta});
-  uint two = g.add_constant((natural_t)2);
+  uint two = g.add_constant_natural(2);
   uint tm = g.add_operator(
       OperatorType::TO_MATRIX, std::vector<uint>{two, two, b1, b2, b3, b4});
 
@@ -1546,7 +1546,7 @@ TEST(testoperator, to_pos_real_matrix) {
   uint b2 = g.add_operator(OperatorType::SAMPLE, std::vector<uint>{beta});
   uint b3 = g.add_operator(OperatorType::SAMPLE, std::vector<uint>{beta});
   uint b4 = g.add_operator(OperatorType::SAMPLE, std::vector<uint>{beta});
-  uint two = g.add_constant((natural_t)2);
+  uint two = g.add_constant_natural(2);
   uint tm = g.add_operator(
       OperatorType::TO_MATRIX, std::vector<uint>{two, two, b1, b2, b3, b4});
 
@@ -1568,15 +1568,15 @@ TEST(testoperator, to_pos_real_matrix) {
 
 TEST(testoperator, to_matrix) {
   Graph g;
-  uint nat_one = g.add_constant((natural_t)1);
-  uint nat_two = g.add_constant((natural_t)2);
+  uint nat_one = g.add_constant_natural(1);
+  uint nat_two = g.add_constant_natural(2);
 
   // negative initialization
   EXPECT_THROW(
       g.add_operator(OperatorType::TO_MATRIX, std::vector<uint>{}),
       std::invalid_argument);
   // requires scalar parents
-  uint three = g.add_constant(3.0);
+  uint three = g.add_constant_real(3.0);
   Eigen::MatrixXd m1(2, 1);
   m1 << 2.0, -1.0;
   uint cm1 = g.add_constant_real_matrix(m1);
@@ -1609,7 +1609,7 @@ TEST(testoperator, to_matrix) {
       std::invalid_argument);
 
   // 1x2 real numbers
-  uint two = g.add_constant(2.0);
+  uint two = g.add_constant_real(2.0);
   uint real_matrix =
       g.add_operator(OperatorType::TO_MATRIX, {nat_one, nat_two, two, three});
   g.query(real_matrix);
@@ -1619,10 +1619,10 @@ TEST(testoperator, to_matrix) {
 
   // 2x2 natural numbers
   Graph g1;
-  nat_two = g1.add_constant((natural_t)2);
-  uint nat_zero = g1.add_constant((natural_t)0);
-  uint nat_three = g1.add_constant((natural_t)3);
-  uint nat_four = g1.add_constant((natural_t)4);
+  nat_two = g1.add_constant_natural(2);
+  uint nat_zero = g1.add_constant_natural(0);
+  uint nat_three = g1.add_constant_natural(3);
+  uint nat_four = g1.add_constant_natural(4);
   uint nat_matrix = g1.add_operator(
       OperatorType::TO_MATRIX,
       {nat_two, nat_two, nat_two, nat_zero, nat_three, nat_four});
@@ -1635,8 +1635,8 @@ TEST(testoperator, to_matrix) {
 
   // 3x1 stochastic boolean samples
   Graph g2;
-  nat_three = g2.add_constant((natural_t)3);
-  nat_one = g2.add_constant((natural_t)1);
+  nat_three = g2.add_constant_natural(3);
+  nat_one = g2.add_constant_natural(1);
   uint half = g2.add_constant_probability(0.5);
   uint bern_dist = g2.add_distribution(
       DistributionType::BERNOULLI, AtomicType::BOOLEAN, {half});
@@ -1657,8 +1657,8 @@ TEST(testoperator, to_matrix) {
 
 TEST(testoperator, broadcast_add) {
   Graph g1;
-  auto c1 = g1.add_constant(1.5);
-  auto bool1 = g1.add_constant(true);
+  auto c1 = g1.add_constant_real(1.5);
+  auto bool1 = g1.add_constant_bool(true);
   Eigen::MatrixXd m1(2, 1);
   m1 << 2.0, -1.0;
   auto matrix1 = g1.add_constant_real_matrix(m1);
@@ -1694,7 +1694,7 @@ TEST(testoperator, broadcast_add) {
   EXPECT_EQ(eval1[0][0]._matrix(1, 0), 0.5);
 
   Graph g2;
-  auto c2 = g2.add_constant(-1.0);
+  auto c2 = g2.add_constant_real(-1.0);
   Eigen::MatrixXd m2(2, 2);
   m2 << 0.0, 1.0, 2.0, 3.0;
   auto matrix2 = g2.add_constant_real_matrix(m2);
@@ -1710,8 +1710,8 @@ TEST(testoperator, broadcast_add) {
 
 TEST(testoperator, to_pos_real) {
   Graph g;
-  auto zero = g.add_constant(0.0);
-  auto c1 = g.add_constant(1.0);
+  auto zero = g.add_constant_real(0.0);
+  auto c1 = g.add_constant_real(1.0);
 
   // normal distribution requires scale to be POS_REAL
   EXPECT_THROW(
@@ -1735,8 +1735,8 @@ TEST(testoperator, to_pos_real) {
 
   // runtime error for negative value should be thrown
   Graph g1;
-  zero = g1.add_constant(0.0);
-  c1 = g1.add_constant(-1.0);
+  zero = g1.add_constant_real(0.0);
+  c1 = g1.add_constant_real(-1.0);
   auto invalid_c1 =
       g1.add_operator(OperatorType::TO_POS_REAL, std::vector<uint>{c1});
   norm_dist = g1.add_distribution(
@@ -1804,7 +1804,7 @@ TEST(testoperator, matrix_exp) {
 
   // negative tests
   // MATRIX_EXP requires matrix parent
-  auto real_number = g.add_constant(2.0);
+  auto real_number = g.add_constant_real(2.0);
   EXPECT_THROW(
       g.add_operator(OperatorType::MATRIX_EXP, {real_number}),
       std::invalid_argument);
@@ -1845,7 +1845,7 @@ TEST(testoperator, matrix_log) {
 
   // negative tests
   // MATRIX_LOG requires matrix parent
-  auto real_number = g.add_constant(2.0);
+  auto real_number = g.add_constant_real(2.0);
   EXPECT_THROW(
       g.add_operator(OperatorType::MATRIX_LOG, {real_number}),
       std::invalid_argument);
@@ -1885,7 +1885,7 @@ TEST(testoperator, matrix_phi) {
   Graph g;
   // negative tests
   // MATRIX_PHI requires matrix parent
-  auto real_number = g.add_constant(2.0);
+  auto real_number = g.add_constant_real(2.0);
   EXPECT_THROW(
       g.add_operator(OperatorType::MATRIX_PHI, {real_number}),
       std::invalid_argument);
@@ -1927,7 +1927,7 @@ TEST(testoperator, log_prob) {
 
   // negative tests
   // LOG_PROB requires two parents
-  auto two = g.add_constant(2.0);
+  auto two = g.add_constant_real(2.0);
   EXPECT_THROW(
       g.add_operator(OperatorType::LOG_PROB, {}), std::invalid_argument);
   EXPECT_THROW(
@@ -1945,7 +1945,7 @@ TEST(testoperator, log_prob) {
 
   // test at 2
   auto log_prob2 = g.add_operator(
-      OperatorType::LOG_PROB, {distribution, g.add_constant(2.0)});
+      OperatorType::LOG_PROB, {distribution, g.add_constant_real(2.0)});
   EXPECT_EQ(g.get_node(log_prob2)->value.type, graph::AtomicType::REAL);
   g.get_node(log_prob2)->eval(gen);
   // log[PDF[NormalDistribution[2, 3], 2]] ~ -2.01755082187
@@ -1953,21 +1953,21 @@ TEST(testoperator, log_prob) {
 
   // test at 3
   auto log_prob3 = g.add_operator(
-      OperatorType::LOG_PROB, {distribution, g.add_constant(3.0)});
+      OperatorType::LOG_PROB, {distribution, g.add_constant_real(3.0)});
   g.get_node(log_prob3)->eval(gen);
   // Log[PDF[NormalDistribution[2, 3], 3]] ~ -2.07310637743
   EXPECT_NEAR(g.get_node(log_prob3)->value._double, -2.07310637743, epsilon);
 
   // test at 5
   auto log_prob5 = g.add_operator(
-      OperatorType::LOG_PROB, {distribution, g.add_constant(5.0)});
+      OperatorType::LOG_PROB, {distribution, g.add_constant_real(5.0)});
   g.get_node(log_prob5)->eval(gen);
   // Log[PDF[NormalDistribution[2, 3], 5]] ~ -2.51755082187
   EXPECT_NEAR(g.get_node(log_prob5)->value._double, -2.51755082187, epsilon);
 
   // test at 10
   auto log_prob10 = g.add_operator(
-      OperatorType::LOG_PROB, {distribution, g.add_constant(10.0)});
+      OperatorType::LOG_PROB, {distribution, g.add_constant_real(10.0)});
   g.get_node(log_prob10)->eval(gen);
   // Log[PDF[NormalDistribution[2, 3], 10]] ~ -5.57310637743
   EXPECT_NEAR(g.get_node(log_prob10)->value._double, -5.57310637743, epsilon);
@@ -1978,7 +1978,7 @@ TEST(testoperator, matrix_sum) {
   Eigen::MatrixXd matrix1(2, 2);
   matrix1 << 2.0, 1.0, 4.0, 3.0;
   auto cm1 = g.add_constant_real_matrix(matrix1);
-  auto six = g.add_constant(6.0);
+  auto six = g.add_constant_real(6.0);
 
   // negative tests
   // MATRIX_SUM requires a matrix parent
@@ -2022,7 +2022,7 @@ TEST(testoperator, log1p) {
   EXPECT_THROW(
       g.add_operator(OperatorType::LOG1P, std::vector<uint>{prob1}),
       std::invalid_argument);
-  auto real1 = g.add_constant(-0.5);
+  auto real1 = g.add_constant_real(-0.5);
   /* ok */ g.add_operator(OperatorType::LOG1P, std::vector<uint>{real1});
   auto pos1 = g.add_constant_pos_real(1.0);
   /* ok */ g.add_operator(OperatorType::LOG1P, std::vector<uint>{pos1});
@@ -2076,7 +2076,7 @@ TEST(testoperator, matrix_log1p) {
 
   // negative tests
   // MATRIX_LOG1P requires matrix parent
-  auto real_number = g.add_constant(2.0);
+  auto real_number = g.add_constant_real(2.0);
   EXPECT_THROW(
       g.add_operator(OperatorType::MATRIX_LOG1P, {real_number}),
       std::invalid_argument);
@@ -2117,7 +2117,7 @@ TEST(testoperator, matrix_log1mexp) {
 
   // negative tests
   // MATRIX_LOG1P requires matrix parent
-  auto real_number = g.add_constant(2.0);
+  auto real_number = g.add_constant_real(2.0);
   EXPECT_THROW(
       g.add_operator(OperatorType::MATRIX_LOG1MEXP, {real_number}),
       std::invalid_argument);
@@ -2156,7 +2156,7 @@ TEST(testoperator, matrix_complement) {
 
   // negative tests
   // MATRIX_COMPLEMENT requires matrix parent
-  auto real_number = g.add_constant(2.0);
+  auto real_number = g.add_constant_real(2.0);
   EXPECT_THROW(
       g.add_operator(OperatorType::MATRIX_COMPLEMENT, {real_number}),
       std::invalid_argument);

--- a/src/beanmachine/graph/tests/graph_stat_test.cpp
+++ b/src/beanmachine/graph/tests/graph_stat_test.cpp
@@ -126,14 +126,14 @@ TEST(testgraph_stats, all_stats) {
   // the stats package against all possible node types
   graph::Graph g;
   // constants
-  g.add_constant(true);
-  uint c_natural_1 = g.add_constant((graph::natural_t)1);
-  uint c_natural_2 = g.add_constant((graph::natural_t)2);
-  g.add_constant((graph::natural_t)42);
+  g.add_constant_bool(true);
+  uint c_natural_1 = g.add_constant_natural(1);
+  uint c_natural_2 = g.add_constant_natural(2);
+  g.add_constant_natural(42);
   uint c_prob = g.add_constant_probability(0.5);
-  uint c_real0 = g.add_constant(-2.5);
-  uint c_real1 = g.add_constant(-42.01);
-  g.add_constant(42.42);
+  uint c_real0 = g.add_constant_real(-2.5);
+  uint c_real1 = g.add_constant_real(-42.01);
+  g.add_constant_real(42.42);
   uint c_neg = g.add_constant_neg_real(-1.5);
   uint c_pos = g.add_constant_pos_real(2.5);
   uint c_pos1 = g.add_constant_pos_real(1.42);

--- a/src/beanmachine/graph/tests/graph_test.cpp
+++ b/src/beanmachine/graph/tests/graph_test.cpp
@@ -115,7 +115,7 @@ TEST(testgraph, remove_node) {
   uint o4 = g->nodes.size() - 3;
 
   // Let's make some new ones that are topologically later
-  uint c4 = g->add_constant(0.7);
+  uint c4 = g->add_constant_real(0.7);
   uint o6 =
       g->add_operator(graph::OperatorType::TO_REAL, std::vector<uint>({o1}));
   uint o7 = g->add_operator(
@@ -246,10 +246,10 @@ TEST(testgraph, clone_graph) {
   // types of nodes to test the copy constructor.
   graph::Graph g;
   // constants
-  uint c_bool = g.add_constant(true);
-  uint c_real = g.add_constant(-2.5);
-  uint c_natural_1 = g.add_constant((graph::natural_t)1);
-  uint c_natural_2 = g.add_constant((graph::natural_t)2);
+  uint c_bool = g.add_constant_bool(true);
+  uint c_real = g.add_constant_real(-2.5);
+  uint c_natural_1 = g.add_constant_natural(1);
+  uint c_natural_2 = g.add_constant_natural(2);
   uint c_prob = g.add_constant_probability(0.5);
   uint c_pos = g.add_constant_pos_real(2.5);
   uint c_neg = g.add_constant_neg_real(-1.5);
@@ -398,7 +398,7 @@ TEST(testgraph, full_log_prob) {
   graph::Graph g;
   uint a = g.add_constant_pos_real(5.0);
   uint b = g.add_constant_pos_real(3.0);
-  uint n = g.add_constant((graph::natural_t)10);
+  uint n = g.add_constant_natural(10);
   uint beta = g.add_distribution(
       graph::DistributionType::BETA,
       graph::AtomicType::PROBABILITY,
@@ -463,8 +463,8 @@ TEST(testgraph, bad_observations) {
   EXPECT_THROW(g.observe(o_sample_bool, real_matrix), std::invalid_argument);
 
   // Observe a bool(2, 1) to be a bool, double, natural, and (1, 2) matrices
-  uint c_natural_1 = g.add_constant((graph::natural_t)1);
-  uint c_natural_2 = g.add_constant((graph::natural_t)2);
+  uint c_natural_1 = g.add_constant_natural(1);
+  uint c_natural_2 = g.add_constant_natural(2);
   uint o_iid_bool = g.add_operator(
       graph::OperatorType::IID_SAMPLE,
       std::vector<uint>{d_bernoulli, c_natural_2, c_natural_1});
@@ -500,7 +500,7 @@ TEST(testgraph, bad_observations) {
   EXPECT_THROW(g.observe(o_iid_nat, real_matrix), std::invalid_argument);
 
   // Observe a real to be bool, natural, matrix:
-  uint c_real = g.add_constant(-2.5);
+  uint c_real = g.add_constant_real(-2.5);
   uint c_pos = g.add_constant_pos_real(2.5);
   uint d_normal = g.add_distribution(
       graph::DistributionType::NORMAL,
@@ -528,7 +528,7 @@ TEST(testgraph, bad_observations) {
 
 TEST(testgraph, infer_runtime_error) {
   graph::Graph g;
-  auto two = g.add_constant((graph::natural_t)2);
+  auto two = g.add_constant_natural(2);
   Eigen::MatrixXd real_matrix(1, 1);
   real_matrix << 1.0;
   auto matrix = g.add_constant_real_matrix(real_matrix);
@@ -559,7 +559,7 @@ TEST(testgraph, eval_and_update_backgrad) {
   torch.autograd.grad(log_prob, x)
   */
   graph::Graph g;
-  auto mean0 = g.add_constant(0.0);
+  auto mean0 = g.add_constant_real(0.0);
   auto sigma0 = g.add_constant_pos_real(5.0);
   auto dist0 = g.add_distribution(
       graph::DistributionType::NORMAL,

--- a/src/beanmachine/graph/tests/graph_test.py
+++ b/src/beanmachine/graph/tests/graph_test.py
@@ -565,7 +565,7 @@ class TestContinuousModels(unittest.TestCase):
 
         MEAN0 = -5.0
         STD0 = 1.0
-        real0 = g.add_constant(MEAN0)
+        real0 = g.add_constant_real(MEAN0)
         pos0 = g.add_constant_pos_real(STD0)
 
         normal_dist0 = g.add_distribution(
@@ -583,7 +583,7 @@ class TestContinuousModels(unittest.TestCase):
 
         MEAN2 = 5.0
         STD2 = 2.0
-        real2 = g.add_constant(MEAN2)
+        real2 = g.add_constant_real(MEAN2)
         pos2 = g.add_constant_pos_real(STD2)
 
         normal_dist2 = g.add_distribution(

--- a/src/beanmachine/graph/tests/nmc_test.cpp
+++ b/src/beanmachine/graph/tests/nmc_test.cpp
@@ -16,7 +16,7 @@ TEST(testnmc, beta_binomial) {
   Graph g;
   uint a = g.add_constant_pos_real(5.0);
   uint b = g.add_constant_pos_real(3.0);
-  uint n = g.add_constant((natural_t)10);
+  uint n = g.add_constant_natural(10);
   uint beta = g.add_distribution(
       DistributionType::BETA,
       AtomicType::PROBABILITY,
@@ -77,7 +77,7 @@ TEST(testnmc, net_norad) {
       {200, 170, {2, 3}},
       {200, 199, {0, 1, 3}}};
   for (const auto& path : paths) {
-    uint pkts_sent = g.add_constant((natural_t)std::get<0>(path));
+    uint pkts_sent = g.add_constant_natural(std::get<0>(path));
     std::vector<uint> path_comp_rates;
     for (uint id : std::get<2>(path)) {
       path_comp_rates.push_back(comp_rates[id]);
@@ -105,7 +105,7 @@ TEST(testnmc, net_norad) {
 
 TEST(testnmc, normal_normal) {
   Graph g;
-  auto mean0 = g.add_constant(0.0);
+  auto mean0 = g.add_constant_real(0.0);
   auto sigma0 = g.add_constant_pos_real(5.0);
   auto dist0 = g.add_distribution(
       DistributionType::NORMAL,
@@ -177,7 +177,7 @@ TEST(testnmc, gmm_two_components) {
   // posterior of mu_true will be close to 9.5
   // posterior of tau is Beta (3, 2) which has a mean of 0.6
   Graph g;
-  auto zero = g.add_constant(0.0);
+  auto zero = g.add_constant_real(0.0);
   auto one = g.add_constant_pos_real(1.0);
   auto hundred = g.add_constant_pos_real(100.0);
   auto tau_prior = g.add_distribution(
@@ -240,7 +240,7 @@ TEST(testnmc, infinite_grad) {
           prob_sign ~ Beta(1, 1)
   */
   Graph g;
-  uint zero = g.add_constant(0.0);
+  uint zero = g.add_constant_real(0.0);
   uint one = g.add_constant_pos_real(1.0);
   uint two = g.add_constant_pos_real(2.0);
   uint sei = g.add_constant_pos_real(0.15);
@@ -348,7 +348,7 @@ TEST(testnmc, bernoulli_dirichlet_beta) {
       g.add_operator(OperatorType::SAMPLE, std::vector<uint>{dirich_dist});
 
   for (uint k = 0; k < 2; k++) {
-    uint idx = g.add_constant((natural_t)k);
+    uint idx = g.add_constant_natural(k);
     uint p =
         g.add_operator(OperatorType::INDEX, std::vector<uint>{dirich_vec, idx});
     uint bern_dist = g.add_distribution(

--- a/src/beanmachine/graph/tests/rejection_test.cpp
+++ b/src/beanmachine/graph/tests/rejection_test.cpp
@@ -22,7 +22,7 @@ TEST(testrejection, beta_bernoulli) {
       AtomicType::PROBABILITY,
       std::vector<uint>({a, b}));
   uint prob = g.add_operator(OperatorType::SAMPLE, std::vector<uint>({prior}));
-  uint n = g.add_constant((natural_t)5);
+  uint n = g.add_constant_natural(5);
   uint like = g.add_distribution(
       DistributionType::BINOMIAL,
       AtomicType::NATURAL,

--- a/src/beanmachine/graph/tests/support_test.cpp
+++ b/src/beanmachine/graph/tests/support_test.cpp
@@ -149,7 +149,7 @@ TEST(testgraph, full_support) {
       DistributionType::NORMAL, AtomicType::REAL, {coin_real, one});
   uint n1 = g.add_operator(OperatorType::SAMPLE, {normal1});
   // should be in support since queried
-  uint five = g.add_constant(5.0);
+  uint five = g.add_constant_real(5.0);
   uint coin_plus_five = g.add_operator(OperatorType::ADD, {coin_real, five});
   uint normal2 = g.add_distribution(
       DistributionType::NORMAL, AtomicType::REAL, {coin_plus_five, one});

--- a/src/beanmachine/graph/transform/transform_test.cpp
+++ b/src/beanmachine/graph/transform/transform_test.cpp
@@ -20,7 +20,7 @@ TEST(test_transform, log) {
   std::mt19937 generator(1234);
   Graph g1;
   NodeValue *x, *y;
-  auto size = g1.add_constant((natural_t)2);
+  auto size = g1.add_constant_natural(2);
   auto flat_real = g1.add_distribution(
       DistributionType::FLAT, AtomicType::REAL, std::vector<uint>{});
   auto real1 =
@@ -72,7 +72,7 @@ TEST(test_transform, log) {
 
   // test log_abs_jacobian_determinant and unconstrained_gradient
   Graph g2;
-  size = g2.add_constant((natural_t)2);
+  size = g2.add_constant_natural(2);
   flat_pos = g2.add_distribution(
       DistributionType::FLAT, AtomicType::POS_REAL, std::vector<uint>{});
   auto rate1 =
@@ -142,7 +142,7 @@ TEST(test_transform, sigmoid_flat) {
   std::mt19937 generator(1234);
   Graph g1;
   NodeValue *x, *y;
-  auto size = g1.add_constant((natural_t)2);
+  auto size = g1.add_constant_natural(2);
   auto flat_real =
       g1.add_distribution(DistributionType::FLAT, AtomicType::REAL, {});
   auto real1 = g1.add_operator(OperatorType::SAMPLE, {flat_real});
@@ -191,7 +191,7 @@ TEST(test_transform, sigmoid_flat) {
   EXPECT_NEAR(x->_matrix.coeff(1), expit(0.0), 0.001);
 
   Graph g2;
-  size = g2.add_constant((natural_t)2);
+  size = g2.add_constant_natural(2);
   auto dist =
       g2.add_distribution(DistributionType::FLAT, AtomicType::PROBABILITY, {});
   auto x1 = g2.add_operator(OperatorType::SAMPLE, {dist});
@@ -207,7 +207,7 @@ TEST(test_transform, sigmoid_beta) {
   std::mt19937 generator(1234);
   Graph g1;
   NodeValue *x, *y;
-  auto size = g1.add_constant((natural_t)2);
+  auto size = g1.add_constant_natural(2);
   auto two = g1.add_constant_pos_real(2.0);
   auto beta = g1.add_distribution(
       DistributionType::BETA, AtomicType::PROBABILITY, {two, two});
@@ -259,8 +259,8 @@ TEST(test_transform, sigmoid_beta_2) {
   g2.customize_transformation(TransformType::SIGMOID, {x1});
   g2.observe(x1, 0.5);
 
-  auto x2 = g2.add_operator(
-      OperatorType::IID_SAMPLE, {dist, g2.add_constant((natural_t)2)});
+  auto c2 = g2.add_constant_natural(2);
+  auto x2 = g2.add_operator(OperatorType::IID_SAMPLE, {dist, c2});
   g2.customize_transformation(TransformType::SIGMOID, {x2});
   Eigen::MatrixXd xobs(2, 1);
   xobs << 0.2, 0.3;
@@ -304,7 +304,7 @@ print("full_log_prob", full_log_prob)
 
 TEST(test_transform, log_unconstrained_type) {
   Graph g1;
-  auto size = g1.add_constant((natural_t)2);
+  auto size = g1.add_constant_natural(2);
 
   // test transform types
   auto flat_pos = g1.add_distribution(
@@ -333,7 +333,7 @@ TEST(test_transform, log_unconstrained_type) {
 
 TEST(test_transform, sigmoid_unconstrained_type) {
   Graph g1;
-  auto size = g1.add_constant((natural_t)2);
+  auto size = g1.add_constant_natural(2);
 
   // test transform types
   auto flat_pos =


### PR DESCRIPTION
Summary:
For historical reasons BMG has a bunch of different ways to add a constant single value:

    uint add_constant(bool value);
    uint add_constant(double value);
    uint add_constant(natural_t value);
    uint add_constant(NodeValue value);
    uint add_constant_probability(double value);
    uint add_constant_pos_real(double value);
    uint add_constant_neg_real(double value);

Notice that the first four are overloads and the rest describe the semantics of the value added.

This then leads to some unfortunate confusion and ambiguities. Notice how all our test cases which I've updated said stuff like:

    add_constant((graph::natural_t)2)

to ensure that we add a natural rather than a real valued constant. If you're having to always insert casts to make overload resolution clear, that's evidence for the proposition that using overloads is a bad idea.

We will solve this problem in two stages, to prevent breaking changes. First, I'll add three named methods:

    uint add_constant_bool(bool value);
    uint add_constant_real(double value);
    uint add_constant_natural(natural_t value);

that are unambiguous. In a later diff I will remove the now-deprecated add_constant overrides.

Differential Revision: D39585600

