### PR TITLE
minibmg: Move observations and queries out of the nodes.

### DIFF
--- a/minibmg/ad/num2.h
+++ b/minibmg/ad/num2.h
@@ -31,10 +31,15 @@ class Num2 {
   /* implicit */ Num2(double primal);
   /* implicit */ Num2(Underlying primal);
   Num2(Underlying primal, Underlying derivative1);
+  Num2();
   Num2(const Num2<Underlying>& other);
   Num2<Underlying>& operator=(const Num2<Underlying>& other) = default;
   double as_double() const;
 };
+
+template <class Underlying>
+requires Number<Underlying> Num2<Underlying>::Num2()
+    : primal{0}, derivative1{0} {}
 
 template <class Underlying>
 requires Number<Underlying> Num2<Underlying>::Num2(double primal)

--- a/minibmg/ad/num3.h
+++ b/minibmg/ad/num3.h
@@ -32,11 +32,16 @@ class Num3 {
 
   /* implicit */ Num3(double primal);
   /* implicit */ Num3(Underlying primal);
+  Num3();
   Num3(Underlying primal, Underlying derivative1, Underlying derivative2);
   Num3(const Num3<Underlying>& other);
   Num3<Underlying>& operator=(const Num3<Underlying>& other) = default;
   double as_double() const;
 };
+
+template <class Underlying>
+requires Number<Underlying> Num3<Underlying>::Num3()
+    : primal{0}, derivative1{0}, derivative2{0} {}
 
 template <class Underlying>
 requires Number<Underlying> Num3<Underlying>::Num3(double primal)

--- a/minibmg/ad/real.h
+++ b/minibmg/ad/real.h
@@ -30,7 +30,10 @@ class Real {
     return value;
   }
   /* implicit */ inline Real(double value) : value{value} {}
+
+  INLINE Real() : value{0} {}
   INLINE Real& operator=(const Real&) = default;
