### PR TITLE
Using namespaces `std` and `graph` in `graph_test.cpp`

### DIFF
--- a/src/beanmachine/graph/distribution/bernoulli.cpp
+++ b/src/beanmachine/graph/distribution/bernoulli.cpp
@@ -14,7 +14,7 @@ namespace beanmachine {
 namespace distribution {
 
 Bernoulli::Bernoulli(
-    graph::AtomicType sample_type,
+    graph::ValueType sample_type,
     const std::vector<graph::Node*>& in_nodes)
     : Distribution(graph::DistributionType::BERNOULLI, sample_type) {
   if (sample_type != graph::AtomicType::BOOLEAN) {
@@ -31,6 +31,11 @@ Bernoulli::Bernoulli(
     throw std::invalid_argument("Bernoulli parent must be a probability");
   }
 }
+
+Bernoulli::Bernoulli(
+    graph::AtomicType sample_type,
+    const std::vector<graph::Node*>& in_nodes)
+    : Bernoulli(graph::ValueType(sample_type), in_nodes) {}
 
 bool Bernoulli::_bool_sampler(std::mt19937& gen) const {
   std::bernoulli_distribution distrib(in_nodes[0]->value._double);

--- a/src/beanmachine/graph/distribution/bernoulli.h
+++ b/src/beanmachine/graph/distribution/bernoulli.h
@@ -14,6 +14,9 @@ namespace distribution {
 class Bernoulli : public Distribution {
  public:
   Bernoulli(
+      graph::ValueType sample_type,
+      const std::vector<graph::Node*>& in_nodes);
+  Bernoulli(
       graph::AtomicType sample_type,
       const std::vector<graph::Node*>& in_nodes);
   ~Bernoulli() override {}

--- a/src/beanmachine/graph/distribution/bernoulli_logit.cpp
+++ b/src/beanmachine/graph/distribution/bernoulli_logit.cpp
@@ -20,7 +20,7 @@ namespace distribution {
 using namespace graph;
 
 BernoulliLogit::BernoulliLogit(
-    AtomicType sample_type,
+    ValueType sample_type,
     const std::vector<Node*>& in_nodes)
     : Distribution(DistributionType::BERNOULLI_LOGIT, sample_type) {
   // a BernoulliLogit distribution has one parent which is a real value
@@ -37,6 +37,11 @@ BernoulliLogit::BernoulliLogit(
         "BernoulliLogit distribution produces boolean samples");
   }
 }
+
+BernoulliLogit::BernoulliLogit(
+    AtomicType sample_type,
+    const std::vector<Node*>& in_nodes)
+    : BernoulliLogit(ValueType(sample_type), in_nodes) {}
 
 bool BernoulliLogit::_bool_sampler(std::mt19937& gen) const {
   double logodds = in_nodes[0]->value._double;

--- a/src/beanmachine/graph/distribution/bernoulli_logit.h
+++ b/src/beanmachine/graph/distribution/bernoulli_logit.h
@@ -14,6 +14,9 @@ namespace distribution {
 class BernoulliLogit : public Distribution {
  public:
   BernoulliLogit(
+      graph::ValueType sample_type,
+      const std::vector<graph::Node*>& in_nodes);
+  BernoulliLogit(
       graph::AtomicType sample_type,
       const std::vector<graph::Node*>& in_nodes);
   ~BernoulliLogit() override {}

--- a/src/beanmachine/graph/distribution/bernoulli_noisy_or.cpp
+++ b/src/beanmachine/graph/distribution/bernoulli_noisy_or.cpp
@@ -29,7 +29,7 @@ static inline double log1mexpm(double x) {
 }
 
 BernoulliNoisyOr::BernoulliNoisyOr(
-    graph::AtomicType sample_type,
+    graph::ValueType sample_type,
     const std::vector<graph::Node*>& in_nodes)
     : Distribution(graph::DistributionType::BERNOULLI_NOISY_OR, sample_type) {
   if (sample_type != graph::AtomicType::BOOLEAN) {
@@ -47,6 +47,11 @@ BernoulliNoisyOr::BernoulliNoisyOr(
         "BernoulliNoisyOr parent probability must be positive real-valued");
   }
 }
+
+BernoulliNoisyOr::BernoulliNoisyOr(
+    graph::AtomicType sample_type,
+    const std::vector<graph::Node*>& in_nodes)
+    : BernoulliNoisyOr(graph::ValueType(sample_type), in_nodes) {}
 
 bool BernoulliNoisyOr::_bool_sampler(std::mt19937& gen) const {
   double param = in_nodes[0]->value._double;

--- a/src/beanmachine/graph/distribution/bernoulli_noisy_or.h
+++ b/src/beanmachine/graph/distribution/bernoulli_noisy_or.h
@@ -18,6 +18,9 @@ is parameterized by a >= 0, s.t. the probability of success = `1 - exp(-a)`.
 class BernoulliNoisyOr : public Distribution {
  public:
   BernoulliNoisyOr(
+      graph::ValueType sample_type,
+      const std::vector<graph::Node*>& in_nodes);
+  BernoulliNoisyOr(
       graph::AtomicType sample_type,
       const std::vector<graph::Node*>& in_nodes);
   ~BernoulliNoisyOr() override {}

--- a/src/beanmachine/graph/distribution/beta.cpp
+++ b/src/beanmachine/graph/distribution/beta.cpp
@@ -15,7 +15,7 @@ namespace beanmachine {
 namespace distribution {
 
 Beta::Beta(
-    graph::AtomicType sample_type,
+    graph::ValueType sample_type,
     const std::vector<graph::Node*>& in_nodes)
     : Distribution(graph::DistributionType::BETA, sample_type) {
   // a Beta has two parents which are real numbers and it outputs a probability
@@ -31,6 +31,11 @@ Beta::Beta(
     throw std::invalid_argument("Beta parents must be positive real-valued");
   }
 }
+
+Beta::Beta(
+    graph::AtomicType sample_type,
+    const std::vector<graph::Node*>& in_nodes)
+    : Beta(graph::ValueType(sample_type), in_nodes) {}
 
 double Beta::_double_sampler(std::mt19937& gen) const {
   return util::sample_beta(

--- a/src/beanmachine/graph/distribution/beta.h
+++ b/src/beanmachine/graph/distribution/beta.h
@@ -13,6 +13,7 @@ namespace distribution {
 
 class Beta : public Distribution {
  public:
+  Beta(graph::ValueType sample_type, const std::vector<graph::Node*>& in_nodes);
   Beta(
       graph::AtomicType sample_type,
       const std::vector<graph::Node*>& in_nodes);

--- a/src/beanmachine/graph/distribution/bimixture.h
+++ b/src/beanmachine/graph/distribution/bimixture.h
@@ -20,7 +20,6 @@ class Bimixture : public Distribution {
       graph::AtomicType sample_type,
       const std::vector<graph::Node*>& in_nodes);
   ~Bimixture() override {}
-
   bool _bool_sampler(std::mt19937& gen) const override;
   double _double_sampler(std::mt19937& gen) const override;
   graph::natural_t _natural_sampler(std::mt19937& gen) const override;

--- a/src/beanmachine/graph/distribution/binomial.cpp
+++ b/src/beanmachine/graph/distribution/binomial.cpp
@@ -16,7 +16,7 @@ namespace beanmachine {
 namespace distribution {
 
 Binomial::Binomial(
-    graph::AtomicType sample_type,
+    graph::ValueType sample_type,
     const std::vector<graph::Node*>& in_nodes)
     : Distribution(graph::DistributionType::BINOMIAL, sample_type) {
   // a Binomial has two parents -- natural, probability and outputs a natural
@@ -33,6 +33,11 @@ Binomial::Binomial(
         "Binomial parents must be a natural number and a probability");
   }
 }
+
+Binomial::Binomial(
+    graph::AtomicType sample_type,
+    const std::vector<graph::Node*>& in_nodes)
+    : Binomial(graph::ValueType(sample_type), in_nodes) {}
 
 graph::natural_t Binomial::_natural_sampler(std::mt19937& gen) const {
   graph::natural_t param_n = in_nodes[0]->value._natural;

--- a/src/beanmachine/graph/distribution/binomial.h
+++ b/src/beanmachine/graph/distribution/binomial.h
@@ -14,6 +14,9 @@ namespace distribution {
 class Binomial : public Distribution {
  public:
   Binomial(
+      graph::ValueType sample_type,
+      const std::vector<graph::Node*>& in_nodes);
+  Binomial(
       graph::AtomicType sample_type,
       const std::vector<graph::Node*>& in_nodes);
   ~Binomial() override {}

--- a/src/beanmachine/graph/distribution/categorical.cpp
+++ b/src/beanmachine/graph/distribution/categorical.cpp
@@ -14,7 +14,7 @@ namespace beanmachine {
 namespace distribution {
 
 Categorical::Categorical(
-    graph::AtomicType sample_type,
+    graph::ValueType sample_type,
     const std::vector<graph::Node*>& in_nodes)
     : Distribution(graph::DistributionType::CATEGORICAL, sample_type) {
   if (sample_type != graph::AtomicType::NATURAL) {
@@ -31,6 +31,11 @@ Categorical::Categorical(
         "Categorical parent must be a one-column simplex");
   }
 }
+
+Categorical::Categorical(
+    graph::AtomicType sample_type,
+    const std::vector<graph::Node*>& in_nodes)
+    : Categorical(graph::ValueType(sample_type), in_nodes) {}
 
 graph::natural_t Categorical::_natural_sampler(std::mt19937& gen) const {
   const Eigen::MatrixXd& matrix = in_nodes[0]->value._matrix;

--- a/src/beanmachine/graph/distribution/categorical.h
+++ b/src/beanmachine/graph/distribution/categorical.h
@@ -14,6 +14,9 @@ namespace distribution {
 class Categorical : public Distribution {
  public:
   Categorical(
+      graph::ValueType sample_type,
+      const std::vector<graph::Node*>& in_nodes);
+  Categorical(
       graph::AtomicType sample_type,
       const std::vector<graph::Node*>& in_nodes);
   ~Categorical() override {}

--- a/src/beanmachine/graph/distribution/cauchy.cpp
+++ b/src/beanmachine/graph/distribution/cauchy.cpp
@@ -17,7 +17,7 @@ namespace distribution {
 
 using namespace graph;
 
-Cauchy::Cauchy(AtomicType sample_type, const std::vector<Node*>& in_nodes)
+Cauchy::Cauchy(ValueType sample_type, const std::vector<Node*>& in_nodes)
     : Distribution(DistributionType::CAUCHY, sample_type) {
   // a Cauchy distribution has two parents - a location and a scale which are
   // positive reals
@@ -40,6 +40,9 @@ Cauchy::Cauchy(AtomicType sample_type, const std::vector<Node*>& in_nodes)
         "Cauchy distribution produces real number samples");
   }
 }
+
+Cauchy::Cauchy(AtomicType sample_type, const std::vector<Node*>& in_nodes)
+    : Cauchy(ValueType(sample_type), in_nodes) {}
 
 double Cauchy::_double_sampler(std::mt19937& gen) const {
   // the CDF of a standard Cauchy is  F(x) = (1/pi) arctan(x)

--- a/src/beanmachine/graph/distribution/cauchy.h
+++ b/src/beanmachine/graph/distribution/cauchy.h
@@ -14,6 +14,9 @@ namespace distribution {
 class Cauchy : public Distribution {
  public:
   Cauchy(
+      graph::ValueType sample_type,
+      const std::vector<graph::Node*>& in_nodes);
+  Cauchy(
       graph::AtomicType sample_type,
       const std::vector<graph::Node*>& in_nodes);
   ~Cauchy() override {}

--- a/src/beanmachine/graph/distribution/dirichlet.cpp
+++ b/src/beanmachine/graph/distribution/dirichlet.cpp
@@ -40,6 +40,11 @@ Dirichlet::Dirichlet(
   }
 }
 
+Dirichlet::Dirichlet(
+    graph::AtomicType sample_type,
+    const std::vector<graph::Node*>& in_nodes)
+    : Dirichlet(graph::ValueType(sample_type), in_nodes) {}
+
 Eigen::MatrixXd Dirichlet::_matrix_sampler(std::mt19937& gen) const {
   int n_rows = static_cast<int>(in_nodes[0]->value._matrix.rows());
   Eigen::MatrixXd sample(n_rows, 1);

--- a/src/beanmachine/graph/distribution/dirichlet.h
+++ b/src/beanmachine/graph/distribution/dirichlet.h
@@ -16,6 +16,9 @@ class Dirichlet : public Distribution {
   Dirichlet(
       graph::ValueType sample_type,
       const std::vector<graph::Node*>& in_nodes);
+  Dirichlet(
+      graph::AtomicType sample_type,
+      const std::vector<graph::Node*>& in_nodes);
   ~Dirichlet() override {}
   Eigen::MatrixXd _matrix_sampler(std::mt19937& gen) const override;
   double log_prob(const graph::NodeValue& value) const override;

--- a/src/beanmachine/graph/distribution/dummy_marginal.h
+++ b/src/beanmachine/graph/distribution/dummy_marginal.h
@@ -7,6 +7,7 @@
 
 #pragma once
 #include <memory>
+#include <stdexcept>
 #include "beanmachine/graph/distribution/distribution.h"
 #include "beanmachine/graph/marginalization/subgraph.h"
 

--- a/src/beanmachine/graph/distribution/gamma.cpp
+++ b/src/beanmachine/graph/distribution/gamma.cpp
@@ -19,7 +19,7 @@ namespace distribution {
 
 using namespace graph;
 
-Gamma::Gamma(AtomicType sample_type, const std::vector<Node*>& in_nodes)
+Gamma::Gamma(ValueType sample_type, const std::vector<Node*>& in_nodes)
     : Distribution(DistributionType::GAMMA, sample_type) {
   // a Gamma distribution has two parents:
   // shape -> positive real; rate -> positive real
@@ -35,6 +35,9 @@ Gamma::Gamma(AtomicType sample_type, const std::vector<Node*>& in_nodes)
     throw std::invalid_argument("Gamma parents must be positive real-valued");
   }
 }
+
+Gamma::Gamma(AtomicType sample_type, const std::vector<Node*>& in_nodes)
+    : Gamma(ValueType(sample_type), in_nodes) {}
 
 double Gamma::_double_sampler(std::mt19937& gen) const {
   std::gamma_distribution<double> dist(

--- a/src/beanmachine/graph/distribution/gamma.h
+++ b/src/beanmachine/graph/distribution/gamma.h
@@ -14,6 +14,9 @@ namespace distribution {
 class Gamma : public Distribution {
  public:
   Gamma(
+      graph::ValueType sample_type,
+      const std::vector<graph::Node*>& in_nodes);
+  Gamma(
       graph::AtomicType sample_type,
       const std::vector<graph::Node*>& in_nodes);
   ~Gamma() override {}

--- a/src/beanmachine/graph/distribution/geometric.cpp
+++ b/src/beanmachine/graph/distribution/geometric.cpp
@@ -14,7 +14,7 @@ namespace beanmachine {
 namespace distribution {
 
 Geometric::Geometric(
-    graph::AtomicType sample_type,
+    graph::ValueType sample_type,
     const std::vector<graph::Node*>& in_nodes)
     : Distribution(graph::DistributionType::GEOMETRIC, sample_type) {
   if (sample_type != graph::AtomicType::NATURAL) {
@@ -31,6 +31,11 @@ Geometric::Geometric(
     throw std::invalid_argument("Geometric parent must be a probability");
   }
 }
+
+Geometric::Geometric(
+    graph::AtomicType sample_type,
+    const std::vector<graph::Node*>& in_nodes)
+    : Geometric(graph::ValueType(sample_type), in_nodes) {}
 
 graph::natural_t Geometric::_natural_sampler(std::mt19937& gen) const {
   std::geometric_distribution<graph::natural_t> distrib(

--- a/src/beanmachine/graph/distribution/geometric.h
+++ b/src/beanmachine/graph/distribution/geometric.h
@@ -18,6 +18,9 @@ class Geometric : public Distribution {
   Geometric(
       graph::AtomicType sample_type,
       const std::vector<graph::Node*>& in_nodes);
+  Geometric(
+      graph::ValueType sample_type,
+      const std::vector<graph::Node*>& in_nodes);
   ~Geometric() override {}
   graph::natural_t _natural_sampler(std::mt19937& gen) const override;
   double log_prob(const graph::NodeValue& value) const override;

--- a/src/beanmachine/graph/distribution/half_cauchy.cpp
+++ b/src/beanmachine/graph/distribution/half_cauchy.cpp
@@ -19,7 +19,7 @@ namespace distribution {
 using namespace graph;
 
 HalfCauchy::HalfCauchy(
-    AtomicType sample_type,
+    ValueType sample_type,
     const std::vector<Node*>& in_nodes)
     : Distribution(DistributionType::HALF_CAUCHY, sample_type) {
   // a HalfCauchy distribution has one parent a scale which is positive real
@@ -37,6 +37,11 @@ HalfCauchy::HalfCauchy(
         "HalfCauchy distribution produces positive real number samples");
   }
 }
+
+HalfCauchy::HalfCauchy(
+    AtomicType sample_type,
+    const std::vector<Node*>& in_nodes)
+    : HalfCauchy(ValueType(sample_type), in_nodes) {}
 
 double HalfCauchy::_double_sampler(std::mt19937& gen) const {
   // the cdf of a standard HalfCauchy is  F(x) = (2/pi) arctan(x)

--- a/src/beanmachine/graph/distribution/half_cauchy.h
+++ b/src/beanmachine/graph/distribution/half_cauchy.h
@@ -14,6 +14,9 @@ namespace distribution {
 class HalfCauchy : public Distribution {
  public:
   HalfCauchy(
+      graph::ValueType sample_type,
+      const std::vector<graph::Node*>& in_nodes);
+  HalfCauchy(
       graph::AtomicType sample_type,
       const std::vector<graph::Node*>& in_nodes);
   ~HalfCauchy() override {}

--- a/src/beanmachine/graph/distribution/half_normal.cpp
+++ b/src/beanmachine/graph/distribution/half_normal.cpp
@@ -19,7 +19,7 @@ namespace distribution {
 using namespace graph;
 
 Half_Normal::Half_Normal(
-    AtomicType sample_type,
+    ValueType sample_type,
     const std::vector<Node*>& in_nodes)
     : Distribution(DistributionType::HALF_NORMAL, sample_type) {
   // a Half_Normal distribution has one parent
@@ -38,6 +38,11 @@ Half_Normal::Half_Normal(
         "Half_Normal distribution produces positive real number samples");
   }
 }
+
+Half_Normal::Half_Normal(
+    AtomicType sample_type,
+    const std::vector<Node*>& in_nodes)
+    : Half_Normal(graph::ValueType(sample_type), in_nodes) {}
 
 double Half_Normal::_double_sampler(std::mt19937& gen) const {
   std::normal_distribution<double> dist(0.0, in_nodes[0]->value._double);

--- a/src/beanmachine/graph/distribution/half_normal.h
+++ b/src/beanmachine/graph/distribution/half_normal.h
@@ -14,6 +14,9 @@ namespace distribution {
 class Half_Normal : public Distribution {
  public:
   Half_Normal(
+      graph::ValueType sample_type,
+      const std::vector<graph::Node*>& in_nodes);
+  Half_Normal(
       graph::AtomicType sample_type,
       const std::vector<graph::Node*>& in_nodes);
   ~Half_Normal() override {}

--- a/src/beanmachine/graph/distribution/log_normal.cpp
+++ b/src/beanmachine/graph/distribution/log_normal.cpp
@@ -18,7 +18,7 @@ namespace distribution {
 
 using namespace graph;
 
-LogNormal::LogNormal(AtomicType sample_type, const std::vector<Node*>& in_nodes)
+LogNormal::LogNormal(ValueType sample_type, const std::vector<Node*>& in_nodes)
     : Distribution(DistributionType::LOG_NORMAL, sample_type) {
   // a Log Normal distribution has two parents
   // mean of logarithm distribution -> real,
@@ -37,6 +37,9 @@ LogNormal::LogNormal(AtomicType sample_type, const std::vector<Node*>& in_nodes)
         "LogNormal distribution produces positive real number samples");
   }
 }
+
+LogNormal::LogNormal(AtomicType sample_type, const std::vector<Node*>& in_nodes)
+    : LogNormal(ValueType(sample_type), in_nodes) {}
 
 double LogNormal::_double_sampler(std::mt19937& gen) const {
   std::lognormal_distribution<double> dist(

--- a/src/beanmachine/graph/distribution/log_normal.h
+++ b/src/beanmachine/graph/distribution/log_normal.h
@@ -14,6 +14,9 @@ namespace distribution {
 class LogNormal : public Distribution {
  public:
   LogNormal(
+      graph::ValueType sample_type,
+      const std::vector<graph::Node*>& in_nodes);
+  LogNormal(
       graph::AtomicType sample_type,
       const std::vector<graph::Node*>& in_nodes);
   ~LogNormal() override {}

--- a/src/beanmachine/graph/distribution/normal.cpp
+++ b/src/beanmachine/graph/distribution/normal.cpp
@@ -19,7 +19,7 @@ namespace distribution {
 
 using namespace graph;
 
-Normal::Normal(AtomicType sample_type, const std::vector<Node*>& in_nodes)
+Normal::Normal(ValueType sample_type, const std::vector<Node*>& in_nodes)
     : Distribution(DistributionType::NORMAL, sample_type) {
   // a Normal distribution has two parents
   // mean -> real, sigma -> positive real
@@ -38,6 +38,9 @@ Normal::Normal(AtomicType sample_type, const std::vector<Node*>& in_nodes)
         "Normal distribution produces real number samples");
   }
 }
+
+Normal::Normal(AtomicType sample_type, const std::vector<Node*>& in_nodes)
+    : Normal(ValueType(sample_type), in_nodes) {}
 
 double Normal::_double_sampler(std::mt19937& gen) const {
   std::normal_distribution<double> dist(

--- a/src/beanmachine/graph/distribution/normal.h
+++ b/src/beanmachine/graph/distribution/normal.h
@@ -14,6 +14,9 @@ namespace distribution {
 class Normal : public Distribution {
  public:
   Normal(
+      graph::ValueType sample_type,
+      const std::vector<graph::Node*>& in_nodes);
+  Normal(
       graph::AtomicType sample_type,
       const std::vector<graph::Node*>& in_nodes);
   ~Normal() override {}

--- a/src/beanmachine/graph/distribution/poisson.cpp
+++ b/src/beanmachine/graph/distribution/poisson.cpp
@@ -17,7 +17,7 @@ namespace beanmachine {
 namespace distribution {
 
 Poisson::Poisson(
-    graph::AtomicType sample_type,
+    graph::ValueType sample_type,
     const std::vector<graph::Node*>& in_nodes)
     : Distribution(graph::DistributionType::POISSON, sample_type) {
   if (sample_type != graph::AtomicType::NATURAL) {
@@ -34,6 +34,11 @@ Poisson::Poisson(
     throw std::invalid_argument("Poisson parent must be a positive real");
   }
 }
+
+Poisson::Poisson(
+    graph::AtomicType sample_type,
+    const std::vector<graph::Node*>& in_nodes)
+    : Poisson(graph::ValueType(sample_type), in_nodes) {}
 
 graph::natural_t Poisson::_natural_sampler(std::mt19937& gen) const {
   std::poisson_distribution<graph::natural_t> distrib(

--- a/src/beanmachine/graph/distribution/poisson.h
+++ b/src/beanmachine/graph/distribution/poisson.h
@@ -14,6 +14,9 @@ namespace distribution {
 class Poisson : public Distribution {
  public:
   Poisson(
+      graph::ValueType sample_type,
+      const std::vector<graph::Node*>& in_nodes);
+  Poisson(
       graph::AtomicType sample_type,
       const std::vector<graph::Node*>& in_nodes);
   ~Poisson() override {}

--- a/src/beanmachine/graph/distribution/student_t.cpp
+++ b/src/beanmachine/graph/distribution/student_t.cpp
@@ -30,7 +30,7 @@ namespace distribution {
 
 using namespace graph;
 
-StudentT::StudentT(AtomicType sample_type, const std::vector<Node*>& in_nodes)
+StudentT::StudentT(ValueType sample_type, const std::vector<Node*>& in_nodes)
     : Distribution(DistributionType::STUDENT_T, sample_type) {
   // a StudentT distribution has three parents
   // n (degrees of freedom) > 0 ; l (location) -> real; scale -> positive real
@@ -50,6 +50,9 @@ StudentT::StudentT(AtomicType sample_type, const std::vector<Node*>& in_nodes)
         "StudentT distribution produces real number samples");
   }
 }
+
+StudentT::StudentT(AtomicType sample_type, const std::vector<Node*>& in_nodes)
+    : StudentT(graph::ValueType(sample_type), in_nodes) {}
 
 double StudentT::_double_sampler(std::mt19937& gen) const {
   double n = in_nodes[0]->value._double;

--- a/src/beanmachine/graph/distribution/student_t.h
+++ b/src/beanmachine/graph/distribution/student_t.h
@@ -14,6 +14,9 @@ namespace distribution {
 class StudentT : public Distribution {
  public:
   StudentT(
+      graph::ValueType sample_type,
+      const std::vector<graph::Node*>& in_nodes);
+  StudentT(
       graph::AtomicType sample_type,
       const std::vector<graph::Node*>& in_nodes);
   ~StudentT() override {}

--- a/src/beanmachine/graph/distribution/tabular.cpp
+++ b/src/beanmachine/graph/distribution/tabular.cpp
@@ -16,7 +16,7 @@ namespace beanmachine {
 namespace distribution {
 
 Tabular::Tabular(
-    graph::AtomicType sample_type,
+    graph::ValueType sample_type,
     const std::vector<graph::Node*>& in_nodes)
     : Distribution(graph::DistributionType::TABULAR, sample_type) {
   // check the sample datatype
@@ -55,6 +55,11 @@ Tabular::Tabular(
     }
   }
 }
+
+Tabular::Tabular(
+    graph::AtomicType sample_type,
+    const std::vector<graph::Node*>& in_nodes)
+    : Tabular(graph::ValueType(sample_type), in_nodes) {}
 
 double Tabular::get_probability() const {
   uint col_id = 0;

--- a/src/beanmachine/graph/distribution/tabular.h
+++ b/src/beanmachine/graph/distribution/tabular.h
@@ -14,6 +14,9 @@ namespace distribution {
 class Tabular : public Distribution {
  public:
   Tabular(
+      graph::ValueType sample_type,
+      const std::vector<graph::Node*>& in_nodes);
+  Tabular(
       graph::AtomicType sample_type,
       const std::vector<graph::Node*>& in_nodes);
   ~Tabular() override {}

--- a/src/beanmachine/graph/graph.cpp
+++ b/src/beanmachine/graph/graph.cpp
@@ -1396,14 +1396,12 @@ void Graph::_compute_affected_nodes() {
 }
 
 const std::vector<Node*>& Graph::get_det_affected_nodes(Node* node) {
-  _ensure_evaluation_and_inference_readiness();
-  return _det_affected_nodes
+  return det_affected_nodes()
       [unobserved_sto_support_index_by_node_id[node->index]];
 }
 
 const std::vector<Node*>& Graph::get_sto_affected_nodes(Node* node) {
-  _ensure_evaluation_and_inference_readiness();
-  return _sto_affected_nodes
+  return sto_affected_nodes()
       [unobserved_sto_support_index_by_node_id[node->index]];
 }
 

--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -1015,36 +1015,41 @@ struct Graph {
   // and inference.
 
   // We define getters for these properties that ensure they are up-to-date.
- public:
-#define CACHE_PROPERTY(type, property)            \
- private:                                         \
-  type _##property;                               \
-                                                  \
- public:                                          \
-  const type& property() {                        \
-    _ensure_evaluation_and_inference_readiness(); \
-    return _##property;                           \
+#define CACHED_PROPERTY(type, property, private_or_public) \
+ private:                                                  \
+  type _##property;                                        \
+                                                           \
+  private_or_public:                                       \
+  const type& property() {                                 \
+    _ensure_evaluation_and_inference_readiness();          \
+    return _##property;                                    \
   }
+
+#define CACHED_PUBLIC_PROPERTY(type, property) \
+  CACHED_PROPERTY(type, property, public)
+
+#define CACHED_PRIVATE_PROPERTY(type, property) \
+  CACHED_PROPERTY(type, property, private)
 
   // A graph maintains of a vector of nodes; the index into that vector is
   // the id of the node. We often need to translate from node ids into node
   // pointers; to do so quickly we obtain the address of
   // every node in the graph up front and then look it up when we need it.
-  CACHE_PROPERTY(std::vector<Node*>, node_ptrs)
+  CACHED_PUBLIC_PROPERTY(std::vector<Node*>, node_ptrs)
 
   // The support is the set of all nodes in the graph that are queried or
   // observed, directly or indirectly. We keep both node ids and node pointer
   // forms.
-  CACHE_PROPERTY(std::set<uint>, supp_ids)
-  CACHE_PROPERTY(std::vector<Node*>, supp)
+  CACHED_PUBLIC_PROPERTY(std::set<uint>, supp_ids)
+  CACHED_PUBLIC_PROPERTY(std::vector<Node*>, supp)
 
   // Nodes in support that are not directly observed. Note that
   // the order of nodes in this vector matters! We must enumerate
   // them in order from lowest node identifier to highest.
-  CACHE_PROPERTY(std::vector<Node*>, unobserved_supp)
+  CACHED_PUBLIC_PROPERTY(std::vector<Node*>, unobserved_supp)
 
   // Nodes in unobserved_supp that are stochastic; similarly, order matters.
-  CACHE_PROPERTY(std::vector<Node*>, unobserved_sto_supp)
+  CACHED_PUBLIC_PROPERTY(std::vector<Node*>, unobserved_sto_supp)
 
   // These vectors are the same size as unobserved_sto_support.
   // The i-th elements are vectors of nodes which are
@@ -1055,9 +1060,14 @@ struct Graph {
   // In other words, these are the cached results of
   // invoking graph::compute_affected_nodes
   // for each node.
+
  private:
-  std::vector<std::vector<Node*>> _sto_affected_nodes;
-  std::vector<std::vector<Node*>> _det_affected_nodes;
+  CACHED_PRIVATE_PROPERTY(std::vector<std::vector<Node*>>, det_affected_nodes)
+  CACHED_PRIVATE_PROPERTY(std::vector<std::vector<Node*>>, sto_affected_nodes)
+
+#undef CACHED_PROPERTY
+#undef CACHED_PUBLIC_PROPERTY
+#undef CACHED_PRIVATE_PROPERTY
 
   // Because unobserved_supp and unobserved_sto_supp do not contain
   // all nodes in the graph, it does not hold that a node id

--- a/src/beanmachine/graph/tests/graph_test.cpp
+++ b/src/beanmachine/graph/tests/graph_test.cpp
@@ -34,25 +34,18 @@ void populate_arithmetic_graph(unique_ptr<Graph>& g) {
   */
   uint c1 = g->add_constant_probability(0.1);
   uint d1 = g->add_distribution(
-      graph::DistributionType::BERNOULLI,
-      graph::AtomicType::BOOLEAN,
-      std::vector<uint>({c1}));
-  uint o1 =
-      g->add_operator(graph::OperatorType::SAMPLE, std::vector<uint>({d1}));
-  uint o2 = g->add_operator(
-      graph::OperatorType::TO_POS_REAL, std::vector<uint>({o1}));
+      DistributionType::BERNOULLI, AtomicType::BOOLEAN, vector<uint>({c1}));
+  uint o1 = g->add_operator(OperatorType::SAMPLE, vector<uint>({d1}));
+  uint o2 = g->add_operator(OperatorType::TO_POS_REAL, vector<uint>({o1}));
   uint c2 = g->add_constant_pos_real(0.8);
-  uint o3 = g->add_operator(
-      graph::OperatorType::MULTIPLY, std::vector<uint>({c2, o2}));
+  uint o3 = g->add_operator(OperatorType::MULTIPLY, vector<uint>({c2, o2}));
   uint c3 = g->add_constant_pos_real(0.1);
-  uint o4 =
-      g->add_operator(graph::OperatorType::ADD, std::vector<uint>({c3, o3}));
+  uint o4 = g->add_operator(OperatorType::ADD, vector<uint>({c3, o3}));
   uint d2 = g->add_distribution(
-      graph::DistributionType::BERNOULLI_NOISY_OR,
-      graph::AtomicType::BOOLEAN,
-      std::vector<uint>({o4}));
-  uint o5 =
-      g->add_operator(graph::OperatorType::SAMPLE, std::vector<uint>({d2}));
+      DistributionType::BERNOULLI_NOISY_OR,
+      AtomicType::BOOLEAN,
+      vector<uint>({o4}));
+  uint o5 = g->add_operator(OperatorType::SAMPLE, vector<uint>({d2}));
   // P(o5|o1=T) = 1 - exp(-.9)=0.5934 and P(o5|o1=F) = 1-exp(-.1)=0.09516
   // Since P(o1=T)=0.1 and P(o1=F)=0.9. Therefore P(o5=T,o1=T) = 0.05934,
   // P(o5=T,o1=F) = 0.08564 and P(o1=T | o5=T) = 0.4093
@@ -67,35 +60,32 @@ unique_ptr<Graph> make_arithmetic_graph() {
 }
 
 void test_arithmetic_network(unique_ptr<Graph>& g) {
-  std::vector<std::vector<graph::NodeValue>> samples =
-      g->infer(100, graph::InferenceType::GIBBS);
+  vector<vector<NodeValue>> samples = g->infer(100, InferenceType::GIBBS);
   int sum = 0;
   for (const auto& sample : samples) {
     const auto& s = sample.front();
-    ASSERT_EQ(s.type, graph::AtomicType::BOOLEAN);
+    ASSERT_EQ(s.type, AtomicType::BOOLEAN);
     sum += s._bool ? 1 : 0;
   }
   // less than 1 in million odds of failing these tests with correct infer
   EXPECT_LT(sum, 65);
   EXPECT_GT(sum, 15);
   // infer_mean should give almost exactly the same answer
-  std::vector<double> means = g->infer_mean(100, graph::InferenceType::GIBBS);
-  EXPECT_TRUE(std::abs(sum - int(means[0] * 100)) <= 1);
+  vector<double> means = g->infer_mean(100, InferenceType::GIBBS);
+  EXPECT_TRUE(abs(sum - int(means[0] * 100)) <= 1);
   // repeat the test with rejection sampling
-  std::vector<std::vector<graph::NodeValue>> samples2 =
-      g->infer(100, graph::InferenceType::REJECTION);
+  vector<vector<NodeValue>> samples2 = g->infer(100, InferenceType::REJECTION);
   sum = 0;
   for (const auto& sample : samples2) {
     const auto& s = sample.front();
-    ASSERT_EQ(s.type, graph::AtomicType::BOOLEAN);
+    ASSERT_EQ(s.type, AtomicType::BOOLEAN);
     sum += s._bool ? 1 : 0;
   }
   EXPECT_LT(sum, 65);
   EXPECT_GT(sum, 15);
   // infer_mean should give the same answer
-  std::vector<double> means2 =
-      g->infer_mean(100, graph::InferenceType::REJECTION);
-  EXPECT_TRUE(std::abs(sum - int(means2[0] * 100)) <= 1);
+  vector<double> means2 = g->infer_mean(100, InferenceType::REJECTION);
+  EXPECT_TRUE(abs(sum - int(means2[0] * 100)) <= 1);
 }
 
 TEST(testgraph, infer_arithmetic) {
@@ -115,18 +105,14 @@ TEST(testgraph, remove_node) {
   uint o4 = g->nodes.size() - 3;
 
   // Let's make some new ones that are topologically later
-  uint c4 = g->add_constant_real(0.7);
-  uint o6 =
-      g->add_operator(graph::OperatorType::TO_REAL, std::vector<uint>({o1}));
-  uint o7 = g->add_operator(
-      graph::OperatorType::MULTIPLY, std::vector<uint>({c4, o6}));
-  uint o8 =
-      g->add_operator(graph::OperatorType::TO_REAL, std::vector<uint>({o5}));
-  uint o9 = g->add_operator(
-      graph::OperatorType::MULTIPLY, std::vector<uint>({c4, o8}));
+  uint c4 = g->add_constant(0.7);
+  uint o6 = g->add_operator(OperatorType::TO_REAL, vector<uint>({o1}));
+  uint o7 = g->add_operator(OperatorType::MULTIPLY, vector<uint>({c4, o6}));
+  uint o8 = g->add_operator(OperatorType::TO_REAL, vector<uint>({o5}));
+  uint o9 = g->add_operator(OperatorType::MULTIPLY, vector<uint>({c4, o8}));
 
   // Cannot remove a node with out-nodes
-  ASSERT_THROW(g->remove_node(c4), std::invalid_argument);
+  ASSERT_THROW(g->remove_node(c4), invalid_argument);
 
   // Need to remove them in reverse topological order
   // (that is, only nodes without out-nodes)
@@ -151,60 +137,55 @@ TEST(testgraph, remove_node) {
   // c4 did not change
   ASSERT_EQ(from_old_to_new_id2(from_old_to_new_id1(c4)), c4);
 
+  // Let's remove all new nodes
   g->remove_node(o9);
   g->remove_node(o8);
   g->remove_node(c4);
 
+  // Now are are back to the original graph
   test_arithmetic_network(g);
-
-  // At this point the graph should be as originally.
   ASSERT_EQ(g->nodes.size(), original_number_of_nodes);
 
   // Now let's remove all nodes and put them back to see if nothing breaks.
-  auto node_id = original_number_of_nodes;
-  do {
-    g->remove_node(--node_id);
-  } while (node_id != 0);
+  auto number_of_remaining_nodes = original_number_of_nodes;
+  while (number_of_remaining_nodes != 0) {
+    auto last_node_id = number_of_remaining_nodes - 1;
+    g->remove_node(last_node_id);
+    number_of_remaining_nodes--;
+  }
   populate_arithmetic_graph(g);
   test_arithmetic_network(g);
 }
 
 TEST(testgraph, infer_bn) {
-  graph::Graph g;
+  Graph g;
   // classic sprinkler BN, see the diagram here:
   // https://upload.wikimedia.org/wikipedia/commons/0/0e/SimpleBayesNet.svg
   Eigen::MatrixXd matrix1(2, 1);
   matrix1 << 0.8, 0.2;
   uint c1 = g.add_constant_col_simplex_matrix(matrix1);
   uint d1 = g.add_distribution(
-      graph::DistributionType::TABULAR,
-      graph::AtomicType::BOOLEAN,
-      std::vector<uint>({c1}));
-  uint RAIN =
-      g.add_operator(graph::OperatorType::SAMPLE, std::vector<uint>({d1}));
+      DistributionType::TABULAR, AtomicType::BOOLEAN, vector<uint>({c1}));
+  uint RAIN = g.add_operator(OperatorType::SAMPLE, vector<uint>({d1}));
   Eigen::MatrixXd matrix2(2, 2);
   matrix2 << 0.6, 0.99, 0.4, 0.01;
   uint c2 = g.add_constant_col_simplex_matrix(matrix2);
   uint d2 = g.add_distribution(
-      graph::DistributionType::TABULAR,
-      graph::AtomicType::BOOLEAN,
-      std::vector<uint>({c2, RAIN}));
-  uint SPRINKLER =
-      g.add_operator(graph::OperatorType::SAMPLE, std::vector<uint>({d2}));
+      DistributionType::TABULAR, AtomicType::BOOLEAN, vector<uint>({c2, RAIN}));
+  uint SPRINKLER = g.add_operator(OperatorType::SAMPLE, vector<uint>({d2}));
   Eigen::MatrixXd matrix3(2, 4);
   matrix3 << 1.0, 0.2, 0.1, 0.01, 0.0, 0.8, 0.9, 0.99;
   uint c3 = g.add_constant_col_simplex_matrix(matrix3);
   uint d3 = g.add_distribution(
-      graph::DistributionType::TABULAR,
-      graph::AtomicType::BOOLEAN,
-      std::vector<uint>({c3, SPRINKLER, RAIN}));
-  uint GRASSWET =
-      g.add_operator(graph::OperatorType::SAMPLE, std::vector<uint>({d3}));
+      DistributionType::TABULAR,
+      AtomicType::BOOLEAN,
+      vector<uint>({c3, SPRINKLER, RAIN}));
+  uint GRASSWET = g.add_operator(OperatorType::SAMPLE, vector<uint>({d3}));
   g.observe(GRASSWET, true);
   g.query(RAIN);
   uint n_iter = 100;
-  const std::vector<std::vector<graph::NodeValue>>& samples =
-      g.infer(n_iter, graph::InferenceType::REJECTION);
+  const vector<vector<NodeValue>>& samples =
+      g.infer(n_iter, InferenceType::REJECTION);
   ASSERT_EQ(samples.size(), n_iter);
   uint sum = 0;
   for (const auto& sample : samples) {
@@ -216,8 +197,7 @@ TEST(testgraph, infer_bn) {
   EXPECT_LT(sum, 60);
   EXPECT_GT(sum, 10);
   // using multiple chains
-  const auto& all_samples =
-      g.infer(n_iter, graph::InferenceType::REJECTION, 123, 2);
+  const auto& all_samples = g.infer(n_iter, InferenceType::REJECTION, 123, 2);
   ASSERT_EQ(all_samples.size(), 2);
   ASSERT_EQ(all_samples[0].size(), n_iter);
   ASSERT_EQ(all_samples[1].size(), n_iter);
@@ -232,7 +212,7 @@ TEST(testgraph, infer_bn) {
   ASSERT_LT(eqsum, n_iter);
 
   const auto& all_means =
-      g.infer_mean(n_iter, graph::InferenceType::REJECTION, 123, 2);
+      g.infer_mean(n_iter, InferenceType::REJECTION, 123, 2);
   ASSERT_EQ(all_means.size(), 2);
   ASSERT_NE(all_means[0].front(), all_means[1].front());
   ASSERT_GT(all_means[0].front(), 0.1);
@@ -395,28 +375,22 @@ TEST(testgraph, clone_graph) {
 }
 
 TEST(testgraph, full_log_prob) {
-  graph::Graph g;
+  Graph g;
   uint a = g.add_constant_pos_real(5.0);
   uint b = g.add_constant_pos_real(3.0);
   uint n = g.add_constant_natural(10);
   uint beta = g.add_distribution(
-      graph::DistributionType::BETA,
-      graph::AtomicType::PROBABILITY,
-      std::vector<uint>({a, b}));
-  uint prob =
-      g.add_operator(graph::OperatorType::SAMPLE, std::vector<uint>({beta}));
+      DistributionType::BETA, AtomicType::PROBABILITY, vector<uint>({a, b}));
+  uint prob = g.add_operator(OperatorType::SAMPLE, vector<uint>({beta}));
   uint binomial = g.add_distribution(
-      graph::DistributionType::BINOMIAL,
-      graph::AtomicType::NATURAL,
-      std::vector<uint>({n, prob}));
-  uint k = g.add_operator(
-      graph::OperatorType::SAMPLE, std::vector<uint>({binomial}));
-  g.observe(k, (graph::natural_t)8);
+      DistributionType::BINOMIAL, AtomicType::NATURAL, vector<uint>({n, prob}));
+  uint k = g.add_operator(OperatorType::SAMPLE, vector<uint>({binomial}));
+  g.observe(k, (natural_t)8);
   g.query(prob);
   // Note: the posterior is p ~ Beta(13, 5).
   int num_samples = 10;
-  auto conf = graph::InferConfig(true);
-  auto samples = g.infer(num_samples, graph::InferenceType::NMC, 123, 2, conf);
+  auto conf = InferConfig(true);
+  auto samples = g.infer(num_samples, InferenceType::NMC, 123, 2, conf);
   auto log_probs = g.get_log_prob();
   EXPECT_EQ(log_probs.size(), 2);
   EXPECT_EQ(log_probs[0].size(), num_samples);
@@ -425,13 +399,13 @@ TEST(testgraph, full_log_prob) {
       auto& s = samples[c][i][0];
       double l = log_probs[c][i];
       g.remove_observations();
-      g.observe(k, (graph::natural_t)8);
+      g.observe(k, (natural_t)8);
       g.observe(prob, s._double);
       EXPECT_NEAR(g.full_log_prob(), l, 1e-3);
     }
   }
   g.remove_observations();
-  g.observe(k, (graph::natural_t)8);
+  g.observe(k, (natural_t)8);
   g.observe(prob, 0.6);
   EXPECT_NEAR(g.full_log_prob(), -1.3344, 1e-3);
 }
@@ -444,86 +418,82 @@ TEST(testgraph, bad_observations) {
   nat_matrix << 2, 3;
   Eigen::MatrixXd real_matrix(1, 2);
   real_matrix << 1.5, 2.5;
-  graph::natural_t nat = 2;
+  natural_t nat = 2;
 
-  graph::Graph g;
+  Graph g;
 
   // Observe a bool to be a double, natural, matrix:
   uint c_prob = g.add_constant_probability(0.5);
   uint d_bernoulli = g.add_distribution(
-      graph::DistributionType::BERNOULLI,
-      graph::AtomicType::BOOLEAN,
-      std::vector<uint>{c_prob});
-  uint o_sample_bool = g.add_operator(
-      graph::OperatorType::SAMPLE, std::vector<uint>{d_bernoulli});
-  EXPECT_THROW(g.observe(o_sample_bool, 0.1), std::invalid_argument);
-  EXPECT_THROW(g.observe(o_sample_bool, nat), std::invalid_argument);
-  EXPECT_THROW(g.observe(o_sample_bool, bool_matrix), std::invalid_argument);
-  EXPECT_THROW(g.observe(o_sample_bool, nat_matrix), std::invalid_argument);
-  EXPECT_THROW(g.observe(o_sample_bool, real_matrix), std::invalid_argument);
+      DistributionType::BERNOULLI, AtomicType::BOOLEAN, vector<uint>{c_prob});
+  uint o_sample_bool =
+      g.add_operator(OperatorType::SAMPLE, vector<uint>{d_bernoulli});
+  EXPECT_THROW(g.observe(o_sample_bool, 0.1), invalid_argument);
+  EXPECT_THROW(g.observe(o_sample_bool, nat), invalid_argument);
+  EXPECT_THROW(g.observe(o_sample_bool, bool_matrix), invalid_argument);
+  EXPECT_THROW(g.observe(o_sample_bool, nat_matrix), invalid_argument);
+  EXPECT_THROW(g.observe(o_sample_bool, real_matrix), invalid_argument);
 
   // Observe a bool(2, 1) to be a bool, double, natural, and (1, 2) matrices
   uint c_natural_1 = g.add_constant_natural(1);
   uint c_natural_2 = g.add_constant_natural(2);
   uint o_iid_bool = g.add_operator(
-      graph::OperatorType::IID_SAMPLE,
-      std::vector<uint>{d_bernoulli, c_natural_2, c_natural_1});
-  EXPECT_THROW(g.observe(o_iid_bool, false), std::invalid_argument);
-  EXPECT_THROW(g.observe(o_iid_bool, 0.1), std::invalid_argument);
-  EXPECT_THROW(g.observe(o_iid_bool, nat), std::invalid_argument);
-  EXPECT_THROW(g.observe(o_iid_bool, bool_matrix), std::invalid_argument);
-  EXPECT_THROW(g.observe(o_iid_bool, nat_matrix), std::invalid_argument);
-  EXPECT_THROW(g.observe(o_iid_bool, real_matrix), std::invalid_argument);
+      OperatorType::IID_SAMPLE,
+      vector<uint>{d_bernoulli, c_natural_2, c_natural_1});
+  EXPECT_THROW(g.observe(o_iid_bool, false), invalid_argument);
+  EXPECT_THROW(g.observe(o_iid_bool, 0.1), invalid_argument);
+  EXPECT_THROW(g.observe(o_iid_bool, nat), invalid_argument);
+  EXPECT_THROW(g.observe(o_iid_bool, bool_matrix), invalid_argument);
+  EXPECT_THROW(g.observe(o_iid_bool, nat_matrix), invalid_argument);
+  EXPECT_THROW(g.observe(o_iid_bool, real_matrix), invalid_argument);
 
   // Observe a natural to be bool, real, matrix
   uint d_binomial = g.add_distribution(
-      graph::DistributionType::BINOMIAL,
-      graph::AtomicType::NATURAL,
-      std::vector<uint>{c_natural_2, c_prob});
-  uint o_sample_natural = g.add_operator(
-      graph::OperatorType::SAMPLE, std::vector<uint>{d_binomial});
-  EXPECT_THROW(g.observe(o_sample_natural, true), std::invalid_argument);
-  EXPECT_THROW(g.observe(o_sample_natural, 0.5), std::invalid_argument);
-  EXPECT_THROW(g.observe(o_sample_natural, bool_matrix), std::invalid_argument);
-  EXPECT_THROW(g.observe(o_sample_natural, nat_matrix), std::invalid_argument);
-  EXPECT_THROW(g.observe(o_sample_natural, real_matrix), std::invalid_argument);
+      DistributionType::BINOMIAL,
+      AtomicType::NATURAL,
+      vector<uint>{c_natural_2, c_prob});
+  uint o_sample_natural =
+      g.add_operator(OperatorType::SAMPLE, vector<uint>{d_binomial});
+  EXPECT_THROW(g.observe(o_sample_natural, true), invalid_argument);
+  EXPECT_THROW(g.observe(o_sample_natural, 0.5), invalid_argument);
+  EXPECT_THROW(g.observe(o_sample_natural, bool_matrix), invalid_argument);
+  EXPECT_THROW(g.observe(o_sample_natural, nat_matrix), invalid_argument);
+  EXPECT_THROW(g.observe(o_sample_natural, real_matrix), invalid_argument);
 
   // Observe a natural(2, 1) to be a bool, double, natural, and (1, 2) matrices
   uint o_iid_nat = g.add_operator(
-      graph::OperatorType::IID_SAMPLE,
-      std::vector<uint>{d_binomial, c_natural_2, c_natural_1});
-  EXPECT_THROW(g.observe(o_iid_nat, false), std::invalid_argument);
-  EXPECT_THROW(g.observe(o_iid_nat, 0.1), std::invalid_argument);
-  EXPECT_THROW(g.observe(o_iid_nat, nat), std::invalid_argument);
-  EXPECT_THROW(g.observe(o_iid_nat, bool_matrix), std::invalid_argument);
-  EXPECT_THROW(g.observe(o_iid_nat, nat_matrix), std::invalid_argument);
-  EXPECT_THROW(g.observe(o_iid_nat, real_matrix), std::invalid_argument);
+      OperatorType::IID_SAMPLE,
+      vector<uint>{d_binomial, c_natural_2, c_natural_1});
+  EXPECT_THROW(g.observe(o_iid_nat, false), invalid_argument);
+  EXPECT_THROW(g.observe(o_iid_nat, 0.1), invalid_argument);
+  EXPECT_THROW(g.observe(o_iid_nat, nat), invalid_argument);
+  EXPECT_THROW(g.observe(o_iid_nat, bool_matrix), invalid_argument);
+  EXPECT_THROW(g.observe(o_iid_nat, nat_matrix), invalid_argument);
+  EXPECT_THROW(g.observe(o_iid_nat, real_matrix), invalid_argument);
 
   // Observe a real to be bool, natural, matrix:
   uint c_real = g.add_constant_real(-2.5);
   uint c_pos = g.add_constant_pos_real(2.5);
   uint d_normal = g.add_distribution(
-      graph::DistributionType::NORMAL,
-      graph::AtomicType::REAL,
-      std::vector<uint>{c_real, c_pos});
+      DistributionType::NORMAL, AtomicType::REAL, vector<uint>{c_real, c_pos});
   uint o_sample_real =
-      g.add_operator(graph::OperatorType::SAMPLE, std::vector<uint>{d_normal});
-  EXPECT_THROW(g.observe(o_sample_real, true), std::invalid_argument);
-  EXPECT_THROW(g.observe(o_sample_real, nat), std::invalid_argument);
-  EXPECT_THROW(g.observe(o_sample_real, bool_matrix), std::invalid_argument);
-  EXPECT_THROW(g.observe(o_sample_real, nat_matrix), std::invalid_argument);
-  EXPECT_THROW(g.observe(o_sample_real, real_matrix), std::invalid_argument);
+      g.add_operator(OperatorType::SAMPLE, vector<uint>{d_normal});
+  EXPECT_THROW(g.observe(o_sample_real, true), invalid_argument);
+  EXPECT_THROW(g.observe(o_sample_real, nat), invalid_argument);
+  EXPECT_THROW(g.observe(o_sample_real, bool_matrix), invalid_argument);
+  EXPECT_THROW(g.observe(o_sample_real, nat_matrix), invalid_argument);
+  EXPECT_THROW(g.observe(o_sample_real, real_matrix), invalid_argument);
 
   // Observe a real(2, 1) to be a bool, double, natural, and (1, 2) matrices
   uint o_iid_real = g.add_operator(
-      graph::OperatorType::IID_SAMPLE,
-      std::vector<uint>{d_normal, c_natural_2, c_natural_1});
-  EXPECT_THROW(g.observe(o_iid_real, false), std::invalid_argument);
-  EXPECT_THROW(g.observe(o_iid_real, 0.1), std::invalid_argument);
-  EXPECT_THROW(g.observe(o_iid_real, nat), std::invalid_argument);
-  EXPECT_THROW(g.observe(o_iid_real, bool_matrix), std::invalid_argument);
-  EXPECT_THROW(g.observe(o_iid_real, nat_matrix), std::invalid_argument);
-  EXPECT_THROW(g.observe(o_iid_real, real_matrix), std::invalid_argument);
+      OperatorType::IID_SAMPLE,
+      vector<uint>{d_normal, c_natural_2, c_natural_1});
+  EXPECT_THROW(g.observe(o_iid_real, false), invalid_argument);
+  EXPECT_THROW(g.observe(o_iid_real, 0.1), invalid_argument);
+  EXPECT_THROW(g.observe(o_iid_real, nat), invalid_argument);
+  EXPECT_THROW(g.observe(o_iid_real, bool_matrix), invalid_argument);
+  EXPECT_THROW(g.observe(o_iid_real, nat_matrix), invalid_argument);
+  EXPECT_THROW(g.observe(o_iid_real, real_matrix), invalid_argument);
 }
 
 TEST(testgraph, infer_runtime_error) {
@@ -533,19 +503,16 @@ TEST(testgraph, infer_runtime_error) {
   real_matrix << 1.0;
   auto matrix = g.add_constant_real_matrix(real_matrix);
   // index out of bounds during runtime
-  auto indexed_matrix =
-      g.add_operator(graph::OperatorType::INDEX, {matrix, two});
+  auto indexed_matrix = g.add_operator(OperatorType::INDEX, {matrix, two});
   g.query(indexed_matrix);
 
   int num_samples = 10;
   int seed = 19;
   // test with one chain
-  EXPECT_THROW(
-      g.infer(num_samples, graph::InferenceType::NMC), std::runtime_error);
+  EXPECT_THROW(g.infer(num_samples, InferenceType::NMC), runtime_error);
   // test with threads from multiple chains
   EXPECT_THROW(
-      g.infer(num_samples, graph::InferenceType::NMC, seed, 2),
-      std::runtime_error);
+      g.infer(num_samples, InferenceType::NMC, seed, 2), runtime_error);
 }
 
 TEST(testgraph, eval_and_update_backgrad) {
@@ -558,24 +525,17 @@ TEST(testgraph, eval_and_update_backgrad) {
   log_prob = normal_dist.log_prob(x) + normal1_dist.log_prob(y)
   torch.autograd.grad(log_prob, x)
   */
-  graph::Graph g;
+  Graph g;
   auto mean0 = g.add_constant_real(0.0);
   auto sigma0 = g.add_constant_pos_real(5.0);
   auto dist0 = g.add_distribution(
-      graph::DistributionType::NORMAL,
-      graph::AtomicType::REAL,
-      std::vector<uint>{mean0, sigma0});
-  auto x =
-      g.add_operator(graph::OperatorType::SAMPLE, std::vector<uint>{dist0});
-  auto x_sq =
-      g.add_operator(graph::OperatorType::MULTIPLY, std::vector<uint>{x, x});
+      DistributionType::NORMAL, AtomicType::REAL, vector<uint>{mean0, sigma0});
+  auto x = g.add_operator(OperatorType::SAMPLE, vector<uint>{dist0});
+  auto x_sq = g.add_operator(OperatorType::MULTIPLY, vector<uint>{x, x});
   auto sigma1 = g.add_constant_pos_real(10.0);
   auto dist1 = g.add_distribution(
-      graph::DistributionType::NORMAL,
-      graph::AtomicType::REAL,
-      std::vector<uint>{x_sq, sigma1});
-  auto y =
-      g.add_operator(graph::OperatorType::SAMPLE, std::vector<uint>{dist1});
+      DistributionType::NORMAL, AtomicType::REAL, vector<uint>{x_sq, sigma1});
+  auto y = g.add_operator(OperatorType::SAMPLE, vector<uint>{dist1});
   g.observe(y, 100.0);
   g.query(x_sq);
   g.nodes[x]->value._double = 2.0;


### PR DESCRIPTION
Summary: `graph_test.cpp` uses `std` and `graph` namespaces all over, so I included `using namespace` directives for them. Because this changes many lines, I've made it into its own diff so these lines do not obscure more significant changes in other diffs.

Differential Revision: D39659050

