### PR TITLE
minibmg: make topological sort deterministic

### DIFF
--- a/minibmg/ad/tests/traced_test.cpp
+++ b/minibmg/ad/tests/traced_test.cpp
@@ -12,6 +12,12 @@
 using namespace ::testing;
 using namespace ::beanmachine::minibmg;
 
+TEST(traced_test, simple0) {
+  Traced x = Traced::variable("x", 0);
+  Traced r = 100 + x;
+  ASSERT_EQ("100 + x", to_string(r));
+}
+
 TEST(traced_test, simple1) {
   Traced x = Traced::variable("x", 0);
   auto r = 100 * pow(x, 3) + 10 * pow(x, 2) + 1 * x - 5;

--- a/minibmg/ad/traced.cpp
+++ b/minibmg/ad/traced.cpp
@@ -9,158 +9,170 @@
 #include <functional>
 #include <memory>
 #include <set>
+#include <vector>
+#include "beanmachine/minibmg/ad/real.h"
 #include "beanmachine/minibmg/eval.h"
+
+namespace {
+
+using namespace beanmachine::minibmg;
+
+inline Nodep make_operator(
+    Operator op,
+    std::vector<Nodep> in_nodes,
+    Type type = Type::REAL) {
+  return std::make_shared<OperatorNode>(in_nodes, op, type);
+}
+
+} // namespace
 
 namespace beanmachine::minibmg {
 
-Traced::Traced(const Operator op, shared_ptr<const TracedBody> p)
-    : m_op{op}, m_ptr{p} {}
-
-Traced::Traced(double n)
-    : m_op{Operator::CONSTANT}, m_ptr{make_shared<TracedConstant>(n)} {}
-
-Traced Traced::variable(const std::string& name, const unsigned identifier) {
-  return Traced{
-      Operator::VARIABLE, make_shared<TracedVariable>(name, identifier)};
-}
-
 double Traced::as_double() const {
-  if (this->m_op != Operator::CONSTANT) {
-    throw EvalError(
-        "constant value expected but found " +
-        beanmachine::minibmg::to_string(this->m_op));
+  double value;
+  if (is_constant(node, value)) {
+    return value;
   }
-  auto v1 = dynamic_cast<const TracedConstant&>(*this->m_ptr);
-  return v1.value.as_double();
+
+  throw EvalError("constant value expected but found " + to_string(*this));
 }
 
 // We perform some optimizations during construction.
 // It might be better to do no optimizations at this point and have a tree
 // rewriter that can be reused, but for now this is a simpler approach.
 Traced operator+(const Traced& left, const Traced& right) {
-  if (left.m_op == Operator::CONSTANT && right.m_op == Operator::CONSTANT) {
-    auto v1 = dynamic_cast<const TracedConstant&>(*left.m_ptr).value;
-    auto v2 = dynamic_cast<const TracedConstant&>(*right.m_ptr).value;
-    return Traced{Operator::CONSTANT, make_shared<TracedConstant>(v1 + v2)};
-  } else if (is_constant(left, 0)) {
-    return right;
-  } else if (is_constant(right, 0)) {
-    return left;
-  } else {
-    return Traced{Operator::ADD, make_shared<TracedOp>(TracedOp{left, right})};
+  double left_value, right_value;
+  auto left_is_constant = is_constant(left, left_value);
+  auto right_is_constant = is_constant(right, right_value);
+  if (left_is_constant && right_is_constant) {
+    return left_value + right_value;
   }
+  if (left_is_constant && left_value == 0) {
+    return right;
+  }
+  if (right_is_constant && right_value == 0) {
+    return left;
+  }
+  return make_operator(Operator::ADD, {left.node, right.node});
 }
 
 Traced operator-(const Traced& left, const Traced& right) {
-  if (left.m_op == Operator::CONSTANT && right.m_op == Operator::CONSTANT) {
-    auto v1 = dynamic_cast<const TracedConstant&>(*left.m_ptr).value;
-    auto v2 = dynamic_cast<const TracedConstant&>(*right.m_ptr).value;
-    return Traced{Operator::CONSTANT, make_shared<TracedConstant>(v1 - v2)};
-  } else if (is_constant(left, 0)) {
-    return -right;
-  } else if (is_constant(right, 0)) {
-    return left;
-  } else {
-    return Traced{
-        Operator::SUBTRACT, make_shared<TracedOp>(TracedOp{left, right})};
+  double left_value, right_value;
+  auto left_is_constant = is_constant(left, left_value);
+  auto right_is_constant = is_constant(right, right_value);
+  if (left_is_constant && right_is_constant) {
+    return left_value - right_value;
   }
+  if (left_is_constant && left_value == 0) {
+    return -right;
+  }
+  if (right_is_constant && right_value == 0) {
+    return left;
+  }
+  return make_operator(Operator::SUBTRACT, {left.node, right.node});
 }
 
 Traced operator-(const Traced& x) {
-  if (x.m_op == Operator::CONSTANT) {
-    auto v1 = dynamic_cast<const TracedConstant&>(*x.m_ptr).value;
-    return Traced{Operator::CONSTANT, make_shared<TracedConstant>(-v1)};
-  } else {
-    return Traced{Operator::NEGATE, make_shared<TracedOp>(TracedOp{x})};
+  double value;
+  if (is_constant(x.node, value)) {
+    return -value;
   }
+  return make_operator(Operator::NEGATE, {x.node});
 }
 
 Traced operator*(const Traced& left, const Traced& right) {
-  if (left.m_op == Operator::CONSTANT && right.m_op == Operator::CONSTANT) {
-    auto v1 = dynamic_cast<const TracedConstant&>(*left.m_ptr).value;
-    auto v2 = dynamic_cast<const TracedConstant&>(*right.m_ptr).value;
-    return Traced{Operator::CONSTANT, make_shared<TracedConstant>(v1 * v2)};
-  } else if (is_constant(left, 0) || is_constant(right, 1)) {
-    return left;
-  } else if (is_constant(right, 0) || is_constant(left, 1)) {
-    return right;
-  } else {
-    return Traced{
-        Operator::MULTIPLY, make_shared<TracedOp>(TracedOp{left, right})};
+  double left_value, right_value;
+  auto left_is_constant = is_constant(left, left_value);
+  auto right_is_constant = is_constant(right, right_value);
+  if (left_is_constant && right_is_constant) {
+    return left_value * right_value;
   }
+  if ((left_is_constant && left_value == 0) ||
+      (right_is_constant && right_value == 1)) {
+    return left;
+  }
+  if ((right_is_constant && right_value == 0) ||
+      (left_is_constant && left_value == 1)) {
+    return right;
+  }
+  return make_operator(Operator::MULTIPLY, {left.node, right.node});
 }
 
 Traced operator/(const Traced& left, const Traced& right) {
-  if (left.m_op == Operator::CONSTANT && right.m_op == Operator::CONSTANT) {
-    auto v1 = dynamic_cast<const TracedConstant&>(*left.m_ptr).value;
-    auto v2 = dynamic_cast<const TracedConstant&>(*right.m_ptr).value;
-    return Traced{Operator::CONSTANT, make_shared<TracedConstant>(v1 / v2)};
-  } else if (is_constant(left, 0) || is_constant(right, 1)) {
-    return left;
-  } else {
-    return Traced{
-        Operator::DIVIDE, make_shared<TracedOp>(TracedOp{left, right})};
+  double left_value, right_value;
+  auto left_is_constant = is_constant(left, left_value);
+  auto right_is_constant = is_constant(right, right_value);
+  if (left_is_constant && right_is_constant) {
+    return left_value / right_value;
   }
+  if ((left_is_constant && left_value == 0) ||
+      (right_is_constant && right_value == 1)) {
+    return left;
+  }
+  return make_operator(Operator::DIVIDE, {left.node, right.node});
 }
 
 Traced pow(const Traced& base, const Traced& exponent) {
-  if (base.m_op == Operator::CONSTANT && exponent.m_op == Operator::CONSTANT) {
-    auto v1 = dynamic_cast<const TracedConstant&>(*base.m_ptr).value;
-    auto v2 = dynamic_cast<const TracedConstant&>(*exponent.m_ptr).value;
-    return Traced{Operator::CONSTANT, make_shared<TracedConstant>(pow(v1, v2))};
+  double left_value, right_value;
+  auto left_is_constant = is_constant(base, left_value);
+  auto right_is_constant = is_constant(exponent, right_value);
+  if (left_is_constant && right_is_constant) {
+    return pow(Real{left_value}, Real{right_value});
   }
-  double power;
-  if (is_constant(exponent, power)) {
-    if (power == 0) {
+  if (right_is_constant) {
+    if (right_value == 0) {
       return 1;
     }
-    if (power == 1) {
+    if (right_value == 1) {
       return base;
     }
   }
-  return Traced{Operator::POW, make_shared<TracedOp>(TracedOp{base, exponent})};
+  return make_operator(Operator::POW, {base.node, exponent.node});
 }
 
 Traced exp(const Traced& x) {
-  if (x.m_op == Operator::CONSTANT) {
-    auto v1 = dynamic_cast<const TracedConstant&>(*x.m_ptr).value;
-    return Traced{Operator::CONSTANT, make_shared<TracedConstant>(exp(v1))};
+  double value;
+  auto value_is_constant = is_constant(x, value);
+  if (value_is_constant) {
+    return exp(Real{value});
   }
-  return Traced{Operator::EXP, make_shared<TracedOp>(TracedOp{x})};
+  return make_operator(Operator::EXP, {x.node});
 }
 
 Traced log(const Traced& x) {
-  if (x.m_op == Operator::CONSTANT) {
-    auto v1 = dynamic_cast<const TracedConstant&>(*x.m_ptr).value;
-    return Traced{Operator::CONSTANT, make_shared<TracedConstant>(log(v1))};
+  double value;
+  auto value_is_constant = is_constant(x, value);
+  if (value_is_constant) {
+    return log(Real{value});
   }
-  return Traced{Operator::LOG, make_shared<TracedOp>(TracedOp{x})};
+  return make_operator(Operator::LOG, {x.node});
 }
 
 Traced atan(const Traced& x) {
-  if (x.m_op == Operator::CONSTANT) {
-    auto v1 = dynamic_cast<const TracedConstant&>(*x.m_ptr).value;
-    return Traced{Operator::CONSTANT, make_shared<TracedConstant>(atan(v1))};
+  double value;
+  auto value_is_constant = is_constant(x, value);
+  if (value_is_constant) {
+    return atan(Real{value});
   }
-  return Traced{Operator::ATAN, make_shared<TracedOp>(TracedOp{x})};
+  return make_operator(Operator::ATAN, {x.node});
 }
 
 Traced lgamma(const Traced& x) {
-  if (x.m_op == Operator::CONSTANT) {
-    auto v1 = dynamic_cast<const TracedConstant&>(*x.m_ptr).value;
-    return Traced{Operator::CONSTANT, make_shared<TracedConstant>(lgamma(v1))};
+  double value;
+  auto value_is_constant = is_constant(x, value);
+  if (value_is_constant) {
+    return lgamma(Real{value});
   }
-  return Traced{Operator::LGAMMA, make_shared<TracedOp>(TracedOp{x})};
+  return make_operator(Operator::LGAMMA, {x.node});
 }
 
 Traced polygamma(const int n, const Traced& x) {
-  if (x.m_op == Operator::CONSTANT) {
-    auto v1 = dynamic_cast<const TracedConstant&>(*x.m_ptr).value;
-    return Traced{
-        Operator::CONSTANT, make_shared<TracedConstant>(polygamma(n, v1))};
+  double value;
+  auto value_is_constant = is_constant(x, value);
+  if (value_is_constant) {
+    return polygamma(n, Real{value});
   }
-  Traced kn{Operator::CONSTANT, make_shared<TracedConstant>(n)};
-  return Traced{Operator::POLYGAMMA, make_shared<TracedOp>(TracedOp{kn, x})};
+  return make_operator(Operator::POLYGAMMA, {Traced{(double)n}.node, x.node});
 }
 
 Traced if_equal(
@@ -168,16 +180,14 @@ Traced if_equal(
     const Traced& comparand,
     const Traced& when_equal,
     const Traced& when_not_equal) {
-  if (value.m_op == Operator::CONSTANT &&
-      comparand.m_op == Operator::CONSTANT) {
-    auto v1 = dynamic_cast<const TracedConstant&>(*value.m_ptr).value;
-    auto v2 = dynamic_cast<const TracedConstant&>(*comparand.m_ptr).value;
-    return if_equal(v1, v2, when_equal, when_not_equal);
+  double v;
+  double c;
+  if (is_constant(value, v) && is_constant(comparand, c)) {
+    return (v == c) ? when_equal : when_not_equal;
   }
-  return Traced{
+  return make_operator(
       Operator::IF_EQUAL,
-      make_shared<TracedOp>(
-          TracedOp{value, comparand, when_equal, when_not_equal})};
+      {value.node, comparand.node, when_equal.node, when_not_equal.node});
 }
 
 Traced if_less(
@@ -185,24 +195,22 @@ Traced if_less(
     const Traced& comparand,
     const Traced& when_less,
     const Traced& when_not_less) {
-  if (value.m_op == Operator::CONSTANT &&
-      comparand.m_op == Operator::CONSTANT) {
-    auto v1 = dynamic_cast<const TracedConstant&>(*value.m_ptr).value;
-    auto v2 = dynamic_cast<const TracedConstant&>(*comparand.m_ptr).value;
-    return if_less(v1, v2, when_less, when_not_less);
+  double v;
+  double c;
+  if (is_constant(value, v) && is_constant(comparand, c)) {
+    return (v < c) ? when_less : when_not_less;
   }
-  return Traced{
+  return make_operator(
       Operator::IF_LESS,
-      make_shared<TracedOp>(
-          TracedOp{value, comparand, when_less, when_not_less})};
+      {value.node, comparand.node, when_less.node, when_not_less.node});
 }
 
 bool is_constant(const Traced& x, double& value) {
-  if (x.m_op != Operator::CONSTANT) {
+  if (x.op() != Operator::CONSTANT) {
     return false;
   }
-  auto k = dynamic_cast<const TracedConstant&>(*x.m_ptr);
-  value = k.value.as_double();
+  auto knode = std::dynamic_pointer_cast<const ConstantNode>(x.node);
+  value = knode->value;
   return true;
 }
 

--- a/minibmg/ad/traced.h
+++ b/minibmg/ad/traced.h
@@ -7,42 +7,42 @@
 
 #pragma once
 
-#include <boost/math/special_functions/polygamma.hpp>
-#include <cmath>
 #include <memory>
+#include <stdexcept>
 #include <vector>
 #include "beanmachine/minibmg/ad/number.h"
 #include "beanmachine/minibmg/ad/real.h"
-#include "beanmachine/minibmg/minibmg.h"
+#include "beanmachine/minibmg/node.h"
 
 namespace beanmachine::minibmg {
-
-using namespace std;
-
-class TracedBody;
 
 /*
 An implementation of the Number concept that simply builds an expression tree
 (actually, a DAG: directed acyclic graph) representing the computation
-performed.
+performed.  This is also used for the fluent factory.
  */
 class Traced {
  public:
-  Operator m_op;
-  shared_ptr<const TracedBody> m_ptr;
+  Nodep node;
 
-  /* implicit */ Traced(double d);
-  static Traced variable(const std::string& name, const unsigned identifier);
-  inline Operator op() const {
-    return m_op;
+  inline Traced(Nodep node) : node{node} {
+    if (node->type != Type::REAL) {
+      throw std::invalid_argument("node is not a value");
+    }
   }
-  inline shared_ptr<const TracedBody> ptr() const {
-    return m_ptr;
+  /* implicit */ inline Traced(double value)
+      : node{std::make_shared<ConstantNode>(value)} {}
+  /* implicit */ inline Traced(Real value)
+      : node{std::make_shared<ConstantNode>(value.as_double())} {}
+  inline Operator op() const {
+    return node->op;
+  }
+
+  static Traced variable(const std::string& name, const unsigned identifier) {
+    return Traced{std::make_shared<VariableNode>(name, identifier)};
   }
 
   double as_double() const;
-
-  Traced(const Operator op, shared_ptr<const TracedBody> p);
 };
 
 Traced operator+(const Traced& left, const Traced& right);
@@ -70,43 +70,19 @@ bool is_constant(const Traced& x, double& value);
 bool is_constant(const Traced& x, const double& value);
 std::string to_string(const Traced& x);
 
-class TracedBody {
- public:
-  virtual ~TracedBody() {}
-};
-
-class TracedVariable : public TracedBody {
- public:
-  const string name;
-  const unsigned sequence;
-  TracedVariable(const std::string& name, const unsigned sequence)
-      : name{name}, sequence{sequence} {}
-};
-class TracedConstant : public TracedBody {
- public:
-  const Real value;
-  /* implicit */ TracedConstant(const Real value) : value{value} {}
-};
-class TracedOp : public TracedBody {
- public:
-  const std::vector<Traced> args;
-  explicit TracedOp(std::initializer_list<Traced> args) : args{args} {}
-};
-
 static_assert(Number<Traced>);
 
 } // namespace beanmachine::minibmg
 
 // We want to use Traced values in (unordered) maps and sets, so we need a good
-// comparison function.  We delegate to the underlying TracedBody pointer for
+// comparison function.  We delegate to the underlying node pointer for
 // that comparison.
 template <>
 struct ::std::less<beanmachine::minibmg::Traced> {
   bool operator()(
       const beanmachine::minibmg::Traced& lhs,
       const beanmachine::minibmg::Traced& rhs) const {
-    static const auto x =
-        ::std::less<const beanmachine::minibmg::TracedBody*>{};
-    return x(lhs.ptr().get(), rhs.ptr().get());
+    static const auto x = ::std::less<beanmachine::minibmg::Nodep>{};
+    return x(lhs.node, rhs.node);
   }
 };

--- a/minibmg/ad/traced_to_string.cpp
+++ b/minibmg/ad/traced_to_string.cpp
@@ -192,11 +192,9 @@ std::string to_string(const Nodep& node) {
         return std::dynamic_pointer_cast<const OperatorNode>(t)->in_nodes;
     }
   };
-  auto pred_counts = count_predecessors<Nodep>({node}, successors);
-  std::map<Nodep, unsigned> pred_counts_copy = pred_counts;
   std::vector<Nodep> topologically_sorted;
-  bool sorted = topological_sort<Nodep>(
-      pred_counts_copy, successors, topologically_sorted);
+  bool sorted =
+      topological_sort<Nodep>({node}, successors, topologically_sorted);
   if (!sorted) {
     throw std::invalid_argument("cycle in graph");
   }

--- a/minibmg/eval.h
+++ b/minibmg/eval.h
@@ -100,6 +100,11 @@ void eval_graph(
     std::function<T(const std::string& name, const unsigned identifier)>
         read_variable,
     std::unordered_map<Nodep, T>& data) {
+  // Copy observations into a map for easy access.
+  std::unordered_map<Nodep, double> observations;
+  for (auto p : graph.observations) {
+    observations[p.first] = p.second;
+  }
   int n = graph.size();
   for (int i = 0; i < n; i++) {
     Nodep node = graph[i];
@@ -115,29 +120,22 @@ void eval_graph(
         break;
       }
       case Operator::SAMPLE: {
-        auto sample = std::dynamic_pointer_cast<const OperatorNode>(node);
-        Nodep in0 = sample->in_nodes[0];
-        auto dist = std::dynamic_pointer_cast<const OperatorNode>(in0);
-        std::function<double(unsigned)> get_parameter = [&](unsigned i) {
-          return data[dist->in_nodes[i]].as_double();
-        };
-        put(data, node, T{sample_distribution(dist->op, get_parameter, gen)});
+        auto obsp = observations.find(node);
+        double value;
+        if (obsp != observations.end()) {
+          value = obsp->second;
+        } else {
+          auto sample = std::dynamic_pointer_cast<const OperatorNode>(node);
+          Nodep in0 = sample->in_nodes[0];
+          auto dist = std::dynamic_pointer_cast<const OperatorNode>(in0);
+          std::function<double(unsigned)> get_parameter = [&](unsigned i) {
+            return data[dist->in_nodes[i]].as_double();
+          };
+          value = sample_distribution(dist->op, get_parameter, gen);
+        }
+        put(data, node, T{value});
         break;
       }
-      case Operator::QUERY: {
-        // We treat a query like a sample.
-        auto sample = std::dynamic_pointer_cast<const QueryNode>(node);
-        Nodep in0 = sample->in_node;
-        auto dist = std::dynamic_pointer_cast<const OperatorNode>(in0);
-        std::function<double(unsigned)> get_parameter = [&](unsigned i) {
-          return data[dist->in_nodes[i]].as_double();
-        };
-        put(data, node, T{sample_distribution(dist->op, get_parameter, gen)});
-        break;
-      }
-      case Operator::OBSERVE:
-        // OBSERVE has no result and has no effect during evaluation.
-        break;
       case Operator::NO_OPERATOR:
         throw EvalError(
             "sample_distribution does not support " + to_string(node->op));

--- a/minibmg/factory.cpp
+++ b/minibmg/factory.cpp
@@ -10,17 +10,11 @@
 
 namespace beanmachine::minibmg {
 
-std::atomic<unsigned long> NodeId::_next_value{0};
-
-NodeId::NodeId() {
-  this->value = _next_value.fetch_add(1);
-}
-
 NodeId Graph::Factory::add_node(Nodep node) {
   if (built) {
     throw std::invalid_argument("Graph has already been built");
   }
-  NodeId identifier{};
+  NodeId identifier{next_identifier++};
   identifer_to_node.insert({identifier, node});
   return identifier;
 }

--- a/minibmg/factory.cpp
+++ b/minibmg/factory.cpp
@@ -21,7 +21,7 @@ NodeId Graph::Factory::add_node(Nodep node) {
     throw std::invalid_argument("Graph has already been built");
   }
   NodeId identifier{};
-  nodes.insert({identifier, node});
+  identifer_to_node.insert({identifier, node});
   return identifier;
 }
 
@@ -137,7 +137,7 @@ NodeId Graph::Factory::add_operator(
   }
   for (int i = 0, n = expected.size(); i < n; i++) {
     NodeId p = parents[i];
-    auto parent_node = nodes[p];
+    auto parent_node = identifer_to_node[p];
     if (parent_node == nullptr) {
       throw std::invalid_argument("Reference to nonexistent node.");
     }
@@ -160,7 +160,7 @@ NodeId Graph::Factory::add_variable(
 }
 
 void Graph::Factory::add_observation(NodeId sample, double value) {
-  auto parent_node = nodes[sample];
+  auto parent_node = identifer_to_node[sample];
   if (parent_node == nullptr) {
     throw std::invalid_argument("Reference to nonexistent node.");
   }
@@ -168,7 +168,7 @@ void Graph::Factory::add_observation(NodeId sample, double value) {
 }
 
 unsigned Graph::Factory::add_query(NodeId queried) {
-  auto parent_node = nodes[queried];
+  auto parent_node = identifer_to_node[queried];
   if (parent_node == nullptr) {
     throw std::invalid_argument("Reference to nonexistent node.");
   }
@@ -187,11 +187,11 @@ Graph Graph::Factory::build() {
 
   // We preserve this->nodes so it can be used for lookup.
   built = true;
-  return Graph::create(queries, observations);
+  return Graph{queries, observations};
 }
 
 Graph::Factory::~Factory() {
-  this->nodes.clear();
+  this->identifer_to_node.clear();
 }
 
 } // namespace beanmachine::minibmg

--- a/minibmg/factory.h
+++ b/minibmg/factory.h
@@ -22,30 +22,19 @@ class Node;
 // An opaque identifier for a node.
 class NodeId {
  public:
-  // Create a fresh, new, never-before-seen NodeId
-  NodeId();
   explicit NodeId(unsigned long value) : value{value} {}
-  explicit NodeId(long value) : value{(unsigned long)value} {}
+
   inline bool operator==(const NodeId& other) const {
     return value == other.value;
   }
   NodeId(const NodeId& other) : value{other.value} {} // copy ctor
-  NodeId& operator=(const NodeId& other) { // assignment
-    this->value = other.value;
-    return *this;
-  }
   ~NodeId() {} // dtor
 
   inline unsigned long _value() const {
     return value;
   }
 
-  static void _reset_for_testing() {
-    _next_value = 0;
-  }
-
  private:
-  static std::atomic<unsigned long> _next_value;
   unsigned long value;
 };
 
@@ -97,6 +86,7 @@ class Graph::Factory {
   std::unordered_map<NodeId, Nodep> identifer_to_node;
   std::vector<Nodep> queries;
   std::list<std::pair<Nodep, double>> observations;
+  unsigned long next_identifier = 0;
 
   NodeId add_node(Nodep node);
 };

--- a/minibmg/factory.h
+++ b/minibmg/factory.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <unordered_map>
+#include <list>
 #include <vector>
 #include "beanmachine/minibmg/graph.h"
 #include "beanmachine/minibmg/node.h"
@@ -72,12 +73,13 @@ namespace beanmachine::minibmg {
 class Graph::Factory {
  public:
   NodeId add_constant(double value);
-
   NodeId add_operator(enum Operator op, std::vector<NodeId> parents);
+
+  // Add an observation to the graph.  The sample must identify a SAMPLE node.
+  void add_observation(NodeId sample, double value);
 
   // returns the index of the query in the samples, not a NodeId
   unsigned add_query(NodeId parent);
-  unsigned add_query(NodeId parent, NodeId& new_node_id);
 
   NodeId add_variable(const std::string& name, const unsigned variable_index);
 
@@ -93,8 +95,8 @@ class Graph::Factory {
  private:
   bool built = false;
   std::unordered_map<NodeId, Nodep> nodes;
-  std::vector<Nodep> all_nodes;
-  unsigned next_query = 0;
+  std::vector<Nodep> queries;
+  std::list<std::pair<Nodep, double>> observations;
 
   NodeId add_node(Nodep node);
 };

--- a/minibmg/factory.h
+++ b/minibmg/factory.h
@@ -7,8 +7,8 @@
 
 #pragma once
 
-#include <unordered_map>
 #include <list>
+#include <unordered_map>
 #include <vector>
 #include "beanmachine/minibmg/graph.h"
 #include "beanmachine/minibmg/node.h"
@@ -84,8 +84,8 @@ class Graph::Factory {
   NodeId add_variable(const std::string& name, const unsigned variable_index);
 
   inline Nodep operator[](const NodeId& node_id) const {
-    auto t = nodes.find(node_id);
-    if (t == nodes.end())
+    auto t = identifer_to_node.find(node_id);
+    if (t == identifer_to_node.end())
       return nullptr;
     return t->second;
   }
@@ -94,7 +94,7 @@ class Graph::Factory {
 
  private:
   bool built = false;
-  std::unordered_map<NodeId, Nodep> nodes;
+  std::unordered_map<NodeId, Nodep> identifer_to_node;
   std::vector<Nodep> queries;
   std::list<std::pair<Nodep, double>> observations;
 

--- a/minibmg/graph.cpp
+++ b/minibmg/graph.cpp
@@ -29,6 +29,25 @@ std::vector<Nodep> successors(const Nodep& n) {
   }
 }
 
+const std::vector<Nodep> roots(
+    const std::vector<Nodep>& queries,
+    const std::list<std::pair<Nodep, double>>& observations) {
+  std::list<Nodep> roots;
+  for (auto p : observations) {
+    if (p.first->op != Operator::SAMPLE) {
+      throw std::invalid_argument(fmt::format("can only observe a sample"));
+    }
+    roots.push_front(p.first);
+  }
+  for (auto n : queries)
+    roots.push_back(n);
+  std::vector<Nodep> all_nodes;
+  if (!topological_sort<Nodep>(roots, &successors, all_nodes))
+    throw std::invalid_argument("graph has a cycle");
+  std::reverse(all_nodes.begin(), all_nodes.end());
+  return all_nodes;
+}
+
 } // namespace
 
 namespace beanmachine::minibmg {
@@ -36,33 +55,21 @@ namespace beanmachine::minibmg {
 using dynamic = folly::dynamic;
 
 Graph::Graph(
-    std::vector<Nodep> nodes,
-    std::vector<Nodep> queries,
-    std::list<std::pair<Nodep, double>> observations)
-    : nodes{nodes}, queries{queries}, observations{observations} {}
+    const std::vector<Nodep>& queries,
+    const std::list<std::pair<Nodep, double>>& observations)
+    : nodes{roots(queries, observations)},
+      queries{queries},
+      observations{observations} {
+  Graph::validate(nodes);
+}
 
 Graph::~Graph() {}
 
-Graph Graph::create(
-    std::vector<Nodep> queries,
-    std::list<std::pair<Nodep, double>> observations) {
-  std::list<Nodep> roots;
-  for (auto n : queries)
-    roots.push_back(n);
-  for (auto p : observations) {
-    if (p.first->op != Operator::SAMPLE) {
-      throw std::invalid_argument(fmt::format("can only observe a sample"));
-    }
-    roots.push_back(p.first);
-  }
-  std::vector<Nodep> all_nodes;
-  if (!topological_sort<Nodep>(roots, &successors, all_nodes))
-    throw std::invalid_argument("graph has a cycle");
-  std::reverse(all_nodes.begin(), all_nodes.end());
-
-  Graph::validate(all_nodes);
-  return Graph{all_nodes, queries, observations};
-}
+Graph::Graph(
+    const std::vector<Nodep>& nodes,
+    const std::vector<Nodep>& queries,
+    const std::list<std::pair<Nodep, double>>& observations)
+    : nodes{nodes}, queries{queries}, observations{observations} {}
 
 void Graph::validate(std::vector<Nodep> nodes) {
   std::unordered_set<Nodep> seen;
@@ -124,7 +131,7 @@ void Graph::validate(std::vector<Nodep> nodes) {
 }
 
 folly::dynamic graph_to_json(const Graph& g) {
-  std::unordered_map<Nodep, unsigned long> id_map{};
+  std::unordered_map<Nodep, unsigned long> node_to_identifier;
   dynamic result = dynamic::object;
   result["comment"] = "created by graph_to_json";
   dynamic a = dynamic::array;
@@ -134,7 +141,7 @@ folly::dynamic graph_to_json(const Graph& g) {
     // assign node identifiers sequentially.  They are called "sequence" in the
     // generated json.
     auto identifier = next_identifier++;
-    id_map[node] = identifier;
+    node_to_identifier[node] = identifier;
     dynamic dyn_node = dynamic::object;
     dyn_node["sequence"] = identifier;
     dyn_node["operator"] = to_string(node->op);
@@ -150,7 +157,7 @@ folly::dynamic graph_to_json(const Graph& g) {
         auto n = std::dynamic_pointer_cast<const OperatorNode>(node);
         dynamic in_nodes = dynamic::array;
         for (auto pred : n->in_nodes) {
-          in_nodes.push_back(id_map[pred]);
+          in_nodes.push_back(node_to_identifier[pred]);
         }
         dyn_node["in_nodes"] = in_nodes;
         break;
@@ -158,23 +165,24 @@ folly::dynamic graph_to_json(const Graph& g) {
     }
     a.push_back(dyn_node);
   }
+  result["nodes"] = a;
 
-  dynamic queries = dynamic::array;
   dynamic observations = dynamic::array;
-
-  for (auto q : g.queries) {
-    queries.push_back(id_map[q]);
-  }
   for (auto q : g.observations) {
     dynamic d = dynamic::object;
-    d["node"] = id_map[q.first];
+    auto id = node_to_identifier[q.first];
+    d["node"] = id;
     d["value"] = q.second;
     observations.push_back(d);
   }
-
-  result["queries"] = queries;
   result["observations"] = observations;
-  result["nodes"] = a;
+
+  dynamic queries = dynamic::array;
+  for (auto q : g.queries) {
+    queries.push_back(node_to_identifier[q]);
+  }
+  result["queries"] = queries;
+
   return result;
 }
 
@@ -282,22 +290,6 @@ Graph json_to_graph(folly::dynamic d) {
     identifier_to_node[identifier] = node;
   }
 
-  std::vector<Nodep> queries;
-  auto query_nodes = d["queries"];
-  if (query_nodes.isArray()) {
-    for (auto query : query_nodes) {
-      if (!query.isInt()) {
-        throw JsonError("bad query value.");
-      }
-      auto query_i = query.asInt();
-      if (identifier_to_node.find(query_i) == identifier_to_node.end()) {
-        throw JsonError(fmt::format("bad in_node {} for query.", query_i));
-      }
-      auto query_node = identifier_to_node.find(query_i)->second;
-      queries.push_back(query_node);
-    }
-  }
-
   std::list<std::pair<Nodep, double>> observations;
   auto observation_nodes = d["observations"];
   if (observation_nodes.isArray()) {
@@ -320,7 +312,23 @@ Graph json_to_graph(folly::dynamic d) {
     }
   }
 
-  return Graph::create(queries, observations);
+  std::vector<Nodep> queries;
+  auto query_nodes = d["queries"];
+  if (query_nodes.isArray()) {
+    for (auto query : query_nodes) {
+      if (!query.isInt()) {
+        throw JsonError("bad query value.");
+      }
+      auto query_i = query.asInt();
+      if (identifier_to_node.find(query_i) == identifier_to_node.end()) {
+        throw JsonError(fmt::format("bad in_node {} for query.", query_i));
+      }
+      auto query_node = identifier_to_node.find(query_i)->second;
+      queries.push_back(query_node);
+    }
+  }
+
+  return Graph{queries, observations};
 }
 
 } // namespace beanmachine::minibmg

--- a/minibmg/graph.h
+++ b/minibmg/graph.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <folly/json.h>
+#include <list>
 #include "beanmachine/minibmg/container.h"
 #include "beanmachine/minibmg/node.h"
 
@@ -15,10 +16,14 @@ namespace beanmachine::minibmg {
 
 class Graph : public Container {
  public:
-  // valudates that the list of nodes forms a valid graph,
-  // and returns that graph.  Throws an exception if the
-  // nodes do not form a valid graph.
-  static Graph create(std::vector<Nodep> nodes);
+  // produces a graph by computing the transitive closure of the input queries
+  // and observations and topologically sorting the set of nodes so reached.
+  // valudates that the list of nodes so reached forms a valid graph, and
+  // returns that graph.  Throws an exception if the nodes do not form a valid
+  // graph.
+  static Graph create(
+      std::vector<Nodep> queries,
+      std::list<std::pair<Nodep, double>> observations);
   ~Graph();
 
   // Implement the iterator pattern so clients can iterate over the nodes.
@@ -35,12 +40,25 @@ class Graph : public Container {
     return nodes.size();
   }
 
- private:
+  // All of the nodes, in a topologically sorted order such that a node can only
+  // be used as an input in subsequent (and not previous) nodes.
   const std::vector<Nodep> nodes;
 
+  // Queries of the model.  These are nodes whose values are sampled by
+  // inference.
+  const std::vector<Nodep> queries;
+
+  // Observations of the model.  These are SAMPLE nodes in the model whose
+  // values are known.
+  const std::list<std::pair<Nodep, double>> observations;
+
+ private:
   // A private constructor that forms a graph without validation.
   // Used internally.  All exposed graphs should be validated.
-  explicit Graph(std::vector<Nodep> nodes);
+  Graph(
+      std::vector<Nodep> nodes,
+      std::vector<Nodep> queries,
+      std::list<std::pair<Nodep, double>> observations);
   static void validate(std::vector<Nodep> nodes);
 
  public:

--- a/minibmg/graph.h
+++ b/minibmg/graph.h
@@ -21,9 +21,9 @@ class Graph : public Container {
   // valudates that the list of nodes so reached forms a valid graph, and
   // returns that graph.  Throws an exception if the nodes do not form a valid
   // graph.
-  static Graph create(
-      std::vector<Nodep> queries,
-      std::list<std::pair<Nodep, double>> observations);
+  Graph(
+      const std::vector<Nodep>& queries,
+      const std::list<std::pair<Nodep, double>>& observations);
   ~Graph();
 
   // Implement the iterator pattern so clients can iterate over the nodes.
@@ -56,9 +56,9 @@ class Graph : public Container {
   // A private constructor that forms a graph without validation.
   // Used internally.  All exposed graphs should be validated.
   Graph(
-      std::vector<Nodep> nodes,
-      std::vector<Nodep> queries,
-      std::list<std::pair<Nodep, double>> observations);
+      const std::vector<Nodep>& nodes,
+      const std::vector<Nodep>& queries,
+      const std::list<std::pair<Nodep, double>>& observations);
   static void validate(std::vector<Nodep> nodes);
 
  public:

--- a/minibmg/node.cpp
+++ b/minibmg/node.cpp
@@ -21,18 +21,12 @@ OperatorNode::OperatorNode(
     : Node{op, type}, in_nodes{in_nodes} {
   switch (op) {
     case Operator::CONSTANT:
-    case Operator::QUERY:
     case Operator::VARIABLE:
       throw std::invalid_argument(
           "OperatorNode cannot be used for " + to_string(op) + ".");
     default:;
   }
 }
-
-QueryNode::QueryNode(const unsigned query_index, Nodep in_node)
-    : Node{Operator::QUERY, Type::NONE},
-      query_index{query_index},
-      in_node{in_node} {}
 
 ConstantNode::ConstantNode(const double value)
     : Node{Operator::CONSTANT, Type::REAL}, value{value} {}

--- a/minibmg/node.h
+++ b/minibmg/node.h
@@ -55,11 +55,4 @@ class VariableNode : public Node {
   unsigned identifier;
 };
 
-class QueryNode : public Node {
- public:
-  QueryNode(const unsigned query_index, Nodep in_node);
-  unsigned query_index;
-  Nodep in_node;
-};
-
 } // namespace beanmachine::minibmg

--- a/minibmg/operator.cpp
+++ b/minibmg/operator.cpp
@@ -48,8 +48,6 @@ bool _c0 = [] {
   add(Operator::DISTRIBUTION_BETA, "DISTRIBUTION_BETA");
   add(Operator::DISTRIBUTION_BERNOULLI, "DISTRIBUTION_BERNOULLI");
   add(Operator::SAMPLE, "SAMPLE");
-  add(Operator::OBSERVE, "OBSERVE");
-  add(Operator::QUERY, "QUERY");
 
   // check that we have set the name for every operator.
   for (Operator op = Operator::NO_OPERATOR; op < Operator::LAST_OPERATOR;

--- a/minibmg/operator.h
+++ b/minibmg/operator.h
@@ -104,19 +104,6 @@ enum class Operator {
   // Result: A sample from the distribution (REAL)
   SAMPLE,
 
-  // Observe a sample from the distribution parameter.
-  // Parameters:
-  // - ditribution (DISTRIBUTION)
-  // - value (REAL)
-  // Result: NONE.
-  OBSERVE,
-
-  // Query an intermediate result in the graph.
-  // Parameters:
-  // - value (REAL)
-  // Result: NONE.
-  QUERY,
-
   // Not a real operator.  Used as a limit when looping through operators.
   LAST_OPERATOR,
 };

--- a/minibmg/out_nodes.cpp
+++ b/minibmg/out_nodes.cpp
@@ -45,13 +45,6 @@ class Out_Nodes_Property
         case Operator::VARIABLE:
           // these nodes do not have inputs.
           break;
-        case Operator::QUERY: {
-          // query has one input.
-          auto query = std::dynamic_pointer_cast<const QueryNode>(node);
-          auto& predecessor_out_set = data->for_node(query->in_node);
-          predecessor_out_set.push_back(node);
-          break;
-        }
         default: {
           // the rest are operator nodes.
           auto opnode = std::dynamic_pointer_cast<const OperatorNode>(node);

--- a/minibmg/out_nodes.cpp
+++ b/minibmg/out_nodes.cpp
@@ -9,7 +9,6 @@
 #include <exception>
 #include <list>
 #include <map>
-#include <unordered_set>
 #include "beanmachine/minibmg/minibmg.h"
 
 namespace {

--- a/minibmg/out_nodes.cpp
+++ b/minibmg/out_nodes.cpp
@@ -18,18 +18,13 @@ using namespace beanmachine::minibmg;
 
 class Out_Nodes_Data {
  public:
-  std::map<Nodep, std::list<Nodep>*> node_map{};
-  ~Out_Nodes_Data() {
-    for (auto e : node_map) {
-      delete e.second;
-    }
-  }
+  std::map<Nodep, std::list<Nodep>> node_map{};
   std::list<Nodep>& for_node(Nodep node) {
     auto found = node_map.find(node);
     if (found == node_map.end()) {
       throw std::invalid_argument("node not in graph");
     }
-    return *found->second;
+    return found->second;
   }
 };
 
@@ -39,7 +34,7 @@ class Out_Nodes_Property
   Out_Nodes_Data* create(const Graph& g) const override {
     Out_Nodes_Data* data = new Out_Nodes_Data{};
     for (auto node : g) {
-      data->node_map[node] = new std::list<Nodep>{};
+      data->node_map[node] = std::list<Nodep>{};
       switch (node->op) {
         case Operator::CONSTANT:
         case Operator::VARIABLE:

--- a/minibmg/tests/eval_test.cpp
+++ b/minibmg/tests/eval_test.cpp
@@ -29,6 +29,7 @@ TEST(eval_test, simple1) {
   auto v1 = fac.add_variable("x", 0); // 1.15
   auto mul1 = fac.add_operator(Operator::MULTIPLY, {add0, v1}); // 6.095
   auto sub1 = fac.add_operator(Operator::SUBTRACT, {mul1, k1}); // 1.995
+  fac.add_query(sub1); // add a root to the graph.
   auto graph = fac.build();
   std::mt19937 gen;
   auto read_variable = [](const std::string&, const unsigned) { return 1.15; };
@@ -49,6 +50,7 @@ TEST(eval_test, sample1) {
   auto k1 = fac.add_constant(expected_stdev);
   auto normal0 = fac.add_operator(Operator::DISTRIBUTION_NORMAL, {k0, k1});
   auto sample0 = fac.add_operator(Operator::SAMPLE, {normal0});
+  fac.add_query(sample0); // add a root to the graph.
   auto graph = fac.build();
   // We create a new random number generator with its default (deterministic)
   // seed so that this test will not be flaky.
@@ -103,6 +105,7 @@ TEST(eval_test, derivative_dual) {
       {fac.add_constant(1.1),
        fac.add_operator(
            Operator::POW, {fac.add_variable("x", 0), fac.add_constant(2)})});
+  fac.add_query(s); // add a root to the graph.
   Graph graph = fac.build();
   int graph_size = graph.size();
 
@@ -135,6 +138,7 @@ TEST(eval_test, derivatives_triune) {
       {fac.add_constant(1.1),
        fac.add_operator(
            Operator::POW, {fac.add_variable("x", 0), fac.add_constant(2)})});
+  fac.add_query(s); // add a root to the graph.
   auto sn = fac[s];
   Graph graph = fac.build();
   int graph_size = graph.size();

--- a/minibmg/tests/json_test.cpp
+++ b/minibmg/tests/json_test.cpp
@@ -12,6 +12,8 @@
 using namespace ::testing;
 using namespace ::beanmachine::minibmg;
 
+namespace json_test {
+
 std::string raw_json = R"({
   "comment": "created by graph_to_json",
   "nodes": [
@@ -198,3 +200,5 @@ TEST(json_test, test_from_string_without_types) {
   std::string s = folly::toPrettyJson(graph_to_json(graph));
   ASSERT_EQ(raw_json, s);
 }
+
+} // namespace json_test

--- a/minibmg/tests/json_test.cpp
+++ b/minibmg/tests/json_test.cpp
@@ -47,60 +47,58 @@ std::string raw_json = R"({
       "type": "DISTRIBUTION"
     },
     {
-      "operator": "CONSTANT",
+      "in_nodes": [
+        3
+      ],
+      "operator": "SAMPLE",
       "sequence": 4,
-      "type": "REAL",
-      "value": 0
+      "type": "REAL"
     },
     {
-      "operator": "CONSTANT",
+      "in_nodes": [
+        3
+      ],
+      "operator": "SAMPLE",
       "sequence": 5,
-      "type": "REAL",
+      "type": "REAL"
+    },
+    {
+      "in_nodes": [
+        3
+      ],
+      "operator": "SAMPLE",
+      "sequence": 6,
+      "type": "REAL"
+    },
+    {
+      "in_nodes": [
+        3
+      ],
+      "operator": "SAMPLE",
+      "sequence": 7,
+      "type": "REAL"
+    }
+  ],
+  "observations": [
+    {
+      "node": 4,
       "value": 1
     },
     {
-      "in_nodes": [
-        3,
-        5
-      ],
-      "operator": "OBSERVE",
-      "sequence": 6,
-      "type": "NONE"
+      "node": 5,
+      "value": 1.1
     },
     {
-      "in_nodes": [
-        3,
-        5
-      ],
-      "operator": "OBSERVE",
-      "sequence": 7,
-      "type": "NONE"
+      "node": 6,
+      "value": 1.11
     },
     {
-      "in_nodes": [
-        3,
-        5
-      ],
-      "operator": "OBSERVE",
-      "sequence": 8,
-      "type": "NONE"
-    },
-    {
-      "in_nodes": [
-        3,
-        4
-      ],
-      "operator": "OBSERVE",
-      "sequence": 9,
-      "type": "NONE"
-    },
-    {
-      "in_node": 2,
-      "operator": "QUERY",
-      "query_index": 0,
-      "sequence": 10,
-      "type": "NONE"
+      "node": 7,
+      "value": 0.111
     }
+  ],
+  "queries": [
+    2
   ]
 })";
 
@@ -113,82 +111,84 @@ TEST(json_test, test_from_string) {
 }
 
 std::string raw_json_without_types = R"({
+  "comment": "created by graph_to_json",
   "nodes": [
     {
-      "sequence": 0,
       "operator": "CONSTANT",
+      "sequence": 0,
       "value": 2
     },
     {
-      "sequence": 1,
-      "operator": "DISTRIBUTION_BETA",
       "in_nodes": [
         0,
         0
-      ]
+      ],
+      "operator": "DISTRIBUTION_BETA",
+      "sequence": 1
     },
     {
-      "sequence": 2,
-      "operator": "SAMPLE",
       "in_nodes": [
         1
-      ]
+      ],
+      "operator": "SAMPLE",
+      "sequence": 2
     },
     {
-      "sequence": 3,
-      "operator": "DISTRIBUTION_BERNOULLI",
       "in_nodes": [
         2
-      ]
+      ],
+      "operator": "DISTRIBUTION_BERNOULLI",
+      "sequence": 3
     },
     {
-      "sequence": 4,
-      "operator": "CONSTANT",
-      "value": 0
+      "in_nodes": [
+        3
+      ],
+      "operator": "SAMPLE",
+      "sequence": 4
     },
     {
-      "sequence": 5,
-      "operator": "CONSTANT",
+      "in_nodes": [
+        3
+      ],
+      "operator": "SAMPLE",
+      "sequence": 5
+    },
+    {
+      "in_nodes": [
+        3
+      ],
+      "operator": "SAMPLE",
+      "sequence": 6
+    },
+    {
+      "in_nodes": [
+        3
+      ],
+      "operator": "SAMPLE",
+      "sequence": 7
+    }
+  ],
+  "observations": [
+    {
+      "node": 4,
       "value": 1
     },
     {
-      "sequence": 6,
-      "operator": "OBSERVE",
-      "in_nodes": [
-        3,
-        5
-      ]
+      "node": 5,
+      "value": 1.1
     },
     {
-      "sequence": 7,
-      "operator": "OBSERVE",
-      "in_nodes": [
-        3,
-        5
-      ]
+      "node": 6,
+      "value": 1.11
     },
     {
-      "sequence": 8,
-      "operator": "OBSERVE",
-      "in_nodes": [
-        3,
-        5
-      ]
-    },
-    {
-      "sequence": 9,
-      "operator": "OBSERVE",
-      "in_nodes": [
-        3,
-        4
-      ]
-    },
-    {
-      "sequence": 10,
-      "operator": "QUERY",
-      "in_node": 2,
-      "query_index": 0
+      "node": 7,
+      "value": 0.111
     }
+  ],
+  "queries": [
+    2
   ]
 })";
 

--- a/minibmg/tests/minibmg_test.cpp
+++ b/minibmg/tests/minibmg_test.cpp
@@ -16,7 +16,6 @@ using namespace beanmachine::minibmg;
 #define ASSERT_ID(node, num) ASSERT_EQ(node, NodeId{(unsigned long)(num)})
 
 TEST(test_minibmg, basic_building_1) {
-  NodeId::_reset_for_testing();
   Graph::Factory gf;
   auto k12 = gf.add_constant(1.2);
   ASSERT_ID(k12, 0);
@@ -38,7 +37,6 @@ TEST(test_minibmg, basic_building_1) {
 }
 
 TEST(test_minibmg, dead_code_dropped) {
-  NodeId::_reset_for_testing();
   Graph::Factory gf;
   auto k12 = gf.add_constant(1.2);
   ASSERT_ID(k12, 0);

--- a/minibmg/tests/out_nodes_test.cpp
+++ b/minibmg/tests/out_nodes_test.cpp
@@ -7,7 +7,6 @@
 
 #include <gtest/gtest.h>
 #include <list>
-#include <unordered_set>
 #include "beanmachine/minibmg/minibmg.h"
 #include "beanmachine/minibmg/out_nodes.h"
 

--- a/minibmg/tests/out_nodes_test.cpp
+++ b/minibmg/tests/out_nodes_test.cpp
@@ -20,12 +20,10 @@ TEST(out_nodes_test, simple) {
   auto k34 = gf.add_constant(3.4);
   auto plus = gf.add_operator(Operator::ADD, {k12, k34});
   auto k56 = gf.add_constant(5.6);
-  auto beta = gf.add_operator(Operator::DISTRIBUTION_BETA, {k34, k56});
+  auto beta = gf.add_operator(Operator::DISTRIBUTION_BETA, {plus, k56});
   auto sample = gf.add_operator(Operator::SAMPLE, {beta});
-  auto k78 = gf.add_constant(7.8);
-  auto observe = gf.add_operator(Operator::OBSERVE, {beta, k78});
-  NodeId query;
-  /* auto query_ = */ gf.add_query(beta, query);
+  gf.add_observation(sample, 7.8);
+  /* auto query_ = */ gf.add_query(sample);
   Graph g = gf.build();
 
   Nodep k12n = gf[k12];
@@ -34,19 +32,18 @@ TEST(out_nodes_test, simple) {
   Nodep k56n = gf[k56];
   Nodep betan = gf[beta];
   Nodep samplen = gf[sample];
-  Nodep k78n = gf[k78];
-  Nodep observen = gf[observe];
-  Nodep queryn = gf[query];
 
   ASSERT_EQ(out_nodes(g, k12n), std::list{plusn});
-  ASSERT_EQ(out_nodes(g, k34n), (std::list{plusn, betan}));
-  ASSERT_EQ(out_nodes(g, plusn), std::list<Nodep>{});
+  ASSERT_EQ(out_nodes(g, k34n), (std::list{plusn}));
+  ASSERT_EQ(out_nodes(g, plusn), std::list<Nodep>{betan});
   ASSERT_EQ(out_nodes(g, k56n), std::list{betan});
-  ASSERT_EQ(out_nodes(g, betan), (std::list{samplen, observen, queryn}));
+  ASSERT_EQ(out_nodes(g, betan), (std::list{samplen}));
   ASSERT_EQ(out_nodes(g, samplen), std::list<Nodep>{});
-  ASSERT_EQ(out_nodes(g, k78n), std::list{observen});
-  ASSERT_EQ(out_nodes(g, observen), std::list<Nodep>{});
-  ASSERT_EQ(out_nodes(g, queryn), std::list<Nodep>{});
+
+  ASSERT_EQ(g.queries, std::vector{samplen});
+  std::list<std::pair<Nodep, double>> expected_observations;
+  expected_observations.push_back(std::pair{samplen, 7.8});
+  ASSERT_EQ(g.observations, expected_observations);
 }
 
 TEST(out_nodes_test, not_found2) {

--- a/minibmg/topological.h
+++ b/minibmg/topological.h
@@ -12,6 +12,15 @@
 #include <map>
 #include <set>
 
+namespace {
+
+template <class K, class V>
+class insertion_ordered_map {
+ private:
+
+};
+
+}
 namespace beanmachine::minibmg {
 
 // Compute the predecessor count for all nodes reachable from the set of roots


### PR DESCRIPTION
Summary: The topological sort used to iterate through the keys of the map giving the counts of the nodes to find the nodes with no predecessors.  However, the iteration order of a map is not reliable.  This diff makes the order deterministic.

Differential Revision: D39741135