+  INLINE Real(const Real& other) : value{other.value} {}
 };
 
 INLINE Real operator+(const Real left, const Real right) {

--- a/minibmg/eval.h
+++ b/minibmg/eval.h
@@ -9,6 +9,7 @@
 
 #include <cmath>
 #include <functional>
+#include <memory>
 #include <random>
 #include <unordered_map>
 #include "beanmachine/minibmg/ad/number.h"
@@ -30,19 +31,16 @@ namespace {
 using namespace beanmachine::minibmg;
 
 template <class T>
-T get(const std::unordered_map<const Node*, T>& map, const Node* id) {
+T get(const std::unordered_map<Nodep, T>& map, Nodep id) {
   auto t = map.find(id);
   if (t == map.end()) {
-    throw EvalError(fmt::format("Missing data for node {}", id));
+    throw EvalError(fmt::format("Missing data for node"));
   }
   return t->second;
 }
 
 template <class T>
-void put(
-    std::unordered_map<const Node*, T>& map,
-    const Node* id,
-    const T& value) {
+void put(std::unordered_map<Nodep, T>& map, Nodep id, const T& value) {
   map[id] = value;
 }
 
@@ -101,25 +99,25 @@ void eval_graph(
     std::mt19937& gen,
     std::function<T(const std::string& name, const unsigned sequence)>
         read_variable,
-    std::unordered_map<const Node*, T>& data) {
+    std::unordered_map<Nodep, T>& data) {
   int n = graph.size();
   for (int i = 0; i < n; i++) {
-    const Node* node = graph[i];
+    Nodep node = graph[i];
     switch (node->op) {
       case Operator::VARIABLE: {
-        const VariableNode* v = static_cast<const VariableNode*>(node);
+        auto v = std::dynamic_pointer_cast<const VariableNode>(node);
         put(data, node, read_variable(v->name, v->variable_index));
         break;
       }
       case Operator::CONSTANT: {
-        const ConstantNode* c = static_cast<const ConstantNode*>(node);
+        auto c = std::dynamic_pointer_cast<const ConstantNode>(node);
         put(data, node, T{c->value});
         break;
       }
       case Operator::SAMPLE: {
-        const OperatorNode* sample = static_cast<const OperatorNode*>(node);
-        const Node* in0 = sample->in_nodes[0];
-        const OperatorNode* dist = static_cast<const OperatorNode*>(in0);
+        auto sample = std::dynamic_pointer_cast<const OperatorNode>(node);
+        Nodep in0 = sample->in_nodes[0];
+        auto dist = std::dynamic_pointer_cast<const OperatorNode>(in0);
         std::function<double(unsigned)> get_parameter = [&](unsigned i) {
           return data[dist->in_nodes[i]].as_double();
         };
@@ -128,9 +126,9 @@ void eval_graph(
       }
       case Operator::QUERY: {
         // We treat a query like a sample.
-        const QueryNode* sample = static_cast<const QueryNode*>(node);
-        const Node* in0 = sample->in_node;
-        const OperatorNode* dist = static_cast<const OperatorNode*>(in0);
+        auto sample = std::dynamic_pointer_cast<const QueryNode>(node);
+        Nodep in0 = sample->in_node;
+        auto dist = std::dynamic_pointer_cast<const OperatorNode>(in0);
         std::function<double(unsigned)> get_parameter = [&](unsigned i) {
           return data[dist->in_nodes[i]].as_double();
         };
@@ -152,7 +150,7 @@ void eval_graph(
         // distribution here (once we figure out where to store it).
         break;
       default:
-        const OperatorNode* opnode = static_cast<const OperatorNode*>(node);
+        auto opnode = std::dynamic_pointer_cast<const OperatorNode>(node);
         std::function<T(unsigned)> get_parameter = [&](unsigned i) {
           return data[opnode->in_nodes[i]];
         };

--- a/minibmg/eval.h
+++ b/minibmg/eval.h
@@ -30,7 +30,7 @@ namespace {
 using namespace beanmachine::minibmg;
 
 template <class T>
-T get(const std::unordered_map<NodeId, T>& map, const NodeId& id) {
+T get(const std::unordered_map<const Node*, T>& map, const Node* id) {
   auto t = map.find(id);
   if (t == map.end()) {
     throw EvalError(fmt::format("Missing data for node {}", id));
@@ -39,7 +39,10 @@ T get(const std::unordered_map<NodeId, T>& map, const NodeId& id) {
 }
 
 template <class T>
-void put(std::unordered_map<NodeId, T>& map, const NodeId& id, const T& value) {
+void put(
+    std::unordered_map<const Node*, T>& map,
+    const Node* id,
+    const T& value) {
   map[id] = value;
 }
 
@@ -98,19 +101,19 @@ void eval_graph(
     std::mt19937& gen,
     std::function<T(const std::string& name, const unsigned sequence)>
         read_variable,
-    std::unordered_map<NodeId, T>& data) {
+    std::unordered_map<const Node*, T>& data) {
   int n = graph.size();
   for (int i = 0; i < n; i++) {
     const Node* node = graph[i];
     switch (node->op) {
       case Operator::VARIABLE: {
         const VariableNode* v = static_cast<const VariableNode*>(node);
-        put(data, node->sequence, read_variable(v->name, v->variable_index));
+        put(data, node, read_variable(v->name, v->variable_index));
         break;
       }
       case Operator::CONSTANT: {
         const ConstantNode* c = static_cast<const ConstantNode*>(node);
-        put(data, node->sequence, T{c->value});
+        put(data, node, T{c->value});
         break;
       }
       case Operator::SAMPLE: {
@@ -118,11 +121,9 @@ void eval_graph(
         const Node* in0 = sample->in_nodes[0];
         const OperatorNode* dist = static_cast<const OperatorNode*>(in0);
         std::function<double(unsigned)> get_parameter = [&](unsigned i) {
-          return data[dist->in_nodes[i]->sequence].as_double();
+          return data[dist->in_nodes[i]].as_double();
         };
-        put(data,
-            node->sequence,
-            T{sample_distribution(dist->op, get_parameter, gen)});
+        put(data, node, T{sample_distribution(dist->op, get_parameter, gen)});
         break;
       }
       case Operator::QUERY: {
@@ -131,11 +132,9 @@ void eval_graph(
         const Node* in0 = sample->in_node;
         const OperatorNode* dist = static_cast<const OperatorNode*>(in0);
         std::function<double(unsigned)> get_parameter = [&](unsigned i) {
-          return data[dist->in_nodes[i]->sequence].as_double();
+          return data[dist->in_nodes[i]].as_double();
         };
-        put(data,
-            node->sequence,
-            T{sample_distribution(dist->op, get_parameter, gen)});
+        put(data, node, T{sample_distribution(dist->op, get_parameter, gen)});
         break;
       }
       case Operator::OBSERVE:
@@ -155,10 +154,10 @@ void eval_graph(
       default:
         const OperatorNode* opnode = static_cast<const OperatorNode*>(node);
         std::function<T(unsigned)> get_parameter = [&](unsigned i) {
-          return data[opnode->in_nodes[i]->sequence];
+          return data[opnode->in_nodes[i]];
         };
         T result = eval_operator<T>(node->op, get_parameter);
-        put(data, node->sequence, result);
+        put(data, node, result);
     }
   }
 }

--- a/minibmg/factory.cpp
+++ b/minibmg/factory.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "beanmachine/minibmg/factory.h"
+#include <stdexcept>
 
 namespace beanmachine::minibmg {
 
@@ -16,6 +17,9 @@ NodeId::NodeId() {
 }
 
 NodeId Graph::Factory::add_node(Nodep node) {
+  if (built) {
+    throw std::invalid_argument("Graph has already been built");
+  }
   all_nodes.push_back(node);
   NodeId sequence{};
   nodes.insert({sequence, node});
@@ -158,6 +162,9 @@ NodeId Graph::Factory::add_operator(
 }
 
 unsigned Graph::Factory::add_query(NodeId parent, NodeId& new_node_id) {
+  if (built) {
+    throw std::invalid_argument("Graph has already been built");
+  }
   auto parent_node = nodes[parent];
   if (parent_node->type != Type::DISTRIBUTION) {
     throw std::invalid_argument("Incorrect parent for QUERY node.");
@@ -185,8 +192,13 @@ NodeId Graph::Factory::add_variable(
 }
 
 Graph Graph::Factory::build() {
+  if (built) {
+    throw std::invalid_argument("Graph has already been built");
+  }
   auto nodes = this->all_nodes;
   this->all_nodes.clear();
+  // We preserve this->nodes so it can be used for lookup.
+  built = true;
   return Graph{nodes};
 }
 

--- a/minibmg/factory.cpp
+++ b/minibmg/factory.cpp
@@ -9,9 +9,15 @@
 
 namespace beanmachine::minibmg {
 
+std::atomic<unsigned long> NodeId::_next_value{0};
+
+NodeId::NodeId() {
+  this->value = _next_value.fetch_add(1);
+}
+
 NodeId Graph::Factory::add_node(const Node* node) {
   all_nodes.push_back(node);
-  const NodeId& sequence = node->sequence;
+  NodeId sequence{};
   nodes.insert({sequence, node});
   return sequence;
 }
@@ -179,7 +185,6 @@ NodeId Graph::Factory::add_variable(
 
 Graph Graph::Factory::build() {
   auto nodes = this->all_nodes;
-  this->nodes.clear();
   this->all_nodes.clear();
   return Graph{nodes};
 }

--- a/minibmg/factory.cpp
+++ b/minibmg/factory.cpp
@@ -20,7 +20,6 @@ NodeId Graph::Factory::add_node(Nodep node) {
   if (built) {
     throw std::invalid_argument("Graph has already been built");
   }
-  all_nodes.push_back(node);
   NodeId sequence{};
   nodes.insert({sequence, node});
   return sequence;
@@ -54,9 +53,6 @@ enum Type op_type(enum Operator op) {
     case Operator::DISTRIBUTION_BETA:
     case Operator::DISTRIBUTION_BERNOULLI:
       return Type::DISTRIBUTION;
-    case Operator::OBSERVE:
-    case Operator::QUERY:
-      return Type::NONE;
     default:
       throw std::invalid_argument("op_type not defined for operator.");
   }
@@ -92,8 +88,6 @@ const std::vector<std::vector<enum Type>> make_expected_parents() {
   result[(unsigned)Operator::DISTRIBUTION_BETA] = {Type::REAL, Type::REAL};
   result[(unsigned)Operator::DISTRIBUTION_BERNOULLI] = {Type::REAL};
   result[(unsigned)Operator::SAMPLE] = {Type::DISTRIBUTION};
-  result[(unsigned)Operator::OBSERVE] = {Type::DISTRIBUTION, Type::REAL};
-  result[(unsigned)Operator::QUERY] = {Type::DISTRIBUTION};
   return result;
 }
 
@@ -113,16 +107,13 @@ enum Type expected_result_type(enum Operator op) {
     case Operator::POLYGAMMA:
     case Operator::IF_EQUAL:
     case Operator::IF_LESS:
+    case Operator::VARIABLE:
       return Type::REAL;
 
     case Operator::DISTRIBUTION_NORMAL:
     case Operator::DISTRIBUTION_BETA:
     case Operator::DISTRIBUTION_BERNOULLI:
       return Type::DISTRIBUTION;
-
-    case Operator::OBSERVE:
-    case Operator::QUERY:
-      return Type::NONE;
 
     default:
       throw std::invalid_argument("Unknown type for operator.");
@@ -161,29 +152,6 @@ NodeId Graph::Factory::add_operator(
   return add_node(new_node);
 }
 
-unsigned Graph::Factory::add_query(NodeId parent, NodeId& new_node_id) {
-  if (built) {
-    throw std::invalid_argument("Graph has already been built");
-  }
-  auto parent_node = nodes[parent];
-  if (parent_node->type != Type::DISTRIBUTION) {
-    throw std::invalid_argument("Incorrect parent for QUERY node.");
-  }
-  if (parent_node == nullptr) {
-    throw std::invalid_argument("Reference to nonexistent node.");
-  }
-  auto query_id = next_query;
-  next_query++;
-  auto new_node = std::make_shared<QueryNode>(query_id, parent_node);
-  new_node_id = add_node(new_node);
-  return query_id;
-}
-
-unsigned Graph::Factory::add_query(NodeId parent) {
-  NodeId new_node_id;
-  return add_query(parent, new_node_id); // discard new node id
-}
-
 NodeId Graph::Factory::add_variable(
     const std::string& name,
     const unsigned variable_index) {
@@ -191,20 +159,39 @@ NodeId Graph::Factory::add_variable(
   return add_node(new_node);
 }
 
+void Graph::Factory::add_observation(NodeId sample, double value) {
+  auto parent_node = nodes[sample];
+  if (parent_node == nullptr) {
+    throw std::invalid_argument("Reference to nonexistent node.");
+  }
+  this->observations[parent_node] = value;
+}
+
+unsigned Graph::Factory::add_query(NodeId queried) {
+  auto parent_node = nodes[queried];
+  if (parent_node == nullptr) {
+    throw std::invalid_argument("Reference to nonexistent node.");
+  }
+  if (parent_node->type != Type::REAL) {
+    throw std::invalid_argument("Can only query a scalar.");
+  }
+  auto result = (unsigned)this->queries.size();
+  this->queries.push_back(parent_node);
+  return result;
+}
+
 Graph Graph::Factory::build() {
   if (built) {
     throw std::invalid_argument("Graph has already been built");
   }
-  auto nodes = this->all_nodes;
-  this->all_nodes.clear();
+
   // We preserve this->nodes so it can be used for lookup.
   built = true;
-  return Graph{nodes};
+  return Graph::create(queries, observations);
 }
 
 Graph::Factory::~Factory() {
   this->nodes.clear();
-  this->all_nodes.clear();
 }
 
 } // namespace beanmachine::minibmg

--- a/minibmg/factory.cpp
+++ b/minibmg/factory.cpp
@@ -9,11 +9,16 @@
 
 namespace beanmachine::minibmg {
 
-NodeId Graph::Factory::add_constant(double value) {
-  auto sequence = (unsigned)nodes.size();
-  const auto new_node = new ConstantNode{value, sequence};
-  nodes.push_back(new_node);
+NodeId Graph::Factory::add_node(const Node* node) {
+  all_nodes.push_back(node);
+  const NodeId& sequence = node->sequence;
+  nodes.insert({sequence, node});
   return sequence;
+}
+
+NodeId Graph::Factory::add_constant(double value) {
+  const auto new_node = new ConstantNode{value};
+  return add_node(new_node);
 }
 
 enum Type op_type(enum Operator op) {
@@ -124,7 +129,6 @@ unsigned arity(Operator op) {
 NodeId Graph::Factory::add_operator(
     enum Operator op,
     std::vector<NodeId> parents) {
-  auto sequence = (unsigned)nodes.size();
   auto expected = expected_parents[(unsigned)op];
   std::vector<const Node*> in_nodes;
   if (parents.size() != expected.size()) {
@@ -132,58 +136,61 @@ NodeId Graph::Factory::add_operator(
   }
   for (int i = 0, n = expected.size(); i < n; i++) {
     NodeId p = parents[i];
-    if (p >= sequence) {
+    auto parent_node = nodes[p];
+    if (parent_node == nullptr) {
       throw std::invalid_argument("Reference to nonexistent node.");
     }
-    auto parent_node = nodes[p];
     if (parent_node->type != expected[i]) {
       throw std::invalid_argument("Incorrect type for parent node.");
     }
     in_nodes.push_back(parent_node);
   }
 
-  auto new_node =
-      new OperatorNode{in_nodes, sequence, op, expected_result_type(op)};
-  nodes.push_back(new_node);
-  return sequence;
+  auto new_node = new OperatorNode{in_nodes, op, expected_result_type(op)};
+  return add_node(new_node);
 }
 
-NodeId Graph::Factory::add_query(NodeId parent) {
-  auto sequence = (unsigned)nodes.size();
-  if (parent >= sequence) {
-    throw std::invalid_argument("Reference to nonexistent node.");
-  }
+unsigned Graph::Factory::add_query(NodeId parent, NodeId& new_node_id) {
   auto parent_node = nodes[parent];
   if (parent_node->type != Type::DISTRIBUTION) {
     throw std::invalid_argument("Incorrect parent for QUERY node.");
   }
+  if (parent_node == nullptr) {
+    throw std::invalid_argument("Reference to nonexistent node.");
+  }
   auto query_id = next_query;
   next_query++;
-  auto new_node = new QueryNode{query_id, parent_node, sequence};
-  nodes.push_back(new_node);
+  auto new_node = new QueryNode{query_id, parent_node};
+  new_node_id = add_node(new_node);
   return query_id;
+}
+
+unsigned Graph::Factory::add_query(NodeId parent) {
+  NodeId new_node_id;
+  return add_query(parent, new_node_id); // discard new node id
 }
 
 NodeId Graph::Factory::add_variable(
     const std::string& name,
     const unsigned variable_index) {
-  auto sequence = (unsigned)nodes.size();
-  auto new_node = new VariableNode{name, variable_index, sequence};
-  nodes.push_back(new_node);
-  return sequence;
+  auto new_node = new VariableNode{name, variable_index};
+  return add_node(new_node);
 }
 
 Graph Graph::Factory::build() {
-  auto nodes = this->nodes;
+  auto nodes = this->all_nodes;
   this->nodes.clear();
+  this->all_nodes.clear();
   return Graph{nodes};
 }
 
 Graph::Factory::~Factory() {
+  auto nodes = this->all_nodes;
+  this->nodes.clear();
+  this->all_nodes.clear();
   for (auto node : nodes) {
     delete node;
   }
-  nodes.clear();
 }
 
 } // namespace beanmachine::minibmg

--- a/minibmg/factory.h
+++ b/minibmg/factory.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <unordered_map>
 #include <vector>
 #include "beanmachine/minibmg/graph.h"
 #include "beanmachine/minibmg/node.h"
@@ -23,18 +24,25 @@ class Graph::Factory {
 
   // returns the index of the query in the samples, not a NodeId
   unsigned add_query(NodeId parent);
+  unsigned add_query(NodeId parent, NodeId& new_node_id);
 
   NodeId add_variable(const std::string& name, const unsigned variable_index);
 
-  inline const Node* operator[](NodeId node_id) const {
-    return nodes[node_id];
+  inline const Node* operator[](const NodeId& node_id) const {
+    auto t = nodes.find(node_id);
+    if (t == nodes.end())
+      return nullptr;
+    return t->second;
   }
   Graph build();
   ~Factory();
 
  private:
-  std::vector<const Node*> nodes;
+  std::unordered_map<NodeId, const Node*> nodes;
+  std::vector<const Node*> all_nodes;
   unsigned next_query = 0;
+
+  NodeId add_node(const Node* node);
 };
 
 enum Type expected_result_type(enum Operator op);

--- a/minibmg/factory.h
+++ b/minibmg/factory.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <unordered_map>
+#include <list>
 #include <vector>
 #include "beanmachine/minibmg/graph.h"
 #include "beanmachine/minibmg/node.h"
@@ -72,12 +73,13 @@ namespace beanmachine::minibmg {
 class Graph::Factory {
  public:
   NodeId add_constant(double value);
-
   NodeId add_operator(enum Operator op, std::vector<NodeId> parents);
+
+  // Add an observation to the graph.  The sample must identify a SAMPLE node.
+  void add_observation(NodeId sample, double value);
 
   // returns the index of the query in the samples, not a NodeId
   unsigned add_query(NodeId parent);
-  unsigned add_query(NodeId parent, NodeId& new_node_id);
 
   NodeId add_variable(const std::string& name, const unsigned variable_index);
 
@@ -93,8 +95,8 @@ class Graph::Factory {
  private:
   bool built = false;
   std::unordered_map<NodeId, Nodep> nodes;
-  std::vector<Nodep> all_nodes;
-  unsigned next_query = 0;
+  std::vector<Nodep> queries;
+  std::unordered_map<Nodep, double> observations;
 
   NodeId add_node(Nodep node);
 };

--- a/minibmg/factory.h
+++ b/minibmg/factory.h
@@ -91,6 +91,7 @@ class Graph::Factory {
   ~Factory();
 
  private:
+  bool built = false;
   std::unordered_map<NodeId, Nodep> nodes;
   std::vector<Nodep> all_nodes;
   unsigned next_query = 0;

--- a/minibmg/factory.h
+++ b/minibmg/factory.h
@@ -81,7 +81,7 @@ class Graph::Factory {
 
   NodeId add_variable(const std::string& name, const unsigned variable_index);
 
-  inline const Node* operator[](const NodeId& node_id) const {
+  inline Nodep operator[](const NodeId& node_id) const {
     auto t = nodes.find(node_id);
     if (t == nodes.end())
       return nullptr;
@@ -91,11 +91,11 @@ class Graph::Factory {
   ~Factory();
 
  private:
-  std::unordered_map<NodeId, const Node*> nodes;
-  std::vector<const Node*> all_nodes;
+  std::unordered_map<NodeId, Nodep> nodes;
+  std::vector<Nodep> all_nodes;
   unsigned next_query = 0;
 
-  NodeId add_node(const Node* node);
+  NodeId add_node(Nodep node);
 };
 
 enum Type expected_result_type(enum Operator op);

--- a/minibmg/factory.h
+++ b/minibmg/factory.h
@@ -16,6 +16,59 @@
 
 namespace beanmachine::minibmg {
 
+class Node;
+
+// An opaque identifier for a node.
+class NodeId {
+ public:
+  // Create a fresh, new, never-before-seen NodeId
+  NodeId();
+  explicit NodeId(unsigned long value) : value{value} {}
+  explicit NodeId(long value) : value{(unsigned long)value} {}
+  inline bool operator==(const NodeId& other) const {
+    return value == other.value;
+  }
+  NodeId(const NodeId& other) : value{other.value} {} // copy ctor
+  NodeId& operator=(const NodeId& other) { // assignment
+    this->value = other.value;
+    return *this;
+  }
+  ~NodeId() {} // dtor
+
+  inline unsigned long _value() const {
+    return value;
+  }
+
+  static void _reset_for_testing() {
+    _next_value = 0;
+  }
+
+ private:
+  static std::atomic<unsigned long> _next_value;
+  unsigned long value;
+};
+
+} // namespace beanmachine::minibmg
+
+// Make NodeId values usable as a key in a hash table.
+template <>
+struct std::hash<beanmachine::minibmg::NodeId> {
+  std::size_t operator()(const beanmachine::minibmg::NodeId& n) const noexcept {
+    return (std::size_t)n._value();
+  }
+};
+
+// Make NodeId values printable using format.
+template <>
+struct fmt::formatter<beanmachine::minibmg::NodeId>
+    : fmt::formatter<std::string> {
+  auto format(const beanmachine::minibmg::NodeId& n, format_context& ctx) {
+    return formatter<std::string>::format(fmt::format("{}", n._value()), ctx);
+  }
+};
+
+namespace beanmachine::minibmg {
+
 class Graph::Factory {
  public:
   NodeId add_constant(double value);

--- a/minibmg/graph.cpp
+++ b/minibmg/graph.cpp
@@ -8,30 +8,70 @@
 #include "beanmachine/minibmg/graph.h"
 #include <fmt/core.h>
 #include <folly/json.h>
+#include <algorithm>
 #include <unordered_map>
 #include "beanmachine/minibmg/factory.h"
+#include "beanmachine/minibmg/topological.h"
+#include "graph.h"
+#include "operator.h"
+
+namespace {
+
+using namespace beanmachine::minibmg;
+
+std::vector<Nodep> successors(const Nodep& n) {
+  switch (n->op) {
+    case Operator::CONSTANT:
+    case Operator::VARIABLE:
+      return {};
+    default:
+      return std::dynamic_pointer_cast<const OperatorNode>(n)->in_nodes;
+  }
+}
+
+} // namespace
 
 namespace beanmachine::minibmg {
 
 using dynamic = folly::dynamic;
 
-Graph::Graph(std::vector<Nodep> nodes) : nodes{nodes} {}
+Graph::Graph(
+    std::vector<Nodep> nodes,
+    std::vector<Nodep> queries,
+    std::unordered_map<Nodep, double> observations)
+    : nodes{nodes}, queries{queries}, observations{observations} {}
 
 Graph::~Graph() {}
 
-Graph Graph::create(std::vector<Nodep> nodes) {
-  Graph::validate(nodes);
-  return Graph{nodes};
+Graph Graph::create(
+    std::vector<Nodep> queries,
+    std::unordered_map<Nodep, double> observations) {
+  std::list<Nodep> roots;
+  for (auto n : queries)
+    roots.push_back(n);
+  for (auto p : observations) {
+    if (p.first->op != Operator::SAMPLE) {
+      throw std::invalid_argument(fmt::format("can only observe a sample"));
+    }
+    roots.push_back(p.first);
+  }
+  std::vector<Nodep> all_nodes;
+  if (!topological_sort<Nodep>(roots, &successors, all_nodes))
+    throw std::invalid_argument("graph has a cycle");
+  std::reverse(all_nodes.begin(), all_nodes.end());
+
+  Graph::validate(all_nodes);
+  return Graph{all_nodes, queries, observations};
 }
 
 void Graph::validate(std::vector<Nodep> nodes) {
   std::unordered_set<Nodep> seen;
-  unsigned next_query = 0;
   // Check the nodes.
   for (int i = 0, n = nodes.size(); i < n; i++) {
     auto node = nodes[i];
 
-    // TODO: check that node identifiers are unique
+    // TODO: improve the exception diagnostics on failure.  e.g. how to identify
+    // a node?
 
     // Check that the operator is in range.
     if (node->op < (Operator)0 || node->op >= Operator::LAST_OPERATOR) {
@@ -51,27 +91,8 @@ void Graph::validate(std::vector<Nodep> nodes) {
     // Check the predecessor nodes
     switch (node->op) {
       case Operator::CONSTANT:
+      case Operator::VARIABLE:
         break;
-      case Operator::QUERY: {
-        auto q = std::dynamic_pointer_cast<const QueryNode>(node);
-        if (q->query_index != next_query) {
-          throw std::invalid_argument(fmt::format(
-              "Node {0} has query index {1} but should be {2}",
-              i,
-              q->query_index,
-              next_query));
-        }
-        next_query++;
-        if (!seen.count(q->in_node)) {
-          throw std::invalid_argument(
-              fmt::format("Query Node {0} parent not previously seen", i));
-        }
-        if (q->in_node->type == Type::DISTRIBUTION) {
-          throw std::invalid_argument(fmt::format(
-              "Query Node {0} should have a distribution input", i));
-        }
-        break;
-      }
 
       // Check other operators.
       default: {
@@ -117,17 +138,12 @@ folly::dynamic graph_to_json(const Graph& g) {
     dyn_node["operator"] = to_string(node->op);
     dyn_node["type"] = to_string(node->type);
     switch (node->op) {
-      case Operator::QUERY: {
-        auto n = std::dynamic_pointer_cast<const QueryNode>(node);
-        dyn_node["query_index"] = n->query_index;
-        dyn_node["in_node"] = id_map[n->in_node];
-        break;
-      }
       case Operator::CONSTANT: {
         auto n = std::dynamic_pointer_cast<const ConstantNode>(node);
         dyn_node["value"] = n->value;
         break;
       }
+      // TODO: case Operator::VARIABLE:
       default: {
         auto n = std::dynamic_pointer_cast<const OperatorNode>(node);
         dynamic in_nodes = dynamic::array;
@@ -141,6 +157,20 @@ folly::dynamic graph_to_json(const Graph& g) {
     a.push_back(dyn_node);
   }
 
+  dynamic queries = dynamic::array;
+  result["queries"] = queries;
+  dynamic observations = dynamic::array;
+  result["observations"] = observations;
+
+  for (auto q : g.queries) {
+    queries.push_back(id_map[q]);
+  }
+  for (auto q : g.observations) {
+    dynamic d = dynamic::object;
+    d["node"] = id_map[q.first];
+    d["value"] = q.second;
+  }
+
   result["nodes"] = a;
   return result;
 }
@@ -148,9 +178,7 @@ folly::dynamic graph_to_json(const Graph& g) {
 JsonError::JsonError(const std::string& message) : message(message) {}
 
 Graph json_to_graph(folly::dynamic d) {
-  Graph::Factory gf;
   std::unordered_map<int, Nodep> sequence_to_node;
-  std::vector<Nodep> all_nodes;
 
   auto json_nodes = d["nodes"];
   if (!json_nodes.isArray()) {
@@ -182,28 +210,6 @@ Graph json_to_graph(folly::dynamic d) {
 
     Nodep node;
     switch (op) {
-      case Operator::QUERY: {
-        auto query_indexv = json_node["query_index"];
-        if (!query_indexv.isInt()) {
-          throw JsonError("missing query_index for query.");
-        }
-        auto query_index = (unsigned)query_indexv.asInt();
-
-        auto in_nodev = json_node["in_node"];
-        if (!in_nodev.isInt()) {
-          throw JsonError("missing in_node for query.");
-        }
-        auto in_node_i = in_nodev.asInt();
-        if (sequence_to_node.find(in_node_i) == sequence_to_node.end()) {
-          throw JsonError("bad in_node for query.");
-        }
-        auto in_node = sequence_to_node.find(in_node_i)->second;
-        if (type != Type::NONE) {
-          throw JsonError("bad type for query.");
-        }
-        node = std::make_shared<const QueryNode>(query_index, in_node);
-        break;
-      }
       case Operator::CONSTANT: {
         auto valuev = json_node["value"];
         double value;
@@ -215,7 +221,7 @@ Graph json_to_graph(folly::dynamic d) {
           throw JsonError("bad value for constant.");
         }
         if (type != Type::REAL) {
-          throw JsonError("bad type for query.");
+          throw JsonError("bad type for constant.");
         }
         node = std::make_shared<const ConstantNode>(value);
         break;
@@ -247,11 +253,11 @@ Graph json_to_graph(folly::dynamic d) {
         std::vector<Nodep> in_nodes;
         for (auto in_nodev : in_nodesv) {
           if (!in_nodev.isInt()) {
-            throw JsonError("missing in_node for query.");
+            throw JsonError("missing in_node for operator.");
           }
           auto in_node_i = in_nodev.asInt();
           if (sequence_to_node.find(in_node_i) == sequence_to_node.end()) {
-            throw JsonError("bad in_node for query.");
+            throw JsonError("bad in_node for operator.");
           }
           auto in_node = sequence_to_node.find(in_node_i)->second;
           in_nodes.push_back(in_node);
@@ -265,10 +271,47 @@ Graph json_to_graph(folly::dynamic d) {
       throw JsonError(fmt::format("duplicate node ID {}.", sequence));
     }
     sequence_to_node[sequence] = node;
-    all_nodes.push_back(node);
   }
 
-  return Graph::create(all_nodes);
+  std::vector<Nodep> queries;
+  auto query_nodes = d["queries"];
+  if (query_nodes.isArray()) {
+    for (auto query : query_nodes) {
+      if (!query.isInt()) {
+        throw JsonError("bad query value.");
+      }
+      auto query_i = query.asInt();
+      if (sequence_to_node.find(query_i) == sequence_to_node.end()) {
+        throw JsonError(fmt::format("bad in_node {} for query.", query_i));
+      }
+      auto query_node = sequence_to_node.find(query_i)->second;
+      queries.push_back(query_node);
+    }
+  }
+
+  std::unordered_map<Nodep, double> observations;
+  auto observation_nodes = d["observations"];
+  if (observation_nodes.isArray()) {
+    for (auto obs : observation_nodes) {
+      auto node = obs["node"];
+      if (!node.isInt()) {
+        throw JsonError("bad observation node.");
+      }
+      auto node_i = node.asInt();
+      if (sequence_to_node.find(node_i) == sequence_to_node.end()) {
+        throw JsonError(fmt::format("bad in_node {} for observation.", node_i));
+      }
+      auto obs_node = sequence_to_node.find(node_i)->second;
+      auto value = obs["value"];
+      if (!node.isDouble()) {
+        throw JsonError("bad value for observation.");
+      }
+      auto value_d = value.asDouble();
+      observations[obs_node] = value_d;
+    }
+  }
+
+  return Graph::create(queries, observations);
 }
 
 } // namespace beanmachine::minibmg

--- a/minibmg/graph.cpp
+++ b/minibmg/graph.cpp
@@ -15,22 +15,17 @@ namespace beanmachine::minibmg {
 
 using dynamic = folly::dynamic;
 
-Graph::Graph(std::vector<const Node*> nodes)
-    : nodes{nodes} {}
+Graph::Graph(std::vector<Nodep> nodes) : nodes{nodes} {}
 
-Graph::~Graph() {
-  for (auto node : nodes) {
-    delete node;
-  }
-}
+Graph::~Graph() {}
 
-Graph Graph::create(std::vector<const Node*> nodes) {
+Graph Graph::create(std::vector<Nodep> nodes) {
   Graph::validate(nodes);
   return Graph{nodes};
 }
 
-void Graph::validate(std::vector<const Node*> nodes) {
-  std::unordered_set<const Node*> seen;
+void Graph::validate(std::vector<Nodep> nodes) {
+  std::unordered_set<Nodep> seen;
   unsigned next_query = 0;
   // Check the nodes.
   for (int i = 0, n = nodes.size(); i < n; i++) {
@@ -58,7 +53,7 @@ void Graph::validate(std::vector<const Node*> nodes) {
       case Operator::CONSTANT:
         break;
       case Operator::QUERY: {
-        const QueryNode* q = (QueryNode*)node;
+        auto q = std::dynamic_pointer_cast<const QueryNode>(node);
         if (q->query_index != next_query) {
           throw std::invalid_argument(fmt::format(
               "Node {0} has query index {1} but should be {2}",
@@ -80,7 +75,7 @@ void Graph::validate(std::vector<const Node*> nodes) {
 
       // Check other operators.
       default: {
-        const OperatorNode* op = (OperatorNode*)node;
+        auto op = std::dynamic_pointer_cast<const OperatorNode>(node);
         unsigned ix = (unsigned)node->op;
         auto parent_types = expected_parents[ix];
         if (op->in_nodes.size() != parent_types.size()) {
@@ -88,7 +83,7 @@ void Graph::validate(std::vector<const Node*> nodes) {
               "Node {0} should have {1} parents", i, parent_types.size()));
         }
         for (int j = 0, m = parent_types.size(); j < m; j++) {
-          const Node* parent = op->in_nodes[j];
+          Nodep parent = op->in_nodes[j];
           if (!seen.count(parent)) {
             throw std::invalid_argument(
                 fmt::format("Node {0} has a parent not previously seen", i));
@@ -108,7 +103,7 @@ void Graph::validate(std::vector<const Node*> nodes) {
 }
 
 folly::dynamic graph_to_json(const Graph& g) {
-  std::unordered_map<const Node*, unsigned long> id_map{};
+  std::unordered_map<Nodep, unsigned long> id_map{};
   dynamic result = dynamic::object;
   result["comment"] = "created by graph_to_json";
   dynamic a = dynamic::array;
@@ -123,18 +118,18 @@ folly::dynamic graph_to_json(const Graph& g) {
     dyn_node["type"] = to_string(node->type);
     switch (node->op) {
       case Operator::QUERY: {
-        auto n = (const QueryNode*)node;
+        auto n = std::dynamic_pointer_cast<const QueryNode>(node);
         dyn_node["query_index"] = n->query_index;
         dyn_node["in_node"] = id_map[n->in_node];
         break;
       }
       case Operator::CONSTANT: {
-        auto n = (const ConstantNode*)node;
+        auto n = std::dynamic_pointer_cast<const ConstantNode>(node);
         dyn_node["value"] = n->value;
         break;
       }
       default: {
-        auto n = (const OperatorNode*)node;
+        auto n = std::dynamic_pointer_cast<const OperatorNode>(node);
         dynamic in_nodes = dynamic::array;
         for (auto pred : n->in_nodes) {
           in_nodes.push_back(id_map[pred]);
@@ -154,8 +149,8 @@ JsonError::JsonError(const std::string& message) : message(message) {}
 
 Graph json_to_graph(folly::dynamic d) {
   Graph::Factory gf;
-  std::unordered_map<int, const Node*> sequence_to_node;
-  std::vector<const Node*> all_nodes;
+  std::unordered_map<int, Nodep> sequence_to_node;
+  std::vector<Nodep> all_nodes;
 
   auto json_nodes = d["nodes"];
   if (!json_nodes.isArray()) {
@@ -185,7 +180,7 @@ Graph json_to_graph(folly::dynamic d) {
       type = type_from_name(typev.asString());
     }
 
-    Node* node;
+    Nodep node;
     switch (op) {
       case Operator::QUERY: {
         auto query_indexv = json_node["query_index"];
@@ -206,7 +201,7 @@ Graph json_to_graph(folly::dynamic d) {
         if (type != Type::NONE) {
           throw JsonError("bad type for query.");
         }
-        node = new QueryNode{query_index, in_node};
+        node = std::make_shared<const QueryNode>(query_index, in_node);
         break;
       }
       case Operator::CONSTANT: {
@@ -222,7 +217,7 @@ Graph json_to_graph(folly::dynamic d) {
         if (type != Type::REAL) {
           throw JsonError("bad type for query.");
         }
-        node = new ConstantNode{value};
+        node = std::make_shared<const ConstantNode>(value);
         break;
       }
       case Operator::VARIABLE: {
@@ -241,7 +236,7 @@ Graph json_to_graph(folly::dynamic d) {
           throw JsonError("bad variable_index for variable.");
         }
         auto variable_index = (unsigned)variable_indexv.asInt();
-        node = new VariableNode{name, variable_index};
+        node = std::make_shared<const VariableNode>(name, variable_index);
         break;
       }
       default: {
@@ -249,7 +244,7 @@ Graph json_to_graph(folly::dynamic d) {
         if (!in_nodesv.isArray()) {
           throw JsonError("missing in_nodes.");
         }
-        std::vector<const Node*> in_nodes;
+        std::vector<Nodep> in_nodes;
         for (auto in_nodev : in_nodesv) {
           if (!in_nodev.isInt()) {
             throw JsonError("missing in_node for query.");
@@ -261,7 +256,7 @@ Graph json_to_graph(folly::dynamic d) {
           auto in_node = sequence_to_node.find(in_node_i)->second;
           in_nodes.push_back(in_node);
         }
-        node = new OperatorNode{in_nodes, op, type};
+        node = std::make_shared<const OperatorNode>(in_nodes, op, type);
         break;
       }
     }

--- a/minibmg/graph.h
+++ b/minibmg/graph.h
@@ -18,7 +18,7 @@ class Graph : public Container {
   // valudates that the list of nodes forms a valid graph,
   // and returns that graph.  Throws an exception if the
   // nodes do not form a valid graph.
-  static Graph create(std::vector<const Node*> nodes);
+  static Graph create(std::vector<Nodep> nodes);
   ~Graph();
 
   // Implement the iterator pattern so clients can iterate over the nodes.
@@ -28,7 +28,7 @@ class Graph : public Container {
   inline auto end() const {
     return nodes.end();
   }
-  inline const Node* operator[](int index) const {
+  inline Nodep operator[](int index) const {
     return nodes[index];
   }
   inline int size() const {
@@ -36,12 +36,12 @@ class Graph : public Container {
   }
 
  private:
-  const std::vector<const Node*> nodes;
+  const std::vector<Nodep> nodes;
 
   // A private constructor that forms a graph without validation.
   // Used internally.  All exposed graphs should be validated.
-  explicit Graph(std::vector<const Node*> nodes);
-  static void validate(std::vector<const Node*> nodes);
+  explicit Graph(std::vector<Nodep> nodes);
+  static void validate(std::vector<Nodep> nodes);
 
  public:
   // A factory for making graphs, like the bmg API

--- a/minibmg/graph.h
+++ b/minibmg/graph.h
@@ -35,11 +35,8 @@ class Graph : public Container {
     return nodes.size();
   }
 
-  const Node* operator[](const NodeId& node_id) const;
-
  private:
   const std::vector<const Node*> nodes;
-  const std::unordered_map<NodeId, const Node*> nodes_by_id;
 
   // A private constructor that forms a graph without validation.
   // Used internally.  All exposed graphs should be validated.

--- a/minibmg/graph.h
+++ b/minibmg/graph.h
@@ -35,12 +35,11 @@ class Graph : public Container {
     return nodes.size();
   }
 
-  inline const Node* operator[](NodeId node_id) const {
-    return nodes[node_id];
-  }
+  const Node* operator[](const NodeId& node_id) const;
 
  private:
   const std::vector<const Node*> nodes;
+  const std::unordered_map<NodeId, const Node*> nodes_by_id;
 
   // A private constructor that forms a graph without validation.
   // Used internally.  All exposed graphs should be validated.
@@ -48,7 +47,10 @@ class Graph : public Container {
   static void validate(std::vector<const Node*> nodes);
 
  public:
+  // A factory for making graphs, like the bmg API
   class Factory;
+
+  // A fluent factory for making graphs, using operator overloading.
   class FluentFactory;
 };
 

--- a/minibmg/node.cpp
+++ b/minibmg/node.cpp
@@ -10,17 +10,22 @@
 
 namespace beanmachine::minibmg {
 
-Node::Node(const NodeId sequence, const enum Operator op, const Type type)
-    : sequence{sequence}, op{op}, type{type} {}
+std::atomic<unsigned long> NodeId::_next_value{0};
+
+NodeId::NodeId() {
+  this->value = _next_value.fetch_add(1);
+}
+
+Node::Node(const enum Operator op, const Type type)
+    : sequence{}, op{op}, type{type} {}
 
 Node::~Node() {}
 
 OperatorNode::OperatorNode(
     const std::vector<const Node*>& in_nodes,
-    const NodeId sequence,
     const enum Operator op,
     const Type type)
-    : Node{sequence, op, type}, in_nodes{in_nodes} {
+    : Node{op, type}, in_nodes{in_nodes} {
   switch (op) {
     case Operator::CONSTANT:
     case Operator::QUERY:
@@ -31,22 +36,18 @@ OperatorNode::OperatorNode(
   }
 }
 
-QueryNode::QueryNode(
-    const unsigned query_index,
-    const Node* in_node,
-    const NodeId sequence)
-    : Node{sequence, Operator::QUERY, Type::NONE},
+QueryNode::QueryNode(const unsigned query_index, const Node* in_node)
+    : Node{Operator::QUERY, Type::NONE},
       query_index{query_index},
       in_node{in_node} {}
 
-ConstantNode::ConstantNode(const double value, const NodeId sequence)
-    : Node{sequence, Operator::CONSTANT, Type::REAL}, value{value} {}
+ConstantNode::ConstantNode(const double value)
+    : Node{Operator::CONSTANT, Type::REAL}, value{value} {}
 
 VariableNode::VariableNode(
     const std::string& name,
-    const unsigned variable_index,
-    const NodeId sequence)
-    : Node{sequence, Operator::VARIABLE, Type::REAL},
+    const unsigned variable_index)
+    : Node{Operator::VARIABLE, Type::REAL},
       name{name},
       variable_index{variable_index} {}
 

--- a/minibmg/node.cpp
+++ b/minibmg/node.cpp
@@ -10,14 +10,7 @@
 
 namespace beanmachine::minibmg {
 
-std::atomic<unsigned long> NodeId::_next_value{0};
-
-NodeId::NodeId() {
-  this->value = _next_value.fetch_add(1);
-}
-
-Node::Node(const enum Operator op, const Type type)
-    : sequence{}, op{op}, type{type} {}
+Node::Node(const enum Operator op, const Type type) : op{op}, type{type} {}
 
 Node::~Node() {}
 

--- a/minibmg/node.cpp
+++ b/minibmg/node.cpp
@@ -21,18 +21,12 @@ OperatorNode::OperatorNode(
     : Node{op, type}, in_nodes{in_nodes} {
   switch (op) {
     case Operator::CONSTANT:
-    case Operator::QUERY:
     case Operator::VARIABLE:
       throw std::invalid_argument(
           "OperatorNode cannot be used for " + to_string(op) + ".");
     default:;
   }
 }
-
-QueryNode::QueryNode(const unsigned query_index, Nodep in_node)
-    : Node{Operator::QUERY, Type::NONE},
-      query_index{query_index},
-      in_node{in_node} {}
 
 ConstantNode::ConstantNode(const double value)
     : Node{Operator::CONSTANT, Type::REAL}, value{value} {}

--- a/minibmg/node.cpp
+++ b/minibmg/node.cpp
@@ -15,7 +15,7 @@ Node::Node(const enum Operator op, const Type type) : op{op}, type{type} {}
 Node::~Node() {}
 
 OperatorNode::OperatorNode(
-    const std::vector<const Node*>& in_nodes,
+    const std::vector<Nodep>& in_nodes,
     const enum Operator op,
     const Type type)
     : Node{op, type}, in_nodes{in_nodes} {
@@ -29,7 +29,7 @@ OperatorNode::OperatorNode(
   }
 }
 
-QueryNode::QueryNode(const unsigned query_index, const Node* in_node)
+QueryNode::QueryNode(const unsigned query_index, Nodep in_node)
     : Node{Operator::QUERY, Type::NONE},
       query_index{query_index},
       in_node{in_node} {}

--- a/minibmg/node.h
+++ b/minibmg/node.h
@@ -18,6 +18,10 @@
 
 namespace beanmachine::minibmg {
 
+class Node;
+
+using Nodep = std::shared_ptr<const Node>;
+
 class Node {
  public:
   Node(const enum Operator op, const Type type);
@@ -29,10 +33,10 @@ class Node {
 class OperatorNode : public Node {
  public:
   OperatorNode(
-      const std::vector<const Node*>& in_nodes,
+      const std::vector<Nodep>& in_nodes,
       const enum Operator op,
       const enum Type type);
-  std::vector<const Node*> in_nodes;
+  std::vector<Nodep> in_nodes;
 };
 
 class ConstantNode : public Node {
@@ -50,9 +54,9 @@ class VariableNode : public Node {
 
 class QueryNode : public Node {
  public:
-  QueryNode(const unsigned query_index, const Node* in_node);
+  QueryNode(const unsigned query_index, Nodep in_node);
   unsigned query_index;
-  const Node* in_node;
+  Nodep in_node;
 };
 
 } // namespace beanmachine::minibmg

--- a/minibmg/node.h
+++ b/minibmg/node.h
@@ -5,6 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <fmt/format.h>
+#include <atomic>
+#include <functional>
+#include <memory>
+#include <unordered_set>
 #include <vector>
 #include "beanmachine/minibmg/operator.h"
 #include "beanmachine/minibmg/type.h"
@@ -13,15 +18,65 @@
 
 namespace beanmachine::minibmg {
 
-// TODO: replace this with an opaque identifier.
-using NodeId = unsigned;
+class Node;
+
+// An opaque identifier for a node.
+class NodeId {
+ public:
+  // Create a fresh, new, never-before-seen NodeId
+  NodeId();
+  explicit NodeId(unsigned long value) : value{value} {}
+  explicit NodeId(long value) : value{(unsigned long)value} {}
+  inline bool operator==(const NodeId& other) const {
+    return value == other.value;
+  }
+  NodeId(const NodeId& other) : value{other.value} {} // copy ctor
+  NodeId& operator=(const NodeId& other) { // assignment
+    this->value = other.value;
+    return *this;
+  }
+  ~NodeId() {} // dtor
+
+  inline unsigned long _value() const {
+    return value;
+  }
+
+  static void _reset_for_testing() {
+    _next_value = 0;
+  }
+
+ private:
+  static std::atomic<unsigned long> _next_value;
+  unsigned long value;
+};
+
+} // namespace beanmachine::minibmg
+
+// Make NodeId values usable as a key in a hash table.
+template <>
+struct std::hash<beanmachine::minibmg::NodeId> {
+  std::size_t operator()(const beanmachine::minibmg::NodeId& n) const noexcept {
+    return (std::size_t)n._value();
+  }
+};
+
+// Make NodeId values printable using format.
+template <>
+struct fmt::formatter<beanmachine::minibmg::NodeId>
+    : fmt::formatter<std::string> {
+  auto format(const beanmachine::minibmg::NodeId& n, format_context& ctx) {
+    return formatter<std::string>::format(fmt::format("{}", n._value()), ctx);
+  }
+};
+
+namespace beanmachine::minibmg {
 
 class Node {
  public:
-  Node(const NodeId sequence, const enum Operator op, const Type type);
-  const NodeId sequence;
-  const enum Operator op;
-  const enum Type type;
+  Node(const enum Operator op, const Type type);
+  NodeId sequence;
+  enum Operator op;
+  enum Type type;
   virtual ~Node() = 0;
 };
 
@@ -29,36 +84,29 @@ class OperatorNode : public Node {
  public:
   OperatorNode(
       const std::vector<const Node*>& in_nodes,
-      const NodeId sequence,
       const enum Operator op,
       const enum Type type);
-  const std::vector<const Node*> in_nodes;
+  std::vector<const Node*> in_nodes;
 };
 
 class ConstantNode : public Node {
  public:
-  ConstantNode(const double value, const NodeId sequence);
-  const double value;
+  explicit ConstantNode(const double value);
+  double value;
 };
 
 class VariableNode : public Node {
  public:
-  VariableNode(
-      const std::string& name,
-      const unsigned variable_index,
-      const NodeId sequence);
-  const std::string name;
-  const unsigned variable_index;
+  VariableNode(const std::string& name, const unsigned variable_index);
+  std::string name;
+  unsigned variable_index;
 };
 
 class QueryNode : public Node {
  public:
-  QueryNode(
-      const unsigned query_index,
-      const Node* in_node,
-      const NodeId sequence);
-  const unsigned query_index;
-  const Node* const in_node;
+  QueryNode(const unsigned query_index, const Node* in_node);
+  unsigned query_index;
+  const Node* in_node;
 };
 
 } // namespace beanmachine::minibmg

--- a/minibmg/node.h
+++ b/minibmg/node.h
@@ -52,11 +52,4 @@ class VariableNode : public Node {
   unsigned variable_index;
 };
 
-class QueryNode : public Node {
- public:
-  QueryNode(const unsigned query_index, Nodep in_node);
-  unsigned query_index;
-  Nodep in_node;
-};
-
 } // namespace beanmachine::minibmg

--- a/minibmg/node.h
+++ b/minibmg/node.h
@@ -18,63 +18,9 @@
 
 namespace beanmachine::minibmg {
 
-class Node;
-
-// An opaque identifier for a node.
-class NodeId {
- public:
-  // Create a fresh, new, never-before-seen NodeId
-  NodeId();
-  explicit NodeId(unsigned long value) : value{value} {}
-  explicit NodeId(long value) : value{(unsigned long)value} {}
-  inline bool operator==(const NodeId& other) const {
-    return value == other.value;
-  }
-  NodeId(const NodeId& other) : value{other.value} {} // copy ctor
-  NodeId& operator=(const NodeId& other) { // assignment
-    this->value = other.value;
-    return *this;
-  }
-  ~NodeId() {} // dtor
-
-  inline unsigned long _value() const {
-    return value;
-  }
-
-  static void _reset_for_testing() {
-    _next_value = 0;
-  }
-
- private:
-  static std::atomic<unsigned long> _next_value;
-  unsigned long value;
-};
-
-} // namespace beanmachine::minibmg
-
-// Make NodeId values usable as a key in a hash table.
-template <>
-struct std::hash<beanmachine::minibmg::NodeId> {
-  std::size_t operator()(const beanmachine::minibmg::NodeId& n) const noexcept {
-    return (std::size_t)n._value();
-  }
-};
-
-// Make NodeId values printable using format.
-template <>
-struct fmt::formatter<beanmachine::minibmg::NodeId>
-    : fmt::formatter<std::string> {
-  auto format(const beanmachine::minibmg::NodeId& n, format_context& ctx) {
-    return formatter<std::string>::format(fmt::format("{}", n._value()), ctx);
-  }
-};
-
-namespace beanmachine::minibmg {
-
 class Node {
  public:
   Node(const enum Operator op, const Type type);
-  NodeId sequence;
   enum Operator op;
   enum Type type;
   virtual ~Node() = 0;

--- a/minibmg/operator.cpp
+++ b/minibmg/operator.cpp
@@ -48,8 +48,6 @@ bool _c0 = [] {
   add(Operator::DISTRIBUTION_BETA, "DISTRIBUTION_BETA");
   add(Operator::DISTRIBUTION_BERNOULLI, "DISTRIBUTION_BERNOULLI");
   add(Operator::SAMPLE, "SAMPLE");
-  add(Operator::OBSERVE, "OBSERVE");
-  add(Operator::QUERY, "QUERY");
 
   // check that we have set the name for every operator.
   for (Operator op = Operator::NO_OPERATOR; op < Operator::LAST_OPERATOR;

--- a/minibmg/operator.h
+++ b/minibmg/operator.h
@@ -104,19 +104,6 @@ enum class Operator {
   // Result: A sample from the distribution (REAL)
   SAMPLE,
 
-  // Observe a sample from the distribution parameter.
-  // Parameters:
-  // - ditribution (DISTRIBUTION)
-  // - value (REAL)
-  // Result: NONE.
-  OBSERVE,
-
-  // Query an intermediate result in the graph.
-  // Parameters:
-  // - value (REAL)
-  // Result: NONE.
-  QUERY,
-
   // Not a real operator.  Used as a limit when looping through operators.
   LAST_OPERATOR,
 };

--- a/minibmg/out_nodes.cpp
+++ b/minibmg/out_nodes.cpp
@@ -45,13 +45,6 @@ class Out_Nodes_Property
         case Operator::VARIABLE:
           // these nodes do not have inputs.
           break;
-        case Operator::QUERY: {
-          // query has one input.
-          auto query = std::dynamic_pointer_cast<const QueryNode>(node);
-          auto& predecessor_out_set = data->for_node(query->in_node);
-          predecessor_out_set.push_back(node);
-          break;
-        }
         default: {
           // the rest are operator nodes.
           auto opnode = std::dynamic_pointer_cast<const OperatorNode>(node);

--- a/minibmg/out_nodes.cpp
+++ b/minibmg/out_nodes.cpp
@@ -9,7 +9,7 @@
 #include <exception>
 #include <list>
 #include <map>
-#include <set>
+#include <unordered_set>
 #include "beanmachine/minibmg/minibmg.h"
 
 namespace {
@@ -18,7 +18,7 @@ using namespace beanmachine::minibmg;
 
 class Out_Nodes_Data {
  public:
-  std::map<const Node*, std::set<NodeId>*> id_map{};
+  std::map<const Node*, std::unordered_set<NodeId>*> id_map{};
   std::map<const Node*, std::list<const Node*>*> node_map{};
   ~Out_Nodes_Data() {
     for (auto e : id_map) {
@@ -28,7 +28,7 @@ class Out_Nodes_Data {
       delete e.second;
     }
   }
-  std::set<NodeId>& for_ids(const Node* node) {
+  std::unordered_set<NodeId>& for_ids(const Node* node) {
     auto found = id_map.find(node);
     if (found == id_map.end()) {
       throw std::invalid_argument("node not in graph");
@@ -51,7 +51,7 @@ class Out_Nodes_Property
     Out_Nodes_Data* data = new Out_Nodes_Data{};
     // create the version using NodeId values
     for (auto node : g) {
-      data->id_map[node] = new std::set<NodeId>{};
+      data->id_map[node] = new std::unordered_set<NodeId>{};
       switch (node->op) {
         case Operator::CONSTANT:
         case Operator::VARIABLE:
@@ -94,12 +94,13 @@ class Out_Nodes_Property
 
 namespace beanmachine::minibmg {
 
-const std::set<NodeId>& out_nodes(const Graph& graph, NodeId node) {
-  if (node < 0 || node >= graph.size()) {
+const std::unordered_set<NodeId>& out_nodes(const Graph& graph, NodeId node) {
+  const Node* n = graph[node];
+  if (n == nullptr) {
     throw std::invalid_argument("node not in graph");
   }
   Out_Nodes_Data* data = Out_Nodes_Property::get(graph);
-  std::set<NodeId>& result = data->for_ids(graph[node]);
+  std::unordered_set<NodeId>& result = data->for_ids(graph[node]);
   return result;
 }
 

--- a/minibmg/out_nodes.cpp
+++ b/minibmg/out_nodes.cpp
@@ -18,13 +18,13 @@ using namespace beanmachine::minibmg;
 
 class Out_Nodes_Data {
  public:
-  std::map<const Node*, std::list<const Node*>*> node_map{};
+  std::map<Nodep, std::list<Nodep>*> node_map{};
   ~Out_Nodes_Data() {
     for (auto e : node_map) {
       delete e.second;
     }
   }
-  std::list<const Node*>& for_node(const Node* node) {
+  std::list<Nodep>& for_node(Nodep node) {
     auto found = node_map.find(node);
     if (found == node_map.end()) {
       throw std::invalid_argument("node not in graph");
@@ -39,7 +39,7 @@ class Out_Nodes_Property
   Out_Nodes_Data* create(const Graph& g) const override {
     Out_Nodes_Data* data = new Out_Nodes_Data{};
     for (auto node : g) {
-      data->node_map[node] = new std::list<const Node*>{};
+      data->node_map[node] = new std::list<Nodep>{};
       switch (node->op) {
         case Operator::CONSTANT:
         case Operator::VARIABLE:
@@ -47,14 +47,14 @@ class Out_Nodes_Property
           break;
         case Operator::QUERY: {
           // query has one input.
-          auto query = static_cast<const QueryNode*>(node);
+          auto query = std::dynamic_pointer_cast<const QueryNode>(node);
           auto& predecessor_out_set = data->for_node(query->in_node);
           predecessor_out_set.push_back(node);
           break;
         }
         default: {
           // the rest are operator nodes.
-          auto opnode = static_cast<const OperatorNode*>(node);
+          auto opnode = std::dynamic_pointer_cast<const OperatorNode>(node);
           for (auto in_node : opnode->in_nodes) {
             auto& predecessor_out_set = data->for_node(in_node);
             predecessor_out_set.push_back(node);
@@ -72,9 +72,9 @@ class Out_Nodes_Property
 
 namespace beanmachine::minibmg {
 
-const std::list<const Node*>& out_nodes(const Graph& graph, const Node* node) {
+const std::list<Nodep>& out_nodes(const Graph& graph, Nodep node) {
   Out_Nodes_Data* data = Out_Nodes_Property::get(graph);
-  std::list<const Node*>& result = data->for_node(node);
+  std::list<Nodep>& result = data->for_node(node);
   return result;
 }
 

--- a/minibmg/out_nodes.h
+++ b/minibmg/out_nodes.h
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <list>
-#include <set>
+#include <unordered_set>
 #include "beanmachine/minibmg/graph.h"
 #include "beanmachine/minibmg/node.h"
 
@@ -17,6 +17,6 @@ namespace beanmachine::minibmg {
 // return the set of nodes that have the given node as an input in the given
 // graph.
 const std::list<const Node*>& out_nodes(const Graph& graph, const Node* node);
-const std::set<NodeId>& out_nodes(const Graph& graph, NodeId node);
+const std::unordered_set<NodeId>& out_nodes(const Graph& graph, NodeId node);
 
 } // namespace beanmachine::minibmg

--- a/minibmg/out_nodes.h
+++ b/minibmg/out_nodes.h
@@ -16,6 +16,6 @@ namespace beanmachine::minibmg {
 
 // return the set of nodes that have the given node as an input in the given
 // graph.
-const std::list<const Node*>& out_nodes(const Graph& graph, const Node* node);
+const std::list<Nodep>& out_nodes(const Graph& graph, Nodep node);
 
 } // namespace beanmachine::minibmg

--- a/minibmg/out_nodes.h
+++ b/minibmg/out_nodes.h
@@ -17,6 +17,5 @@ namespace beanmachine::minibmg {
 // return the set of nodes that have the given node as an input in the given
 // graph.
 const std::list<const Node*>& out_nodes(const Graph& graph, const Node* node);
-const std::unordered_set<NodeId>& out_nodes(const Graph& graph, NodeId node);
 
 } // namespace beanmachine::minibmg

--- a/minibmg/tests/eval_test.cpp
+++ b/minibmg/tests/eval_test.cpp
@@ -33,7 +33,7 @@ TEST(eval_test, simple1) {
   std::mt19937 gen;
   auto read_variable = [](const std::string&, const unsigned) { return 1.15; };
   int graph_size = graph.size();
-  unordered_map<const Node*, Real> data;
+  unordered_map<Nodep, Real> data;
   eval_graph<Real>(graph, gen, read_variable, data);
   EXPECT_CLOSE(1.995, data[fac[sub1]].as_double());
 }
@@ -58,7 +58,7 @@ TEST(eval_test, sample1) {
   double sum = 0;
   double sum_squared = 0;
   int graph_size = graph.size();
-  std::unordered_map<const Node*, Real> data;
+  std::unordered_map<Nodep, Real> data;
   for (int i = 0; i < n; i++) {
     eval_graph<Real>(graph, gen, nullptr, data);
     auto sample = data[fac[sample0]].as_double();
@@ -109,7 +109,7 @@ TEST(eval_test, derivative_dual) {
   // We generate several doubles between -2.0 and 2.0 to test with.
   std::uniform_real_distribution<double> unif(-2.0, 2.0);
 
-  std::unordered_map<const Node*, Dual> data;
+  std::unordered_map<Nodep, Dual> data;
   for (int i = 0; i < 10; i++) {
     double input = unif(gen);
     auto read_variable = [=](const std::string&, const unsigned) {
@@ -141,7 +141,7 @@ TEST(eval_test, derivatives_triune) {
   // We generate several doubles between -2.0 and 2.0 to test with.
   std::uniform_real_distribution<double> unif(-2.0, 2.0);
 
-  std::unordered_map<const Node*, Triune> data;
+  std::unordered_map<Nodep, Triune> data;
   for (int i = 0; i < 10; i++) {
     double input = unif(gen);
     auto read_variable = [=](const std::string&, const unsigned) {

--- a/minibmg/tests/eval_test.cpp
+++ b/minibmg/tests/eval_test.cpp
@@ -33,8 +33,7 @@ TEST(eval_test, simple1) {
   std::mt19937 gen;
   auto read_variable = [](const std::string&, const unsigned) { return 1.15; };
   int graph_size = graph.size();
-  vector<Real> data;
-  data.assign(graph_size, 0);
+  unordered_map<NodeId, Real> data;
   eval_graph<Real>(graph, gen, read_variable, data);
   EXPECT_CLOSE(1.995, data[sub1].as_double());
 }
@@ -42,6 +41,7 @@ TEST(eval_test, simple1) {
 TEST(eval_test, sample1) {
   // a graph that produces normal samples is evaluated many times
   // and the statistics of the samples are compared to their expected values.
+  std::exception x1;
   Graph::Factory fac;
   double expected_mean = 12.34;
   double expected_stdev = 41.78;
@@ -58,8 +58,7 @@ TEST(eval_test, sample1) {
   double sum = 0;
   double sum_squared = 0;
   int graph_size = graph.size();
-  vector<Real> data;
-  data.assign(graph_size, 0);
+  std::unordered_map<NodeId, Real> data;
   for (int i = 0; i < n; i++) {
     eval_graph<Real>(graph, gen, nullptr, data);
     auto sample = data[sample0].as_double();
@@ -110,14 +109,13 @@ TEST(eval_test, derivative_dual) {
   // We generate several doubles between -2.0 and 2.0 to test with.
   std::uniform_real_distribution<double> unif(-2.0, 2.0);
 
-  vector<Dual> data;
+  std::unordered_map<NodeId, Dual> data;
   for (int i = 0; i < 10; i++) {
     double input = unif(gen);
     auto read_variable = [=](const std::string&, const unsigned) {
       return Dual{input, 1};
     };
     data.clear();
-    data.assign(graph_size, 0);
     eval_graph<Dual>(graph, gen, read_variable, data);
     EXPECT_CLOSE(f<Real>(input).as_double(), data[s].primal.as_double());
     EXPECT_CLOSE(fp<Real>(input).as_double(), data[s].derivative1.as_double());
@@ -142,14 +140,13 @@ TEST(eval_test, derivatives_triune) {
   // We generate several doubles between -2.0 and 2.0 to test with.
   std::uniform_real_distribution<double> unif(-2.0, 2.0);
 
-  vector<Triune> data;
+  std::unordered_map<NodeId, Triune> data;
   for (int i = 0; i < 10; i++) {
     double input = unif(gen);
     auto read_variable = [=](const std::string&, const unsigned) {
       return Triune{input, 1, 0};
     };
     data.clear();
-    data.assign(graph_size, 0);
     eval_graph<Triune>(graph, gen, read_variable, data);
     EXPECT_CLOSE(f<Real>(input).as_double(), data[s].primal.as_double());
     EXPECT_CLOSE(fp<Real>(input).as_double(), data[s].derivative1.as_double());

--- a/minibmg/tests/eval_test.cpp
+++ b/minibmg/tests/eval_test.cpp
@@ -29,6 +29,7 @@ TEST(eval_test, simple1) {
   auto v1 = fac.add_variable("x", 0); // 1.15
   auto mul1 = fac.add_operator(Operator::MULTIPLY, {add0, v1}); // 6.095
   auto sub1 = fac.add_operator(Operator::SUBTRACT, {mul1, k1}); // 1.995
+  fac.add_query(sub1); // add a root to the graph.
   auto graph = fac.build();
   std::mt19937 gen;
   auto read_variable = [](const std::string&, const unsigned) { return 1.15; };
@@ -49,6 +50,7 @@ TEST(eval_test, sample1) {
   auto k1 = fac.add_constant(expected_stdev);
   auto normal0 = fac.add_operator(Operator::DISTRIBUTION_NORMAL, {k0, k1});
   auto sample0 = fac.add_operator(Operator::SAMPLE, {normal0});
+  fac.add_query(sample0); // add a root to the graph.
   auto graph = fac.build();
   // We create a new random number generator with its default (deterministic)
   // seed so that this test will not be flaky.
@@ -103,6 +105,7 @@ TEST(eval_test, derivative_dual) {
       {fac.add_constant(1.1),
        fac.add_operator(
            Operator::POW, {fac.add_variable("x", 0), fac.add_constant(2)})});
+  fac.add_query(s); // add a root to the graph.
   Graph graph = fac.build();
   int graph_size = graph.size();
 
@@ -118,7 +121,8 @@ TEST(eval_test, derivative_dual) {
     data.clear();
     eval_graph<Dual>(graph, gen, read_variable, data);
     EXPECT_CLOSE(f<Real>(input).as_double(), data[fac[s]].primal.as_double());
-    EXPECT_CLOSE(fp<Real>(input).as_double(), data[fac[s]].derivative1.as_double());
+    EXPECT_CLOSE(
+        fp<Real>(input).as_double(), data[fac[s]].derivative1.as_double());
   }
 }
 
@@ -134,6 +138,7 @@ TEST(eval_test, derivatives_triune) {
       {fac.add_constant(1.1),
        fac.add_operator(
            Operator::POW, {fac.add_variable("x", 0), fac.add_constant(2)})});
+  fac.add_query(s); // add a root to the graph.
   auto sn = fac[s];
   Graph graph = fac.build();
   int graph_size = graph.size();

--- a/minibmg/tests/eval_test.cpp
+++ b/minibmg/tests/eval_test.cpp
@@ -33,9 +33,9 @@ TEST(eval_test, simple1) {
   std::mt19937 gen;
   auto read_variable = [](const std::string&, const unsigned) { return 1.15; };
   int graph_size = graph.size();
-  unordered_map<NodeId, Real> data;
+  unordered_map<const Node*, Real> data;
   eval_graph<Real>(graph, gen, read_variable, data);
-  EXPECT_CLOSE(1.995, data[sub1].as_double());
+  EXPECT_CLOSE(1.995, data[fac[sub1]].as_double());
 }
 
 TEST(eval_test, sample1) {
@@ -58,10 +58,10 @@ TEST(eval_test, sample1) {
   double sum = 0;
   double sum_squared = 0;
   int graph_size = graph.size();
-  std::unordered_map<NodeId, Real> data;
+  std::unordered_map<const Node*, Real> data;
   for (int i = 0; i < n; i++) {
     eval_graph<Real>(graph, gen, nullptr, data);
-    auto sample = data[sample0].as_double();
+    auto sample = data[fac[sample0]].as_double();
     sum += sample;
     sum_squared += sample * sample;
   }
@@ -109,7 +109,7 @@ TEST(eval_test, derivative_dual) {
   // We generate several doubles between -2.0 and 2.0 to test with.
   std::uniform_real_distribution<double> unif(-2.0, 2.0);
 
-  std::unordered_map<NodeId, Dual> data;
+  std::unordered_map<const Node*, Dual> data;
   for (int i = 0; i < 10; i++) {
     double input = unif(gen);
     auto read_variable = [=](const std::string&, const unsigned) {
@@ -117,8 +117,8 @@ TEST(eval_test, derivative_dual) {
     };
     data.clear();
     eval_graph<Dual>(graph, gen, read_variable, data);
-    EXPECT_CLOSE(f<Real>(input).as_double(), data[s].primal.as_double());
-    EXPECT_CLOSE(fp<Real>(input).as_double(), data[s].derivative1.as_double());
+    EXPECT_CLOSE(f<Real>(input).as_double(), data[fac[s]].primal.as_double());
+    EXPECT_CLOSE(fp<Real>(input).as_double(), data[fac[s]].derivative1.as_double());
   }
 }
 
@@ -134,13 +134,14 @@ TEST(eval_test, derivatives_triune) {
       {fac.add_constant(1.1),
        fac.add_operator(
            Operator::POW, {fac.add_variable("x", 0), fac.add_constant(2)})});
+  auto sn = fac[s];
   Graph graph = fac.build();
   int graph_size = graph.size();
 
   // We generate several doubles between -2.0 and 2.0 to test with.
   std::uniform_real_distribution<double> unif(-2.0, 2.0);
 
-  std::unordered_map<NodeId, Triune> data;
+  std::unordered_map<const Node*, Triune> data;
   for (int i = 0; i < 10; i++) {
     double input = unif(gen);
     auto read_variable = [=](const std::string&, const unsigned) {
@@ -148,8 +149,9 @@ TEST(eval_test, derivatives_triune) {
     };
     data.clear();
     eval_graph<Triune>(graph, gen, read_variable, data);
-    EXPECT_CLOSE(f<Real>(input).as_double(), data[s].primal.as_double());
-    EXPECT_CLOSE(fp<Real>(input).as_double(), data[s].derivative1.as_double());
-    EXPECT_CLOSE(fpp<Real>(input).as_double(), data[s].derivative2.as_double());
+    EXPECT_CLOSE(f<Real>(input).as_double(), data[sn].primal.as_double());
+    EXPECT_CLOSE(fp<Real>(input).as_double(), data[sn].derivative1.as_double());
+    EXPECT_CLOSE(
+        fpp<Real>(input).as_double(), data[sn].derivative2.as_double());
   }
 }

--- a/minibmg/tests/json_test.cpp
+++ b/minibmg/tests/json_test.cpp
@@ -14,6 +14,13 @@ using namespace ::beanmachine::minibmg;
 
 std::string raw_json = R"({
   "comment": "created by graph_to_json",
+  "queries": [ 2 ],
+  "observations": [
+    { "node": 4, "value": 1.0 },
+    { "node": 5, "value": 1.0 },
+    { "node": 6, "value": 1.0 },
+    { "node": 7, "value": 0.0 }
+  ],
   "nodes": [
     {
       "operator": "CONSTANT",
@@ -47,59 +54,36 @@ std::string raw_json = R"({
       "type": "DISTRIBUTION"
     },
     {
-      "operator": "CONSTANT",
+      "in_nodes": [
+        3
+      ],
+      "operator": "SAMPLE",
       "sequence": 4,
-      "type": "REAL",
-      "value": 0
+      "type": "REAL"
     },
     {
-      "operator": "CONSTANT",
+      "in_nodes": [
+        3
+      ],
+      "operator": "SAMPLE",
       "sequence": 5,
-      "type": "REAL",
-      "value": 1
+      "type": "REAL"
     },
     {
       "in_nodes": [
-        3,
-        5
+        3
       ],
-      "operator": "OBSERVE",
+      "operator": "SAMPLE",
       "sequence": 6,
-      "type": "NONE"
+      "type": "REAL"
     },
     {
       "in_nodes": [
-        3,
-        5
+        3
       ],
-      "operator": "OBSERVE",
+      "operator": "SAMPLE",
       "sequence": 7,
-      "type": "NONE"
-    },
-    {
-      "in_nodes": [
-        3,
-        5
-      ],
-      "operator": "OBSERVE",
-      "sequence": 8,
-      "type": "NONE"
-    },
-    {
-      "in_nodes": [
-        3,
-        4
-      ],
-      "operator": "OBSERVE",
-      "sequence": 9,
-      "type": "NONE"
-    },
-    {
-      "in_node": 2,
-      "operator": "QUERY",
-      "query_index": 0,
-      "sequence": 10,
-      "type": "NONE"
+      "type": "REAL"
     }
   ]
 })";
@@ -113,82 +97,70 @@ TEST(json_test, test_from_string) {
 }
 
 std::string raw_json_without_types = R"({
+  "comment": "created by graph_to_json",
+  "queries": [ 2 ],
+  "observations": [
+    { "node": 4, "value": 1.0 },
+    { "node": 5, "value": 1.0 },
+    { "node": 6, "value": 1.0 },
+    { "node": 7, "value": 0.0 }
+  ],
   "nodes": [
     {
-      "sequence": 0,
       "operator": "CONSTANT",
+      "sequence": 0,
       "value": 2
     },
     {
-      "sequence": 1,
-      "operator": "DISTRIBUTION_BETA",
       "in_nodes": [
         0,
         0
-      ]
+      ],
+      "operator": "DISTRIBUTION_BETA",
+      "sequence": 1,
     },
     {
-      "sequence": 2,
-      "operator": "SAMPLE",
       "in_nodes": [
         1
-      ]
+      ],
+      "operator": "SAMPLE",
+      "sequence": 2,
     },
     {
-      "sequence": 3,
-      "operator": "DISTRIBUTION_BERNOULLI",
       "in_nodes": [
         2
-      ]
+      ],
+      "operator": "DISTRIBUTION_BERNOULLI",
+      "sequence": 3,
     },
     {
+      "in_nodes": [
+        3
+      ],
+      "operator": "SAMPLE",
       "sequence": 4,
-      "operator": "CONSTANT",
-      "value": 0
     },
     {
+      "in_nodes": [
+        3
+      ],
+      "operator": "SAMPLE",
       "sequence": 5,
-      "operator": "CONSTANT",
-      "value": 1
     },
     {
+      "in_nodes": [
+        3
+      ],
+      "operator": "SAMPLE",
       "sequence": 6,
-      "operator": "OBSERVE",
-      "in_nodes": [
-        3,
-        5
-      ]
     },
     {
+      "in_nodes": [
+        3
+      ],
+      "operator": "SAMPLE",
       "sequence": 7,
-      "operator": "OBSERVE",
-      "in_nodes": [
-        3,
-        5
-      ]
     },
-    {
-      "sequence": 8,
-      "operator": "OBSERVE",
-      "in_nodes": [
-        3,
-        5
-      ]
-    },
-    {
-      "sequence": 9,
-      "operator": "OBSERVE",
-      "in_nodes": [
-        3,
-        4
-      ]
-    },
-    {
-      "sequence": 10,
-      "operator": "QUERY",
-      "in_node": 2,
-      "query_index": 0
-    }
   ]
 })";
 

--- a/minibmg/tests/minibmg_test.cpp
+++ b/minibmg/tests/minibmg_test.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <gtest/gtest.h>
+#include <stdexcept>
 
 #include "beanmachine/minibmg/minibmg.h"
 
@@ -88,4 +89,11 @@ TEST(test_minibmg, type_to_string) {
 
   // with runtime checks enabled, the following would crash at the cast.
   // ASSERT_EQ(to_string((Type)10000), "NONE");
+}
+
+TEST(test_minibmg, duplicate_build) {
+  Graph::Factory gf;
+  Graph g = gf.build();
+  ASSERT_THROW(gf.add_constant(1.2);, std::invalid_argument);
+  ASSERT_THROW(gf.build();, std::invalid_argument);
 }

--- a/minibmg/tests/minibmg_test.cpp
+++ b/minibmg/tests/minibmg_test.cpp
@@ -12,24 +12,27 @@
 using namespace ::testing;
 using namespace beanmachine::minibmg;
 
+#define ASSERT_ID(node, num) ASSERT_EQ(node, NodeId{(unsigned long)(num)})
+
 TEST(test_minibmg, basic_building) {
+  NodeId::_reset_for_testing();
   Graph::Factory gf;
   auto k12 = gf.add_constant(1.2);
-  ASSERT_EQ(k12, 0);
+  ASSERT_ID(k12, 0);
   auto k34 = gf.add_constant(3.4);
-  ASSERT_EQ(k34, 1);
+  ASSERT_ID(k34, 1);
   auto plus = gf.add_operator(Operator::ADD, {k12, k34});
-  ASSERT_EQ(plus, 2);
+  ASSERT_ID(plus, 2);
   auto k56 = gf.add_constant(5.6);
-  ASSERT_EQ(k56, 3);
+  ASSERT_ID(k56, 3);
   auto beta = gf.add_operator(Operator::DISTRIBUTION_BETA, {k34, k56});
-  ASSERT_EQ(beta, 4);
+  ASSERT_ID(beta, 4);
   auto sample = gf.add_operator(Operator::SAMPLE, {beta});
-  ASSERT_EQ(sample, 5);
+  ASSERT_ID(sample, 5);
   auto k78 = gf.add_constant(7.8);
-  ASSERT_EQ(k78, 6);
+  ASSERT_ID(k78, 6);
   auto observe = gf.add_operator(Operator::OBSERVE, {beta, k78});
-  ASSERT_EQ(observe, 7);
+  ASSERT_ID(observe, 7);
   auto query = gf.add_query(beta);
   ASSERT_EQ(query, 0); // we get the query number back from add_query
   Graph g = gf.build();

--- a/minibmg/tests/out_nodes_test.cpp
+++ b/minibmg/tests/out_nodes_test.cpp
@@ -7,15 +7,15 @@
 
 #include <gtest/gtest.h>
 #include <list>
-#include <set>
+#include <unordered_set>
 #include "beanmachine/minibmg/minibmg.h"
 #include "beanmachine/minibmg/out_nodes.h"
 
 using namespace ::testing;
 using namespace ::beanmachine::minibmg;
 
-std::set<NodeId> set(std::list<NodeId> values) {
-  std::set<NodeId> result{};
+std::unordered_set<NodeId> set(std::list<NodeId> values) {
+  std::unordered_set<NodeId> result{};
   for (auto x : values) {
     result.insert(x);
   }
@@ -32,11 +32,10 @@ TEST(out_nodes_test, simple) {
   auto sample = gf.add_operator(Operator::SAMPLE, {beta});
   auto k78 = gf.add_constant(7.8);
   auto observe = gf.add_operator(Operator::OBSERVE, {beta, k78});
-  /* auto query_ = */ gf.add_query(beta);
-  // We don't get the node index of the query from the factory.  The factory
-  // only gives us the query number.
-  unsigned query = observe + 1;
+  NodeId query;
+  /* auto query_ = */ gf.add_query(beta, query);
   Graph g = gf.build();
+
   ASSERT_EQ(out_nodes(g, k12), set({plus}));
   ASSERT_EQ(out_nodes(g, k34), set({plus, beta}));
   ASSERT_EQ(out_nodes(g, plus), set({}));
@@ -58,7 +57,7 @@ TEST(out_nodes_test, not_found1) {
 TEST(out_nodes_test, not_found2) {
   Graph::Factory gf;
   Graph g = gf.build();
-  Node* n = new ConstantNode(0, 0);
+  Node* n = new ConstantNode(0);
   ASSERT_THROW(out_nodes(g, n), std::invalid_argument);
   delete n;
 }

--- a/minibmg/tests/out_nodes_test.cpp
+++ b/minibmg/tests/out_nodes_test.cpp
@@ -27,32 +27,31 @@ TEST(out_nodes_test, simple) {
   NodeId query;
   /* auto query_ = */ gf.add_query(beta, query);
 
-  const Node* k12n = gf[k12];
-  const Node* k34n = gf[k34];
-  const Node* plusn = gf[plus];
-  const Node* k56n = gf[k56];
-  const Node* betan = gf[beta];
-  const Node* samplen = gf[sample];
-  const Node* k78n = gf[k78];
-  const Node* observen = gf[observe];
-  const Node* queryn = gf[query];
+  Nodep k12n = gf[k12];
+  Nodep k34n = gf[k34];
+  Nodep plusn = gf[plus];
+  Nodep k56n = gf[k56];
+  Nodep betan = gf[beta];
+  Nodep samplen = gf[sample];
+  Nodep k78n = gf[k78];
+  Nodep observen = gf[observe];
+  Nodep queryn = gf[query];
   Graph g = gf.build();
 
   ASSERT_EQ(out_nodes(g, k12n), std::list{plusn});
   ASSERT_EQ(out_nodes(g, k34n), (std::list{plusn, betan}));
-  ASSERT_EQ(out_nodes(g, plusn), std::list<const Node*>{});
+  ASSERT_EQ(out_nodes(g, plusn), std::list<Nodep>{});
   ASSERT_EQ(out_nodes(g, k56n), std::list{betan});
   ASSERT_EQ(out_nodes(g, betan), (std::list{samplen, observen, queryn}));
-  ASSERT_EQ(out_nodes(g, samplen), std::list<const Node*>{});
+  ASSERT_EQ(out_nodes(g, samplen), std::list<Nodep>{});
   ASSERT_EQ(out_nodes(g, k78n), std::list{observen});
-  ASSERT_EQ(out_nodes(g, observen), std::list<const Node*>{});
-  ASSERT_EQ(out_nodes(g, queryn), std::list<const Node*>{});
+  ASSERT_EQ(out_nodes(g, observen), std::list<Nodep>{});
+  ASSERT_EQ(out_nodes(g, queryn), std::list<Nodep>{});
 }
 
 TEST(out_nodes_test, not_found2) {
   Graph::Factory gf;
   Graph g = gf.build();
-  Node* n = new ConstantNode(0);
+  Nodep n = std::make_shared<const ConstantNode>(0);
   ASSERT_THROW(out_nodes(g, n), std::invalid_argument);
-  delete n;
 }

--- a/minibmg/tests/out_nodes_test.cpp
+++ b/minibmg/tests/out_nodes_test.cpp
@@ -26,6 +26,7 @@ TEST(out_nodes_test, simple) {
   auto observe = gf.add_operator(Operator::OBSERVE, {beta, k78});
   NodeId query;
   /* auto query_ = */ gf.add_query(beta, query);
+  Graph g = gf.build();
 
   Nodep k12n = gf[k12];
   Nodep k34n = gf[k34];
@@ -36,7 +37,6 @@ TEST(out_nodes_test, simple) {
   Nodep k78n = gf[k78];
   Nodep observen = gf[observe];
   Nodep queryn = gf[query];
-  Graph g = gf.build();
 
   ASSERT_EQ(out_nodes(g, k12n), std::list{plusn});
   ASSERT_EQ(out_nodes(g, k34n), (std::list{plusn, betan}));

--- a/minibmg/tests/out_nodes_test.cpp
+++ b/minibmg/tests/out_nodes_test.cpp
@@ -14,14 +14,6 @@
 using namespace ::testing;
 using namespace ::beanmachine::minibmg;
 
-std::unordered_set<NodeId> set(std::list<NodeId> values) {
-  std::unordered_set<NodeId> result{};
-  for (auto x : values) {
-    result.insert(x);
-  }
-  return result;
-}
-
 TEST(out_nodes_test, simple) {
   Graph::Factory gf;
   auto k12 = gf.add_constant(1.2);
@@ -34,24 +26,27 @@ TEST(out_nodes_test, simple) {
   auto observe = gf.add_operator(Operator::OBSERVE, {beta, k78});
   NodeId query;
   /* auto query_ = */ gf.add_query(beta, query);
+
+  const Node* k12n = gf[k12];
+  const Node* k34n = gf[k34];
+  const Node* plusn = gf[plus];
+  const Node* k56n = gf[k56];
+  const Node* betan = gf[beta];
+  const Node* samplen = gf[sample];
+  const Node* k78n = gf[k78];
+  const Node* observen = gf[observe];
+  const Node* queryn = gf[query];
   Graph g = gf.build();
 
-  ASSERT_EQ(out_nodes(g, k12), set({plus}));
-  ASSERT_EQ(out_nodes(g, k34), set({plus, beta}));
-  ASSERT_EQ(out_nodes(g, plus), set({}));
-  ASSERT_EQ(out_nodes(g, k56), set({beta}));
-  ASSERT_EQ(out_nodes(g, beta), set({sample, observe, query}));
-  ASSERT_EQ(out_nodes(g, sample), set({}));
-  ASSERT_EQ(out_nodes(g, k78), set({observe}));
-  ASSERT_EQ(out_nodes(g, observe), set({}));
-  ASSERT_EQ(out_nodes(g, query), set({}));
-}
-
-TEST(out_nodes_test, not_found1) {
-  Graph::Factory gf;
-  Graph g = gf.build();
-  NodeId not_found_node{};
-  ASSERT_THROW(out_nodes(g, not_found_node), std::invalid_argument);
+  ASSERT_EQ(out_nodes(g, k12n), std::list{plusn});
+  ASSERT_EQ(out_nodes(g, k34n), (std::list{plusn, betan}));
+  ASSERT_EQ(out_nodes(g, plusn), std::list<const Node*>{});
+  ASSERT_EQ(out_nodes(g, k56n), std::list{betan});
+  ASSERT_EQ(out_nodes(g, betan), (std::list{samplen, observen, queryn}));
+  ASSERT_EQ(out_nodes(g, samplen), std::list<const Node*>{});
+  ASSERT_EQ(out_nodes(g, k78n), std::list{observen});
+  ASSERT_EQ(out_nodes(g, observen), std::list<const Node*>{});
+  ASSERT_EQ(out_nodes(g, queryn), std::list<const Node*>{});
 }
 
 TEST(out_nodes_test, not_found2) {


### PR DESCRIPTION
Summary: queries and observations are moved out of the nodes in the graph, and into separate data structures (a list of queried nodes, and a map from observed node to observed value).

Differential Revision: D39673068

