### PR TITLE
minibmg: Remove NodeId from Node.

### DIFF
--- a/minibmg/ad/num2.h
+++ b/minibmg/ad/num2.h
@@ -31,10 +31,15 @@ class Num2 {
   /* implicit */ Num2(double primal);
   /* implicit */ Num2(Underlying primal);
   Num2(Underlying primal, Underlying derivative1);
+  Num2();
   Num2(const Num2<Underlying>& other);
   Num2<Underlying>& operator=(const Num2<Underlying>& other) = default;
   double as_double() const;
 };
+
+template <class Underlying>
+requires Number<Underlying> Num2<Underlying>::Num2()
+    : primal{0}, derivative1{0} {}
 
 template <class Underlying>
 requires Number<Underlying> Num2<Underlying>::Num2(double primal)

--- a/minibmg/ad/num3.h
+++ b/minibmg/ad/num3.h
@@ -32,11 +32,16 @@ class Num3 {
 
   /* implicit */ Num3(double primal);
   /* implicit */ Num3(Underlying primal);
+  Num3();
   Num3(Underlying primal, Underlying derivative1, Underlying derivative2);
   Num3(const Num3<Underlying>& other);
   Num3<Underlying>& operator=(const Num3<Underlying>& other) = default;
   double as_double() const;
 };
+
+template <class Underlying>
+requires Number<Underlying> Num3<Underlying>::Num3()
+    : primal{0}, derivative1{0}, derivative2{0} {}
 
 template <class Underlying>
 requires Number<Underlying> Num3<Underlying>::Num3(double primal)

--- a/minibmg/ad/real.h
+++ b/minibmg/ad/real.h
@@ -30,7 +30,10 @@ class Real {
     return value;
   }
   /* implicit */ inline Real(double value) : value{value} {}
+
+  INLINE Real() : value{0} {}
   INLINE Real& operator=(const Real&) = default;
