### PR TITLE
Fix three small compiler/BMG bugs

### DIFF
--- a/src/beanmachine/graph/operator/tests/operator_test.cpp
+++ b/src/beanmachine/graph/operator/tests/operator_test.cpp
@@ -1556,11 +1556,14 @@ TEST(testoperator, to_pos_real_matrix) {
           OperatorType::TO_POS_REAL_MATRIX, std::vector<uint>{tm, tm}),
       std::invalid_argument);
 
-  uint tr = g.add_operator(OperatorType::TO_REAL_MATRIX, std::vector<uint>{tm});
+  // Input must not be neg real matrix
 
-  // Input must not be real matrix
+  uint l1 = g.add_operator(OperatorType::LOG, std::vector<uint>{b1});
+  uint nrm = g.add_operator(
+      OperatorType::TO_MATRIX, std::vector<uint>{two, two, l1, l1, l1, l1});
+
   EXPECT_THROW(
-      g.add_operator(OperatorType::TO_POS_REAL_MATRIX, std::vector<uint>{tr}),
+      g.add_operator(OperatorType::TO_POS_REAL_MATRIX, std::vector<uint>{nrm}),
       std::invalid_argument);
 
   g.add_operator(OperatorType::TO_POS_REAL_MATRIX, std::vector<uint>{tm});

