### PR TITLE
Reorganize header files to avoid mutual inclusion

### DIFF
--- a/src/beanmachine/graph/distribution/distribution.h
+++ b/src/beanmachine/graph/distribution/distribution.h
@@ -6,6 +6,7 @@
  */
 
 #pragma once
+#include <boost/iterator/transform_iterator.hpp>
 #include <string>
 #include "beanmachine/graph/graph.h"
 
@@ -166,6 +167,27 @@ class Distribution : public graph::Node {
         "_matrix_sampler has not been implemented for this distribution.");
   }
 };
+
+/* Returns a function (distribution::Distribution* d) -> d->log_prob(value). */
+inline auto log_prob_getter(const graph::NodeValue& value) {
+  return [&](distribution::Distribution* d) { return d->log_prob(value); };
+}
+
+/* Downcasts node pointer to distribution::Distribution* d and returns
+ * d->sample_type.
+ */
+inline graph::ValueType get_sample_type(graph::Node* node) {
+  return dynamic_cast<distribution::Distribution*>(node)->sample_type;
+}
+
+/*
+ * Takes iterator over Node pointers to distributions
+ * and returns iterator over their sample types.
+ */
+template <typename Iterator>
+inline auto sample_type_iterator(Iterator it) {
+  return boost::make_transform_iterator(it, get_sample_type);
+}
 
 } // namespace distribution
 } // namespace beanmachine

--- a/src/beanmachine/graph/distribution/tests/product_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/product_test.cpp
@@ -10,6 +10,7 @@
 #include "beanmachine/graph/distribution/distribution.h"
 #include "beanmachine/graph/global/nuts.h"
 #include "beanmachine/graph/graph.h"
+#include "beanmachine/graph/testing_util.h"
 #include "beanmachine/graph/third-party/nameof.h"
 #include "beanmachine/graph/util.h"
 

--- a/src/beanmachine/graph/global/tests/conjugate_util_test.cpp
+++ b/src/beanmachine/graph/global/tests/conjugate_util_test.cpp
@@ -8,6 +8,7 @@
 #include "beanmachine/graph/global/tests/conjugate_util_test.h"
 #include <gtest/gtest.h>
 #include "beanmachine/graph/graph.h"
