### PR TITLE
Add support for using NUTS inference from BMGInference

### DIFF
--- a/src/beanmachine/graph/global/nuts.cpp
+++ b/src/beanmachine/graph/global/nuts.cpp
@@ -22,5 +22,10 @@ void NUTS::prepare_graph() {
   set_default_transforms(graph);
 }
 
+void Graph::nuts(uint num_samples, uint seed, InferConfig infer_config) {
+  NUTS(*this).infer(
+      num_samples, seed, infer_config.num_warmup, infer_config.keep_warmup);
+}
+
 } // namespace graph
 } // namespace beanmachine

--- a/src/beanmachine/graph/graph.cpp
+++ b/src/beanmachine/graph/graph.cpp
@@ -1098,6 +1098,8 @@ void Graph::_infer(
     gibbs(num_samples, seed, infer_config);
   } else if (algorithm == InferenceType::NMC) {
     nmc(num_samples, seed, infer_config);
+  } else if (algorithm == InferenceType::NUTS) {
+    nuts(num_samples, seed, infer_config);
   }
 }
 

--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -430,6 +430,7 @@ enum class InferenceType {
   REJECTION,
   GIBBS,
   NMC,
+  NUTS,
 };
 
 enum class AggregationType {
@@ -984,6 +985,7 @@ struct Graph {
   void rejection(uint num_samples, uint seed, InferConfig infer_config);
   void gibbs(uint num_samples, uint seed, InferConfig infer_config);
   void nmc(uint num_samples, uint seed, InferConfig infer_config);
+  void nuts(uint num_samples, uint seed, InferConfig infer_config);
   void cavi(
       uint num_iters,
       uint steps_per_iter,

--- a/src/beanmachine/graph/pybindings.cpp
+++ b/src/beanmachine/graph/pybindings.cpp
@@ -134,7 +134,8 @@ PYBIND11_MODULE(graph, module) {
   py::enum_<InferenceType>(module, "InferenceType")
       .value("REJECTION", InferenceType::REJECTION)
       .value("GIBBS", InferenceType::GIBBS)
-      .value("NMC", InferenceType::NMC);
+      .value("NMC", InferenceType::NMC)
+      .value("NUTS", InferenceType::NUTS);
 
   py::class_<Node>(module, "Node");
 

--- a/src/beanmachine/ppl/compiler/tests/bmg_infer_interface_test.py
+++ b/src/beanmachine/ppl/compiler/tests/bmg_infer_interface_test.py
@@ -7,6 +7,7 @@
 import unittest
 
 import beanmachine.ppl as bm
+from beanmachine.graph import InferenceType
 from beanmachine.ppl.inference import BMGInference
 from torch import tensor
 from torch.distributions import Bernoulli, Dirichlet
@@ -149,6 +150,32 @@ tensor([[[ 1.5000, -2.5000]],
         num_adaptive_samples = 10
         samples = BMGInference().infer(
             [c(), c2()], {}, num_samples, 1, num_adaptive_samples=num_adaptive_samples
+        )
+        observed = len(samples[c()][0])
+        expected = num_samples
+        self.assertEqual(expected, observed)
+
+    def test_infer_interface_nuts(self) -> None:
+        # Check default case when num_adaptive_samples = 0
+        num_samples = 25
+        num_adaptive_samples = 0
+        samples = BMGInference().infer(
+            [c(), c2()], {}, num_samples, 1, inference_type=InferenceType.NUTS
+        )
+        observed = len(samples[c()][0])
+        expected = num_samples
+        self.assertEqual(expected, observed)
+
+        # Check case when num_adaptive_samples = 10
+        num_samples = 25
+        num_adaptive_samples = 10
+        samples = BMGInference().infer(
+            [c(), c2()],
+            {},
+            num_samples,
+            1,
+            num_adaptive_samples=num_adaptive_samples,
+            inference_type=InferenceType.NUTS,
         )
         observed = len(samples[c()][0])
         expected = num_samples

--- a/src/beanmachine/ppl/inference/bmg_inference.py
+++ b/src/beanmachine/ppl/inference/bmg_inference.py
@@ -204,7 +204,6 @@ class BMGInference:
         g = generated_graph.graph
         query_to_query_id = generated_graph.query_to_query_id
 
-        num_samples = num_samples + num_adaptive_samples
         samples = []
 
         # BMG requires that we have at least one query.
@@ -212,6 +211,9 @@ class BMGInference:
             g.collect_performance_data(produce_report)
             self._begin(prof.graph_infer)
             default_config = InferConfig()
+            default_config.num_warmup = num_adaptive_samples
+            num_adaptive_samples = 0
+
             # TODO[Walid]: In the following we were previously silently using the default seed
             # specified in pybindings.cpp (and not passing the local one in). In the current
             # code we are explicitly passing in the same default value used in that file (5123401).


### PR DESCRIPTION
Summary: We want to support NUTS inference via `BMGInference`. In this diff I update `graph.cpp` to expose NUTS api, this is similar to how NMC exposes its API. We make use of `InferConfig` object for both NUTS and NMC to communicate number of warm up samples.

Differential Revision: D39767773

