### PR TITLE
Fix the end of adaptation check

### DIFF
--- a/src/beanmachine/ppl/inference/sampler.py
+++ b/src/beanmachine/ppl/inference/sampler.py
@@ -91,7 +91,7 @@ class Sampler(Generator[World, Optional[World], None]):
                 proposer.do_adaptation(
                     world=world, accept_log_prob=accept_log_prob, is_accepted=accepted
                 )
-                if self._num_samples_remaining == 1:
+                if self._num_adaptive_sample_remaining == 1:
                     # we just reach the end of adaptation period
                     proposer.finish_adaptation()
 


### PR DESCRIPTION
Summary:
Just realized that there's a serious typo in the implementation of `Sampler`. As a result, it will never call `proposer.finish_adaptation()` (unless `num_samples=0`, which is rarely the case).

I suspect this is what causes the big variance in run time in some of the HMC/NUTS runs. In particular, without calling `finish_adaptation()`, we will *not* be setting the step size to the dual-averaged value. Instead, we will be using the step size learned from the last [adaptation window](https://mc-stan.org/docs/reference-manual/hmc-algorithm-parameters.html), which is only 50 iterations wide.

Differential Revision: D39707018