--- a/src/beanmachine/graph/operator/unaryop.cpp
+++ b/src/beanmachine/graph/operator/unaryop.cpp
@@ -205,11 +205,12 @@ ToPosRealMatrix::ToPosRealMatrix(const std::vector<graph::Node*>& in_nodes)
 
   if (element_type != graph::AtomicType::PROBABILITY and
       element_type != graph::AtomicType::POS_REAL and
+      element_type != graph::AtomicType::REAL and
       element_type != graph::AtomicType::NATURAL and
       element_type != graph::AtomicType::BOOLEAN) {
     throw std::invalid_argument(
         "operator TO_POS_REAL_MATRIX requires a "
-        "pos_real, probability, natural or boolean matrix parent");
+        "real, pos_real, probability, natural or boolean matrix parent");
   }
 
   value = graph::NodeValue(graph::ValueType(

--- a/src/beanmachine/ppl/compiler/bmg_requirements.py
+++ b/src/beanmachine/ppl/compiler/bmg_requirements.py
@@ -35,6 +35,7 @@ from beanmachine.ppl.compiler.lattice_typer import LatticeTyper
 # what their inputs are.
 
 _known_requirements: Dict[type, List[bt.Requirement]] = {
+    # TODO See comment below regarding RealMatrix
     bn.ElementwiseMultiplyNode: [bt.RealMatrix, bt.RealMatrix],
     bn.Observation: [bt.any_requirement],
     bn.Query: [bt.any_requirement],
@@ -55,6 +56,15 @@ _known_requirements: Dict[type, List[bt.Requirement]] = {
     bn.LogisticNode: [bt.Real],
     bn.Log1mexpNode: [bt.NegativeReal],
     bn.MatrixMultiplicationNode: [bt.any_real_matrix, bt.any_real_matrix],
+    # TODO: This is wrong in several ways.
+    # First, RealMatrix does not meet the contract of a requirement;
+    # in particular, it cannot be printed out by the requirement diagnostic
+    # in gen_to_dot.
+    # Second, it is too strict; the requirement on matrix add is actually
+    # that the two operands be any double matrix (real, neg real,
+    # pos real or probability).
+    # Third, this requirement is too weak; we are missing the requirement
+    # that the operands have the same element type and shape.
     bn.MatrixAddNode: [bt.RealMatrix, bt.RealMatrix],
     bn.MatrixExpNode: [bt.any_real_matrix],
     bn.MatrixLogNode: [bt.any_pos_real_matrix],

--- a/src/beanmachine/ppl/compiler/lattice_typer.py
+++ b/src/beanmachine/ppl/compiler/lattice_typer.py
@@ -277,6 +277,8 @@ class LatticeTyper(TyperBase[bt.BMGLatticeType]):
         op = self[node.operand]
         assert op is not bt.Untypable
         assert isinstance(op, bt.BMGMatrixType)
+        if isinstance(op, bt.NegativeRealMatrix):
+            return bt.ProbabilityMatrix(op.rows, op.columns)
         return bt.PositiveRealMatrix(op.rows, op.columns)
 
     def _type_matrix_log(self, node: bn.MatrixLogNode) -> bt.BMGLatticeType:

--- a/src/beanmachine/ppl/compiler/tests/lromm_test.py
+++ b/src/beanmachine/ppl/compiler/tests/lromm_test.py
@@ -12,7 +12,6 @@ from beanmachine.ppl.inference.bmg_inference import BMGInference
 from torch import logaddexp, ones, tensor
 from torch.distributions import Bernoulli, Beta, Gamma, Normal
 
-
 _x_obs = tensor([0, 3, 9])
 _y_obs = tensor([33, 68, 34])
 _err_obs = tensor([3.6, 3.9, 2.6])
@@ -59,6 +58,16 @@ def y():
 @bm.random_variable
 def d():
     return Bernoulli(f().exp())
+
+
+# Same model, but using a logits Bernoulli
+
+
+@bm.random_variable
+def d2():
+    log_prob = f()
+    logit = log_prob - (1 - log_prob.exp()).log()
+    return Bernoulli(logits=logit)
 
 
 class LROMMTest(unittest.TestCase):
@@ -260,4 +269,253 @@ digraph "graph" {
   N69 -> N72;
 }
 """
+        self.assertEqual(expected.strip(), observed.strip())
+
+    def test_lromm_logits_to_bmg_dot(self) -> None:
+        self.maxDiff = None
+        queries = [beta_0(), beta_1(), sigma_out(), theta()]
+        observations = {d2(): ones(len(_y_obs))}
+        # Go all the way to BMG.
+        # (This regression-tests the bug described t131976521.)
+        g, _ = BMGInference().to_graph(queries, observations)
+        observed = g.to_dot()
+        expected = """
+digraph "graph" {
+  N0[label="2"];
+  N1[label="5"];
+  N2[label="Beta"];
+  N3[label="~"];
+  N4[label="0"];
+  N5[label="10"];
+  N6[label="Normal"];
+  N7[label="~"];
+  N8[label="~"];
+  N9[label="1"];
+  N10[label="Gamma"];
+  N11[label="~"];
+  N12[label="3"];
+  N13[label="1"];
+  N14[label="Log"];
+  N15[label="ToReal"];
+  N16[label="matrix"];
+  N17[label="MatrixScale"];
+  N18[label="0"];
+  N19[label="Index"];
+  N20[label="+"];
+  N21[label="Normal"];
+  N22[label="33"];
+  N23[label="LogProb"];
+  N24[label="+"];
+  N25[label="Complement"];
+  N26[label="Log"];
+  N27[label="ToReal"];
+  N28[label="3.6"];
+  N29[label="Normal"];
+  N30[label="LogProb"];
+  N31[label="+"];
+  N32[label="LogSumExp"];
+  N33[label="Index"];
+  N34[label="+"];
+  N35[label="Normal"];
+  N36[label="68"];
+  N37[label="LogProb"];
+  N38[label="+"];
+  N39[label="3.9"];
+  N40[label="Normal"];
+  N41[label="LogProb"];
+  N42[label="+"];
+  N43[label="LogSumExp"];
+  N44[label="2"];
+  N45[label="Index"];
+  N46[label="+"];
+  N47[label="Normal"];
+  N48[label="34"];
+  N49[label="LogProb"];
+  N50[label="+"];
+  N51[label="2.6"];
+  N52[label="Normal"];
+  N53[label="LogProb"];
+  N54[label="+"];
+  N55[label="LogSumExp"];
+  N56[label="ToMatrix"];
+  N57[label="1"];
+  N58[label="MatrixExp"];
+  N59[label="Index"];
+  N60[label="Negate"];
+  N61[label="ToReal"];
+  N62[label="+"];
+  N63[label="Index"];
+  N64[label="Negate"];
+  N65[label="ToReal"];
+  N66[label="+"];
+  N67[label="Index"];
+  N68[label="Negate"];
+  N69[label="ToReal"];
+  N70[label="+"];
+  N71[label="ToMatrix"];
+  N72[label="ToPosReal"];
+  N73[label="MatrixLog"];
+  N74[label="Index"];
+  N75[label="Negate"];
+  N76[label="Index"];
+  N77[label="Negate"];
+  N78[label="Index"];
+  N79[label="Negate"];
+  N80[label="ToMatrix"];
+  N81[label="MatrixAdd"];
+  N82[label="Index"];
+  N83[label="BernoulliLogit"];
+  N84[label="~"];
+  N85[label="Index"];
+  N86[label="BernoulliLogit"];
+  N87[label="~"];
+  N88[label="Index"];
+  N89[label="BernoulliLogit"];
+  N90[label="~"];
+  N0 -> N2;
+  N1 -> N2;
+  N2 -> N3;
+  N3 -> N14;
+  N3 -> N25;
+  N4 -> N6;
+  N5 -> N6;
+  N6 -> N7;
+  N6 -> N8;
+  N7 -> N20;
+  N7 -> N34;
+  N7 -> N46;
+  N8 -> N17;
+  N9 -> N10;
+  N9 -> N10;
+  N10 -> N11;
+  N11 -> N21;
+  N11 -> N35;
+  N11 -> N47;
+  N12 -> N56;
+  N12 -> N71;
+  N12 -> N80;
+  N13 -> N33;
+  N13 -> N56;
+  N13 -> N63;
+  N13 -> N71;
+  N13 -> N76;
+  N13 -> N80;
+  N13 -> N85;
+  N14 -> N15;
+  N15 -> N24;
+  N15 -> N38;
+  N15 -> N50;
+  N16 -> N17;
+  N17 -> N19;
+  N17 -> N33;
+  N17 -> N45;
+  N18 -> N19;
+  N18 -> N59;
+  N18 -> N74;
+  N18 -> N82;
+  N19 -> N20;
+  N20 -> N21;
+  N20 -> N29;
+  N21 -> N23;
+  N22 -> N23;
+  N22 -> N30;
+  N23 -> N24;
+  N24 -> N32;
+  N25 -> N26;
+  N26 -> N27;
+  N27 -> N31;
+  N27 -> N42;
+  N27 -> N54;
+  N28 -> N29;
+  N29 -> N30;
+  N30 -> N31;
+  N31 -> N32;
+  N32 -> N56;
+  N33 -> N34;
+  N34 -> N35;
+  N34 -> N40;
+  N35 -> N37;
+  N36 -> N37;
+  N36 -> N41;
+  N37 -> N38;
+  N38 -> N43;
+  N39 -> N40;
+  N40 -> N41;
+  N41 -> N42;
+  N42 -> N43;
+  N43 -> N56;
+  N44 -> N45;
+  N44 -> N67;
+  N44 -> N78;
+  N44 -> N88;
+  N45 -> N46;
+  N46 -> N47;
+  N46 -> N52;
+  N47 -> N49;
+  N48 -> N49;
+  N48 -> N53;
+  N49 -> N50;
+  N50 -> N55;
+  N51 -> N52;
+  N52 -> N53;
+  N53 -> N54;
+  N54 -> N55;
+  N55 -> N56;
+  N56 -> N58;
+  N56 -> N81;
+  N57 -> N62;
+  N57 -> N66;
+  N57 -> N70;
+  N58 -> N59;
+  N58 -> N63;
+  N58 -> N67;
+  N59 -> N60;
+  N60 -> N61;
+  N61 -> N62;
+  N62 -> N71;
+  N63 -> N64;
+  N64 -> N65;
+  N65 -> N66;
+  N66 -> N71;
+  N67 -> N68;
+  N68 -> N69;
+  N69 -> N70;
+  N70 -> N71;
+  N71 -> N72;
+  N72 -> N73;
+  N73 -> N74;
+  N73 -> N76;
+  N73 -> N78;
+  N74 -> N75;
+  N75 -> N80;
+  N76 -> N77;
+  N77 -> N80;
+  N78 -> N79;
+  N79 -> N80;
+  N80 -> N81;
+  N81 -> N82;
+  N81 -> N85;
+  N81 -> N88;
+  N82 -> N83;
+  N83 -> N84;
+  N85 -> N86;
+  N86 -> N87;
+  N88 -> N89;
+  N89 -> N90;
+  O0[label="Observation"];
+  N84 -> O0;
+  O1[label="Observation"];
+  N87 -> O1;
+  O2[label="Observation"];
+  N90 -> O2;
+  Q0[label="Query"];
+  N7 -> Q0;
+  Q1[label="Query"];
+  N8 -> Q1;
+  Q2[label="Query"];
+  N11 -> Q2;
+  Q3[label="Query"];
+  N3 -> Q3;
+}
+        """
         self.assertEqual(expected.strip(), observed.strip())


### PR DESCRIPTION
Summary:
This diff fixes three small bugs which worked together to break the model described in t131976521. The model is the linear regression model modified slightly to use a logits Bernoulli.

* I've added this version of the model to the LROMM test cases, to regress the issue.

* The first bug was that the type requirements on incoming edges to a TO_MATRIX node were set to `RealMatrix`, which is the *class name* of the requirement, not an *instance* of the requirement object. Of course in Python, classes are just functions and there is no restriction on using one where an instance of the class is expected. This did not directly cause the bug, but it did crash my diagnostics while attempting to diagnose it.

* The second bug was that the lattice typer deduces that MATRIX_EXP nodes always produce a matrix of positive reals. But BMG's type system deduces that MATRIX_EXP produces a matrix of probabilities if its input is a matrix of negative reals.  This mismatch led to the compiler failing to produce a graph that met BMG's type requirements...

* ... which were wrong to begin with. The BMG TO_POS_REAL_MATRIX node is supposed to have the same semantics as the TO_POS_REAL node. That is, it asserts that we know this node to be a matrix of positive reals, even if the compiler cannot deduce that fact directly. It should accept any matrix as its input except a matrix which we know to be negative reals.  That was the third bug.

Reviewed By: gafter

Differential Revision: D39676706