+  INLINE Real(const Real& other) : value{other.value} {}
 };
 
 INLINE Real operator+(const Real left, const Real right) {

--- a/minibmg/ad/traced.cpp
+++ b/minibmg/ad/traced.cpp
@@ -19,7 +19,7 @@ Traced::Traced(const Operator op, shared_ptr<const TracedBody> p)
 Traced::Traced(double n)
     : m_op{Operator::CONSTANT}, m_ptr{make_shared<TracedConstant>(n)} {}
 
-Traced Traced::variable(const std::string& name, const uint sequence) {
+Traced Traced::variable(const std::string& name, const unsigned sequence) {
   return Traced{
       Operator::VARIABLE, make_shared<TracedVariable>(name, sequence)};
 }

--- a/minibmg/ad/traced.h
+++ b/minibmg/ad/traced.h
@@ -32,7 +32,7 @@ class Traced {
   shared_ptr<const TracedBody> m_ptr;
 
   /* implicit */ Traced(double d);
-  static Traced variable(const std::string& name, const uint sequence);
+  static Traced variable(const std::string& name, const unsigned sequence);
   inline Operator op() const {
     return m_op;
   }
@@ -78,8 +78,8 @@ class TracedBody {
 class TracedVariable : public TracedBody {
  public:
   const string name;
-  const uint sequence;
-  TracedVariable(const std::string& name, const uint sequence)
+  const unsigned sequence;
+  TracedVariable(const std::string& name, const unsigned sequence)
       : name{name}, sequence{sequence} {}
 };
 class TracedConstant : public TracedBody {

--- a/minibmg/ad/traced_to_string.cpp
+++ b/minibmg/ad/traced_to_string.cpp
@@ -213,7 +213,7 @@ std::string to_string(const Traced& traced) {
     }
   };
   auto pred_counts = count_predecessors<Traced>({traced}, successors);
-  std::map<Traced, uint> pred_counts_copy = pred_counts;
+  std::map<Traced, unsigned> pred_counts_copy = pred_counts;
   std::vector<Traced> topologically_sorted;
   bool sorted = topological_sort<Traced>(
       pred_counts_copy, successors, topologically_sorted);

--- a/minibmg/eval.cpp
+++ b/minibmg/eval.cpp
@@ -16,7 +16,7 @@ namespace beanmachine::minibmg {
 
 double sample_distribution(
     Operator distribution,
-    function<double(uint)> get_parameter,
+    function<double(unsigned)> get_parameter,
     mt19937& gen) {
   switch (distribution) {
     case Operator::DISTRIBUTION_NORMAL: {

--- a/minibmg/eval.h
+++ b/minibmg/eval.h
@@ -24,7 +24,7 @@ class EvalError : public std::exception {
 
 template <class N>
 requires Number<N> N
-eval_operator(Operator op, std::function<N(uint)> get_value) {
+eval_operator(Operator op, std::function<N(unsigned)> get_value) {
   switch (op) {
     case Operator::ADD:
       return get_value(0) + get_value(1);
@@ -59,7 +59,7 @@ eval_operator(Operator op, std::function<N(uint)> get_value) {
 // Sample from the given distribution.
 double sample_distribution(
     Operator distribution,
-    std::function<double(uint)> get_parameter,
+    std::function<double(unsigned)> get_parameter,
     std::mt19937& gen);
 
 // Evaluating an entire graph, returning an array of doubles that contains, for
@@ -71,7 +71,7 @@ requires Number<T>
 void eval_graph(
     const Graph& graph,
     std::mt19937& gen,
-    std::function<T(const std::string& name, const uint sequence)>
+    std::function<T(const std::string& name, const unsigned sequence)>
         read_variable,
     std::vector<T>& data) {
   int n = graph.size();
@@ -96,7 +96,7 @@ void eval_graph(
         const OperatorNode* sample = static_cast<const OperatorNode*>(node);
         const Node* in0 = sample->in_nodes[0];
         const OperatorNode* dist = static_cast<const OperatorNode*>(in0);
-        std::function<double(uint)> get_parameter = [=](uint i) {
+        std::function<double(unsigned)> get_parameter = [=](unsigned i) {
           return data[dist->in_nodes[i]->sequence].as_double();
         };
         data[i] = sample_distribution(dist->op, get_parameter, gen);
@@ -107,7 +107,7 @@ void eval_graph(
         const QueryNode* sample = static_cast<const QueryNode*>(node);
         const Node* in0 = sample->in_node;
         const OperatorNode* dist = static_cast<const OperatorNode*>(in0);
-        std::function<double(uint)> get_parameter = [=](uint i) {
+        std::function<double(unsigned)> get_parameter = [=](unsigned i) {
           return data[dist->in_nodes[i]->sequence].as_double();
         };
         data[i] = sample_distribution(dist->op, get_parameter, gen);
@@ -129,7 +129,7 @@ void eval_graph(
         break;
       default:
         const OperatorNode* opnode = static_cast<const OperatorNode*>(node);
-        std::function<T(uint)> get_parameter = [=](uint i) {
+        std::function<T(unsigned)> get_parameter = [=](unsigned i) {
           return data[opnode->in_nodes[i]->sequence];
         };
         T result = eval_operator<T>(node->op, get_parameter);

--- a/minibmg/eval.h
+++ b/minibmg/eval.h
@@ -30,7 +30,7 @@ namespace {
 using namespace beanmachine::minibmg;
 
 template <class T>
-T get(const std::unordered_map<NodeId, T>& map, const NodeId& id) {
+T get(const std::unordered_map<const Node*, T>& map, const Node* id) {
   auto t = map.find(id);
   if (t == map.end()) {
     throw EvalError(fmt::format("Missing data for node {}", id));
@@ -39,7 +39,10 @@ T get(const std::unordered_map<NodeId, T>& map, const NodeId& id) {
 }
 
 template <class T>
-void put(std::unordered_map<NodeId, T>& map, const NodeId& id, const T& value) {
+void put(
+    std::unordered_map<const Node*, T>& map,
+    const Node* id,
+    const T& value) {
   map[id] = value;
 }
 
@@ -98,19 +101,19 @@ void eval_graph(
     std::mt19937& gen,
     std::function<T(const std::string& name, const unsigned sequence)>
         read_variable,
-    std::unordered_map<NodeId, T>& data) {
+    std::unordered_map<const Node*, T>& data) {
   int n = graph.size();
   for (int i = 0; i < n; i++) {
     const Node* node = graph[i];
     switch (node->op) {
       case Operator::VARIABLE: {
         const VariableNode* v = static_cast<const VariableNode*>(node);
-        put(data, node->sequence, read_variable(v->name, v->variable_index));
+        put(data, node, read_variable(v->name, v->variable_index));
         break;
       }
       case Operator::CONSTANT: {
         const ConstantNode* c = static_cast<const ConstantNode*>(node);
-        put(data, node->sequence, T{c->value});
+        put(data, node, T{c->value});
         break;
       }
       case Operator::SAMPLE: {
@@ -118,11 +121,9 @@ void eval_graph(
         const Node* in0 = sample->in_nodes[0];
         const OperatorNode* dist = static_cast<const OperatorNode*>(in0);
         std::function<double(unsigned)> get_parameter = [&](unsigned i) {
-          return data[dist->in_nodes[i]->sequence].as_double();
+          return data[dist->in_nodes[i]].as_double();
         };
-        put(data,
-            node->sequence,
-            T{sample_distribution(dist->op, get_parameter, gen)});
+        put(data, node, T{sample_distribution(dist->op, get_parameter, gen)});
         break;
       }
       case Operator::QUERY: {
@@ -131,11 +132,9 @@ void eval_graph(
         const Node* in0 = sample->in_node;
         const OperatorNode* dist = static_cast<const OperatorNode*>(in0);
         std::function<double(unsigned)> get_parameter = [&](unsigned i) {
-          return data[dist->in_nodes[i]->sequence].as_double();
+          return data[dist->in_nodes[i]].as_double();
         };
-        put(data,
-            node->sequence,
-            T{sample_distribution(dist->op, get_parameter, gen)});
+        put(data, node, T{sample_distribution(dist->op, get_parameter, gen)});
         break;
       }
       case Operator::OBSERVE:
@@ -155,10 +154,10 @@ void eval_graph(
       default:
         const OperatorNode* opnode = static_cast<const OperatorNode*>(node);
         std::function<T(unsigned)> get_parameter = [&](unsigned i) {
-          return data[opnode->in_nodes[i]->sequence];
+          return data[opnode->in_nodes[i]];
         };
         T result = eval_operator<T>(node->op, get_parameter);
-        put(data, node->sequence, result);
+        put(data, node, result);
     }
   }
 }

--- a/minibmg/factory.cpp
+++ b/minibmg/factory.cpp
@@ -9,9 +9,15 @@
 
 namespace beanmachine::minibmg {
 
+std::atomic<unsigned long> NodeId::_next_value{0};
+
+NodeId::NodeId() {
+  this->value = _next_value.fetch_add(1);
+}
+
 NodeId Graph::Factory::add_node(const Node* node) {
   all_nodes.push_back(node);
-  const NodeId& sequence = node->sequence;
+  NodeId sequence{};
   nodes.insert({sequence, node});
   return sequence;
 }
@@ -181,7 +187,6 @@ NodeId Graph::Factory::add_variable(
 
 Graph Graph::Factory::build() {
   auto nodes = this->all_nodes;
-  this->nodes.clear();
   this->all_nodes.clear();
   return Graph{nodes};
 }

--- a/minibmg/factory.cpp
+++ b/minibmg/factory.cpp
@@ -9,8 +9,8 @@
 
 namespace beanmachine::minibmg {
 
-uint Graph::Factory::add_constant(double value) {
-  auto sequence = (uint)nodes.size();
+NodeId Graph::Factory::add_constant(double value) {
+  auto sequence = (unsigned)nodes.size();
   const auto new_node = new ConstantNode{value, sequence};
   nodes.push_back(new_node);
   return sequence;
@@ -56,29 +56,29 @@ const std::vector<std::vector<enum Type>> make_expected_parents() {
     result.push_back(empty);
   }
   assert(result.size() == (int)Operator::LAST_OPERATOR);
-  result[(uint)Operator::CONSTANT] = {};
-  result[(uint)Operator::VARIABLE] = {};
-  result[(uint)Operator::ADD] = {Type::REAL, Type::REAL};
-  result[(uint)Operator::SUBTRACT] = {Type::REAL, Type::REAL};
-  result[(uint)Operator::NEGATE] = {Type::REAL};
-  result[(uint)Operator::MULTIPLY] = {Type::REAL, Type::REAL};
-  result[(uint)Operator::DIVIDE] = {Type::REAL, Type::REAL};
-  result[(uint)Operator::POW] = {Type::REAL, Type::REAL};
-  result[(uint)Operator::EXP] = {Type::REAL};
-  result[(uint)Operator::LOG] = {Type::REAL};
-  result[(uint)Operator::ATAN] = {Type::REAL};
-  result[(uint)Operator::LGAMMA] = {Type::REAL};
-  result[(uint)Operator::POLYGAMMA] = {Type::REAL, Type::REAL};
-  result[(uint)Operator::IF_EQUAL] = {
+  result[(unsigned)Operator::CONSTANT] = {};
+  result[(unsigned)Operator::VARIABLE] = {};
+  result[(unsigned)Operator::ADD] = {Type::REAL, Type::REAL};
+  result[(unsigned)Operator::SUBTRACT] = {Type::REAL, Type::REAL};
+  result[(unsigned)Operator::NEGATE] = {Type::REAL};
+  result[(unsigned)Operator::MULTIPLY] = {Type::REAL, Type::REAL};
+  result[(unsigned)Operator::DIVIDE] = {Type::REAL, Type::REAL};
+  result[(unsigned)Operator::POW] = {Type::REAL, Type::REAL};
+  result[(unsigned)Operator::EXP] = {Type::REAL};
+  result[(unsigned)Operator::LOG] = {Type::REAL};
+  result[(unsigned)Operator::ATAN] = {Type::REAL};
+  result[(unsigned)Operator::LGAMMA] = {Type::REAL};
+  result[(unsigned)Operator::POLYGAMMA] = {Type::REAL, Type::REAL};
+  result[(unsigned)Operator::IF_EQUAL] = {
       Type::REAL, Type::REAL, Type::REAL, Type::REAL};
-  result[(uint)Operator::IF_LESS] = {
+  result[(unsigned)Operator::IF_LESS] = {
       Type::REAL, Type::REAL, Type::REAL, Type::REAL};
-  result[(uint)Operator::DISTRIBUTION_NORMAL] = {Type::REAL, Type::REAL};
-  result[(uint)Operator::DISTRIBUTION_BETA] = {Type::REAL, Type::REAL};
-  result[(uint)Operator::DISTRIBUTION_BERNOULLI] = {Type::REAL};
-  result[(uint)Operator::SAMPLE] = {Type::DISTRIBUTION};
-  result[(uint)Operator::OBSERVE] = {Type::DISTRIBUTION, Type::REAL};
-  result[(uint)Operator::QUERY] = {Type::DISTRIBUTION};
+  result[(unsigned)Operator::DISTRIBUTION_NORMAL] = {Type::REAL, Type::REAL};
+  result[(unsigned)Operator::DISTRIBUTION_BETA] = {Type::REAL, Type::REAL};
+  result[(unsigned)Operator::DISTRIBUTION_BERNOULLI] = {Type::REAL};
+  result[(unsigned)Operator::SAMPLE] = {Type::DISTRIBUTION};
+  result[(unsigned)Operator::OBSERVE] = {Type::DISTRIBUTION, Type::REAL};
+  result[(unsigned)Operator::QUERY] = {Type::DISTRIBUTION};
   return result;
 }
 
@@ -118,18 +118,20 @@ const std::vector<std::vector<enum Type>> expected_parents =
     make_expected_parents();
 
 unsigned arity(Operator op) {
-  return expected_parents[(uint)op].size();
+  return expected_parents[(unsigned)op].size();
 }
 
-uint Graph::Factory::add_operator(enum Operator op, std::vector<uint> parents) {
-  auto sequence = (uint)nodes.size();
-  auto expected = expected_parents[(uint)op];
+NodeId Graph::Factory::add_operator(
+    enum Operator op,
+    std::vector<NodeId> parents) {
+  auto sequence = (unsigned)nodes.size();
+  auto expected = expected_parents[(unsigned)op];
   std::vector<const Node*> in_nodes;
   if (parents.size() != expected.size()) {
     throw std::invalid_argument("Incorrect number of parent nodes.");
   }
   for (int i = 0, n = expected.size(); i < n; i++) {
-    uint p = parents[i];
+    NodeId p = parents[i];
     if (p >= sequence) {
       throw std::invalid_argument("Reference to nonexistent node.");
     }
@@ -146,8 +148,8 @@ uint Graph::Factory::add_operator(enum Operator op, std::vector<uint> parents) {
   return sequence;
 }
 
-uint Graph::Factory::add_query(uint parent) {
-  auto sequence = (uint)nodes.size();
+NodeId Graph::Factory::add_query(NodeId parent) {
+  auto sequence = (unsigned)nodes.size();
   if (parent >= sequence) {
     throw std::invalid_argument("Reference to nonexistent node.");
   }
@@ -162,10 +164,10 @@ uint Graph::Factory::add_query(uint parent) {
   return query_id;
 }
 
-uint Graph::Factory::add_variable(
+NodeId Graph::Factory::add_variable(
     const std::string& name,
-    const uint variable_index) {
-  auto sequence = (uint)nodes.size();
+    const unsigned variable_index) {
+  auto sequence = (unsigned)nodes.size();
   auto new_node = new VariableNode{name, variable_index, sequence};
   nodes.push_back(new_node);
   return sequence;

--- a/minibmg/factory.h
+++ b/minibmg/factory.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <unordered_map>
 #include <vector>
 #include "beanmachine/minibmg/graph.h"
 #include "beanmachine/minibmg/node.h"
@@ -23,18 +24,25 @@ class Graph::Factory {
 
   // returns the index of the query in the samples, not a NodeId
   unsigned add_query(NodeId parent);
+  unsigned add_query(NodeId parent, NodeId& new_node_id);
 
   NodeId add_variable(const std::string& name, const unsigned variable_index);
 
-  inline const Node* operator[](NodeId node_id) const {
-    return nodes[node_id];
+  inline const Node* operator[](const NodeId& node_id) const {
+    auto t = nodes.find(node_id);
+    if (t == nodes.end())
+      return nullptr;
+    return t->second;
   }
   Graph build();
   ~Factory();
 
  private:
-  std::vector<const Node*> nodes;
+  std::unordered_map<NodeId, const Node*> nodes;
+  std::vector<const Node*> all_nodes;
   unsigned next_query = 0;
+
+  NodeId add_node(const Node* node);
 };
 
 enum Type expected_result_type(enum Operator op);

--- a/minibmg/factory.h
+++ b/minibmg/factory.h
@@ -17,16 +17,16 @@ namespace beanmachine::minibmg {
 
 class Graph::Factory {
  public:
-  uint add_constant(double value);
+  NodeId add_constant(double value);
 
-  uint add_operator(enum Operator op, std::vector<uint> parents);
+  NodeId add_operator(enum Operator op, std::vector<NodeId> parents);
 
-  // returns the index of the query in the samples
-  uint add_query(uint parent);
+  // returns the index of the query in the samples, not a NodeId
+  unsigned add_query(NodeId parent);
 
-  uint add_variable(const std::string& name, const uint variable_index);
+  NodeId add_variable(const std::string& name, const unsigned variable_index);
 
-  inline const Node* operator[](uint node_id) const {
+  inline const Node* operator[](NodeId node_id) const {
     return nodes[node_id];
   }
   Graph build();
@@ -34,12 +34,12 @@ class Graph::Factory {
 
  private:
   std::vector<const Node*> nodes;
-  uint next_query = 0;
+  unsigned next_query = 0;
 };
 
 enum Type expected_result_type(enum Operator op);
 extern const std::vector<std::vector<enum Type>> expected_parents;
-uint arity(Operator op);
+unsigned arity(Operator op);
 enum Type op_type(enum Operator op);
 
 } // namespace beanmachine::minibmg

--- a/minibmg/factory.h
+++ b/minibmg/factory.h
@@ -16,6 +16,59 @@
 
 namespace beanmachine::minibmg {
 
+class Node;
+
+// An opaque identifier for a node.
+class NodeId {
+ public:
+  // Create a fresh, new, never-before-seen NodeId
+  NodeId();
+  explicit NodeId(unsigned long value) : value{value} {}
+  explicit NodeId(long value) : value{(unsigned long)value} {}
+  inline bool operator==(const NodeId& other) const {
+    return value == other.value;
+  }
+  NodeId(const NodeId& other) : value{other.value} {} // copy ctor
+  NodeId& operator=(const NodeId& other) { // assignment
+    this->value = other.value;
+    return *this;
+  }
+  ~NodeId() {} // dtor
+
+  inline unsigned long _value() const {
+    return value;
+  }
+
+  static void _reset_for_testing() {
+    _next_value = 0;
+  }
+
+ private:
+  static std::atomic<unsigned long> _next_value;
+  unsigned long value;
+};
+
+} // namespace beanmachine::minibmg
+
+// Make NodeId values usable as a key in a hash table.
+template <>
+struct std::hash<beanmachine::minibmg::NodeId> {
+  std::size_t operator()(const beanmachine::minibmg::NodeId& n) const noexcept {
+    return (std::size_t)n._value();
+  }
+};
+
+// Make NodeId values printable using format.
+template <>
+struct fmt::formatter<beanmachine::minibmg::NodeId>
+    : fmt::formatter<std::string> {
+  auto format(const beanmachine::minibmg::NodeId& n, format_context& ctx) {
+    return formatter<std::string>::format(fmt::format("{}", n._value()), ctx);
+  }
+};
+
+namespace beanmachine::minibmg {
+
 class Graph::Factory {
  public:
   NodeId add_constant(double value);

--- a/minibmg/graph.cpp
+++ b/minibmg/graph.cpp
@@ -28,7 +28,7 @@ Graph Graph::create(std::vector<const Node*> nodes) {
 
 void Graph::validate(std::vector<const Node*> nodes) {
   std::unordered_set<const Node*> seen;
-  uint next_query = 0;
+  unsigned next_query = 0;
   // Check the nodes.
   for (int i = 0, n = nodes.size(); i < n; i++) {
     auto node = nodes[i];
@@ -84,7 +84,7 @@ void Graph::validate(std::vector<const Node*> nodes) {
       // Check other operators.
       default: {
         const OperatorNode* op = (OperatorNode*)node;
-        uint ix = (uint)node->op;
+        unsigned ix = (unsigned)node->op;
         auto parent_types = expected_parents[ix];
         if (op->in_nodes.size() != parent_types.size()) {
           throw std::invalid_argument(fmt::format(
@@ -153,7 +153,7 @@ JsonError::JsonError(const std::string& message) : message(message) {}
 
 Graph json_to_graph(folly::dynamic d) {
   Graph::Factory gf;
-  std::unordered_map<uint, const Node*> sequence_to_node;
+  std::unordered_map<NodeId, const Node*> sequence_to_node;
   std::vector<const Node*> all_nodes;
 
   auto json_nodes = d["nodes"];
@@ -165,7 +165,7 @@ Graph json_to_graph(folly::dynamic d) {
     if (!sequencev.isInt()) {
       throw JsonError("missing sequence number.");
     }
-    auto sequence = (uint)sequencev.asInt();
+    auto sequence = (NodeId)sequencev.asInt();
 
     auto opv = json_node["operator"];
     if (!opv.isString()) {
@@ -191,7 +191,7 @@ Graph json_to_graph(folly::dynamic d) {
         if (!query_indexv.isInt()) {
           throw JsonError("missing query_index for query.");
         }
-        auto query_index = (uint)query_indexv.asInt();
+        auto query_index = (unsigned)query_indexv.asInt();
 
         auto in_nodev = json_node["in_node"];
         if (!in_nodev.isInt()) {
@@ -239,7 +239,7 @@ Graph json_to_graph(folly::dynamic d) {
         if (!variable_indexv.isInt()) {
           throw JsonError("bad variable_index for variable.");
         }
-        auto variable_index = (uint)variable_indexv.asInt();
+        auto variable_index = (unsigned)variable_indexv.asInt();
         node = new VariableNode{name, variable_index, sequence};
         break;
       }

--- a/minibmg/graph.h
+++ b/minibmg/graph.h
@@ -34,7 +34,8 @@ class Graph : public Container {
   inline int size() const {
     return nodes.size();
   }
-  inline const Node* operator[](uint node_id) const {
+
+  inline const Node* operator[](NodeId node_id) const {
     return nodes[node_id];
   }
 

--- a/minibmg/graph.h
+++ b/minibmg/graph.h
@@ -35,11 +35,8 @@ class Graph : public Container {
     return nodes.size();
   }
 
-  const Node* operator[](const NodeId& node_id) const;
-
  private:
   const std::vector<const Node*> nodes;
-  const std::unordered_map<NodeId, const Node*> nodes_by_id;
 
   // A private constructor that forms a graph without validation.
   // Used internally.  All exposed graphs should be validated.

--- a/minibmg/graph.h
+++ b/minibmg/graph.h
@@ -35,12 +35,11 @@ class Graph : public Container {
     return nodes.size();
   }
 
-  inline const Node* operator[](NodeId node_id) const {
-    return nodes[node_id];
-  }
+  const Node* operator[](const NodeId& node_id) const;
 
  private:
   const std::vector<const Node*> nodes;
+  const std::unordered_map<NodeId, const Node*> nodes_by_id;
 
   // A private constructor that forms a graph without validation.
   // Used internally.  All exposed graphs should be validated.
@@ -48,7 +47,10 @@ class Graph : public Container {
   static void validate(std::vector<const Node*> nodes);
 
  public:
+  // A factory for making graphs, like the bmg API
   class Factory;
+
+  // A fluent factory for making graphs, using operator overloading.
   class FluentFactory;
 };
 

--- a/minibmg/log_prob.h
+++ b/minibmg/log_prob.h
@@ -23,7 +23,7 @@ using namespace beanmachine::minibmg::distribution;
 // by the given distribution with the given parameters.
 template <class N>
 requires Number<N> N
-log_prob(Operator distribution, N v, std::function<N(uint)> get_parameter) {
+log_prob(Operator distribution, N v, std::function<N(unsigned)> get_parameter) {
   switch (distribution) {
     case Operator::DISTRIBUTION_NORMAL: {
       N mean = get_parameter(0);

--- a/minibmg/minibmg.h
+++ b/minibmg/minibmg.h
@@ -12,7 +12,3 @@
 #include "beanmachine/minibmg/node.h"
 #include "beanmachine/minibmg/operator.h"
 #include "beanmachine/minibmg/type.h"
-
-// TODO: remove this declaration and introduce an opaque type for node
-// identifier.
-using uint = unsigned int;

--- a/minibmg/node.cpp
+++ b/minibmg/node.cpp
@@ -10,14 +10,14 @@
 
 namespace beanmachine::minibmg {
 
-Node::Node(const uint sequence, const enum Operator op, const Type type)
+Node::Node(const NodeId sequence, const enum Operator op, const Type type)
     : sequence{sequence}, op{op}, type{type} {}
 
 Node::~Node() {}
 
 OperatorNode::OperatorNode(
     const std::vector<const Node*>& in_nodes,
-    const uint sequence,
+    const NodeId sequence,
     const enum Operator op,
     const Type type)
     : Node{sequence, op, type}, in_nodes{in_nodes} {
@@ -32,20 +32,20 @@ OperatorNode::OperatorNode(
 }
 
 QueryNode::QueryNode(
-    const uint query_index,
+    const unsigned query_index,
     const Node* in_node,
-    const uint sequence)
+    const NodeId sequence)
     : Node{sequence, Operator::QUERY, Type::NONE},
       query_index{query_index},
       in_node{in_node} {}
 
-ConstantNode::ConstantNode(const double value, const uint sequence)
+ConstantNode::ConstantNode(const double value, const NodeId sequence)
     : Node{sequence, Operator::CONSTANT, Type::REAL}, value{value} {}
 
 VariableNode::VariableNode(
     const std::string& name,
-    const uint variable_index,
-    const uint sequence)
+    const unsigned variable_index,
+    const NodeId sequence)
     : Node{sequence, Operator::VARIABLE, Type::REAL},
       name{name},
       variable_index{variable_index} {}

--- a/minibmg/node.cpp
+++ b/minibmg/node.cpp
@@ -10,17 +10,22 @@
 
 namespace beanmachine::minibmg {
 
-Node::Node(const NodeId sequence, const enum Operator op, const Type type)
-    : sequence{sequence}, op{op}, type{type} {}
+std::atomic<unsigned long> NodeId::_next_value{0};
+
+NodeId::NodeId() {
+  this->value = _next_value.fetch_add(1);
+}
+
+Node::Node(const enum Operator op, const Type type)
+    : sequence{}, op{op}, type{type} {}
 
 Node::~Node() {}
 
 OperatorNode::OperatorNode(
     const std::vector<const Node*>& in_nodes,
-    const NodeId sequence,
     const enum Operator op,
     const Type type)
-    : Node{sequence, op, type}, in_nodes{in_nodes} {
+    : Node{op, type}, in_nodes{in_nodes} {
   switch (op) {
     case Operator::CONSTANT:
     case Operator::QUERY:
@@ -31,22 +36,18 @@ OperatorNode::OperatorNode(
   }
 }
 
-QueryNode::QueryNode(
-    const unsigned query_index,
-    const Node* in_node,
-    const NodeId sequence)
-    : Node{sequence, Operator::QUERY, Type::NONE},
+QueryNode::QueryNode(const unsigned query_index, const Node* in_node)
+    : Node{Operator::QUERY, Type::NONE},
       query_index{query_index},
       in_node{in_node} {}
 
-ConstantNode::ConstantNode(const double value, const NodeId sequence)
-    : Node{sequence, Operator::CONSTANT, Type::REAL}, value{value} {}
+ConstantNode::ConstantNode(const double value)
+    : Node{Operator::CONSTANT, Type::REAL}, value{value} {}
 
 VariableNode::VariableNode(
     const std::string& name,
-    const unsigned variable_index,
-    const NodeId sequence)
-    : Node{sequence, Operator::VARIABLE, Type::REAL},
+    const unsigned variable_index)
+    : Node{Operator::VARIABLE, Type::REAL},
       name{name},
       variable_index{variable_index} {}
 

--- a/minibmg/node.cpp
+++ b/minibmg/node.cpp
@@ -10,14 +10,7 @@
 
 namespace beanmachine::minibmg {
 
-std::atomic<unsigned long> NodeId::_next_value{0};
-
-NodeId::NodeId() {
-  this->value = _next_value.fetch_add(1);
-}
-
-Node::Node(const enum Operator op, const Type type)
-    : sequence{}, op{op}, type{type} {}
+Node::Node(const enum Operator op, const Type type) : op{op}, type{type} {}
 
 Node::~Node() {}
 

--- a/minibmg/node.h
+++ b/minibmg/node.h
@@ -5,6 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <fmt/format.h>
+#include <atomic>
+#include <functional>
+#include <memory>
+#include <unordered_set>
 #include <vector>
 #include "beanmachine/minibmg/operator.h"
 #include "beanmachine/minibmg/type.h"
@@ -13,15 +18,65 @@
 
 namespace beanmachine::minibmg {
 
-// TODO: replace this with an opaque identifier.
-using NodeId = unsigned;
+class Node;
+
+// An opaque identifier for a node.
+class NodeId {
+ public:
+  // Create a fresh, new, never-before-seen NodeId
+  NodeId();
+  explicit NodeId(unsigned long value) : value{value} {}
+  explicit NodeId(long value) : value{(unsigned long)value} {}
+  inline bool operator==(const NodeId& other) const {
+    return value == other.value;
+  }
+  NodeId(const NodeId& other) : value{other.value} {} // copy ctor
+  NodeId& operator=(const NodeId& other) { // assignment
+    this->value = other.value;
+    return *this;
+  }
+  ~NodeId() {} // dtor
+
+  inline unsigned long _value() const {
+    return value;
+  }
+
+  static void _reset_for_testing() {
+    _next_value = 0;
+  }
+
+ private:
+  static std::atomic<unsigned long> _next_value;
+  unsigned long value;
+};
+
+} // namespace beanmachine::minibmg
+
+// Make NodeId values usable as a key in a hash table.
+template <>
+struct std::hash<beanmachine::minibmg::NodeId> {
+  std::size_t operator()(const beanmachine::minibmg::NodeId& n) const noexcept {
+    return (std::size_t)n._value();
+  }
+};
+
+// Make NodeId values printable using format.
+template <>
+struct fmt::formatter<beanmachine::minibmg::NodeId>
+    : fmt::formatter<std::string> {
+  auto format(const beanmachine::minibmg::NodeId& n, format_context& ctx) {
+    return formatter<std::string>::format(fmt::format("{}", n._value()), ctx);
+  }
+};
+
+namespace beanmachine::minibmg {
 
 class Node {
  public:
-  Node(const NodeId sequence, const enum Operator op, const Type type);
-  const NodeId sequence;
-  const enum Operator op;
-  const enum Type type;
+  Node(const enum Operator op, const Type type);
+  NodeId sequence;
+  enum Operator op;
+  enum Type type;
   virtual ~Node() = 0;
 };
 
@@ -29,36 +84,29 @@ class OperatorNode : public Node {
  public:
   OperatorNode(
       const std::vector<const Node*>& in_nodes,
-      const NodeId sequence,
       const enum Operator op,
       const enum Type type);
-  const std::vector<const Node*> in_nodes;
+  std::vector<const Node*> in_nodes;
 };
 
 class ConstantNode : public Node {
  public:
-  ConstantNode(const double value, const NodeId sequence);
-  const double value;
+  ConstantNode(const double value);
+  double value;
 };
 
 class VariableNode : public Node {
  public:
-  VariableNode(
-      const std::string& name,
-      const unsigned variable_index,
-      const NodeId sequence);
-  const std::string name;
-  const unsigned variable_index;
+  VariableNode(const std::string& name, const unsigned variable_index);
+  std::string name;
+  unsigned variable_index;
 };
 
 class QueryNode : public Node {
  public:
-  QueryNode(
-      const unsigned query_index,
-      const Node* in_node,
-      const NodeId sequence);
-  const unsigned query_index;
-  const Node* const in_node;
+  QueryNode(const unsigned query_index, const Node* in_node);
+  unsigned query_index;
+  const Node* in_node;
 };
 
 } // namespace beanmachine::minibmg

--- a/minibmg/node.h
+++ b/minibmg/node.h
@@ -13,10 +13,13 @@
 
 namespace beanmachine::minibmg {
 
+// TODO: replace this with an opaque identifier.
+using NodeId = unsigned;
+
 class Node {
  public:
-  Node(const uint sequence, const enum Operator op, const Type type);
-  const uint sequence;
+  Node(const NodeId sequence, const enum Operator op, const Type type);
+  const NodeId sequence;
   const enum Operator op;
   const enum Type type;
   virtual ~Node() = 0;
@@ -26,7 +29,7 @@ class OperatorNode : public Node {
  public:
   OperatorNode(
       const std::vector<const Node*>& in_nodes,
-      const uint sequence,
+      const NodeId sequence,
       const enum Operator op,
       const enum Type type);
   const std::vector<const Node*> in_nodes;
@@ -34,7 +37,7 @@ class OperatorNode : public Node {
 
 class ConstantNode : public Node {
  public:
-  ConstantNode(const double value, const uint sequence);
+  ConstantNode(const double value, const NodeId sequence);
   const double value;
 };
 
@@ -42,16 +45,19 @@ class VariableNode : public Node {
  public:
   VariableNode(
       const std::string& name,
-      const uint variable_index,
-      const uint sequence);
+      const unsigned variable_index,
+      const NodeId sequence);
   const std::string name;
-  const uint variable_index;
+  const unsigned variable_index;
 };
 
 class QueryNode : public Node {
  public:
-  QueryNode(const uint query_index, const Node* in_node, const uint sequence);
-  const uint query_index;
+  QueryNode(
+      const unsigned query_index,
+      const Node* in_node,
+      const NodeId sequence);
+  const unsigned query_index;
   const Node* const in_node;
 };
 

--- a/minibmg/node.h
+++ b/minibmg/node.h
@@ -18,63 +18,9 @@
 
 namespace beanmachine::minibmg {
 
-class Node;
-
-// An opaque identifier for a node.
-class NodeId {
- public:
-  // Create a fresh, new, never-before-seen NodeId
-  NodeId();
-  explicit NodeId(unsigned long value) : value{value} {}
-  explicit NodeId(long value) : value{(unsigned long)value} {}
-  inline bool operator==(const NodeId& other) const {
-    return value == other.value;
-  }
-  NodeId(const NodeId& other) : value{other.value} {} // copy ctor
-  NodeId& operator=(const NodeId& other) { // assignment
-    this->value = other.value;
-    return *this;
-  }
-  ~NodeId() {} // dtor
-
-  inline unsigned long _value() const {
-    return value;
-  }
-
-  static void _reset_for_testing() {
-    _next_value = 0;
-  }
-
- private:
-  static std::atomic<unsigned long> _next_value;
-  unsigned long value;
-};
-
-} // namespace beanmachine::minibmg
-
-// Make NodeId values usable as a key in a hash table.
-template <>
-struct std::hash<beanmachine::minibmg::NodeId> {
-  std::size_t operator()(const beanmachine::minibmg::NodeId& n) const noexcept {
-    return (std::size_t)n._value();
-  }
-};
-
-// Make NodeId values printable using format.
-template <>
-struct fmt::formatter<beanmachine::minibmg::NodeId>
-    : fmt::formatter<std::string> {
-  auto format(const beanmachine::minibmg::NodeId& n, format_context& ctx) {
-    return formatter<std::string>::format(fmt::format("{}", n._value()), ctx);
-  }
-};
-
-namespace beanmachine::minibmg {
-
 class Node {
  public:
   Node(const enum Operator op, const Type type);
-  NodeId sequence;
   enum Operator op;
   enum Type type;
   virtual ~Node() = 0;

--- a/minibmg/out_nodes.cpp
+++ b/minibmg/out_nodes.cpp
@@ -9,7 +9,7 @@
 #include <exception>
 #include <list>
 #include <map>
-#include <set>
+#include <unordered_set>
 #include "beanmachine/minibmg/minibmg.h"
 
 namespace {
@@ -18,7 +18,7 @@ using namespace beanmachine::minibmg;
 
 class Out_Nodes_Data {
  public:
-  std::map<const Node*, std::set<NodeId>*> id_map{};
+  std::map<const Node*, std::unordered_set<NodeId>*> id_map{};
   std::map<const Node*, std::list<const Node*>*> node_map{};
   ~Out_Nodes_Data() {
     for (auto e : id_map) {
@@ -28,7 +28,7 @@ class Out_Nodes_Data {
       delete e.second;
     }
   }
-  std::set<NodeId>& for_ids(const Node* node) {
+  std::unordered_set<NodeId>& for_ids(const Node* node) {
     auto found = id_map.find(node);
     if (found == id_map.end()) {
       throw std::invalid_argument("node not in graph");
@@ -51,7 +51,7 @@ class Out_Nodes_Property
     Out_Nodes_Data* data = new Out_Nodes_Data{};
     // create the version using NodeId values
     for (auto node : g) {
-      data->id_map[node] = new std::set<NodeId>{};
+      data->id_map[node] = new std::unordered_set<NodeId>{};
       switch (node->op) {
         case Operator::CONSTANT:
         case Operator::VARIABLE:
@@ -94,12 +94,13 @@ class Out_Nodes_Property
 
 namespace beanmachine::minibmg {
 
-const std::set<NodeId>& out_nodes(const Graph& graph, NodeId node) {
-  if (node < 0 || node >= graph.size()) {
+const std::unordered_set<NodeId>& out_nodes(const Graph& graph, NodeId node) {
+  const Node* n = graph[node];
+  if (n == nullptr) {
     throw std::invalid_argument("node not in graph");
   }
   Out_Nodes_Data* data = Out_Nodes_Property::get(graph);
-  std::set<NodeId>& result = data->for_ids(graph[node]);
+  std::unordered_set<NodeId>& result = data->for_ids(graph[node]);
   return result;
 }
 

--- a/minibmg/out_nodes.cpp
+++ b/minibmg/out_nodes.cpp
@@ -18,19 +18,19 @@ using namespace beanmachine::minibmg;
 
 class Out_Nodes_Data {
  public:
-  std::map<const Node*, std::set<uint>*> uint_map{};
+  std::map<const Node*, std::set<NodeId>*> id_map{};
   std::map<const Node*, std::list<const Node*>*> node_map{};
   ~Out_Nodes_Data() {
-    for (auto e : uint_map) {
+    for (auto e : id_map) {
       delete e.second;
     }
     for (auto e : node_map) {
       delete e.second;
     }
   }
-  std::set<uint>& for_uints(const Node* node) {
-    auto found = uint_map.find(node);
-    if (found == uint_map.end()) {
+  std::set<NodeId>& for_ids(const Node* node) {
+    auto found = id_map.find(node);
+    if (found == id_map.end()) {
       throw std::invalid_argument("node not in graph");
     }
     return *found->second;
@@ -49,9 +49,9 @@ class Out_Nodes_Property
  public:
   Out_Nodes_Data* create(const Graph& g) const override {
     Out_Nodes_Data* data = new Out_Nodes_Data{};
-    // create the version using uint values
+    // create the version using NodeId values
     for (auto node : g) {
-      data->uint_map[node] = new std::set<uint>{};
+      data->id_map[node] = new std::set<NodeId>{};
       switch (node->op) {
         case Operator::CONSTANT:
         case Operator::VARIABLE:
@@ -60,7 +60,7 @@ class Out_Nodes_Property
         case Operator::QUERY: {
           // query has one input.
           auto query = static_cast<const QueryNode*>(node);
-          auto predecessor_out_set = data->uint_map[query->in_node];
+          auto predecessor_out_set = data->id_map[query->in_node];
           predecessor_out_set->insert(node->sequence);
           break;
         }
@@ -68,7 +68,7 @@ class Out_Nodes_Property
           // the rest are operator nodes.
           auto opnode = static_cast<const OperatorNode*>(node);
           for (auto in_node : opnode->in_nodes) {
-            auto predecessor_out_set = data->uint_map[in_node];
+            auto predecessor_out_set = data->id_map[in_node];
             predecessor_out_set->insert(node->sequence);
           }
           break;
@@ -79,7 +79,7 @@ class Out_Nodes_Property
     // create the version using const Node* values
     for (auto node : g) {
       auto new_list = new std::list<const Node*>{};
-      auto& uset = *data->uint_map[node];
+      auto& uset = *data->id_map[node];
       for (auto u : uset) {
         new_list->push_back(g[u]);
       }
@@ -94,12 +94,12 @@ class Out_Nodes_Property
 
 namespace beanmachine::minibmg {
 
-const std::set<uint>& out_nodes(const Graph& graph, uint node) {
+const std::set<NodeId>& out_nodes(const Graph& graph, NodeId node) {
   if (node < 0 || node >= graph.size()) {
     throw std::invalid_argument("node not in graph");
   }
   Out_Nodes_Data* data = Out_Nodes_Property::get(graph);
-  std::set<uint>& result = data->for_uints(graph[node]);
+  std::set<NodeId>& result = data->for_ids(graph[node]);
   return result;
 }
 

--- a/minibmg/out_nodes.h
+++ b/minibmg/out_nodes.h
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <list>
-#include <set>
+#include <unordered_set>
 #include "beanmachine/minibmg/graph.h"
 #include "beanmachine/minibmg/node.h"
 
@@ -17,6 +17,6 @@ namespace beanmachine::minibmg {
 // return the set of nodes that have the given node as an input in the given
 // graph.
 const std::list<const Node*>& out_nodes(const Graph& graph, const Node* node);
-const std::set<NodeId>& out_nodes(const Graph& graph, NodeId node);
+const std::unordered_set<NodeId>& out_nodes(const Graph& graph, NodeId node);
 
 } // namespace beanmachine::minibmg

--- a/minibmg/out_nodes.h
+++ b/minibmg/out_nodes.h
@@ -17,6 +17,6 @@ namespace beanmachine::minibmg {
 // return the set of nodes that have the given node as an input in the given
 // graph.
 const std::list<const Node*>& out_nodes(const Graph& graph, const Node* node);
-const std::set<uint>& out_nodes(const Graph& graph, uint node);
+const std::set<NodeId>& out_nodes(const Graph& graph, NodeId node);
 
 } // namespace beanmachine::minibmg

--- a/minibmg/out_nodes.h
+++ b/minibmg/out_nodes.h
@@ -17,6 +17,5 @@ namespace beanmachine::minibmg {
 // return the set of nodes that have the given node as an input in the given
 // graph.
 const std::list<const Node*>& out_nodes(const Graph& graph, const Node* node);
-const std::unordered_set<NodeId>& out_nodes(const Graph& graph, NodeId node);
 
 } // namespace beanmachine::minibmg

--- a/minibmg/tests/eval_test.cpp
+++ b/minibmg/tests/eval_test.cpp
@@ -31,7 +31,7 @@ TEST(eval_test, simple1) {
   auto sub1 = fac.add_operator(Operator::SUBTRACT, {mul1, k1}); // 1.995
   auto graph = fac.build();
   std::mt19937 gen;
-  auto read_variable = [](const std::string&, const uint) { return 1.15; };
+  auto read_variable = [](const std::string&, const unsigned) { return 1.15; };
   int graph_size = graph.size();
   vector<Real> data;
   data.assign(graph_size, 0);
@@ -113,7 +113,7 @@ TEST(eval_test, derivative_dual) {
   vector<Dual> data;
   for (int i = 0; i < 10; i++) {
     double input = unif(gen);
-    auto read_variable = [=](const std::string&, const uint) {
+    auto read_variable = [=](const std::string&, const unsigned) {
       return Dual{input, 1};
     };
     data.clear();
@@ -145,7 +145,7 @@ TEST(eval_test, derivatives_triune) {
   vector<Triune> data;
   for (int i = 0; i < 10; i++) {
     double input = unif(gen);
-    auto read_variable = [=](const std::string&, const uint) {
+    auto read_variable = [=](const std::string&, const unsigned) {
       return Triune{input, 1, 0};
     };
     data.clear();

--- a/minibmg/tests/eval_test.cpp
+++ b/minibmg/tests/eval_test.cpp
@@ -33,8 +33,7 @@ TEST(eval_test, simple1) {
   std::mt19937 gen;
   auto read_variable = [](const std::string&, const unsigned) { return 1.15; };
   int graph_size = graph.size();
-  vector<Real> data;
-  data.assign(graph_size, 0);
+  unordered_map<NodeId, Real> data;
   eval_graph<Real>(graph, gen, read_variable, data);
   EXPECT_CLOSE(1.995, data[sub1].as_double());
 }
@@ -42,6 +41,7 @@ TEST(eval_test, simple1) {
 TEST(eval_test, sample1) {
   // a graph that produces normal samples is evaluated many times
   // and the statistics of the samples are compared to their expected values.
+  std::exception x1;
   Graph::Factory fac;
   double expected_mean = 12.34;
   double expected_stdev = 41.78;
@@ -58,8 +58,7 @@ TEST(eval_test, sample1) {
   double sum = 0;
   double sum_squared = 0;
   int graph_size = graph.size();
-  vector<Real> data;
-  data.assign(graph_size, 0);
+  std::unordered_map<NodeId, Real> data;
   for (int i = 0; i < n; i++) {
     eval_graph<Real>(graph, gen, nullptr, data);
     auto sample = data[sample0].as_double();
@@ -110,14 +109,13 @@ TEST(eval_test, derivative_dual) {
   // We generate several doubles between -2.0 and 2.0 to test with.
   std::uniform_real_distribution<double> unif(-2.0, 2.0);
 
-  vector<Dual> data;
+  std::unordered_map<NodeId, Dual> data;
   for (int i = 0; i < 10; i++) {
     double input = unif(gen);
     auto read_variable = [=](const std::string&, const unsigned) {
       return Dual{input, 1};
     };
     data.clear();
-    data.assign(graph_size, 0);
     eval_graph<Dual>(graph, gen, read_variable, data);
     EXPECT_CLOSE(f<Real>(input).as_double(), data[s].primal.as_double());
     EXPECT_CLOSE(fp<Real>(input).as_double(), data[s].derivative1.as_double());
@@ -142,14 +140,13 @@ TEST(eval_test, derivatives_triune) {
   // We generate several doubles between -2.0 and 2.0 to test with.
   std::uniform_real_distribution<double> unif(-2.0, 2.0);
 
-  vector<Triune> data;
+  std::unordered_map<NodeId, Triune> data;
   for (int i = 0; i < 10; i++) {
     double input = unif(gen);
     auto read_variable = [=](const std::string&, const unsigned) {
       return Triune{input, 1, 0};
     };
     data.clear();
-    data.assign(graph_size, 0);
     eval_graph<Triune>(graph, gen, read_variable, data);
     EXPECT_CLOSE(f<Real>(input).as_double(), data[s].primal.as_double());
     EXPECT_CLOSE(fp<Real>(input).as_double(), data[s].derivative1.as_double());

--- a/minibmg/tests/eval_test.cpp
+++ b/minibmg/tests/eval_test.cpp
@@ -33,9 +33,9 @@ TEST(eval_test, simple1) {
   std::mt19937 gen;
   auto read_variable = [](const std::string&, const unsigned) { return 1.15; };
   int graph_size = graph.size();
-  unordered_map<NodeId, Real> data;
+  unordered_map<const Node*, Real> data;
   eval_graph<Real>(graph, gen, read_variable, data);
-  EXPECT_CLOSE(1.995, data[sub1].as_double());
+  EXPECT_CLOSE(1.995, data[fac[sub1]].as_double());
 }
 
 TEST(eval_test, sample1) {
@@ -58,10 +58,10 @@ TEST(eval_test, sample1) {
   double sum = 0;
   double sum_squared = 0;
   int graph_size = graph.size();
-  std::unordered_map<NodeId, Real> data;
+  std::unordered_map<const Node*, Real> data;
   for (int i = 0; i < n; i++) {
     eval_graph<Real>(graph, gen, nullptr, data);
-    auto sample = data[sample0].as_double();
+    auto sample = data[fac[sample0]].as_double();
     sum += sample;
     sum_squared += sample * sample;
   }
@@ -109,7 +109,7 @@ TEST(eval_test, derivative_dual) {
   // We generate several doubles between -2.0 and 2.0 to test with.
   std::uniform_real_distribution<double> unif(-2.0, 2.0);
 
-  std::unordered_map<NodeId, Dual> data;
+  std::unordered_map<const Node*, Dual> data;
   for (int i = 0; i < 10; i++) {
     double input = unif(gen);
     auto read_variable = [=](const std::string&, const unsigned) {
@@ -117,8 +117,8 @@ TEST(eval_test, derivative_dual) {
     };
     data.clear();
     eval_graph<Dual>(graph, gen, read_variable, data);
-    EXPECT_CLOSE(f<Real>(input).as_double(), data[s].primal.as_double());
-    EXPECT_CLOSE(fp<Real>(input).as_double(), data[s].derivative1.as_double());
+    EXPECT_CLOSE(f<Real>(input).as_double(), data[fac[s]].primal.as_double());
+    EXPECT_CLOSE(fp<Real>(input).as_double(), data[fac[s]].derivative1.as_double());
   }
 }
 
@@ -134,13 +134,14 @@ TEST(eval_test, derivatives_triune) {
       {fac.add_constant(1.1),
        fac.add_operator(
            Operator::POW, {fac.add_variable("x", 0), fac.add_constant(2)})});
+  auto sn = fac[s];
   Graph graph = fac.build();
   int graph_size = graph.size();
 
   // We generate several doubles between -2.0 and 2.0 to test with.
   std::uniform_real_distribution<double> unif(-2.0, 2.0);
 
-  std::unordered_map<NodeId, Triune> data;
+  std::unordered_map<const Node*, Triune> data;
   for (int i = 0; i < 10; i++) {
     double input = unif(gen);
     auto read_variable = [=](const std::string&, const unsigned) {
@@ -148,8 +149,9 @@ TEST(eval_test, derivatives_triune) {
     };
     data.clear();
     eval_graph<Triune>(graph, gen, read_variable, data);
-    EXPECT_CLOSE(f<Real>(input).as_double(), data[s].primal.as_double());
-    EXPECT_CLOSE(fp<Real>(input).as_double(), data[s].derivative1.as_double());
-    EXPECT_CLOSE(fpp<Real>(input).as_double(), data[s].derivative2.as_double());
+    EXPECT_CLOSE(f<Real>(input).as_double(), data[sn].primal.as_double());
+    EXPECT_CLOSE(fp<Real>(input).as_double(), data[sn].derivative1.as_double());
+    EXPECT_CLOSE(
+        fpp<Real>(input).as_double(), data[sn].derivative2.as_double());
   }
 }

--- a/minibmg/tests/minibmg_test.cpp
+++ b/minibmg/tests/minibmg_test.cpp
@@ -12,24 +12,27 @@
 using namespace ::testing;
 using namespace beanmachine::minibmg;
 
+#define ASSERT_ID(node, num) ASSERT_EQ(node, NodeId{(unsigned long)(num)})
+
 TEST(test_minibmg, basic_building) {
+  NodeId::_reset_for_testing();
   Graph::Factory gf;
   auto k12 = gf.add_constant(1.2);
-  ASSERT_EQ(k12, 0);
+  ASSERT_ID(k12, 0);
   auto k34 = gf.add_constant(3.4);
-  ASSERT_EQ(k34, 1);
+  ASSERT_ID(k34, 1);
   auto plus = gf.add_operator(Operator::ADD, {k12, k34});
-  ASSERT_EQ(plus, 2);
+  ASSERT_ID(plus, 2);
   auto k56 = gf.add_constant(5.6);
-  ASSERT_EQ(k56, 3);
+  ASSERT_ID(k56, 3);
   auto beta = gf.add_operator(Operator::DISTRIBUTION_BETA, {k34, k56});
-  ASSERT_EQ(beta, 4);
+  ASSERT_ID(beta, 4);
   auto sample = gf.add_operator(Operator::SAMPLE, {beta});
-  ASSERT_EQ(sample, 5);
+  ASSERT_ID(sample, 5);
   auto k78 = gf.add_constant(7.8);
-  ASSERT_EQ(k78, 6);
+  ASSERT_ID(k78, 6);
   auto observe = gf.add_operator(Operator::OBSERVE, {beta, k78});
-  ASSERT_EQ(observe, 7);
+  ASSERT_ID(observe, 7);
   auto query = gf.add_query(beta);
   ASSERT_EQ(query, 0); // we get the query number back from add_query
   Graph g = gf.build();

--- a/minibmg/tests/out_nodes_test.cpp
+++ b/minibmg/tests/out_nodes_test.cpp
@@ -7,15 +7,15 @@
 
 #include <gtest/gtest.h>
 #include <list>
-#include <set>
+#include <unordered_set>
 #include "beanmachine/minibmg/minibmg.h"
 #include "beanmachine/minibmg/out_nodes.h"
 
 using namespace ::testing;
 using namespace ::beanmachine::minibmg;
 
-std::set<NodeId> set(std::list<NodeId> values) {
-  std::set<NodeId> result{};
+std::unordered_set<NodeId> set(std::list<NodeId> values) {
+  std::unordered_set<NodeId> result{};
   for (auto x : values) {
     result.insert(x);
   }
@@ -32,11 +32,10 @@ TEST(out_nodes_test, simple) {
   auto sample = gf.add_operator(Operator::SAMPLE, {beta});
   auto k78 = gf.add_constant(7.8);
   auto observe = gf.add_operator(Operator::OBSERVE, {beta, k78});
-  /* auto query_ = */ gf.add_query(beta);
-  // We don't get the node index of the query from the factory.  The factory
-  // only gives us the query number.
-  unsigned query = observe + 1;
+  NodeId query;
+  /* auto query_ = */ gf.add_query(beta, query);
   Graph g = gf.build();
+
   ASSERT_EQ(out_nodes(g, k12), set({plus}));
   ASSERT_EQ(out_nodes(g, k34), set({plus, beta}));
   ASSERT_EQ(out_nodes(g, plus), set({}));
@@ -58,7 +57,7 @@ TEST(out_nodes_test, not_found1) {
 TEST(out_nodes_test, not_found2) {
   Graph::Factory gf;
   Graph g = gf.build();
-  Node* n = new ConstantNode(0, 0);
+  Node* n = new ConstantNode(0);
   ASSERT_THROW(out_nodes(g, n), std::invalid_argument);
   delete n;
 }

--- a/minibmg/tests/out_nodes_test.cpp
+++ b/minibmg/tests/out_nodes_test.cpp
@@ -14,8 +14,8 @@
 using namespace ::testing;
 using namespace ::beanmachine::minibmg;
 
-std::set<uint> set(std::list<uint> values) {
-  std::set<uint> result{};
+std::set<NodeId> set(std::list<NodeId> values) {
+  std::set<NodeId> result{};
   for (auto x : values) {
     result.insert(x);
   }
@@ -35,7 +35,7 @@ TEST(out_nodes_test, simple) {
   /* auto query_ = */ gf.add_query(beta);
   // We don't get the node index of the query from the factory.  The factory
   // only gives us the query number.
-  uint query = observe + 1;
+  unsigned query = observe + 1;
   Graph g = gf.build();
   ASSERT_EQ(out_nodes(g, k12), set({plus}));
   ASSERT_EQ(out_nodes(g, k34), set({plus, beta}));
@@ -51,7 +51,7 @@ TEST(out_nodes_test, simple) {
 TEST(out_nodes_test, not_found1) {
   Graph::Factory gf;
   Graph g = gf.build();
-  uint not_found_node = 0;
+  NodeId not_found_node{};
   ASSERT_THROW(out_nodes(g, not_found_node), std::invalid_argument);
 }
 

--- a/minibmg/tests/out_nodes_test.cpp
+++ b/minibmg/tests/out_nodes_test.cpp
@@ -14,14 +14,6 @@
 using namespace ::testing;
 using namespace ::beanmachine::minibmg;
 
-std::unordered_set<NodeId> set(std::list<NodeId> values) {
-  std::unordered_set<NodeId> result{};
-  for (auto x : values) {
-    result.insert(x);
-  }
-  return result;
-}
-
 TEST(out_nodes_test, simple) {
   Graph::Factory gf;
   auto k12 = gf.add_constant(1.2);
@@ -34,24 +26,27 @@ TEST(out_nodes_test, simple) {
   auto observe = gf.add_operator(Operator::OBSERVE, {beta, k78});
   NodeId query;
   /* auto query_ = */ gf.add_query(beta, query);
+
+  const Node* k12n = gf[k12];
+  const Node* k34n = gf[k34];
+  const Node* plusn = gf[plus];
+  const Node* k56n = gf[k56];
+  const Node* betan = gf[beta];
+  const Node* samplen = gf[sample];
+  const Node* k78n = gf[k78];
+  const Node* observen = gf[observe];
+  const Node* queryn = gf[query];
   Graph g = gf.build();
 
-  ASSERT_EQ(out_nodes(g, k12), set({plus}));
-  ASSERT_EQ(out_nodes(g, k34), set({plus, beta}));
-  ASSERT_EQ(out_nodes(g, plus), set({}));
-  ASSERT_EQ(out_nodes(g, k56), set({beta}));
-  ASSERT_EQ(out_nodes(g, beta), set({sample, observe, query}));
-  ASSERT_EQ(out_nodes(g, sample), set({}));
-  ASSERT_EQ(out_nodes(g, k78), set({observe}));
-  ASSERT_EQ(out_nodes(g, observe), set({}));
-  ASSERT_EQ(out_nodes(g, query), set({}));
-}
-
-TEST(out_nodes_test, not_found1) {
-  Graph::Factory gf;
-  Graph g = gf.build();
-  NodeId not_found_node{};
-  ASSERT_THROW(out_nodes(g, not_found_node), std::invalid_argument);
+  ASSERT_EQ(out_nodes(g, k12n), std::list{plusn});
+  ASSERT_EQ(out_nodes(g, k34n), (std::list{plusn, betan}));
+  ASSERT_EQ(out_nodes(g, plusn), std::list<const Node*>{});
+  ASSERT_EQ(out_nodes(g, k56n), std::list{betan});
+  ASSERT_EQ(out_nodes(g, betan), (std::list{samplen, observen, queryn}));
+  ASSERT_EQ(out_nodes(g, samplen), std::list<const Node*>{});
+  ASSERT_EQ(out_nodes(g, k78n), std::list{observen});
+  ASSERT_EQ(out_nodes(g, observen), std::list<const Node*>{});
+  ASSERT_EQ(out_nodes(g, queryn), std::list<const Node*>{});
 }
 
 TEST(out_nodes_test, not_found2) {

--- a/minibmg/topological.h
+++ b/minibmg/topological.h
@@ -17,10 +17,10 @@ namespace beanmachine::minibmg {
 // Compute the predecessor count for all nodes reachable from the set of roots
 // given.
 template <class T>
-std::map<T, uint> count_predecessors(
+std::map<T, unsigned> count_predecessors(
     const std::list<T>& root_nodes,
     std::function<std::vector<T>(const T&)> successors) {
-  std::map<T, uint> predecessor_counts;
+  std::map<T, unsigned> predecessor_counts;
   std::list<T> to_count;
   std::set<T> counted;
   for (auto node : root_nodes) {
@@ -61,7 +61,7 @@ std::map<T, uint> count_predecessors(
 // sorted result in the `result` parameter.  Note: clears `predecessor_counts`.
 template <class T>
 bool topological_sort(
-    std::map<T, uint>& predecessor_counts,
+    std::map<T, unsigned>& predecessor_counts,
     std::function<std::vector<T>(const T&)> successors,
     std::vector<T>& result) {
   // initialize the ready set with those nodes that have no predecessors
@@ -104,7 +104,7 @@ bool topological_sort(
     std::function<std::vector<T>(const T&)> successors,
     std::vector<T>& result) {
   // count the predecessors of each node.
-  std::map<T, uint> predecessor_counts =
+  std::map<T, unsigned> predecessor_counts =
       count_predecessors(root_nodes, successors);
   return topological_sort(predecessor_counts, successors, result);
 }


### PR DESCRIPTION
Summary: Remove the Node identifier from the nodes.  It is now only used during graph construction using the Factory.

Differential Revision: D39659720