+#include "beanmachine/graph/testing_util.h"
 #include "beanmachine/graph/util.h"
 
 namespace beanmachine {

--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -125,6 +125,12 @@ struct ValueType {
   std::string to_string() const;
 };
 
+inline bool atomic_type_unknown_or_equal_to(
+    graph::AtomicType a,
+    graph::ValueType v) {
+  return a == graph::AtomicType::UNKNOWN or graph::ValueType(a) == v;
+}
+
 typedef NATURAL_TYPE natural_t;
 
 extern NATURAL_TYPE NATURAL_ZERO;

--- a/src/beanmachine/graph/testing_util.cpp
+++ b/src/beanmachine/graph/testing_util.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <iostream>
+
+#include "beanmachine/graph/global/nuts.h"
+#include "beanmachine/graph/graph.h"
+#include "beanmachine/graph/testing_util.h"
+
+namespace beanmachine::util {
+
+using namespace std;
+
+void test_nmc_against_nuts(
+    graph::Graph& graph,
+    int num_rounds,
+    int num_samples,
+    int warmup_samples,
+    std::function<unsigned()> seed_getter,
+    std::function<void(double, double)> tester) {
+  if (graph.queries.empty()) {
+    throw invalid_argument(
+        "test_nmc_against_nuts requires at least one query in graph.");
+  }
+  auto measured_max_abs_mean_diff = 0.0;
+  for (int i = 0; i != num_rounds; i++) {
+    auto seed = seed_getter();
+
+    auto means_nmc =
+        graph.infer_mean(num_samples, graph::InferenceType::NMC, seed);
+
+    graph::NUTS nuts = graph::NUTS(graph);
+    auto samples = nuts.infer(num_samples, seed, warmup_samples);
+    auto means_nuts = compute_means(samples);
+
+    assert(!means_nmc.empty());
+    assert(!means_nuts.empty());
+
+    tester(means_nmc[0], means_nuts[0]);
+
+    auto abs_diff = std::abs(means_nmc[0] - means_nuts[0]);
+    if (abs_diff > measured_max_abs_mean_diff) {
+      measured_max_abs_mean_diff = abs_diff;
+    }
+
+    cout << "NMC  result: " << means_nmc[0] << endl;
+    cout << "NUTS result: " << means_nuts[0] << endl;
+  }
+  cout << "Measured max absolute difference: " << measured_max_abs_mean_diff
+       << endl;
+}
+
+double compute_mean_at_index(
+    std::vector<std::vector<graph::NodeValue>> samples,
+    std::size_t index) {
+  double mean = 0;
+  for (size_t i = 0; i < samples.size(); i++) {
+    assert(samples[i].size() > index);
+    // NOLINTNEXTLINE(facebook-hte-ParameterUncheckedArrayBounds)
+    mean += samples[i][index]._double;
+  }
+  mean /= samples.size();
+  return mean;
+}
+
+std::vector<double> compute_means(
+    std::vector<std::vector<graph::NodeValue>> samples) {
+  if (samples.empty()) {
+    return std::vector<double>();
+  }
+  auto num_dims = samples[0].size();
+  auto means = std::vector<double>(num_dims);
+  for (size_t i = 0; i != num_dims; i++) {
+    means[i] = compute_mean_at_index(samples, i);
+  }
+  return means;
+}
+
+} // namespace beanmachine::util

--- a/src/beanmachine/graph/testing_util.h
+++ b/src/beanmachine/graph/testing_util.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "beanmachine/graph/graph.h"
+
+#include <functional>
+
+namespace beanmachine::util {
+
+/*
+Returns the mean of the index-th dimension in samples.
+*/
+double compute_mean_at_index(
+    std::vector<std::vector<graph::NodeValue>> samples,
+    std::size_t index);
+
+/*
+Returns the means of samples.
+*/
+std::vector<double> compute_means(
+    std::vector<std::vector<graph::NodeValue>> samples);
+
+/*
+Runs both NMC and NUTS on given graph for a number of rounds
+with a given number of samples (warmup samples is used only for NUTS),
+and calls a tester function on the means of the first query
+variable obtained by both algorithms.
+The seed is provided as a nullary function (so it can vary across rounds).
+Also prints the obtained means and the measured maximum difference over all
+rounds.
+*/
+void test_nmc_against_nuts(
+    graph::Graph& graph,
+    int num_rounds,
+    int num_samples,
+    int warmup_samples,
+    std::function<unsigned()> seed_getter,
+    std::function<void(double, double)> tester);
+
+} // namespace beanmachine::util

--- a/src/beanmachine/graph/util.cpp
+++ b/src/beanmachine/graph/util.cpp
@@ -11,8 +11,6 @@
 #include <boost/math/special_functions/polygamma.hpp>
 #include <stdexcept>
 
-#include "beanmachine/graph/global/nuts.h"
-
 #include <Eigen/Core>
 #include <iostream>
 #include "beanmachine/graph/distribution/distribution.h"
@@ -147,72 +145,6 @@ double log1mexp(double x) {
 
 Eigen::MatrixXd log1mexp(const Eigen::MatrixXd& x) {
   return x.unaryExpr([](double x) { return log1mexp(x); });
-}
-
-double compute_mean_at_index(
-    std::vector<std::vector<graph::NodeValue>> samples,
-    std::size_t index) {
-  double mean = 0;
-  for (size_t i = 0; i < samples.size(); i++) {
-    assert(samples[i].size() > index);
-    // NOLINTNEXTLINE(facebook-hte-ParameterUncheckedArrayBounds)
-    mean += samples[i][index]._double;
-  }
-  mean /= samples.size();
-  return mean;
-}
-
-std::vector<double> compute_means(
-    std::vector<std::vector<graph::NodeValue>> samples) {
-  if (samples.empty()) {
-    return std::vector<double>();
-  }
-  auto num_dims = samples[0].size();
-  auto means = std::vector<double>(num_dims);
-  for (size_t i = 0; i != num_dims; i++) {
-    means[i] = compute_mean_at_index(samples, i);
-  }
-  return means;
-}
-
-void test_nmc_against_nuts(
-    graph::Graph& graph,
-    int num_rounds,
-    int num_samples,
-    int warmup_samples,
-    std::function<unsigned()> seed_getter,
-    std::function<void(double, double)> tester) {
-  using namespace std;
-  if (graph.queries.empty()) {
-    throw invalid_argument(
-        "test_nmc_against_nuts requires at least one query in graph.");
-  }
-  auto measured_max_abs_mean_diff = 0.0;
-  for (int i = 0; i != num_rounds; i++) {
-    auto seed = seed_getter();
-
-    auto means_nmc =
-        graph.infer_mean(num_samples, graph::InferenceType::NMC, seed);
-
-    graph::NUTS nuts = graph::NUTS(graph);
-    auto samples = nuts.infer(num_samples, seed, warmup_samples);
-    auto means_nuts = compute_means(samples);
-
-    assert(!means_nmc.empty());
-    assert(!means_nuts.empty());
-
-    tester(means_nmc[0], means_nuts[0]);
-
-    auto abs_diff = std::abs(means_nmc[0] - means_nuts[0]);
-    if (abs_diff > measured_max_abs_mean_diff) {
-      measured_max_abs_mean_diff = abs_diff;
-    }
-
-    cout << "NMC  result: " << means_nmc[0] << endl;
-    cout << "NUTS result: " << means_nuts[0] << endl;
-  }
-  cout << "Measured max absolute difference: " << measured_max_abs_mean_diff
-       << endl;
 }
 
 } // namespace util

--- a/src/beanmachine/graph/util.h
+++ b/src/beanmachine/graph/util.h
@@ -17,8 +17,7 @@
 #include <numeric>
 #include <random>
 #include <stdexcept>
-#include "beanmachine/graph/distribution/distribution.h"
-#include "beanmachine/graph/graph.h"
+#include <type_traits>
 
 namespace beanmachine {
 namespace util {
@@ -258,36 +257,6 @@ inline auto log_poisson_probability(unsigned k, double lambda) {
 }
 
 /*
-Returns the mean of the index-th dimension in samples.
-*/
-double compute_mean_at_index(
-    std::vector<std::vector<graph::NodeValue>> samples,
-    std::size_t index);
-
-/*
-Returns the means of samples.
-*/
-std::vector<double> compute_means(
-    std::vector<std::vector<graph::NodeValue>> samples);
-
-/*
-Runs both NMC and NUTS on given graph for a number of rounds
-with a given number of samples (warmup samples is used only for NUTS),
-and calls a tester function on the means of the first query
-variable obtained by both algorithms.
-The seed is provided as a nullary function (so it can vary across rounds).
-Also prints the obtained means and the measured maximum difference over all
-rounds.
-*/
-void test_nmc_against_nuts(
-    graph::Graph& graph,
-    int num_rounds,
-    int num_samples,
-    int warmup_samples,
-    std::function<unsigned()> seed_getter,
-    std::function<void(double, double)> tester);
-
-/*
  * Returns a runtime_error exception
  * indicating that the feature of given name is
  * unsupported.
@@ -295,34 +264,6 @@ void test_nmc_against_nuts(
 inline std::runtime_error unsupported(const char* name) {
   return std::runtime_error(std::string(name) + " is unsupported");
 }
-
-/* Returns a function (distribution::Distribution* d) -> d->log_prob(value). */
-inline auto log_prob_getter(const graph::NodeValue& value) {
-  return [&](distribution::Distribution* d) { return d->log_prob(value); };
-}
-
-/* Downcasts node pointer to distribution::Distribution* d and returns
- * d->sample_type.
- */
-inline graph::ValueType get_sample_type(graph::Node* node) {
-  return dynamic_cast<distribution::Distribution*>(node)->sample_type;
-}
-
-/*
- * Takes iterator over Node pointers to distributions
- * and returns iterator over their sample types.
- */
-template <typename Iterator>
-inline auto sample_type_iterator(Iterator it) {
-  return boost::make_transform_iterator(it, get_sample_type);
-}
-
-inline bool atomic_type_unknown_or_equal_to(
-    graph::AtomicType a,
-    graph::ValueType v) {
-  return a == graph::AtomicType::UNKNOWN or graph::ValueType(a) == v;
-}
-
 template <typename T>
 void erase_position(std::vector<T>& vector, std::size_t index) {
   vector.erase(vector.begin() + index);


### PR DESCRIPTION
Summary: In preparation for future header definitions, reorganized header files to avoid mutual dependencies.

Differential Revision: D39735131

