### PR TITLE
minibmg: Use a single namespace for the public API

### DIFF
--- a/minibmg/distribution/bernoulli.h
+++ b/minibmg/distribution/bernoulli.h
@@ -10,7 +10,7 @@
 #include <random>
 #include "beanmachine/minibmg/distribution/distribution.h"
 
-namespace beanmachine::minibmg::distribution {
+namespace beanmachine::minibmg {
 
 template <class Underlying>
 requires Number<Underlying>
@@ -29,6 +29,9 @@ class Bernoulli : public Distribution<Underlying> {
         log(probability_of_one),
         value.if_equal(0, log(probability_of_zero), -INFINITY));
   }
+  bool is_discrete() const override {
+    return false;
+  }
 };
 
-} // namespace beanmachine::minibmg::distribution
+} // namespace beanmachine::minibmg

--- a/minibmg/distribution/beta.h
+++ b/minibmg/distribution/beta.h
@@ -11,7 +11,7 @@
 #include "beanmachine/minibmg/distribution/distribution.h"
 #include "beanmachine/minibmg/eval.h"
 
-namespace beanmachine::minibmg::distribution {
+namespace beanmachine::minibmg {
 
 template <class Underlying>
 requires Number<Underlying>
@@ -36,6 +36,9 @@ class Beta : public Distribution<Underlying> {
     return (a - 1) * log(value) + (b - 1) * log(1 - value) + lgamma(a + b) -
         lgamma(a) - lgamma(b);
   }
+  bool is_discrete() const override {
+    return false;
+  }
 };
 
-} // namespace beanmachine::minibmg::distribution
+} // namespace beanmachine::minibmg

--- a/minibmg/distribution/distribution.h
+++ b/minibmg/distribution/distribution.h
@@ -10,7 +10,7 @@
 #include <random>
 #include "beanmachine/minibmg/ad/number.h"
 
-namespace beanmachine::minibmg::distribution {
+namespace beanmachine::minibmg {
 
 template <class Underlying>
 requires Number<Underlying>
@@ -18,7 +18,8 @@ class Distribution {
  public:
   virtual double sample(std::mt19937& gen) const = 0;
   virtual Underlying log_prob(const Underlying& value) const = 0;
+  virtual bool is_discrete() const = 0;
   virtual ~Distribution() {}
 };
 
-} // namespace beanmachine::minibmg::distribution
+} // namespace beanmachine::minibmg

--- a/minibmg/distribution/normal.h
+++ b/minibmg/distribution/normal.h
@@ -10,7 +10,7 @@
 #include <random>
 #include "beanmachine/minibmg/distribution/distribution.h"
 
-namespace beanmachine::minibmg::distribution {
+namespace beanmachine::minibmg {
 
 template <class Underlying>
 requires Number<Underlying>
@@ -33,6 +33,9 @@ class Normal : public Distribution<Underlying> {
     auto t2 = vmm * vmm;
     return -t2 / (2 * stddev * stddev) - log(stddev) - ls2pi;
   }
+  bool is_discrete() const override {
+    return false;
+  }
 };
 
-} // namespace beanmachine::minibmg::distribution
+} // namespace beanmachine::minibmg

--- a/minibmg/log_prob.h
+++ b/minibmg/log_prob.h
@@ -17,8 +17,6 @@
 
 namespace beanmachine::minibmg {
 
-using namespace beanmachine::minibmg::distribution;
-
 // Compute the log probability of the given sample being generated
 // by the given distribution with the given parameters.
 template <class N>

--- a/minibmg/tests/log_prob_test.cpp
+++ b/minibmg/tests/log_prob_test.cpp
@@ -18,7 +18,6 @@
 
 // using namespace ::testing;
 using namespace ::beanmachine::minibmg;
-using namespace ::beanmachine::minibmg::distribution;
 using namespace ::std;
 
 TEST(log_prob, normal_real) {


### PR DESCRIPTION
Summary: minibmg had a nested namespace for distributions, but there is no reason to use a nested namespace.  This diff flattens the API to a single namespace.

Differential Revision: D39785662

