### PR TITLE
minibmg: unify traced and node.

### DIFF
--- a/minibmg/ad/traced.cpp
+++ b/minibmg/ad/traced.cpp
@@ -9,158 +9,170 @@
 #include <functional>
 #include <memory>
 #include <set>
+#include <vector>
+#include "beanmachine/minibmg/ad/real.h"
 #include "beanmachine/minibmg/eval.h"
+
+namespace {
+
+using namespace beanmachine::minibmg;
+
+inline Nodep make_operator(
+    Operator op,
+    std::vector<Nodep> in_nodes,
+    Type type = Type::REAL) {
+  return std::make_shared<OperatorNode>(in_nodes, op, type);
+}
+
+} // namespace
 
 namespace beanmachine::minibmg {
 
-Traced::Traced(const Operator op, shared_ptr<const TracedBody> p)
-    : m_op{op}, m_ptr{p} {}
-
-Traced::Traced(double n)
-    : m_op{Operator::CONSTANT}, m_ptr{make_shared<TracedConstant>(n)} {}
-
-Traced Traced::variable(const std::string& name, const unsigned identifier) {
-  return Traced{
-      Operator::VARIABLE, make_shared<TracedVariable>(name, identifier)};
-}
-
 double Traced::as_double() const {
-  if (this->m_op != Operator::CONSTANT) {
-    throw EvalError(
-        "constant value expected but found " +
-        beanmachine::minibmg::to_string(this->m_op));
+  double value;
+  if (is_constant(node, value)) {
+    return value;
   }
-  auto v1 = dynamic_cast<const TracedConstant&>(*this->m_ptr);
-  return v1.value.as_double();
+
+  throw EvalError("constant value expected but found " + to_string(*this));
 }
 
 // We perform some optimizations during construction.
 // It might be better to do no optimizations at this point and have a tree
 // rewriter that can be reused, but for now this is a simpler approach.
 Traced operator+(const Traced& left, const Traced& right) {
-  if (left.m_op == Operator::CONSTANT && right.m_op == Operator::CONSTANT) {
-    auto v1 = dynamic_cast<const TracedConstant&>(*left.m_ptr).value;
-    auto v2 = dynamic_cast<const TracedConstant&>(*right.m_ptr).value;
-    return Traced{Operator::CONSTANT, make_shared<TracedConstant>(v1 + v2)};
-  } else if (is_constant(left, 0)) {
-    return right;
-  } else if (is_constant(right, 0)) {
-    return left;
-  } else {
-    return Traced{Operator::ADD, make_shared<TracedOp>(TracedOp{left, right})};
+  double left_value, right_value;
+  auto left_is_constant = is_constant(left, left_value);
+  auto right_is_constant = is_constant(right, right_value);
+  if (left_is_constant && right_is_constant) {
+    return left_value + right_value;
   }
+  if (left_is_constant && left_value == 0) {
+    return right;
+  }
+  if (right_is_constant && right_value == 0) {
+    return left;
+  }
+  return make_operator(Operator::ADD, {left.node, right.node});
 }
 
 Traced operator-(const Traced& left, const Traced& right) {
-  if (left.m_op == Operator::CONSTANT && right.m_op == Operator::CONSTANT) {
-    auto v1 = dynamic_cast<const TracedConstant&>(*left.m_ptr).value;
-    auto v2 = dynamic_cast<const TracedConstant&>(*right.m_ptr).value;
-    return Traced{Operator::CONSTANT, make_shared<TracedConstant>(v1 - v2)};
-  } else if (is_constant(left, 0)) {
-    return -right;
-  } else if (is_constant(right, 0)) {
-    return left;
-  } else {
-    return Traced{
-        Operator::SUBTRACT, make_shared<TracedOp>(TracedOp{left, right})};
+  double left_value, right_value;
+  auto left_is_constant = is_constant(left, left_value);
+  auto right_is_constant = is_constant(right, right_value);
+  if (left_is_constant && right_is_constant) {
+    return left_value - right_value;
   }
+  if (left_is_constant && left_value == 0) {
+    return -right;
+  }
+  if (right_is_constant && right_value == 0) {
+    return left;
+  }
+  return make_operator(Operator::SUBTRACT, {left.node, right.node});
 }
 
 Traced operator-(const Traced& x) {
-  if (x.m_op == Operator::CONSTANT) {
-    auto v1 = dynamic_cast<const TracedConstant&>(*x.m_ptr).value;
-    return Traced{Operator::CONSTANT, make_shared<TracedConstant>(-v1)};
-  } else {
-    return Traced{Operator::NEGATE, make_shared<TracedOp>(TracedOp{x})};
+  double value;
+  if (is_constant(x.node, value)) {
+    return -value;
   }
+  return make_operator(Operator::NEGATE, {x.node});
 }
 
 Traced operator*(const Traced& left, const Traced& right) {
-  if (left.m_op == Operator::CONSTANT && right.m_op == Operator::CONSTANT) {
-    auto v1 = dynamic_cast<const TracedConstant&>(*left.m_ptr).value;
-    auto v2 = dynamic_cast<const TracedConstant&>(*right.m_ptr).value;
-    return Traced{Operator::CONSTANT, make_shared<TracedConstant>(v1 * v2)};
-  } else if (is_constant(left, 0) || is_constant(right, 1)) {
-    return left;
-  } else if (is_constant(right, 0) || is_constant(left, 1)) {
-    return right;
-  } else {
-    return Traced{
-        Operator::MULTIPLY, make_shared<TracedOp>(TracedOp{left, right})};
+  double left_value, right_value;
+  auto left_is_constant = is_constant(left, left_value);
+  auto right_is_constant = is_constant(right, right_value);
+  if (left_is_constant && right_is_constant) {
+    return left_value * right_value;
   }
+  if ((left_is_constant && left_value == 0) ||
+      (right_is_constant && right_value == 1)) {
+    return left;
+  }
+  if ((right_is_constant && right_value == 0) ||
+      (left_is_constant && left_value == 1)) {
+    return right;
+  }
+  return make_operator(Operator::MULTIPLY, {left.node, right.node});
 }
 
 Traced operator/(const Traced& left, const Traced& right) {
-  if (left.m_op == Operator::CONSTANT && right.m_op == Operator::CONSTANT) {
-    auto v1 = dynamic_cast<const TracedConstant&>(*left.m_ptr).value;
-    auto v2 = dynamic_cast<const TracedConstant&>(*right.m_ptr).value;
-    return Traced{Operator::CONSTANT, make_shared<TracedConstant>(v1 / v2)};
-  } else if (is_constant(left, 0) || is_constant(right, 1)) {
-    return left;
-  } else {
-    return Traced{
-        Operator::DIVIDE, make_shared<TracedOp>(TracedOp{left, right})};
+  double left_value, right_value;
+  auto left_is_constant = is_constant(left, left_value);
+  auto right_is_constant = is_constant(right, right_value);
+  if (left_is_constant && right_is_constant) {
+    return left_value / right_value;
   }
+  if ((left_is_constant && left_value == 0) ||
+      (right_is_constant && right_value == 1)) {
+    return left;
+  }
+  return make_operator(Operator::DIVIDE, {left.node, right.node});
 }
 
 Traced pow(const Traced& base, const Traced& exponent) {
-  if (base.m_op == Operator::CONSTANT && exponent.m_op == Operator::CONSTANT) {
-    auto v1 = dynamic_cast<const TracedConstant&>(*base.m_ptr).value;
-    auto v2 = dynamic_cast<const TracedConstant&>(*exponent.m_ptr).value;
-    return Traced{Operator::CONSTANT, make_shared<TracedConstant>(pow(v1, v2))};
+  double left_value, right_value;
+  auto left_is_constant = is_constant(base, left_value);
+  auto right_is_constant = is_constant(exponent, right_value);
+  if (left_is_constant && right_is_constant) {
+    return pow(Real{left_value}, Real{right_value});
   }
-  double power;
-  if (is_constant(exponent, power)) {
-    if (power == 0) {
+  if (right_is_constant) {
+    if (right_value == 0) {
       return 1;
     }
-    if (power == 1) {
+    if (right_value == 1) {
       return base;
     }
   }
-  return Traced{Operator::POW, make_shared<TracedOp>(TracedOp{base, exponent})};
+  return make_operator(Operator::POW, {base.node, exponent.node});
 }
 
 Traced exp(const Traced& x) {
-  if (x.m_op == Operator::CONSTANT) {
-    auto v1 = dynamic_cast<const TracedConstant&>(*x.m_ptr).value;
-    return Traced{Operator::CONSTANT, make_shared<TracedConstant>(exp(v1))};
+  double value;
+  auto value_is_constant = is_constant(x, value);
+  if (value_is_constant) {
+    return exp(Real{value});
   }
-  return Traced{Operator::EXP, make_shared<TracedOp>(TracedOp{x})};
+  return make_operator(Operator::EXP, {x.node});
 }
 
 Traced log(const Traced& x) {
-  if (x.m_op == Operator::CONSTANT) {
-    auto v1 = dynamic_cast<const TracedConstant&>(*x.m_ptr).value;
-    return Traced{Operator::CONSTANT, make_shared<TracedConstant>(log(v1))};
+  double value;
+  auto value_is_constant = is_constant(x, value);
+  if (value_is_constant) {
+    return log(Real{value});
   }
-  return Traced{Operator::LOG, make_shared<TracedOp>(TracedOp{x})};
+  return make_operator(Operator::LOG, {x.node});
 }
 
 Traced atan(const Traced& x) {
-  if (x.m_op == Operator::CONSTANT) {
-    auto v1 = dynamic_cast<const TracedConstant&>(*x.m_ptr).value;
-    return Traced{Operator::CONSTANT, make_shared<TracedConstant>(atan(v1))};
+  double value;
+  auto value_is_constant = is_constant(x, value);
+  if (value_is_constant) {
+    return atan(Real{value});
   }
-  return Traced{Operator::ATAN, make_shared<TracedOp>(TracedOp{x})};
+  return make_operator(Operator::ATAN, {x.node});
 }
 
 Traced lgamma(const Traced& x) {
-  if (x.m_op == Operator::CONSTANT) {
-    auto v1 = dynamic_cast<const TracedConstant&>(*x.m_ptr).value;
-    return Traced{Operator::CONSTANT, make_shared<TracedConstant>(lgamma(v1))};
+  double value;
+  auto value_is_constant = is_constant(x, value);
+  if (value_is_constant) {
+    return lgamma(Real{value});
   }
-  return Traced{Operator::LGAMMA, make_shared<TracedOp>(TracedOp{x})};
+  return make_operator(Operator::LGAMMA, {x.node});
 }
 
 Traced polygamma(const int n, const Traced& x) {
-  if (x.m_op == Operator::CONSTANT) {
-    auto v1 = dynamic_cast<const TracedConstant&>(*x.m_ptr).value;
-    return Traced{
-        Operator::CONSTANT, make_shared<TracedConstant>(polygamma(n, v1))};
+  double value;
+  auto value_is_constant = is_constant(x, value);
+  if (value_is_constant) {
+    return polygamma(n, Real{value});
   }
-  Traced kn{Operator::CONSTANT, make_shared<TracedConstant>(n)};
-  return Traced{Operator::POLYGAMMA, make_shared<TracedOp>(TracedOp{kn, x})};
+  return make_operator(Operator::LGAMMA, {Traced{(double)n}.node, x.node});
 }
 
 Traced if_equal(
@@ -168,16 +180,14 @@ Traced if_equal(
     const Traced& comparand,
     const Traced& when_equal,
     const Traced& when_not_equal) {
-  if (value.m_op == Operator::CONSTANT &&
-      comparand.m_op == Operator::CONSTANT) {
-    auto v1 = dynamic_cast<const TracedConstant&>(*value.m_ptr).value;
-    auto v2 = dynamic_cast<const TracedConstant&>(*comparand.m_ptr).value;
-    return if_equal(v1, v2, when_equal, when_not_equal);
+  double v;
+  double c;
+  if (is_constant(value, v) && is_constant(comparand, c)) {
+    return (v == c) ? when_equal : when_not_equal;
   }
-  return Traced{
+  return make_operator(
       Operator::IF_EQUAL,
-      make_shared<TracedOp>(
-          TracedOp{value, comparand, when_equal, when_not_equal})};
+      {value.node, comparand.node, when_equal.node, when_not_equal.node});
 }
 
 Traced if_less(
@@ -185,24 +195,22 @@ Traced if_less(
     const Traced& comparand,
     const Traced& when_less,
     const Traced& when_not_less) {
-  if (value.m_op == Operator::CONSTANT &&
-      comparand.m_op == Operator::CONSTANT) {
-    auto v1 = dynamic_cast<const TracedConstant&>(*value.m_ptr).value;
-    auto v2 = dynamic_cast<const TracedConstant&>(*comparand.m_ptr).value;
-    return if_less(v1, v2, when_less, when_not_less);
+  double v;
+  double c;
+  if (is_constant(value, v) && is_constant(comparand, c)) {
+    return (v < c) ? when_less : when_not_less;
   }
-  return Traced{
+  return make_operator(
       Operator::IF_LESS,
-      make_shared<TracedOp>(
-          TracedOp{value, comparand, when_less, when_not_less})};
+      {value.node, comparand.node, when_less.node, when_not_less.node});
 }
 
 bool is_constant(const Traced& x, double& value) {
-  if (x.m_op != Operator::CONSTANT) {
+  if (x.op() != Operator::CONSTANT) {
     return false;
   }
-  auto k = dynamic_cast<const TracedConstant&>(*x.m_ptr);
-  value = k.value.as_double();
+  auto knode = std::dynamic_pointer_cast<const ConstantNode>(x.node);
+  value = knode->value;
   return true;
 }
 

--- a/minibmg/ad/traced.h
+++ b/minibmg/ad/traced.h
@@ -7,42 +7,42 @@
 
 #pragma once
 
-#include <boost/math/special_functions/polygamma.hpp>
-#include <cmath>
 #include <memory>
+#include <stdexcept>
 #include <vector>
 #include "beanmachine/minibmg/ad/number.h"
 #include "beanmachine/minibmg/ad/real.h"
-#include "beanmachine/minibmg/minibmg.h"
+#include "beanmachine/minibmg/node.h"
 
 namespace beanmachine::minibmg {
-
-using namespace std;
-
-class TracedBody;
 
 /*
 An implementation of the Number concept that simply builds an expression tree
 (actually, a DAG: directed acyclic graph) representing the computation
-performed.
+performed.  This is also used for the fluent factory.
  */
 class Traced {
  public:
-  Operator m_op;
-  shared_ptr<const TracedBody> m_ptr;
+  Nodep node;
 
-  /* implicit */ Traced(double d);
-  static Traced variable(const std::string& name, const unsigned identifier);
-  inline Operator op() const {
-    return m_op;
+  inline Traced(Nodep node) : node{node} {
+    if (node->type != Type::REAL) {
+      throw std::invalid_argument("node is not a value");
+    }
   }
-  inline shared_ptr<const TracedBody> ptr() const {
-    return m_ptr;
+  /* implicit */ inline Traced(double value)
+      : node{std::make_shared<ConstantNode>(value)} {}
+  /* implicit */ inline Traced(Real value)
+      : node{std::make_shared<ConstantNode>(value.as_double())} {}
+  inline Operator op() const {
+    return node->op;
+  }
+
+  static Traced variable(const std::string& name, const unsigned identifier) {
+    return Traced{std::make_shared<VariableNode>(name, identifier)};
   }
 
   double as_double() const;
-
-  Traced(const Operator op, shared_ptr<const TracedBody> p);
 };
 
 Traced operator+(const Traced& left, const Traced& right);
@@ -70,43 +70,19 @@ bool is_constant(const Traced& x, double& value);
 bool is_constant(const Traced& x, const double& value);
 std::string to_string(const Traced& x);
 
-class TracedBody {
- public:
-  virtual ~TracedBody() {}
-};
-
-class TracedVariable : public TracedBody {
- public:
-  const string name;
-  const unsigned sequence;
-  TracedVariable(const std::string& name, const unsigned sequence)
-      : name{name}, sequence{sequence} {}
-};
-class TracedConstant : public TracedBody {
- public:
-  const Real value;
-  /* implicit */ TracedConstant(const Real value) : value{value} {}
-};
-class TracedOp : public TracedBody {
- public:
-  const std::vector<Traced> args;
-  explicit TracedOp(std::initializer_list<Traced> args) : args{args} {}
-};
-
 static_assert(Number<Traced>);
 
 } // namespace beanmachine::minibmg
 
 // We want to use Traced values in (unordered) maps and sets, so we need a good
-// comparison function.  We delegate to the underlying TracedBody pointer for
+// comparison function.  We delegate to the underlying node pointer for
 // that comparison.
 template <>
 struct ::std::less<beanmachine::minibmg::Traced> {
   bool operator()(
       const beanmachine::minibmg::Traced& lhs,
       const beanmachine::minibmg::Traced& rhs) const {
-    static const auto x =
-        ::std::less<const beanmachine::minibmg::TracedBody*>{};
-    return x(lhs.ptr().get(), rhs.ptr().get());
+    static const auto x = ::std::less<beanmachine::minibmg::Nodep>{};
+    return x(lhs.node, rhs.node);
   }
 };

--- a/minibmg/ad/traced_to_string.cpp
+++ b/minibmg/ad/traced_to_string.cpp
@@ -83,40 +83,31 @@ std::string string_for_operator(Operator op) {
   }
 }
 
-PrintedForm print(const Traced& traced, std::map<Traced, PrintedForm>& cache) {
-  auto op = traced.op();
+PrintedForm print(Nodep node, std::map<Nodep, PrintedForm>& cache) {
+  auto op = node->op;
   switch (op) {
     case Operator::CONSTANT: {
-      const TracedConstant* b =
-          std::static_pointer_cast<const TracedConstant, const TracedBody>(
-              traced.ptr())
-              .get();
-      return PrintedForm{to_string(b->value), Precedence::Term};
+      auto n = std::dynamic_pointer_cast<const ConstantNode>(node);
+      return PrintedForm{fmt::format("{}", n->value), Precedence::Term};
     }
     case Operator::VARIABLE: {
-      const TracedVariable* b =
-          std::static_pointer_cast<const TracedVariable, const TracedBody>(
-              traced.ptr())
-              .get();
-      auto name =
-          (b->name.length() == 0) ? fmt::format("__{0}", b->sequence) : b->name;
+      auto n = std::dynamic_pointer_cast<const VariableNode>(node);
+      auto name = (n->name.length() == 0) ? fmt::format("__{0}", n->identifier)
+                                          : n->name;
       return PrintedForm{name, Precedence::Term};
     }
     case Operator::ADD:
     case Operator::SUBTRACT:
     case Operator::MULTIPLY:
     case Operator::DIVIDE: {
-      const TracedOp* b =
-          std::static_pointer_cast<const TracedOp, const TracedBody>(
-              traced.ptr())
-              .get();
+      auto n = std::dynamic_pointer_cast<const OperatorNode>(node);
       auto this_precedence = precedence_for_operator(op);
       auto this_string = string_for_operator(op);
-      auto left = cache[b->args[0]];
+      auto left = cache[n->in_nodes[0]];
       auto ls = (left.precedence > this_precedence)
           ? fmt::format("({0})", left.string)
           : left.string;
-      auto right = cache[b->args[1]];
+      auto right = cache[n->in_nodes[1]];
       auto rs = (right.precedence >= this_precedence)
           ? fmt::format("({0})", right.string)
           : right.string;
@@ -124,12 +115,9 @@ PrintedForm print(const Traced& traced, std::map<Traced, PrintedForm>& cache) {
           fmt::format("{0} {1} {2}", ls, this_string, rs), this_precedence};
     }
     case Operator::NEGATE: {
-      const TracedOp* b =
-          std::static_pointer_cast<const TracedOp, const TracedBody>(
-              traced.ptr())
-              .get();
+      auto n = std::dynamic_pointer_cast<const OperatorNode>(node);
       auto this_precedence = precedence_for_operator(op);
-      auto right = cache[b->args[0]];
+      auto right = cache[n->in_nodes[0]];
       auto rs = (right.precedence >= this_precedence)
           ? fmt::format("({0})", right.string)
           : right.string;
@@ -137,13 +125,10 @@ PrintedForm print(const Traced& traced, std::map<Traced, PrintedForm>& cache) {
     }
     case Operator::POW:
     case Operator::POLYGAMMA: {
-      const TracedOp* b =
-          std::static_pointer_cast<const TracedOp, const TracedBody>(
-              traced.ptr())
-              .get();
-      auto left = cache[b->args[0]];
+      auto n = std::dynamic_pointer_cast<const OperatorNode>(node);
+      auto left = cache[n->in_nodes[0]];
       auto ls = left.string;
-      auto right = cache[b->args[1]];
+      auto right = cache[n->in_nodes[1]];
       auto rs = right.string;
       auto this_string = string_for_operator(op);
       return PrintedForm{
@@ -153,81 +138,74 @@ PrintedForm print(const Traced& traced, std::map<Traced, PrintedForm>& cache) {
     case Operator::LOG:
     case Operator::ATAN:
     case Operator::LGAMMA: {
-      const TracedOp* b =
-          std::static_pointer_cast<const TracedOp, const TracedBody>(
-              traced.ptr())
-              .get();
+      auto n = std::dynamic_pointer_cast<const OperatorNode>(node);
       auto this_string = string_for_operator(op);
-      auto left = cache[b->args[0]];
+      auto left = cache[n->in_nodes[0]];
       auto ls = left.string;
       return PrintedForm{
           fmt::format("{1}({0})", ls, this_string), Precedence::Term};
     }
     case Operator::IF_LESS:
     case Operator::IF_EQUAL: {
-      const TracedOp* b =
-          std::static_pointer_cast<const TracedOp, const TracedBody>(
-              traced.ptr())
-              .get();
+      auto n = std::dynamic_pointer_cast<const OperatorNode>(node);
       auto this_string = string_for_operator(op);
-      auto left = cache[b->args[0]];
+      auto left = cache[n->in_nodes[0]];
       auto ls = left.string;
       return PrintedForm{
           fmt::format(
               "{1}({0}, {2}, {3}, {4})",
               ls,
               this_string,
-              cache[b->args[1]].string,
-              cache[b->args[2]].string,
-              cache[b->args[3]].string),
+              cache[n->in_nodes[1]].string,
+              cache[n->in_nodes[2]].string,
+              cache[n->in_nodes[3]].string),
           Precedence::Term};
     }
     default: {
       return PrintedForm{
-          "std::string to_string(const Traced& traced) not implemented",
+          fmt::format(
+              "{}:{}: not implemented: to_string(const Traced& traced)",
+              __FILE__,
+              __LINE__),
           Precedence::Term};
     }
   }
 }
 
-PrintedForm to_printed_form(
-    const Traced& traced,
-    std::map<Traced, PrintedForm> cache) {
-  auto p = print(traced, cache);
-  const Traced& t = traced;
-  cache[t] = p;
-  return p;
-}
 } // namespace
 
 namespace beanmachine::minibmg {
 
 std::string to_string(const Traced& traced) {
-  auto successors = [](const Traced& t) {
-    switch (t.op()) {
+  return to_string(traced.node);
+}
+
+std::string to_string(const Nodep& node) {
+  auto successors = [](const Nodep& t) -> std::vector<Nodep> {
+    switch (t->op) {
       case Operator::CONSTANT:
       case Operator::VARIABLE:
-        return std::vector<Traced>{};
+        return {};
       default:
-        return static_cast<const TracedOp*>(t.ptr().get())->args;
+        return std::dynamic_pointer_cast<const OperatorNode>(t)->in_nodes;
     }
   };
-  auto pred_counts = count_predecessors<Traced>({traced}, successors);
-  std::map<Traced, unsigned> pred_counts_copy = pred_counts;
-  std::vector<Traced> topologically_sorted;
-  bool sorted = topological_sort<Traced>(
+  auto pred_counts = count_predecessors<Nodep>({node}, successors);
+  std::map<Nodep, unsigned> pred_counts_copy = pred_counts;
+  std::vector<Nodep> topologically_sorted;
+  bool sorted = topological_sort<Nodep>(
       pred_counts_copy, successors, topologically_sorted);
   if (!sorted) {
-    throw std::invalid_argument("cycle in traced expression");
+    throw std::invalid_argument("cycle in graph");
   }
   std::reverse(topologically_sorted.begin(), topologically_sorted.end());
-  std::map<Traced, PrintedForm> cache{};
+  std::map<Nodep, PrintedForm> cache{};
   for (auto n : topologically_sorted) {
     auto p = print(n, cache);
     cache[n] = p;
   }
 
-  return cache[traced].string;
+  return cache[node].string;
 }
 
 } // namespace beanmachine::minibmg

--- a/minibmg/eval.h
+++ b/minibmg/eval.h
@@ -100,6 +100,11 @@ void eval_graph(
     std::function<T(const std::string& name, const unsigned identifier)>
         read_variable,
     std::unordered_map<Nodep, T>& data) {
+  // Copy observations into a map for easy access.
+  std::unordered_map<Nodep, double> observations;
+  for (auto p : graph.observations) {
+    observations[p.first] = p.second;
+  }
   int n = graph.size();
   for (int i = 0; i < n; i++) {
     Nodep node = graph[i];
@@ -115,29 +120,22 @@ void eval_graph(
         break;
       }
       case Operator::SAMPLE: {
-        auto sample = std::dynamic_pointer_cast<const OperatorNode>(node);
-        Nodep in0 = sample->in_nodes[0];
-        auto dist = std::dynamic_pointer_cast<const OperatorNode>(in0);
-        std::function<double(unsigned)> get_parameter = [&](unsigned i) {
-          return data[dist->in_nodes[i]].as_double();
-        };
-        put(data, node, T{sample_distribution(dist->op, get_parameter, gen)});
+        auto obsp = observations.find(node);
+        double value;
+        if (obsp != observations.end()) {
+          value = obsp->second;
+        } else {
+          auto sample = std::dynamic_pointer_cast<const OperatorNode>(node);
+          Nodep in0 = sample->in_nodes[0];
+          auto dist = std::dynamic_pointer_cast<const OperatorNode>(in0);
+          std::function<double(unsigned)> get_parameter = [&](unsigned i) {
+            return data[dist->in_nodes[i]].as_double();
+          };
+          value = sample_distribution(dist->op, get_parameter, gen);
+        }
+        put(data, node, T{value});
         break;
       }
-      case Operator::QUERY: {
-        // We treat a query like a sample.
-        auto sample = std::dynamic_pointer_cast<const QueryNode>(node);
-        Nodep in0 = sample->in_node;
-        auto dist = std::dynamic_pointer_cast<const OperatorNode>(in0);
-        std::function<double(unsigned)> get_parameter = [&](unsigned i) {
-          return data[dist->in_nodes[i]].as_double();
-        };
-        put(data, node, T{sample_distribution(dist->op, get_parameter, gen)});
-        break;
-      }
-      case Operator::OBSERVE:
-        // OBSERVE has no result and has no effect during evaluation.
-        break;
       case Operator::NO_OPERATOR:
         throw EvalError(
             "sample_distribution does not support " + to_string(node->op));

--- a/minibmg/factory.cpp
+++ b/minibmg/factory.cpp
@@ -187,7 +187,7 @@ Graph Graph::Factory::build() {
 
   // We preserve this->nodes so it can be used for lookup.
   built = true;
-  return Graph::create(queries, observations);
+  return Graph{queries, observations};
 }
 
 Graph::Factory::~Factory() {

--- a/minibmg/factory.h
+++ b/minibmg/factory.h
@@ -7,8 +7,8 @@
 
 #pragma once
 
-#include <unordered_map>
 #include <list>
+#include <unordered_map>
 #include <vector>
 #include "beanmachine/minibmg/graph.h"
 #include "beanmachine/minibmg/node.h"

--- a/minibmg/factory.h
+++ b/minibmg/factory.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <unordered_map>
+#include <list>
 #include <vector>
 #include "beanmachine/minibmg/graph.h"
 #include "beanmachine/minibmg/node.h"
@@ -72,12 +73,13 @@ namespace beanmachine::minibmg {
 class Graph::Factory {
  public:
   NodeId add_constant(double value);
-
   NodeId add_operator(enum Operator op, std::vector<NodeId> parents);
+
+  // Add an observation to the graph.  The sample must identify a SAMPLE node.
+  void add_observation(NodeId sample, double value);
 
   // returns the index of the query in the samples, not a NodeId
   unsigned add_query(NodeId parent);
-  unsigned add_query(NodeId parent, NodeId& new_node_id);
 
   NodeId add_variable(const std::string& name, const unsigned variable_index);
 
@@ -93,8 +95,8 @@ class Graph::Factory {
  private:
   bool built = false;
   std::unordered_map<NodeId, Nodep> nodes;
-  std::vector<Nodep> all_nodes;
-  unsigned next_query = 0;
+  std::vector<Nodep> queries;
+  std::list<std::pair<Nodep, double>> observations;
 
   NodeId add_node(Nodep node);
 };

--- a/minibmg/graph.h
+++ b/minibmg/graph.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <folly/json.h>
+#include <list>
 #include "beanmachine/minibmg/container.h"
 #include "beanmachine/minibmg/node.h"
 
@@ -15,10 +16,14 @@ namespace beanmachine::minibmg {
 
 class Graph : public Container {
  public:
-  // valudates that the list of nodes forms a valid graph,
-  // and returns that graph.  Throws an exception if the
-  // nodes do not form a valid graph.
-  static Graph create(std::vector<Nodep> nodes);
+  // produces a graph by computing the transitive closure of the input queries
+  // and observations and topologically sorting the set of nodes so reached.
+  // valudates that the list of nodes so reached forms a valid graph, and
+  // returns that graph.  Throws an exception if the nodes do not form a valid
+  // graph.
+  static Graph create(
+      std::vector<Nodep> queries,
+      std::list<std::pair<Nodep, double>> observations);
   ~Graph();
 
   // Implement the iterator pattern so clients can iterate over the nodes.
@@ -35,12 +40,25 @@ class Graph : public Container {
     return nodes.size();
   }
 
- private:
+  // All of the nodes, in a topologically sorted order such that a node can only
+  // be used as an input in subsequent (and not previous) nodes.
   const std::vector<Nodep> nodes;
 
+  // Queries of the model.  These are nodes whose values are sampled by
+  // inference.
+  const std::vector<Nodep> queries;
+
+  // Observations of the model.  These are SAMPLE nodes in the model whose
+  // values are known.
+  const std::list<std::pair<Nodep, double>> observations;
+
+ private:
   // A private constructor that forms a graph without validation.
   // Used internally.  All exposed graphs should be validated.
-  explicit Graph(std::vector<Nodep> nodes);
+  Graph(
+      std::vector<Nodep> nodes,
+      std::vector<Nodep> queries,
+      std::list<std::pair<Nodep, double>> observations);
   static void validate(std::vector<Nodep> nodes);
 
  public:

--- a/minibmg/graph.h
+++ b/minibmg/graph.h
@@ -21,9 +21,9 @@ class Graph : public Container {
   // valudates that the list of nodes so reached forms a valid graph, and
   // returns that graph.  Throws an exception if the nodes do not form a valid
   // graph.
-  static Graph create(
-      std::vector<Nodep> queries,
-      std::list<std::pair<Nodep, double>> observations);
+  Graph(
+      const std::vector<Nodep>& queries,
+      const std::list<std::pair<Nodep, double>>& observations);
   ~Graph();
 
   // Implement the iterator pattern so clients can iterate over the nodes.
@@ -56,9 +56,9 @@ class Graph : public Container {
   // A private constructor that forms a graph without validation.
   // Used internally.  All exposed graphs should be validated.
   Graph(
-      std::vector<Nodep> nodes,
-      std::vector<Nodep> queries,
-      std::list<std::pair<Nodep, double>> observations);
+      const std::vector<Nodep>& nodes,
+      const std::vector<Nodep>& queries,
+      const std::list<std::pair<Nodep, double>>& observations);
   static void validate(std::vector<Nodep> nodes);
 
  public:

--- a/minibmg/node.cpp
+++ b/minibmg/node.cpp
@@ -21,18 +21,12 @@ OperatorNode::OperatorNode(
     : Node{op, type}, in_nodes{in_nodes} {
   switch (op) {
     case Operator::CONSTANT:
-    case Operator::QUERY:
     case Operator::VARIABLE:
       throw std::invalid_argument(
           "OperatorNode cannot be used for " + to_string(op) + ".");
     default:;
   }
 }
-
-QueryNode::QueryNode(const unsigned query_index, Nodep in_node)
-    : Node{Operator::QUERY, Type::NONE},
-      query_index{query_index},
-      in_node{in_node} {}
 
 ConstantNode::ConstantNode(const double value)
     : Node{Operator::CONSTANT, Type::REAL}, value{value} {}

--- a/minibmg/node.h
+++ b/minibmg/node.h
@@ -55,11 +55,4 @@ class VariableNode : public Node {
   unsigned identifier;
 };
 
-class QueryNode : public Node {
- public:
-  QueryNode(const unsigned query_index, Nodep in_node);
-  unsigned query_index;
-  Nodep in_node;
-};
-
 } // namespace beanmachine::minibmg

--- a/minibmg/operator.cpp
+++ b/minibmg/operator.cpp
@@ -48,8 +48,6 @@ bool _c0 = [] {
   add(Operator::DISTRIBUTION_BETA, "DISTRIBUTION_BETA");
   add(Operator::DISTRIBUTION_BERNOULLI, "DISTRIBUTION_BERNOULLI");
   add(Operator::SAMPLE, "SAMPLE");
-  add(Operator::OBSERVE, "OBSERVE");
-  add(Operator::QUERY, "QUERY");
 
   // check that we have set the name for every operator.
   for (Operator op = Operator::NO_OPERATOR; op < Operator::LAST_OPERATOR;

--- a/minibmg/operator.h
+++ b/minibmg/operator.h
@@ -104,19 +104,6 @@ enum class Operator {
   // Result: A sample from the distribution (REAL)
   SAMPLE,
 
-  // Observe a sample from the distribution parameter.
-  // Parameters:
-  // - ditribution (DISTRIBUTION)
-  // - value (REAL)
-  // Result: NONE.
-  OBSERVE,
-
-  // Query an intermediate result in the graph.
-  // Parameters:
-  // - value (REAL)
-  // Result: NONE.
-  QUERY,
-
   // Not a real operator.  Used as a limit when looping through operators.
   LAST_OPERATOR,
 };

--- a/minibmg/out_nodes.cpp
+++ b/minibmg/out_nodes.cpp
@@ -45,13 +45,6 @@ class Out_Nodes_Property
         case Operator::VARIABLE:
           // these nodes do not have inputs.
           break;
-        case Operator::QUERY: {
-          // query has one input.
-          auto query = std::dynamic_pointer_cast<const QueryNode>(node);
-          auto& predecessor_out_set = data->for_node(query->in_node);
-          predecessor_out_set.push_back(node);
-          break;
-        }
         default: {
           // the rest are operator nodes.
           auto opnode = std::dynamic_pointer_cast<const OperatorNode>(node);

--- a/minibmg/out_nodes.cpp
+++ b/minibmg/out_nodes.cpp
@@ -18,18 +18,13 @@ using namespace beanmachine::minibmg;
 
 class Out_Nodes_Data {
  public:
-  std::map<Nodep, std::list<Nodep>*> node_map{};
-  ~Out_Nodes_Data() {
-    for (auto e : node_map) {
-      delete e.second;
-    }
-  }
+  std::map<Nodep, std::list<Nodep>> node_map{};
   std::list<Nodep>& for_node(Nodep node) {
     auto found = node_map.find(node);
     if (found == node_map.end()) {
       throw std::invalid_argument("node not in graph");
     }
-    return *found->second;
+    return found->second;
   }
 };
 
@@ -39,7 +34,7 @@ class Out_Nodes_Property
   Out_Nodes_Data* create(const Graph& g) const override {
     Out_Nodes_Data* data = new Out_Nodes_Data{};
     for (auto node : g) {
-      data->node_map[node] = new std::list<Nodep>{};
+      data->node_map[node] = std::list<Nodep>{};
       switch (node->op) {
         case Operator::CONSTANT:
         case Operator::VARIABLE:

--- a/minibmg/tests/eval_test.cpp
+++ b/minibmg/tests/eval_test.cpp
@@ -29,6 +29,7 @@ TEST(eval_test, simple1) {
   auto v1 = fac.add_variable("x", 0); // 1.15
   auto mul1 = fac.add_operator(Operator::MULTIPLY, {add0, v1}); // 6.095
   auto sub1 = fac.add_operator(Operator::SUBTRACT, {mul1, k1}); // 1.995
+  fac.add_query(sub1); // add a root to the graph.
   auto graph = fac.build();
   std::mt19937 gen;
   auto read_variable = [](const std::string&, const unsigned) { return 1.15; };
@@ -49,6 +50,7 @@ TEST(eval_test, sample1) {
   auto k1 = fac.add_constant(expected_stdev);
   auto normal0 = fac.add_operator(Operator::DISTRIBUTION_NORMAL, {k0, k1});
   auto sample0 = fac.add_operator(Operator::SAMPLE, {normal0});
+  fac.add_query(sample0); // add a root to the graph.
   auto graph = fac.build();
   // We create a new random number generator with its default (deterministic)
   // seed so that this test will not be flaky.
@@ -103,6 +105,7 @@ TEST(eval_test, derivative_dual) {
       {fac.add_constant(1.1),
        fac.add_operator(
            Operator::POW, {fac.add_variable("x", 0), fac.add_constant(2)})});
+  fac.add_query(s); // add a root to the graph.
   Graph graph = fac.build();
   int graph_size = graph.size();
 
@@ -135,6 +138,7 @@ TEST(eval_test, derivatives_triune) {
       {fac.add_constant(1.1),
        fac.add_operator(
            Operator::POW, {fac.add_variable("x", 0), fac.add_constant(2)})});
+  fac.add_query(s); // add a root to the graph.
   auto sn = fac[s];
   Graph graph = fac.build();
   int graph_size = graph.size();

--- a/minibmg/tests/json_test.cpp
+++ b/minibmg/tests/json_test.cpp
@@ -12,6 +12,8 @@
 using namespace ::testing;
 using namespace ::beanmachine::minibmg;
 
+namespace {
+
 std::string raw_json = R"({
   "comment": "created by graph_to_json",
   "nodes": [
@@ -102,6 +104,8 @@ std::string raw_json = R"({
   ]
 })";
 
+}
+
 TEST(json_test, test_from_string) {
   folly::dynamic parsed = folly::parseJson(raw_json);
   auto graph = beanmachine::minibmg::json_to_graph(parsed);
@@ -109,6 +113,8 @@ TEST(json_test, test_from_string) {
       folly::toPrettyJson(beanmachine::minibmg::graph_to_json(graph));
   ASSERT_EQ(raw_json, s);
 }
+
+namespace {
 
 std::string raw_json_without_types = R"({
   "comment": "created by graph_to_json",
@@ -191,6 +197,8 @@ std::string raw_json_without_types = R"({
     2
   ]
 })";
+
+}
 
 TEST(json_test, test_from_string_without_types) {
   folly::dynamic parsed = folly::parseJson(raw_json_without_types);

--- a/minibmg/tests/json_test.cpp
+++ b/minibmg/tests/json_test.cpp
@@ -47,60 +47,58 @@ std::string raw_json = R"({
       "type": "DISTRIBUTION"
     },
     {
-      "operator": "CONSTANT",
+      "in_nodes": [
+        3
+      ],
+      "operator": "SAMPLE",
       "sequence": 4,
-      "type": "REAL",
-      "value": 0
+      "type": "REAL"
     },
     {
-      "operator": "CONSTANT",
+      "in_nodes": [
+        3
+      ],
+      "operator": "SAMPLE",
       "sequence": 5,
-      "type": "REAL",
+      "type": "REAL"
+    },
+    {
+      "in_nodes": [
+        3
+      ],
+      "operator": "SAMPLE",
+      "sequence": 6,
+      "type": "REAL"
+    },
+    {
+      "in_nodes": [
+        3
+      ],
+      "operator": "SAMPLE",
+      "sequence": 7,
+      "type": "REAL"
+    }
+  ],
+  "observations": [
+    {
+      "node": 4,
       "value": 1
     },
     {
-      "in_nodes": [
-        3,
-        5
-      ],
-      "operator": "OBSERVE",
-      "sequence": 6,
-      "type": "NONE"
+      "node": 5,
+      "value": 1.1
     },
     {
-      "in_nodes": [
-        3,
-        5
-      ],
-      "operator": "OBSERVE",
-      "sequence": 7,
-      "type": "NONE"
+      "node": 6,
+      "value": 1.11
     },
     {
-      "in_nodes": [
-        3,
-        5
-      ],
-      "operator": "OBSERVE",
-      "sequence": 8,
-      "type": "NONE"
-    },
-    {
-      "in_nodes": [
-        3,
-        4
-      ],
-      "operator": "OBSERVE",
-      "sequence": 9,
-      "type": "NONE"
-    },
-    {
-      "in_node": 2,
-      "operator": "QUERY",
-      "query_index": 0,
-      "sequence": 10,
-      "type": "NONE"
+      "node": 7,
+      "value": 0.111
     }
+  ],
+  "queries": [
+    2
   ]
 })";
 
@@ -113,82 +111,84 @@ TEST(json_test, test_from_string) {
 }
 
 std::string raw_json_without_types = R"({
+  "comment": "created by graph_to_json",
   "nodes": [
     {
-      "sequence": 0,
       "operator": "CONSTANT",
+      "sequence": 0,
       "value": 2
     },
     {
-      "sequence": 1,
-      "operator": "DISTRIBUTION_BETA",
       "in_nodes": [
         0,
         0
-      ]
+      ],
+      "operator": "DISTRIBUTION_BETA",
+      "sequence": 1
     },
     {
-      "sequence": 2,
-      "operator": "SAMPLE",
       "in_nodes": [
         1
-      ]
+      ],
+      "operator": "SAMPLE",
+      "sequence": 2
     },
     {
-      "sequence": 3,
-      "operator": "DISTRIBUTION_BERNOULLI",
       "in_nodes": [
         2
-      ]
+      ],
+      "operator": "DISTRIBUTION_BERNOULLI",
+      "sequence": 3
     },
     {
-      "sequence": 4,
-      "operator": "CONSTANT",
-      "value": 0
+      "in_nodes": [
+        3
+      ],
+      "operator": "SAMPLE",
+      "sequence": 4
     },
     {
-      "sequence": 5,
-      "operator": "CONSTANT",
+      "in_nodes": [
+        3
+      ],
+      "operator": "SAMPLE",
+      "sequence": 5
+    },
+    {
+      "in_nodes": [
+        3
+      ],
+      "operator": "SAMPLE",
+      "sequence": 6
+    },
+    {
+      "in_nodes": [
+        3
+      ],
+      "operator": "SAMPLE",
+      "sequence": 7
+    }
+  ],
+  "observations": [
+    {
+      "node": 4,
       "value": 1
     },
     {
-      "sequence": 6,
-      "operator": "OBSERVE",
-      "in_nodes": [
-        3,
-        5
-      ]
+      "node": 5,
+      "value": 1.1
     },
     {
-      "sequence": 7,
-      "operator": "OBSERVE",
-      "in_nodes": [
-        3,
-        5
-      ]
+      "node": 6,
+      "value": 1.11
     },
     {
-      "sequence": 8,
-      "operator": "OBSERVE",
-      "in_nodes": [
-        3,
-        5
-      ]
-    },
-    {
-      "sequence": 9,
-      "operator": "OBSERVE",
-      "in_nodes": [
-        3,
-        4
-      ]
-    },
-    {
-      "sequence": 10,
-      "operator": "QUERY",
-      "in_node": 2,
-      "query_index": 0
+      "node": 7,
+      "value": 0.111
     }
+  ],
+  "queries": [
+    2
   ]
 })";
 

--- a/minibmg/tests/out_nodes_test.cpp
+++ b/minibmg/tests/out_nodes_test.cpp
@@ -20,12 +20,10 @@ TEST(out_nodes_test, simple) {
   auto k34 = gf.add_constant(3.4);
   auto plus = gf.add_operator(Operator::ADD, {k12, k34});
   auto k56 = gf.add_constant(5.6);
-  auto beta = gf.add_operator(Operator::DISTRIBUTION_BETA, {k34, k56});
+  auto beta = gf.add_operator(Operator::DISTRIBUTION_BETA, {plus, k56});
   auto sample = gf.add_operator(Operator::SAMPLE, {beta});
-  auto k78 = gf.add_constant(7.8);
-  auto observe = gf.add_operator(Operator::OBSERVE, {beta, k78});
-  NodeId query;
-  /* auto query_ = */ gf.add_query(beta, query);
+  gf.add_observation(sample, 7.8);
+  /* auto query_ = */ gf.add_query(sample);
   Graph g = gf.build();
 
   Nodep k12n = gf[k12];
@@ -34,19 +32,18 @@ TEST(out_nodes_test, simple) {
   Nodep k56n = gf[k56];
   Nodep betan = gf[beta];
   Nodep samplen = gf[sample];
-  Nodep k78n = gf[k78];
-  Nodep observen = gf[observe];
-  Nodep queryn = gf[query];
 
   ASSERT_EQ(out_nodes(g, k12n), std::list{plusn});
-  ASSERT_EQ(out_nodes(g, k34n), (std::list{plusn, betan}));
-  ASSERT_EQ(out_nodes(g, plusn), std::list<Nodep>{});
+  ASSERT_EQ(out_nodes(g, k34n), (std::list{plusn}));
+  ASSERT_EQ(out_nodes(g, plusn), std::list<Nodep>{betan});
   ASSERT_EQ(out_nodes(g, k56n), std::list{betan});
-  ASSERT_EQ(out_nodes(g, betan), (std::list{samplen, observen, queryn}));
+  ASSERT_EQ(out_nodes(g, betan), (std::list{samplen}));
   ASSERT_EQ(out_nodes(g, samplen), std::list<Nodep>{});
-  ASSERT_EQ(out_nodes(g, k78n), std::list{observen});
-  ASSERT_EQ(out_nodes(g, observen), std::list<Nodep>{});
-  ASSERT_EQ(out_nodes(g, queryn), std::list<Nodep>{});
+
+  ASSERT_EQ(g.queries, std::vector{samplen});
+  std::list<std::pair<Nodep, double>> expected_observations;
+  expected_observations.push_back(std::pair{samplen, 7.8});
+  ASSERT_EQ(g.observations, expected_observations);
 }
 
 TEST(out_nodes_test, not_found2) {

--- a/minibmg/topological.h
+++ b/minibmg/topological.h
@@ -12,6 +12,15 @@
 #include <map>
 #include <set>
 
+namespace {
+
+template <class K, class V>
+class insertion_ordered_map {
+ private:
+
+};
+
+}
 namespace beanmachine::minibmg {
 
 // Compute the predecessor count for all nodes reachable from the set of roots


### PR DESCRIPTION
Summary:
We used to have two different expression DAG impleemntations: the graph nodes, and `Traced`, which was used for tracing and emitting code for automatic derivatives (AD).  There was no reason for them to be separate, other than the fact that the traced version supports operator overloading.  However, separating them required a number of small changes to make them similar enough to merge as a last step.  This is that last step.

This diff replaces the old traced implementation with a trivial wrapper around a node.

Next will be a fluent graph factory that takes advantage of this.

Differential Revision: D39698758

