### PR TITLE
Making distribution constructors consistent (accepting both ValueType and AtomicType when applicable)

### DIFF
--- a/src/beanmachine/graph/distribution/bernoulli.cpp
+++ b/src/beanmachine/graph/distribution/bernoulli.cpp
@@ -14,7 +14,7 @@ namespace beanmachine {
 namespace distribution {
 
 Bernoulli::Bernoulli(
-    graph::AtomicType sample_type,
+    graph::ValueType sample_type,
     const std::vector<graph::Node*>& in_nodes)
     : Distribution(graph::DistributionType::BERNOULLI, sample_type) {
   if (sample_type != graph::AtomicType::BOOLEAN) {
@@ -31,6 +31,11 @@ Bernoulli::Bernoulli(
     throw std::invalid_argument("Bernoulli parent must be a probability");
   }
 }
+
+Bernoulli::Bernoulli(
+    graph::AtomicType sample_type,
+    const std::vector<graph::Node*>& in_nodes)
+    : Bernoulli(graph::ValueType(sample_type), in_nodes) {}
 
 bool Bernoulli::_bool_sampler(std::mt19937& gen) const {
   std::bernoulli_distribution distrib(in_nodes[0]->value._double);

--- a/src/beanmachine/graph/distribution/bernoulli.h
+++ b/src/beanmachine/graph/distribution/bernoulli.h
@@ -14,6 +14,9 @@ namespace distribution {
 class Bernoulli : public Distribution {
  public:
   Bernoulli(
+      graph::ValueType sample_type,
+      const std::vector<graph::Node*>& in_nodes);
+  Bernoulli(
       graph::AtomicType sample_type,
       const std::vector<graph::Node*>& in_nodes);
   ~Bernoulli() override {}

--- a/src/beanmachine/graph/distribution/bernoulli_logit.cpp
+++ b/src/beanmachine/graph/distribution/bernoulli_logit.cpp
@@ -20,7 +20,7 @@ namespace distribution {
 using namespace graph;
 
 BernoulliLogit::BernoulliLogit(
-    AtomicType sample_type,
+    ValueType sample_type,
     const std::vector<Node*>& in_nodes)
     : Distribution(DistributionType::BERNOULLI_LOGIT, sample_type) {
   // a BernoulliLogit distribution has one parent which is a real value
@@ -37,6 +37,11 @@ BernoulliLogit::BernoulliLogit(
         "BernoulliLogit distribution produces boolean samples");
   }
 }
+
+BernoulliLogit::BernoulliLogit(
+    AtomicType sample_type,
+    const std::vector<Node*>& in_nodes)
+    : BernoulliLogit(ValueType(sample_type), in_nodes) {}
 
 bool BernoulliLogit::_bool_sampler(std::mt19937& gen) const {
   double logodds = in_nodes[0]->value._double;

--- a/src/beanmachine/graph/distribution/bernoulli_logit.h
+++ b/src/beanmachine/graph/distribution/bernoulli_logit.h
@@ -14,6 +14,9 @@ namespace distribution {
 class BernoulliLogit : public Distribution {
  public:
   BernoulliLogit(
+      graph::ValueType sample_type,
+      const std::vector<graph::Node*>& in_nodes);
+  BernoulliLogit(
       graph::AtomicType sample_type,
       const std::vector<graph::Node*>& in_nodes);
   ~BernoulliLogit() override {}

--- a/src/beanmachine/graph/distribution/bernoulli_noisy_or.cpp
+++ b/src/beanmachine/graph/distribution/bernoulli_noisy_or.cpp
@@ -29,7 +29,7 @@ static inline double log1mexpm(double x) {
 }
 
 BernoulliNoisyOr::BernoulliNoisyOr(
-    graph::AtomicType sample_type,
+    graph::ValueType sample_type,
     const std::vector<graph::Node*>& in_nodes)
     : Distribution(graph::DistributionType::BERNOULLI_NOISY_OR, sample_type) {
   if (sample_type != graph::AtomicType::BOOLEAN) {
@@ -47,6 +47,11 @@ BernoulliNoisyOr::BernoulliNoisyOr(
         "BernoulliNoisyOr parent probability must be positive real-valued");
   }
 }
+
+BernoulliNoisyOr::BernoulliNoisyOr(
+    graph::AtomicType sample_type,
+    const std::vector<graph::Node*>& in_nodes)
+    : BernoulliNoisyOr(graph::ValueType(sample_type), in_nodes) {}
 
 bool BernoulliNoisyOr::_bool_sampler(std::mt19937& gen) const {
   double param = in_nodes[0]->value._double;

--- a/src/beanmachine/graph/distribution/bernoulli_noisy_or.h
+++ b/src/beanmachine/graph/distribution/bernoulli_noisy_or.h
@@ -18,6 +18,9 @@ is parameterized by a >= 0, s.t. the probability of success = `1 - exp(-a)`.
 class BernoulliNoisyOr : public Distribution {
  public:
   BernoulliNoisyOr(
+      graph::ValueType sample_type,
+      const std::vector<graph::Node*>& in_nodes);
+  BernoulliNoisyOr(
       graph::AtomicType sample_type,
       const std::vector<graph::Node*>& in_nodes);
   ~BernoulliNoisyOr() override {}

--- a/src/beanmachine/graph/distribution/beta.cpp
+++ b/src/beanmachine/graph/distribution/beta.cpp
@@ -15,7 +15,7 @@ namespace beanmachine {
 namespace distribution {
 
 Beta::Beta(
-    graph::AtomicType sample_type,
+    graph::ValueType sample_type,
     const std::vector<graph::Node*>& in_nodes)
     : Distribution(graph::DistributionType::BETA, sample_type) {
   // a Beta has two parents which are real numbers and it outputs a probability
@@ -31,6 +31,11 @@ Beta::Beta(
     throw std::invalid_argument("Beta parents must be positive real-valued");
   }
 }
+
+Beta::Beta(
+    graph::AtomicType sample_type,
+    const std::vector<graph::Node*>& in_nodes)
+    : Beta(graph::ValueType(sample_type), in_nodes) {}
 
 double Beta::_double_sampler(std::mt19937& gen) const {
   return util::sample_beta(

--- a/src/beanmachine/graph/distribution/beta.h
+++ b/src/beanmachine/graph/distribution/beta.h
@@ -13,6 +13,7 @@ namespace distribution {
 
 class Beta : public Distribution {
  public:
+  Beta(graph::ValueType sample_type, const std::vector<graph::Node*>& in_nodes);
   Beta(
       graph::AtomicType sample_type,
       const std::vector<graph::Node*>& in_nodes);

--- a/src/beanmachine/graph/distribution/bimixture.h
+++ b/src/beanmachine/graph/distribution/bimixture.h
@@ -20,7 +20,6 @@ class Bimixture : public Distribution {
       graph::AtomicType sample_type,
       const std::vector<graph::Node*>& in_nodes);
   ~Bimixture() override {}
-
   bool _bool_sampler(std::mt19937& gen) const override;
   double _double_sampler(std::mt19937& gen) const override;
   graph::natural_t _natural_sampler(std::mt19937& gen) const override;

--- a/src/beanmachine/graph/distribution/binomial.cpp
+++ b/src/beanmachine/graph/distribution/binomial.cpp
@@ -16,7 +16,7 @@ namespace beanmachine {
 namespace distribution {
 
 Binomial::Binomial(
-    graph::AtomicType sample_type,
+    graph::ValueType sample_type,
     const std::vector<graph::Node*>& in_nodes)
     : Distribution(graph::DistributionType::BINOMIAL, sample_type) {
   // a Binomial has two parents -- natural, probability and outputs a natural
@@ -33,6 +33,11 @@ Binomial::Binomial(
         "Binomial parents must be a natural number and a probability");
   }
 }
+
+Binomial::Binomial(
+    graph::AtomicType sample_type,
+    const std::vector<graph::Node*>& in_nodes)
+    : Binomial(graph::ValueType(sample_type), in_nodes) {}
 
 graph::natural_t Binomial::_natural_sampler(std::mt19937& gen) const {
   graph::natural_t param_n = in_nodes[0]->value._natural;

--- a/src/beanmachine/graph/distribution/binomial.h
+++ b/src/beanmachine/graph/distribution/binomial.h
@@ -14,6 +14,9 @@ namespace distribution {
 class Binomial : public Distribution {
  public:
   Binomial(
+      graph::ValueType sample_type,
+      const std::vector<graph::Node*>& in_nodes);
+  Binomial(
       graph::AtomicType sample_type,
       const std::vector<graph::Node*>& in_nodes);
   ~Binomial() override {}

--- a/src/beanmachine/graph/distribution/categorical.cpp
+++ b/src/beanmachine/graph/distribution/categorical.cpp
@@ -14,7 +14,7 @@ namespace beanmachine {
 namespace distribution {
 
 Categorical::Categorical(
-    graph::AtomicType sample_type,
+    graph::ValueType sample_type,
     const std::vector<graph::Node*>& in_nodes)
     : Distribution(graph::DistributionType::CATEGORICAL, sample_type) {
   if (sample_type != graph::AtomicType::NATURAL) {
@@ -31,6 +31,11 @@ Categorical::Categorical(
         "Categorical parent must be a one-column simplex");
   }
 }
+
+Categorical::Categorical(
+    graph::AtomicType sample_type,
+    const std::vector<graph::Node*>& in_nodes)
+    : Categorical(graph::ValueType(sample_type), in_nodes) {}
 
 graph::natural_t Categorical::_natural_sampler(std::mt19937& gen) const {
   const Eigen::MatrixXd& matrix = in_nodes[0]->value._matrix;

--- a/src/beanmachine/graph/distribution/categorical.h
+++ b/src/beanmachine/graph/distribution/categorical.h
@@ -14,6 +14,9 @@ namespace distribution {
 class Categorical : public Distribution {
  public:
   Categorical(
+      graph::ValueType sample_type,
+      const std::vector<graph::Node*>& in_nodes);
+  Categorical(
       graph::AtomicType sample_type,
       const std::vector<graph::Node*>& in_nodes);
   ~Categorical() override {}

--- a/src/beanmachine/graph/distribution/cauchy.cpp
+++ b/src/beanmachine/graph/distribution/cauchy.cpp
@@ -17,7 +17,7 @@ namespace distribution {
 
 using namespace graph;
 
-Cauchy::Cauchy(AtomicType sample_type, const std::vector<Node*>& in_nodes)
+Cauchy::Cauchy(ValueType sample_type, const std::vector<Node*>& in_nodes)
     : Distribution(DistributionType::CAUCHY, sample_type) {
   // a Cauchy distribution has two parents - a location and a scale which are
   // positive reals
@@ -40,6 +40,9 @@ Cauchy::Cauchy(AtomicType sample_type, const std::vector<Node*>& in_nodes)
         "Cauchy distribution produces real number samples");
   }
 }
+
+Cauchy::Cauchy(AtomicType sample_type, const std::vector<Node*>& in_nodes)
+    : Cauchy(ValueType(sample_type), in_nodes) {}
 
 double Cauchy::_double_sampler(std::mt19937& gen) const {
   // the CDF of a standard Cauchy is  F(x) = (1/pi) arctan(x)

--- a/src/beanmachine/graph/distribution/cauchy.h
+++ b/src/beanmachine/graph/distribution/cauchy.h
@@ -14,6 +14,9 @@ namespace distribution {
 class Cauchy : public Distribution {
  public:
   Cauchy(
+      graph::ValueType sample_type,
+      const std::vector<graph::Node*>& in_nodes);
+  Cauchy(
       graph::AtomicType sample_type,
       const std::vector<graph::Node*>& in_nodes);
   ~Cauchy() override {}

--- a/src/beanmachine/graph/distribution/dirichlet.cpp
+++ b/src/beanmachine/graph/distribution/dirichlet.cpp
@@ -40,6 +40,11 @@ Dirichlet::Dirichlet(
   }
 }
 
+Dirichlet::Dirichlet(
+    graph::AtomicType sample_type,
+    const std::vector<graph::Node*>& in_nodes)
+    : Dirichlet(graph::ValueType(sample_type), in_nodes) {}
+
 Eigen::MatrixXd Dirichlet::_matrix_sampler(std::mt19937& gen) const {
   int n_rows = static_cast<int>(in_nodes[0]->value._matrix.rows());
   Eigen::MatrixXd sample(n_rows, 1);

--- a/src/beanmachine/graph/distribution/dirichlet.h
+++ b/src/beanmachine/graph/distribution/dirichlet.h
@@ -16,6 +16,9 @@ class Dirichlet : public Distribution {
   Dirichlet(
       graph::ValueType sample_type,
       const std::vector<graph::Node*>& in_nodes);
+  Dirichlet(
+      graph::AtomicType sample_type,
+      const std::vector<graph::Node*>& in_nodes);
   ~Dirichlet() override {}
   Eigen::MatrixXd _matrix_sampler(std::mt19937& gen) const override;
   double log_prob(const graph::NodeValue& value) const override;

--- a/src/beanmachine/graph/distribution/dummy_marginal.h
+++ b/src/beanmachine/graph/distribution/dummy_marginal.h
@@ -7,6 +7,7 @@
 
 #pragma once
 #include <memory>
+#include <stdexcept>
 #include "beanmachine/graph/distribution/distribution.h"
 #include "beanmachine/graph/marginalization/subgraph.h"
 

--- a/src/beanmachine/graph/distribution/gamma.cpp
+++ b/src/beanmachine/graph/distribution/gamma.cpp
@@ -19,7 +19,7 @@ namespace distribution {
 
 using namespace graph;
 
-Gamma::Gamma(AtomicType sample_type, const std::vector<Node*>& in_nodes)
+Gamma::Gamma(ValueType sample_type, const std::vector<Node*>& in_nodes)
     : Distribution(DistributionType::GAMMA, sample_type) {
   // a Gamma distribution has two parents:
   // shape -> positive real; rate -> positive real
@@ -35,6 +35,9 @@ Gamma::Gamma(AtomicType sample_type, const std::vector<Node*>& in_nodes)
     throw std::invalid_argument("Gamma parents must be positive real-valued");
   }
 }
+
+Gamma::Gamma(AtomicType sample_type, const std::vector<Node*>& in_nodes)
+    : Gamma(ValueType(sample_type), in_nodes) {}
 
 double Gamma::_double_sampler(std::mt19937& gen) const {
   std::gamma_distribution<double> dist(

--- a/src/beanmachine/graph/distribution/gamma.h
+++ b/src/beanmachine/graph/distribution/gamma.h
@@ -14,6 +14,9 @@ namespace distribution {
 class Gamma : public Distribution {
  public:
   Gamma(
+      graph::ValueType sample_type,
+      const std::vector<graph::Node*>& in_nodes);
+  Gamma(
       graph::AtomicType sample_type,
       const std::vector<graph::Node*>& in_nodes);
   ~Gamma() override {}

--- a/src/beanmachine/graph/distribution/geometric.cpp
+++ b/src/beanmachine/graph/distribution/geometric.cpp
@@ -14,7 +14,7 @@ namespace beanmachine {
 namespace distribution {
 
 Geometric::Geometric(
-    graph::AtomicType sample_type,
+    graph::ValueType sample_type,
     const std::vector<graph::Node*>& in_nodes)
     : Distribution(graph::DistributionType::GEOMETRIC, sample_type) {
   if (sample_type != graph::AtomicType::NATURAL) {
@@ -31,6 +31,11 @@ Geometric::Geometric(
     throw std::invalid_argument("Geometric parent must be a probability");
   }
 }
+
+Geometric::Geometric(
+    graph::AtomicType sample_type,
+    const std::vector<graph::Node*>& in_nodes)
+    : Geometric(graph::ValueType(sample_type), in_nodes) {}
 
 graph::natural_t Geometric::_natural_sampler(std::mt19937& gen) const {
   std::geometric_distribution<graph::natural_t> distrib(

--- a/src/beanmachine/graph/distribution/geometric.h
+++ b/src/beanmachine/graph/distribution/geometric.h
@@ -18,6 +18,9 @@ class Geometric : public Distribution {
   Geometric(
       graph::AtomicType sample_type,
       const std::vector<graph::Node*>& in_nodes);
+  Geometric(
+      graph::ValueType sample_type,
+      const std::vector<graph::Node*>& in_nodes);
   ~Geometric() override {}
   graph::natural_t _natural_sampler(std::mt19937& gen) const override;
   double log_prob(const graph::NodeValue& value) const override;

--- a/src/beanmachine/graph/distribution/half_cauchy.cpp
+++ b/src/beanmachine/graph/distribution/half_cauchy.cpp
@@ -19,7 +19,7 @@ namespace distribution {
 using namespace graph;
 
 HalfCauchy::HalfCauchy(
-    AtomicType sample_type,
+    ValueType sample_type,
     const std::vector<Node*>& in_nodes)
     : Distribution(DistributionType::HALF_CAUCHY, sample_type) {
   // a HalfCauchy distribution has one parent a scale which is positive real
@@ -37,6 +37,11 @@ HalfCauchy::HalfCauchy(
         "HalfCauchy distribution produces positive real number samples");
   }
 }
+
+HalfCauchy::HalfCauchy(
+    AtomicType sample_type,
+    const std::vector<Node*>& in_nodes)
+    : HalfCauchy(ValueType(sample_type), in_nodes) {}
 
 double HalfCauchy::_double_sampler(std::mt19937& gen) const {
   // the cdf of a standard HalfCauchy is  F(x) = (2/pi) arctan(x)

--- a/src/beanmachine/graph/distribution/half_cauchy.h
+++ b/src/beanmachine/graph/distribution/half_cauchy.h
@@ -14,6 +14,9 @@ namespace distribution {
 class HalfCauchy : public Distribution {
  public:
   HalfCauchy(
+      graph::ValueType sample_type,
+      const std::vector<graph::Node*>& in_nodes);
+  HalfCauchy(
       graph::AtomicType sample_type,
       const std::vector<graph::Node*>& in_nodes);
   ~HalfCauchy() override {}

--- a/src/beanmachine/graph/distribution/half_normal.cpp
+++ b/src/beanmachine/graph/distribution/half_normal.cpp
@@ -19,7 +19,7 @@ namespace distribution {
 using namespace graph;
 
 Half_Normal::Half_Normal(
-    AtomicType sample_type,
+    ValueType sample_type,
     const std::vector<Node*>& in_nodes)
     : Distribution(DistributionType::HALF_NORMAL, sample_type) {
   // a Half_Normal distribution has one parent
@@ -38,6 +38,11 @@ Half_Normal::Half_Normal(
         "Half_Normal distribution produces positive real number samples");
   }
 }
+
+Half_Normal::Half_Normal(
+    AtomicType sample_type,
+    const std::vector<Node*>& in_nodes)
+    : Half_Normal(graph::ValueType(sample_type), in_nodes) {}
 
 double Half_Normal::_double_sampler(std::mt19937& gen) const {
   std::normal_distribution<double> dist(0.0, in_nodes[0]->value._double);

--- a/src/beanmachine/graph/distribution/half_normal.h
+++ b/src/beanmachine/graph/distribution/half_normal.h
@@ -14,6 +14,9 @@ namespace distribution {
 class Half_Normal : public Distribution {
  public:
   Half_Normal(
+      graph::ValueType sample_type,
+      const std::vector<graph::Node*>& in_nodes);
+  Half_Normal(
       graph::AtomicType sample_type,
       const std::vector<graph::Node*>& in_nodes);
   ~Half_Normal() override {}

--- a/src/beanmachine/graph/distribution/log_normal.cpp
+++ b/src/beanmachine/graph/distribution/log_normal.cpp
@@ -18,7 +18,7 @@ namespace distribution {
 
 using namespace graph;
 
-LogNormal::LogNormal(AtomicType sample_type, const std::vector<Node*>& in_nodes)
+LogNormal::LogNormal(ValueType sample_type, const std::vector<Node*>& in_nodes)
     : Distribution(DistributionType::LOG_NORMAL, sample_type) {
   // a Log Normal distribution has two parents
   // mean of logarithm distribution -> real,
@@ -37,6 +37,9 @@ LogNormal::LogNormal(AtomicType sample_type, const std::vector<Node*>& in_nodes)
         "LogNormal distribution produces positive real number samples");
   }
 }
+
+LogNormal::LogNormal(AtomicType sample_type, const std::vector<Node*>& in_nodes)
+    : LogNormal(ValueType(sample_type), in_nodes) {}
 
 double LogNormal::_double_sampler(std::mt19937& gen) const {
   std::lognormal_distribution<double> dist(

--- a/src/beanmachine/graph/distribution/log_normal.h
+++ b/src/beanmachine/graph/distribution/log_normal.h
@@ -14,6 +14,9 @@ namespace distribution {
 class LogNormal : public Distribution {
  public:
   LogNormal(
+      graph::ValueType sample_type,
+      const std::vector<graph::Node*>& in_nodes);
+  LogNormal(
       graph::AtomicType sample_type,
       const std::vector<graph::Node*>& in_nodes);
   ~LogNormal() override {}

--- a/src/beanmachine/graph/distribution/normal.cpp
+++ b/src/beanmachine/graph/distribution/normal.cpp
@@ -19,7 +19,7 @@ namespace distribution {
 
 using namespace graph;
 
-Normal::Normal(AtomicType sample_type, const std::vector<Node*>& in_nodes)
+Normal::Normal(ValueType sample_type, const std::vector<Node*>& in_nodes)
     : Distribution(DistributionType::NORMAL, sample_type) {
   // a Normal distribution has two parents
   // mean -> real, sigma -> positive real
@@ -38,6 +38,9 @@ Normal::Normal(AtomicType sample_type, const std::vector<Node*>& in_nodes)
         "Normal distribution produces real number samples");
   }
 }
+
+Normal::Normal(AtomicType sample_type, const std::vector<Node*>& in_nodes)
+    : Normal(ValueType(sample_type), in_nodes) {}
 
 double Normal::_double_sampler(std::mt19937& gen) const {
   std::normal_distribution<double> dist(

--- a/src/beanmachine/graph/distribution/normal.h
+++ b/src/beanmachine/graph/distribution/normal.h
@@ -14,6 +14,9 @@ namespace distribution {
 class Normal : public Distribution {
  public:
   Normal(
+      graph::ValueType sample_type,
+      const std::vector<graph::Node*>& in_nodes);
+  Normal(
       graph::AtomicType sample_type,
       const std::vector<graph::Node*>& in_nodes);
   ~Normal() override {}

--- a/src/beanmachine/graph/distribution/poisson.cpp
+++ b/src/beanmachine/graph/distribution/poisson.cpp
@@ -17,7 +17,7 @@ namespace beanmachine {
 namespace distribution {
 
 Poisson::Poisson(
-    graph::AtomicType sample_type,
+    graph::ValueType sample_type,
     const std::vector<graph::Node*>& in_nodes)
     : Distribution(graph::DistributionType::POISSON, sample_type) {
   if (sample_type != graph::AtomicType::NATURAL) {
@@ -34,6 +34,11 @@ Poisson::Poisson(
     throw std::invalid_argument("Poisson parent must be a positive real");
   }
 }
+
+Poisson::Poisson(
+    graph::AtomicType sample_type,
+    const std::vector<graph::Node*>& in_nodes)
+    : Poisson(graph::ValueType(sample_type), in_nodes) {}
 
 graph::natural_t Poisson::_natural_sampler(std::mt19937& gen) const {
   std::poisson_distribution<graph::natural_t> distrib(

--- a/src/beanmachine/graph/distribution/poisson.h
+++ b/src/beanmachine/graph/distribution/poisson.h
@@ -14,6 +14,9 @@ namespace distribution {
 class Poisson : public Distribution {
  public:
   Poisson(
+      graph::ValueType sample_type,
+      const std::vector<graph::Node*>& in_nodes);
+  Poisson(
       graph::AtomicType sample_type,
       const std::vector<graph::Node*>& in_nodes);
   ~Poisson() override {}

--- a/src/beanmachine/graph/distribution/student_t.cpp
+++ b/src/beanmachine/graph/distribution/student_t.cpp
@@ -30,7 +30,7 @@ namespace distribution {
 
 using namespace graph;
 
-StudentT::StudentT(AtomicType sample_type, const std::vector<Node*>& in_nodes)
+StudentT::StudentT(ValueType sample_type, const std::vector<Node*>& in_nodes)
     : Distribution(DistributionType::STUDENT_T, sample_type) {
   // a StudentT distribution has three parents
   // n (degrees of freedom) > 0 ; l (location) -> real; scale -> positive real
@@ -50,6 +50,9 @@ StudentT::StudentT(AtomicType sample_type, const std::vector<Node*>& in_nodes)
         "StudentT distribution produces real number samples");
   }
 }
+
+StudentT::StudentT(AtomicType sample_type, const std::vector<Node*>& in_nodes)
+    : StudentT(graph::ValueType(sample_type), in_nodes) {}
 
 double StudentT::_double_sampler(std::mt19937& gen) const {
   double n = in_nodes[0]->value._double;

--- a/src/beanmachine/graph/distribution/student_t.h
+++ b/src/beanmachine/graph/distribution/student_t.h
@@ -14,6 +14,9 @@ namespace distribution {
 class StudentT : public Distribution {
  public:
   StudentT(
+      graph::ValueType sample_type,
+      const std::vector<graph::Node*>& in_nodes);
+  StudentT(
       graph::AtomicType sample_type,
       const std::vector<graph::Node*>& in_nodes);
   ~StudentT() override {}

--- a/src/beanmachine/graph/distribution/tabular.cpp
+++ b/src/beanmachine/graph/distribution/tabular.cpp
@@ -16,7 +16,7 @@ namespace beanmachine {
 namespace distribution {
 
 Tabular::Tabular(
-    graph::AtomicType sample_type,
+    graph::ValueType sample_type,
     const std::vector<graph::Node*>& in_nodes)
     : Distribution(graph::DistributionType::TABULAR, sample_type) {
   // check the sample datatype
@@ -55,6 +55,11 @@ Tabular::Tabular(
     }
   }
 }
+
+Tabular::Tabular(
+    graph::AtomicType sample_type,
+    const std::vector<graph::Node*>& in_nodes)
+    : Tabular(graph::ValueType(sample_type), in_nodes) {}
 
 double Tabular::get_probability() const {
   uint col_id = 0;

--- a/src/beanmachine/graph/distribution/tabular.h
+++ b/src/beanmachine/graph/distribution/tabular.h
@@ -14,6 +14,9 @@ namespace distribution {
 class Tabular : public Distribution {
  public:
   Tabular(
+      graph::ValueType sample_type,
+      const std::vector<graph::Node*>& in_nodes);
+  Tabular(
       graph::AtomicType sample_type,
       const std::vector<graph::Node*>& in_nodes);
   ~Tabular() override {}

--- a/src/beanmachine/graph/graph.cpp
+++ b/src/beanmachine/graph/graph.cpp
@@ -1396,14 +1396,12 @@ void Graph::_compute_affected_nodes() {
 }
 
 const std::vector<Node*>& Graph::get_det_affected_nodes(Node* node) {
-  _ensure_evaluation_and_inference_readiness();
-  return _det_affected_nodes
+  return det_affected_nodes()
       [unobserved_sto_support_index_by_node_id[node->index]];
 }
 
 const std::vector<Node*>& Graph::get_sto_affected_nodes(Node* node) {
-  _ensure_evaluation_and_inference_readiness();
-  return _sto_affected_nodes
+  return sto_affected_nodes()
       [unobserved_sto_support_index_by_node_id[node->index]];
 }
 

--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -1015,36 +1015,41 @@ struct Graph {
   // and inference.
 
   // We define getters for these properties that ensure they are up-to-date.
- public:
-#define CACHE_PROPERTY(type, property)            \
- private:                                         \
-  type _##property;                               \
-                                                  \
- public:                                          \
-  const type& property() {                        \
-    _ensure_evaluation_and_inference_readiness(); \
-    return _##property;                           \
+#define CACHED_PROPERTY(type, property, private_or_public) \
+ private:                                                  \
+  type _##property;                                        \
+                                                           \
+  private_or_public:                                       \
+  const type& property() {                                 \
+    _ensure_evaluation_and_inference_readiness();          \
+    return _##property;                                    \
   }
+
+#define CACHED_PUBLIC_PROPERTY(type, property) \
+  CACHED_PROPERTY(type, property, public)
+
+#define CACHED_PRIVATE_PROPERTY(type, property) \
+  CACHED_PROPERTY(type, property, private)
 
   // A graph maintains of a vector of nodes; the index into that vector is
   // the id of the node. We often need to translate from node ids into node
   // pointers; to do so quickly we obtain the address of
   // every node in the graph up front and then look it up when we need it.
-  CACHE_PROPERTY(std::vector<Node*>, node_ptrs)
+  CACHED_PUBLIC_PROPERTY(std::vector<Node*>, node_ptrs)
 
   // The support is the set of all nodes in the graph that are queried or
   // observed, directly or indirectly. We keep both node ids and node pointer
   // forms.
-  CACHE_PROPERTY(std::set<uint>, supp_ids)
-  CACHE_PROPERTY(std::vector<Node*>, supp)
+  CACHED_PUBLIC_PROPERTY(std::set<uint>, supp_ids)
+  CACHED_PUBLIC_PROPERTY(std::vector<Node*>, supp)
 
   // Nodes in support that are not directly observed. Note that
   // the order of nodes in this vector matters! We must enumerate
   // them in order from lowest node identifier to highest.
-  CACHE_PROPERTY(std::vector<Node*>, unobserved_supp)
+  CACHED_PUBLIC_PROPERTY(std::vector<Node*>, unobserved_supp)
 
   // Nodes in unobserved_supp that are stochastic; similarly, order matters.
-  CACHE_PROPERTY(std::vector<Node*>, unobserved_sto_supp)
+  CACHED_PUBLIC_PROPERTY(std::vector<Node*>, unobserved_sto_supp)
 
   // These vectors are the same size as unobserved_sto_support.
   // The i-th elements are vectors of nodes which are
@@ -1055,9 +1060,14 @@ struct Graph {
   // In other words, these are the cached results of
   // invoking graph::compute_affected_nodes
   // for each node.
+
  private:
-  std::vector<std::vector<Node*>> _sto_affected_nodes;
-  std::vector<std::vector<Node*>> _det_affected_nodes;
+  CACHED_PRIVATE_PROPERTY(std::vector<std::vector<Node*>>, det_affected_nodes)
+  CACHED_PRIVATE_PROPERTY(std::vector<std::vector<Node*>>, sto_affected_nodes)
+
+#undef CACHED_PROPERTY
+#undef CACHED_PUBLIC_PROPERTY
+#undef CACHED_PRIVATE_PROPERTY
 
   // Because unobserved_supp and unobserved_sto_supp do not contain
   // all nodes in the graph, it does not hold that a node id


### PR DESCRIPTION
Summary: Some scalar distributions had a second constructor accepting typing by an `AtomicType` that got converted as a scalar `ValueType`. This diff makes that true for all scalar distributions

Differential Revision: D39657289

