### PR TITLE
minibmg: remove unnecessary pointers

### DIFF
--- a/minibmg/eval.h
+++ b/minibmg/eval.h
@@ -100,6 +100,11 @@ void eval_graph(
     std::function<T(const std::string& name, const unsigned identifier)>
         read_variable,
     std::unordered_map<Nodep, T>& data) {
+  // Copy observations into a map for easy access.
+  std::unordered_map<Nodep, double> observations;
+  for (auto p : graph.observations) {
+    observations[p.first] = p.second;
+  }
   int n = graph.size();
   for (int i = 0; i < n; i++) {
     Nodep node = graph[i];
@@ -115,29 +120,22 @@ void eval_graph(
         break;
       }
       case Operator::SAMPLE: {
-        auto sample = std::dynamic_pointer_cast<const OperatorNode>(node);
-        Nodep in0 = sample->in_nodes[0];
-        auto dist = std::dynamic_pointer_cast<const OperatorNode>(in0);
-        std::function<double(unsigned)> get_parameter = [&](unsigned i) {
-          return data[dist->in_nodes[i]].as_double();
-        };
-        put(data, node, T{sample_distribution(dist->op, get_parameter, gen)});
+        auto obsp = observations.find(node);
+        double value;
+        if (obsp != observations.end()) {
+          value = obsp->second;
+        } else {
+          auto sample = std::dynamic_pointer_cast<const OperatorNode>(node);
+          Nodep in0 = sample->in_nodes[0];
+          auto dist = std::dynamic_pointer_cast<const OperatorNode>(in0);
+          std::function<double(unsigned)> get_parameter = [&](unsigned i) {
+            return data[dist->in_nodes[i]].as_double();
+          };
+          value = sample_distribution(dist->op, get_parameter, gen);
+        }
+        put(data, node, T{value});
         break;
       }
-      case Operator::QUERY: {
-        // We treat a query like a sample.
-        auto sample = std::dynamic_pointer_cast<const QueryNode>(node);
-        Nodep in0 = sample->in_node;
-        auto dist = std::dynamic_pointer_cast<const OperatorNode>(in0);
-        std::function<double(unsigned)> get_parameter = [&](unsigned i) {
-          return data[dist->in_nodes[i]].as_double();
-        };
-        put(data, node, T{sample_distribution(dist->op, get_parameter, gen)});
-        break;
-      }
-      case Operator::OBSERVE:
-        // OBSERVE has no result and has no effect during evaluation.
-        break;
       case Operator::NO_OPERATOR:
         throw EvalError(
             "sample_distribution does not support " + to_string(node->op));

--- a/minibmg/factory.cpp
+++ b/minibmg/factory.cpp
@@ -15,7 +15,7 @@ NodeId::NodeId() {
   this->value = _next_value.fetch_add(1);
 }
 
-NodeId Graph::Factory::add_node(const Node* node) {
+NodeId Graph::Factory::add_node(Nodep node) {
   all_nodes.push_back(node);
   NodeId identifier{};
   nodes.insert({identifier, node});
@@ -23,7 +23,7 @@ NodeId Graph::Factory::add_node(const Node* node) {
 }
 
 NodeId Graph::Factory::add_constant(double value) {
-  const auto new_node = new ConstantNode{value};
+  const auto new_node = std::make_shared<ConstantNode>(value);
   return add_node(new_node);
 }
 
@@ -136,7 +136,7 @@ NodeId Graph::Factory::add_operator(
     enum Operator op,
     std::vector<NodeId> parents) {
   auto expected = expected_parents[(unsigned)op];
-  std::vector<const Node*> in_nodes;
+  std::vector<Nodep> in_nodes;
   if (parents.size() != expected.size()) {
     throw std::invalid_argument("Incorrect number of parent nodes.");
   }
@@ -152,7 +152,8 @@ NodeId Graph::Factory::add_operator(
     in_nodes.push_back(parent_node);
   }
 
-  auto new_node = new OperatorNode{in_nodes, op, expected_result_type(op)};
+  auto new_node =
+      std::make_shared<OperatorNode>(in_nodes, op, expected_result_type(op));
   return add_node(new_node);
 }
 
@@ -166,7 +167,7 @@ unsigned Graph::Factory::add_query(NodeId parent, NodeId& new_node_id) {
   }
   auto query_id = next_query;
   next_query++;
-  auto new_node = new QueryNode{query_id, parent_node};
+  auto new_node = std::make_shared<QueryNode>(query_id, parent_node);
   new_node_id = add_node(new_node);
   return query_id;
 }
@@ -179,7 +180,7 @@ unsigned Graph::Factory::add_query(NodeId parent) {
 NodeId Graph::Factory::add_variable(
     const std::string& name,
     const unsigned variable_index) {
-  auto new_node = new VariableNode{name, variable_index};
+  auto new_node = std::make_shared<VariableNode>(name, variable_index);
   return add_node(new_node);
 }
 
@@ -190,12 +191,8 @@ Graph Graph::Factory::build() {
 }
 
 Graph::Factory::~Factory() {
-  auto nodes = this->all_nodes;
   this->nodes.clear();
   this->all_nodes.clear();
-  for (auto node : nodes) {
-    delete node;
-  }
 }
 
 } // namespace beanmachine::minibmg

--- a/minibmg/factory.cpp
+++ b/minibmg/factory.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "beanmachine/minibmg/factory.h"
+#include <stdexcept>
 
 namespace beanmachine::minibmg {
 
@@ -16,6 +17,9 @@ NodeId::NodeId() {
 }
 
 NodeId Graph::Factory::add_node(Nodep node) {
+  if (built) {
+    throw std::invalid_argument("Graph has already been built");
+  }
   all_nodes.push_back(node);
   NodeId identifier{};
   nodes.insert({identifier, node});
@@ -158,6 +162,9 @@ NodeId Graph::Factory::add_operator(
 }
 
 unsigned Graph::Factory::add_query(NodeId parent, NodeId& new_node_id) {
+  if (built) {
+    throw std::invalid_argument("Graph has already been built");
+  }
   auto parent_node = nodes[parent];
   if (parent_node->type != Type::DISTRIBUTION) {
     throw std::invalid_argument("Incorrect parent for QUERY node.");
@@ -185,8 +192,13 @@ NodeId Graph::Factory::add_variable(
 }
 
 Graph Graph::Factory::build() {
+  if (built) {
+    throw std::invalid_argument("Graph has already been built");
+  }
   auto nodes = this->all_nodes;
   this->all_nodes.clear();
+  // We preserve this->nodes so it can be used for lookup.
+  built = true;
   return Graph{nodes};
 }
 

--- a/minibmg/factory.cpp
+++ b/minibmg/factory.cpp
@@ -20,7 +20,6 @@ NodeId Graph::Factory::add_node(Nodep node) {
   if (built) {
     throw std::invalid_argument("Graph has already been built");
   }
-  all_nodes.push_back(node);
   NodeId identifier{};
   nodes.insert({identifier, node});
   return identifier;
@@ -54,9 +53,6 @@ enum Type op_type(enum Operator op) {
     case Operator::DISTRIBUTION_BETA:
     case Operator::DISTRIBUTION_BERNOULLI:
       return Type::DISTRIBUTION;
-    case Operator::OBSERVE:
-    case Operator::QUERY:
-      return Type::NONE;
     default:
       throw std::invalid_argument("op_type not defined for operator.");
   }
@@ -92,8 +88,6 @@ const std::vector<std::vector<enum Type>> make_expected_parents() {
   result[(unsigned)Operator::DISTRIBUTION_BETA] = {Type::REAL, Type::REAL};
   result[(unsigned)Operator::DISTRIBUTION_BERNOULLI] = {Type::REAL};
   result[(unsigned)Operator::SAMPLE] = {Type::DISTRIBUTION};
-  result[(unsigned)Operator::OBSERVE] = {Type::DISTRIBUTION, Type::REAL};
-  result[(unsigned)Operator::QUERY] = {Type::DISTRIBUTION};
   return result;
 }
 
@@ -113,16 +107,13 @@ enum Type expected_result_type(enum Operator op) {
     case Operator::POLYGAMMA:
     case Operator::IF_EQUAL:
     case Operator::IF_LESS:
+    case Operator::VARIABLE:
       return Type::REAL;
 
     case Operator::DISTRIBUTION_NORMAL:
     case Operator::DISTRIBUTION_BETA:
     case Operator::DISTRIBUTION_BERNOULLI:
       return Type::DISTRIBUTION;
-
-    case Operator::OBSERVE:
-    case Operator::QUERY:
-      return Type::NONE;
 
     default:
       throw std::invalid_argument("Unknown type for operator.");
@@ -161,29 +152,6 @@ NodeId Graph::Factory::add_operator(
   return add_node(new_node);
 }
 
-unsigned Graph::Factory::add_query(NodeId parent, NodeId& new_node_id) {
-  if (built) {
-    throw std::invalid_argument("Graph has already been built");
-  }
-  auto parent_node = nodes[parent];
-  if (parent_node->type != Type::DISTRIBUTION) {
-    throw std::invalid_argument("Incorrect parent for QUERY node.");
-  }
-  if (parent_node == nullptr) {
-    throw std::invalid_argument("Reference to nonexistent node.");
-  }
-  auto query_id = next_query;
-  next_query++;
-  auto new_node = std::make_shared<QueryNode>(query_id, parent_node);
-  new_node_id = add_node(new_node);
-  return query_id;
-}
-
-unsigned Graph::Factory::add_query(NodeId parent) {
-  NodeId new_node_id;
-  return add_query(parent, new_node_id); // discard new node id
-}
-
 NodeId Graph::Factory::add_variable(
     const std::string& name,
     const unsigned variable_index) {
@@ -191,20 +159,39 @@ NodeId Graph::Factory::add_variable(
   return add_node(new_node);
 }
 
+void Graph::Factory::add_observation(NodeId sample, double value) {
+  auto parent_node = nodes[sample];
+  if (parent_node == nullptr) {
+    throw std::invalid_argument("Reference to nonexistent node.");
+  }
+  this->observations.push_back(std::pair(parent_node, value));
+}
+
+unsigned Graph::Factory::add_query(NodeId queried) {
+  auto parent_node = nodes[queried];
+  if (parent_node == nullptr) {
+    throw std::invalid_argument("Reference to nonexistent node.");
+  }
+  if (parent_node->type != Type::REAL) {
+    throw std::invalid_argument("Can only query a scalar.");
+  }
+  auto result = (unsigned)this->queries.size();
+  this->queries.push_back(parent_node);
+  return result;
+}
+
 Graph Graph::Factory::build() {
   if (built) {
     throw std::invalid_argument("Graph has already been built");
   }
-  auto nodes = this->all_nodes;
-  this->all_nodes.clear();
+
   // We preserve this->nodes so it can be used for lookup.
   built = true;
-  return Graph{nodes};
+  return Graph::create(queries, observations);
 }
 
 Graph::Factory::~Factory() {
   this->nodes.clear();
-  this->all_nodes.clear();
 }
 
 } // namespace beanmachine::minibmg

--- a/minibmg/factory.h
+++ b/minibmg/factory.h
@@ -91,6 +91,7 @@ class Graph::Factory {
   ~Factory();
 
  private:
+  bool built = false;
   std::unordered_map<NodeId, Nodep> nodes;
   std::vector<Nodep> all_nodes;
   unsigned next_query = 0;

--- a/minibmg/factory.h
+++ b/minibmg/factory.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <unordered_map>
+#include <list>
 #include <vector>
 #include "beanmachine/minibmg/graph.h"
 #include "beanmachine/minibmg/node.h"
@@ -72,12 +73,13 @@ namespace beanmachine::minibmg {
 class Graph::Factory {
  public:
   NodeId add_constant(double value);
-
   NodeId add_operator(enum Operator op, std::vector<NodeId> parents);
+
+  // Add an observation to the graph.  The sample must identify a SAMPLE node.
+  void add_observation(NodeId sample, double value);
 
   // returns the index of the query in the samples, not a NodeId
   unsigned add_query(NodeId parent);
-  unsigned add_query(NodeId parent, NodeId& new_node_id);
 
   NodeId add_variable(const std::string& name, const unsigned variable_index);
 
@@ -93,8 +95,8 @@ class Graph::Factory {
  private:
   bool built = false;
   std::unordered_map<NodeId, Nodep> nodes;
-  std::vector<Nodep> all_nodes;
-  unsigned next_query = 0;
+  std::vector<Nodep> queries;
+  std::list<std::pair<Nodep, double>> observations;
 
   NodeId add_node(Nodep node);
 };

--- a/minibmg/factory.h
+++ b/minibmg/factory.h
@@ -81,7 +81,7 @@ class Graph::Factory {
 
   NodeId add_variable(const std::string& name, const unsigned variable_index);
 
-  inline const Node* operator[](const NodeId& node_id) const {
+  inline Nodep operator[](const NodeId& node_id) const {
     auto t = nodes.find(node_id);
     if (t == nodes.end())
       return nullptr;
@@ -91,11 +91,11 @@ class Graph::Factory {
   ~Factory();
 
  private:
-  std::unordered_map<NodeId, const Node*> nodes;
-  std::vector<const Node*> all_nodes;
+  std::unordered_map<NodeId, Nodep> nodes;
+  std::vector<Nodep> all_nodes;
   unsigned next_query = 0;
 
-  NodeId add_node(const Node* node);
+  NodeId add_node(Nodep node);
 };
 
 enum Type expected_result_type(enum Operator op);

--- a/minibmg/graph.h
+++ b/minibmg/graph.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <folly/json.h>
+#include <list>
 #include "beanmachine/minibmg/container.h"
 #include "beanmachine/minibmg/node.h"
 
@@ -15,10 +16,14 @@ namespace beanmachine::minibmg {
 
 class Graph : public Container {
  public:
-  // valudates that the list of nodes forms a valid graph,
-  // and returns that graph.  Throws an exception if the
-  // nodes do not form a valid graph.
-  static Graph create(std::vector<Nodep> nodes);
+  // produces a graph by computing the transitive closure of the input queries
+  // and observations and topologically sorting the set of nodes so reached.
+  // valudates that the list of nodes so reached forms a valid graph, and
+  // returns that graph.  Throws an exception if the nodes do not form a valid
+  // graph.
+  static Graph create(
+      std::vector<Nodep> queries,
+      std::list<std::pair<Nodep, double>> observations);
   ~Graph();
 
   // Implement the iterator pattern so clients can iterate over the nodes.
@@ -35,12 +40,25 @@ class Graph : public Container {
     return nodes.size();
   }
 
- private:
+  // All of the nodes, in a topologically sorted order such that a node can only
+  // be used as an input in subsequent (and not previous) nodes.
   const std::vector<Nodep> nodes;
 
+  // Queries of the model.  These are nodes whose values are sampled by
+  // inference.
+  const std::vector<Nodep> queries;
+
+  // Observations of the model.  These are SAMPLE nodes in the model whose
+  // values are known.
+  const std::list<std::pair<Nodep, double>> observations;
+
+ private:
   // A private constructor that forms a graph without validation.
   // Used internally.  All exposed graphs should be validated.
-  explicit Graph(std::vector<Nodep> nodes);
+  Graph(
+      std::vector<Nodep> nodes,
+      std::vector<Nodep> queries,
+      std::list<std::pair<Nodep, double>> observations);
   static void validate(std::vector<Nodep> nodes);
 
  public:

--- a/minibmg/graph.h
+++ b/minibmg/graph.h
@@ -18,7 +18,7 @@ class Graph : public Container {
   // valudates that the list of nodes forms a valid graph,
   // and returns that graph.  Throws an exception if the
   // nodes do not form a valid graph.
-  static Graph create(std::vector<const Node*> nodes);
+  static Graph create(std::vector<Nodep> nodes);
   ~Graph();
 
   // Implement the iterator pattern so clients can iterate over the nodes.
@@ -28,7 +28,7 @@ class Graph : public Container {
   inline auto end() const {
     return nodes.end();
   }
-  inline const Node* operator[](int index) const {
+  inline Nodep operator[](int index) const {
     return nodes[index];
   }
   inline int size() const {
@@ -36,12 +36,12 @@ class Graph : public Container {
   }
 
  private:
-  const std::vector<const Node*> nodes;
+  const std::vector<Nodep> nodes;
 
   // A private constructor that forms a graph without validation.
   // Used internally.  All exposed graphs should be validated.
-  explicit Graph(std::vector<const Node*> nodes);
-  static void validate(std::vector<const Node*> nodes);
+  explicit Graph(std::vector<Nodep> nodes);
+  static void validate(std::vector<Nodep> nodes);
 
  public:
   // A factory for making graphs, like the bmg API

--- a/minibmg/node.cpp
+++ b/minibmg/node.cpp
@@ -21,18 +21,12 @@ OperatorNode::OperatorNode(
     : Node{op, type}, in_nodes{in_nodes} {
   switch (op) {
     case Operator::CONSTANT:
-    case Operator::QUERY:
     case Operator::VARIABLE:
       throw std::invalid_argument(
           "OperatorNode cannot be used for " + to_string(op) + ".");
     default:;
   }
 }
-
-QueryNode::QueryNode(const unsigned query_index, Nodep in_node)
-    : Node{Operator::QUERY, Type::NONE},
-      query_index{query_index},
-      in_node{in_node} {}
 
 ConstantNode::ConstantNode(const double value)
     : Node{Operator::CONSTANT, Type::REAL}, value{value} {}

--- a/minibmg/node.cpp
+++ b/minibmg/node.cpp
@@ -15,7 +15,7 @@ Node::Node(const enum Operator op, const Type type) : op{op}, type{type} {}
 Node::~Node() {}
 
 OperatorNode::OperatorNode(
-    const std::vector<const Node*>& in_nodes,
+    const std::vector<Nodep>& in_nodes,
     const enum Operator op,
     const Type type)
     : Node{op, type}, in_nodes{in_nodes} {
@@ -29,7 +29,7 @@ OperatorNode::OperatorNode(
   }
 }
 
-QueryNode::QueryNode(const unsigned query_index, const Node* in_node)
+QueryNode::QueryNode(const unsigned query_index, Nodep in_node)
     : Node{Operator::QUERY, Type::NONE},
       query_index{query_index},
       in_node{in_node} {}

--- a/minibmg/node.h
+++ b/minibmg/node.h
@@ -18,6 +18,10 @@
 
 namespace beanmachine::minibmg {
 
+class Node;
+
+using Nodep = std::shared_ptr<const Node>;
+
 class Node {
  public:
   Node(const enum Operator op, const Type type);
@@ -29,10 +33,10 @@ class Node {
 class OperatorNode : public Node {
  public:
   OperatorNode(
-      const std::vector<const Node*>& in_nodes,
+      const std::vector<Nodep>& in_nodes,
       const enum Operator op,
       const enum Type type);
-  std::vector<const Node*> in_nodes;
+  std::vector<Nodep> in_nodes;
 };
 
 class ConstantNode : public Node {
@@ -53,9 +57,9 @@ class VariableNode : public Node {
 
 class QueryNode : public Node {
  public:
-  QueryNode(const unsigned query_index, const Node* in_node);
+  QueryNode(const unsigned query_index, Nodep in_node);
   unsigned query_index;
-  const Node* in_node;
+  Nodep in_node;
 };
 
 } // namespace beanmachine::minibmg

--- a/minibmg/node.h
+++ b/minibmg/node.h
@@ -55,11 +55,4 @@ class VariableNode : public Node {
   unsigned identifier;
 };
 
-class QueryNode : public Node {
- public:
-  QueryNode(const unsigned query_index, Nodep in_node);
-  unsigned query_index;
-  Nodep in_node;
-};
-
 } // namespace beanmachine::minibmg

--- a/minibmg/operator.cpp
+++ b/minibmg/operator.cpp
@@ -48,8 +48,6 @@ bool _c0 = [] {
   add(Operator::DISTRIBUTION_BETA, "DISTRIBUTION_BETA");
   add(Operator::DISTRIBUTION_BERNOULLI, "DISTRIBUTION_BERNOULLI");
   add(Operator::SAMPLE, "SAMPLE");
-  add(Operator::OBSERVE, "OBSERVE");
-  add(Operator::QUERY, "QUERY");
 
   // check that we have set the name for every operator.
   for (Operator op = Operator::NO_OPERATOR; op < Operator::LAST_OPERATOR;

--- a/minibmg/operator.h
+++ b/minibmg/operator.h
@@ -104,19 +104,6 @@ enum class Operator {
   // Result: A sample from the distribution (REAL)
   SAMPLE,
 
-  // Observe a sample from the distribution parameter.
-  // Parameters:
-  // - ditribution (DISTRIBUTION)
-  // - value (REAL)
-  // Result: NONE.
-  OBSERVE,
-
-  // Query an intermediate result in the graph.
-  // Parameters:
-  // - value (REAL)
-  // Result: NONE.
-  QUERY,
-
   // Not a real operator.  Used as a limit when looping through operators.
   LAST_OPERATOR,
 };

--- a/minibmg/out_nodes.cpp
+++ b/minibmg/out_nodes.cpp
@@ -45,13 +45,6 @@ class Out_Nodes_Property
         case Operator::VARIABLE:
           // these nodes do not have inputs.
           break;
-        case Operator::QUERY: {
-          // query has one input.
-          auto query = std::dynamic_pointer_cast<const QueryNode>(node);
-          auto& predecessor_out_set = data->for_node(query->in_node);
-          predecessor_out_set.push_back(node);
-          break;
-        }
         default: {
           // the rest are operator nodes.
           auto opnode = std::dynamic_pointer_cast<const OperatorNode>(node);

--- a/minibmg/out_nodes.cpp
+++ b/minibmg/out_nodes.cpp
@@ -18,13 +18,13 @@ using namespace beanmachine::minibmg;
 
 class Out_Nodes_Data {
  public:
-  std::map<const Node*, std::list<const Node*>*> node_map{};
+  std::map<Nodep, std::list<Nodep>*> node_map{};
   ~Out_Nodes_Data() {
     for (auto e : node_map) {
       delete e.second;
     }
   }
-  std::list<const Node*>& for_node(const Node* node) {
+  std::list<Nodep>& for_node(Nodep node) {
     auto found = node_map.find(node);
     if (found == node_map.end()) {
       throw std::invalid_argument("node not in graph");
@@ -39,7 +39,7 @@ class Out_Nodes_Property
   Out_Nodes_Data* create(const Graph& g) const override {
     Out_Nodes_Data* data = new Out_Nodes_Data{};
     for (auto node : g) {
-      data->node_map[node] = new std::list<const Node*>{};
+      data->node_map[node] = new std::list<Nodep>{};
       switch (node->op) {
         case Operator::CONSTANT:
         case Operator::VARIABLE:
@@ -47,14 +47,14 @@ class Out_Nodes_Property
           break;
         case Operator::QUERY: {
           // query has one input.
-          auto query = static_cast<const QueryNode*>(node);
+          auto query = std::dynamic_pointer_cast<const QueryNode>(node);
           auto& predecessor_out_set = data->for_node(query->in_node);
           predecessor_out_set.push_back(node);
           break;
         }
         default: {
           // the rest are operator nodes.
-          auto opnode = static_cast<const OperatorNode*>(node);
+          auto opnode = std::dynamic_pointer_cast<const OperatorNode>(node);
           for (auto in_node : opnode->in_nodes) {
             auto& predecessor_out_set = data->for_node(in_node);
             predecessor_out_set.push_back(node);
@@ -72,9 +72,9 @@ class Out_Nodes_Property
 
 namespace beanmachine::minibmg {
 
-const std::list<const Node*>& out_nodes(const Graph& graph, const Node* node) {
+const std::list<Nodep>& out_nodes(const Graph& graph, Nodep node) {
   Out_Nodes_Data* data = Out_Nodes_Property::get(graph);
-  std::list<const Node*>& result = data->for_node(node);
+  std::list<Nodep>& result = data->for_node(node);
   return result;
 }
 

--- a/minibmg/out_nodes.cpp
+++ b/minibmg/out_nodes.cpp
@@ -18,18 +18,13 @@ using namespace beanmachine::minibmg;
 
 class Out_Nodes_Data {
  public:
-  std::map<Nodep, std::list<Nodep>*> node_map{};
-  ~Out_Nodes_Data() {
-    for (auto e : node_map) {
-      delete e.second;
-    }
-  }
+  std::map<Nodep, std::list<Nodep>> node_map{};
   std::list<Nodep>& for_node(Nodep node) {
     auto found = node_map.find(node);
     if (found == node_map.end()) {
       throw std::invalid_argument("node not in graph");
     }
-    return *found->second;
+    return found->second;
   }
 };
 
@@ -39,7 +34,7 @@ class Out_Nodes_Property
   Out_Nodes_Data* create(const Graph& g) const override {
     Out_Nodes_Data* data = new Out_Nodes_Data{};
     for (auto node : g) {
-      data->node_map[node] = new std::list<Nodep>{};
+      data->node_map[node] = std::list<Nodep>{};
       switch (node->op) {
         case Operator::CONSTANT:
         case Operator::VARIABLE:

--- a/minibmg/out_nodes.h
+++ b/minibmg/out_nodes.h
@@ -16,6 +16,6 @@ namespace beanmachine::minibmg {
 
 // return the set of nodes that have the given node as an input in the given
 // graph.
-const std::list<const Node*>& out_nodes(const Graph& graph, const Node* node);
+const std::list<Nodep>& out_nodes(const Graph& graph, Nodep node);
 
 } // namespace beanmachine::minibmg

--- a/minibmg/tests/eval_test.cpp
+++ b/minibmg/tests/eval_test.cpp
@@ -33,7 +33,7 @@ TEST(eval_test, simple1) {
   std::mt19937 gen;
   auto read_variable = [](const std::string&, const unsigned) { return 1.15; };
   int graph_size = graph.size();
-  unordered_map<const Node*, Real> data;
+  unordered_map<Nodep, Real> data;
   eval_graph<Real>(graph, gen, read_variable, data);
   EXPECT_CLOSE(1.995, data[fac[sub1]].as_double());
 }
@@ -58,7 +58,7 @@ TEST(eval_test, sample1) {
   double sum = 0;
   double sum_squared = 0;
   int graph_size = graph.size();
-  std::unordered_map<const Node*, Real> data;
+  std::unordered_map<Nodep, Real> data;
   for (int i = 0; i < n; i++) {
     eval_graph<Real>(graph, gen, nullptr, data);
     auto sample = data[fac[sample0]].as_double();
@@ -109,7 +109,7 @@ TEST(eval_test, derivative_dual) {
   // We generate several doubles between -2.0 and 2.0 to test with.
   std::uniform_real_distribution<double> unif(-2.0, 2.0);
 
-  std::unordered_map<const Node*, Dual> data;
+  std::unordered_map<Nodep, Dual> data;
   for (int i = 0; i < 10; i++) {
     double input = unif(gen);
     auto read_variable = [=](const std::string&, const unsigned) {
@@ -142,7 +142,7 @@ TEST(eval_test, derivatives_triune) {
   // We generate several doubles between -2.0 and 2.0 to test with.
   std::uniform_real_distribution<double> unif(-2.0, 2.0);
 
-  std::unordered_map<const Node*, Triune> data;
+  std::unordered_map<Nodep, Triune> data;
   for (int i = 0; i < 10; i++) {
     double input = unif(gen);
     auto read_variable = [=](const std::string&, const unsigned) {

--- a/minibmg/tests/eval_test.cpp
+++ b/minibmg/tests/eval_test.cpp
@@ -29,6 +29,7 @@ TEST(eval_test, simple1) {
   auto v1 = fac.add_variable("x", 0); // 1.15
   auto mul1 = fac.add_operator(Operator::MULTIPLY, {add0, v1}); // 6.095
   auto sub1 = fac.add_operator(Operator::SUBTRACT, {mul1, k1}); // 1.995
+  fac.add_query(sub1); // add a root to the graph.
   auto graph = fac.build();
   std::mt19937 gen;
   auto read_variable = [](const std::string&, const unsigned) { return 1.15; };
@@ -49,6 +50,7 @@ TEST(eval_test, sample1) {
   auto k1 = fac.add_constant(expected_stdev);
   auto normal0 = fac.add_operator(Operator::DISTRIBUTION_NORMAL, {k0, k1});
   auto sample0 = fac.add_operator(Operator::SAMPLE, {normal0});
+  fac.add_query(sample0); // add a root to the graph.
   auto graph = fac.build();
   // We create a new random number generator with its default (deterministic)
   // seed so that this test will not be flaky.
@@ -103,6 +105,7 @@ TEST(eval_test, derivative_dual) {
       {fac.add_constant(1.1),
        fac.add_operator(
            Operator::POW, {fac.add_variable("x", 0), fac.add_constant(2)})});
+  fac.add_query(s); // add a root to the graph.
   Graph graph = fac.build();
   int graph_size = graph.size();
 
@@ -135,6 +138,7 @@ TEST(eval_test, derivatives_triune) {
       {fac.add_constant(1.1),
        fac.add_operator(
            Operator::POW, {fac.add_variable("x", 0), fac.add_constant(2)})});
+  fac.add_query(s); // add a root to the graph.
   auto sn = fac[s];
   Graph graph = fac.build();
   int graph_size = graph.size();

--- a/minibmg/tests/json_test.cpp
+++ b/minibmg/tests/json_test.cpp
@@ -47,60 +47,58 @@ std::string raw_json = R"({
       "type": "DISTRIBUTION"
     },
     {
-      "operator": "CONSTANT",
+      "in_nodes": [
+        3
+      ],
+      "operator": "SAMPLE",
       "sequence": 4,
-      "type": "REAL",
-      "value": 0
+      "type": "REAL"
     },
     {
-      "operator": "CONSTANT",
+      "in_nodes": [
+        3
+      ],
+      "operator": "SAMPLE",
       "sequence": 5,
-      "type": "REAL",
+      "type": "REAL"
+    },
+    {
+      "in_nodes": [
+        3
+      ],
+      "operator": "SAMPLE",
+      "sequence": 6,
+      "type": "REAL"
+    },
+    {
+      "in_nodes": [
+        3
+      ],
+      "operator": "SAMPLE",
+      "sequence": 7,
+      "type": "REAL"
+    }
+  ],
+  "observations": [
+    {
+      "node": 4,
       "value": 1
     },
     {
-      "in_nodes": [
-        3,
-        5
-      ],
-      "operator": "OBSERVE",
-      "sequence": 6,
-      "type": "NONE"
+      "node": 5,
+      "value": 1.1
     },
     {
-      "in_nodes": [
-        3,
-        5
-      ],
-      "operator": "OBSERVE",
-      "sequence": 7,
-      "type": "NONE"
+      "node": 6,
+      "value": 1.11
     },
     {
-      "in_nodes": [
-        3,
-        5
-      ],
-      "operator": "OBSERVE",
-      "sequence": 8,
-      "type": "NONE"
-    },
-    {
-      "in_nodes": [
-        3,
-        4
-      ],
-      "operator": "OBSERVE",
-      "sequence": 9,
-      "type": "NONE"
-    },
-    {
-      "in_node": 2,
-      "operator": "QUERY",
-      "query_index": 0,
-      "sequence": 10,
-      "type": "NONE"
+      "node": 7,
+      "value": 0.111
     }
+  ],
+  "queries": [
+    2
   ]
 })";
 
@@ -113,82 +111,84 @@ TEST(json_test, test_from_string) {
 }
 
 std::string raw_json_without_types = R"({
+  "comment": "created by graph_to_json",
   "nodes": [
     {
-      "sequence": 0,
       "operator": "CONSTANT",
+      "sequence": 0,
       "value": 2
     },
     {
-      "sequence": 1,
-      "operator": "DISTRIBUTION_BETA",
       "in_nodes": [
         0,
         0
-      ]
+      ],
+      "operator": "DISTRIBUTION_BETA",
+      "sequence": 1
     },
     {
-      "sequence": 2,
-      "operator": "SAMPLE",
       "in_nodes": [
         1
-      ]
+      ],
+      "operator": "SAMPLE",
+      "sequence": 2
     },
     {
-      "sequence": 3,
-      "operator": "DISTRIBUTION_BERNOULLI",
       "in_nodes": [
         2
-      ]
+      ],
+      "operator": "DISTRIBUTION_BERNOULLI",
+      "sequence": 3
     },
     {
-      "sequence": 4,
-      "operator": "CONSTANT",
-      "value": 0
+      "in_nodes": [
+        3
+      ],
+      "operator": "SAMPLE",
+      "sequence": 4
     },
     {
-      "sequence": 5,
-      "operator": "CONSTANT",
+      "in_nodes": [
+        3
+      ],
+      "operator": "SAMPLE",
+      "sequence": 5
+    },
+    {
+      "in_nodes": [
+        3
+      ],
+      "operator": "SAMPLE",
+      "sequence": 6
+    },
+    {
+      "in_nodes": [
+        3
+      ],
+      "operator": "SAMPLE",
+      "sequence": 7
+    }
+  ],
+  "observations": [
+    {
+      "node": 4,
       "value": 1
     },
     {
-      "sequence": 6,
-      "operator": "OBSERVE",
-      "in_nodes": [
-        3,
-        5
-      ]
+      "node": 5,
+      "value": 1.1
     },
     {
-      "sequence": 7,
-      "operator": "OBSERVE",
-      "in_nodes": [
-        3,
-        5
-      ]
+      "node": 6,
+      "value": 1.11
     },
     {
-      "sequence": 8,
-      "operator": "OBSERVE",
-      "in_nodes": [
-        3,
-        5
-      ]
-    },
-    {
-      "sequence": 9,
-      "operator": "OBSERVE",
-      "in_nodes": [
-        3,
-        4
-      ]
-    },
-    {
-      "sequence": 10,
-      "operator": "QUERY",
-      "in_node": 2,
-      "query_index": 0
+      "node": 7,
+      "value": 0.111
     }
+  ],
+  "queries": [
+    2
   ]
 })";
 

--- a/minibmg/tests/minibmg_test.cpp
+++ b/minibmg/tests/minibmg_test.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <gtest/gtest.h>
+#include <stdexcept>
 
 #include "beanmachine/minibmg/minibmg.h"
 
@@ -88,4 +89,11 @@ TEST(test_minibmg, type_to_string) {
 
   // with runtime checks enabled, the following would crash at the cast.
   // ASSERT_EQ(to_string((Type)10000), "NONE");
+}
+
+TEST(test_minibmg, duplicate_build) {
+  Graph::Factory gf;
+  Graph g = gf.build();
+  ASSERT_THROW(gf.add_constant(1.2);, std::invalid_argument);
+  ASSERT_THROW(gf.build();, std::invalid_argument);
 }

--- a/minibmg/tests/out_nodes_test.cpp
+++ b/minibmg/tests/out_nodes_test.cpp
@@ -27,32 +27,31 @@ TEST(out_nodes_test, simple) {
   NodeId query;
   /* auto query_ = */ gf.add_query(beta, query);
 
-  const Node* k12n = gf[k12];
-  const Node* k34n = gf[k34];
-  const Node* plusn = gf[plus];
-  const Node* k56n = gf[k56];
-  const Node* betan = gf[beta];
-  const Node* samplen = gf[sample];
-  const Node* k78n = gf[k78];
-  const Node* observen = gf[observe];
-  const Node* queryn = gf[query];
+  Nodep k12n = gf[k12];
+  Nodep k34n = gf[k34];
+  Nodep plusn = gf[plus];
+  Nodep k56n = gf[k56];
+  Nodep betan = gf[beta];
+  Nodep samplen = gf[sample];
+  Nodep k78n = gf[k78];
+  Nodep observen = gf[observe];
+  Nodep queryn = gf[query];
   Graph g = gf.build();
 
   ASSERT_EQ(out_nodes(g, k12n), std::list{plusn});
   ASSERT_EQ(out_nodes(g, k34n), (std::list{plusn, betan}));
-  ASSERT_EQ(out_nodes(g, plusn), std::list<const Node*>{});
+  ASSERT_EQ(out_nodes(g, plusn), std::list<Nodep>{});
   ASSERT_EQ(out_nodes(g, k56n), std::list{betan});
   ASSERT_EQ(out_nodes(g, betan), (std::list{samplen, observen, queryn}));
-  ASSERT_EQ(out_nodes(g, samplen), std::list<const Node*>{});
+  ASSERT_EQ(out_nodes(g, samplen), std::list<Nodep>{});
   ASSERT_EQ(out_nodes(g, k78n), std::list{observen});
-  ASSERT_EQ(out_nodes(g, observen), std::list<const Node*>{});
-  ASSERT_EQ(out_nodes(g, queryn), std::list<const Node*>{});
+  ASSERT_EQ(out_nodes(g, observen), std::list<Nodep>{});
+  ASSERT_EQ(out_nodes(g, queryn), std::list<Nodep>{});
 }
 
 TEST(out_nodes_test, not_found2) {
   Graph::Factory gf;
   Graph g = gf.build();
-  Node* n = new ConstantNode(0);
+  Nodep n = std::make_shared<const ConstantNode>(0);
   ASSERT_THROW(out_nodes(g, n), std::invalid_argument);
-  delete n;
 }

--- a/minibmg/tests/out_nodes_test.cpp
+++ b/minibmg/tests/out_nodes_test.cpp
@@ -26,6 +26,7 @@ TEST(out_nodes_test, simple) {
   auto observe = gf.add_operator(Operator::OBSERVE, {beta, k78});
   NodeId query;
   /* auto query_ = */ gf.add_query(beta, query);
+  Graph g = gf.build();
 
   Nodep k12n = gf[k12];
   Nodep k34n = gf[k34];
@@ -36,7 +37,6 @@ TEST(out_nodes_test, simple) {
   Nodep k78n = gf[k78];
   Nodep observen = gf[observe];
   Nodep queryn = gf[query];
-  Graph g = gf.build();
 
   ASSERT_EQ(out_nodes(g, k12n), std::list{plusn});
   ASSERT_EQ(out_nodes(g, k34n), (std::list{plusn, betan}));

--- a/minibmg/tests/out_nodes_test.cpp
+++ b/minibmg/tests/out_nodes_test.cpp
@@ -20,12 +20,10 @@ TEST(out_nodes_test, simple) {
   auto k34 = gf.add_constant(3.4);
   auto plus = gf.add_operator(Operator::ADD, {k12, k34});
   auto k56 = gf.add_constant(5.6);
-  auto beta = gf.add_operator(Operator::DISTRIBUTION_BETA, {k34, k56});
+  auto beta = gf.add_operator(Operator::DISTRIBUTION_BETA, {plus, k56});
   auto sample = gf.add_operator(Operator::SAMPLE, {beta});
-  auto k78 = gf.add_constant(7.8);
-  auto observe = gf.add_operator(Operator::OBSERVE, {beta, k78});
-  NodeId query;
-  /* auto query_ = */ gf.add_query(beta, query);
+  gf.add_observation(sample, 7.8);
+  /* auto query_ = */ gf.add_query(sample);
   Graph g = gf.build();
 
   Nodep k12n = gf[k12];
@@ -34,19 +32,18 @@ TEST(out_nodes_test, simple) {
   Nodep k56n = gf[k56];
   Nodep betan = gf[beta];
   Nodep samplen = gf[sample];
-  Nodep k78n = gf[k78];
-  Nodep observen = gf[observe];
-  Nodep queryn = gf[query];
 
   ASSERT_EQ(out_nodes(g, k12n), std::list{plusn});
-  ASSERT_EQ(out_nodes(g, k34n), (std::list{plusn, betan}));
-  ASSERT_EQ(out_nodes(g, plusn), std::list<Nodep>{});
+  ASSERT_EQ(out_nodes(g, k34n), (std::list{plusn}));
+  ASSERT_EQ(out_nodes(g, plusn), std::list<Nodep>{betan});
   ASSERT_EQ(out_nodes(g, k56n), std::list{betan});
-  ASSERT_EQ(out_nodes(g, betan), (std::list{samplen, observen, queryn}));
+  ASSERT_EQ(out_nodes(g, betan), (std::list{samplen}));
   ASSERT_EQ(out_nodes(g, samplen), std::list<Nodep>{});
-  ASSERT_EQ(out_nodes(g, k78n), std::list{observen});
-  ASSERT_EQ(out_nodes(g, observen), std::list<Nodep>{});
-  ASSERT_EQ(out_nodes(g, queryn), std::list<Nodep>{});
+
+  ASSERT_EQ(g.queries, std::vector{samplen});
+  std::list<std::pair<Nodep, double>> expected_observations;
+  expected_observations.push_back(std::pair{samplen, 7.8});
+  ASSERT_EQ(g.observations, expected_observations);
 }
 
 TEST(out_nodes_test, not_found2) {


### PR DESCRIPTION
Summary: Pointers are used where not needed in `out_node.cpp`.  We just stop using them.

Differential Revision: D39702426

