### PR TITLE
Ignore arviz warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ filterwarnings = [
     "default:The `torch.nn.utils._stateless` code is deprecated*:DeprecationWarning",
     # BM warns against using torch tensors as arguments of random variables
     "default:PyTorch tensors are hashed by memory address instead of value.*:UserWarning",
+    # Arviz warns against the use of deprecated methods, due to the recent release of matplotlib v3.6.0
+    "default:The register_cmap function will be deprecated in a future version.*:PendingDeprecationWarning",
 ]
 
 [tool.usort]


### PR DESCRIPTION
Summary: Matplotlib made their v3.6.0 release, which marks some API that ArviZ uses as being deprecated. We can ignore this warning until the API is updated.

Differential Revision: D39590119

