### PR TITLE
Fix C++ code generation for typed eigen matrices.

### DIFF
--- a/src/beanmachine/ppl/compiler/fix_observations.py
+++ b/src/beanmachine/ppl/compiler/fix_observations.py
@@ -52,6 +52,7 @@ def observations_fixer(bmg: BMGraphBuilder):
         else:
             # TODO: How should we deal with observations of
             # TODO: matrix-valued samples?
+            # When this gets fixed, also fix _add_observation in gen_bmg_cpp.
             pass
         # TODO: Handle the case where there are two inconsistent
         # TODO: observations of the same sample

--- a/src/beanmachine/ppl/compiler/tests/bmg_query_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_query_test.py
@@ -118,9 +118,13 @@ digraph "graph" {
         # Check if this is wrong and fix it.
         expected = """
 graph::Graph g;
-uint n0 = g.add_constant(torch::from_blob((float[]){2.5}, {}));
+Eigen::MatrixXd m0(1, 1);
+m0 << 2.5;
+uint n0 = g.add_constant_real_matrix(m0);
 uint q0 = g.query(n0);
-uint n1 = g.add_constant(torch::from_blob((float[]){1.5,-2.5}, {2}));
+Eigen::MatrixXd m1(2, 1);
+m1 << 1.5, -2.5;
+uint n1 = g.add_constant_real_matrix(m1);
 uint q1 = g.query(n1);
          """
         self.assertEqual(expected.strip(), observed.strip())


### PR DESCRIPTION
Summary: Eigen distinguishes between matrices of bools, naturals and doubles; when generating a C++ fragment to construct a BMG graph, we always generated a double matrix, but that's bad; it will not type check when compiled by the C++ compiler since the BMG methods for constructing constant matrices require an input of the appropriate type.

Reviewed By: gafter, AishwaryaSivaraman

Differential Revision: D39632858

