### PR TITLE
minibmg: reverse mode automatic differentiation

### DIFF
--- a/minibmg/ad/reverse.h
+++ b/minibmg/ad/reverse.h
@@ -1,0 +1,372 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "beanmachine/minibmg/ad/num2.h"
+#include "beanmachine/minibmg/ad/number.h"
+#include "beanmachine/minibmg/topological.h"
+
+namespace beanmachine::minibmg {
+
+template <class Underlying>
+requires Number<Underlying>
+class ReverseBody;
+
+/*
+ * An implementation of numbers offering reverse-mode differentiation.
+ * Can be used to automatically compute derivatives of more complex functions
+ * by using the overloaded operators for computing new values and their
+ * derivatives.  Implements the Number concept.
+ */
+template <class Underlying>
+requires Number<Underlying>
+class Reverse {
+ public:
+  using Bodyp = std::shared_ptr<ReverseBody<Underlying>>;
+  Bodyp ptr;
+
+  Reverse();
+  /* implicit */ Reverse(double primal);
+  /* implicit */ Reverse(Underlying primal);
+  /* implicit */ Reverse(Bodyp body);
+  Reverse(const Reverse<Underlying>& other);
+  virtual ~Reverse();
+  Reverse<Underlying>& operator=(const Reverse<Underlying>& other);
+  double as_double() const;
+  void reverse(double initial_gradient);
+};
+
+template <class Underlying>
+requires Number<Underlying>
+class ReverseBody {
+ public:
+  Underlying primal;
+  std::list<Reverse<Underlying>> inputs;
+  Underlying gradient = 0;
+
+  ReverseBody(double primal);
+  ReverseBody(Underlying primal);
+  ReverseBody(Underlying primal, const std::list<Reverse<Underlying>>& inputs);
+  ReverseBody(const ReverseBody<Underlying>& other);
+  ReverseBody<Underlying>& operator=(const ReverseBody<Underlying>& other);
+  virtual ~ReverseBody() {}
+  virtual void backprop();
+};
+
+template <class Underlying>
+requires Number<Underlying> Reverse<Underlying>::Reverse(double primal)
+    : ptr{std::make_shared<ReverseBody<Underlying>>(primal)} {}
+
+template <class Underlying>
+requires Number<Underlying> Reverse<Underlying>::Reverse(Underlying primal)
+    : ptr{std::make_shared<ReverseBody<Underlying>>(primal)} {}
+
+template <class Underlying>
+requires Number<Underlying> Reverse<Underlying>::Reverse()
+    : ptr{std::make_shared<ReverseBody<Underlying>>(0)} {}
+
+template <class Underlying>
+requires Number<Underlying> Reverse<Underlying>::~Reverse() {}
+
+template <class Underlying>
+requires Number<Underlying> Reverse<Underlying>::Reverse(
+    std::shared_ptr<ReverseBody<Underlying>> body)
+    : ptr{body} {}
+
+// This implementation of ReverseBody<Underlying> permits the precomputation of
+// the local derivative, and simply multiplies during the reverse phase to
+// implement the chain rule.  Although not necessarily storage efficient for
+// tensors, for scalars it is as good as anything else.
+template <class Underlying>
+class PrecomputedGradients : public ReverseBody<Underlying> {
+ public:
+  const std::list<Underlying> computed_gradients;
+  PrecomputedGradients(
+      Underlying primal,
+      const std::list<Reverse<Underlying>>& inputs,
+      const std::list<Underlying>& computed_gradients)
+      : ReverseBody<Underlying>{primal, inputs},
+        computed_gradients{computed_gradients} {}
+  void backprop() override {
+    auto& /*std::list<Reverse<Underlying>>*/ t = this->inputs;
+    typename std::list<Reverse<Underlying>>::iterator it1 = t.begin();
+    typename std::list<Underlying>::const_iterator it2 =
+        computed_gradients.begin();
+    for (; it1 != t.end() && it2 != computed_gradients.end(); ++it1, ++it2) {
+      auto& grad = *it2;
+      auto& input_grad = it1->ptr->gradient;
+      input_grad = input_grad + this->gradient * grad;
+    }
+  }
+};
+
+template <class Underlying>
+requires Number<Underlying> Reverse<Underlying>::Reverse(
+    const Reverse<Underlying>& other)
+    : ptr{other.ptr} {}
+
+template <class Underlying>
+requires Number<Underlying>
+double Reverse<Underlying>::as_double() const {
+  return ptr->as_double();
+}
+
+template <class Underlying>
+requires Number<Underlying>
+void Reverse<Underlying>::reverse(double initial_gradient) {
+  // topologically sort the set of ReverseBody pointers reachable - these are
+  // the nodes to which we need to backprop.
+  std::list<Bodyp> roots = {ptr};
+  std::function<std::vector<Bodyp>(const Bodyp&)> predecessors =
+      [&](const Bodyp& ptr) -> std::vector<Bodyp> {
+    std::vector<Bodyp> predecessors;
+    for (auto& i : ptr->inputs) {
+      predecessors.push_back(i.ptr);
+    }
+    return predecessors;
+  };
+  std::vector<Bodyp> sorted;
+  if (!topological_sort<Bodyp>(roots, predecessors, sorted)) {
+    throw std::logic_error("reverse nodes have a loop");
+  }
+
+  // clear their gradients
+  for (auto p : sorted) {
+    p->gradient = 0;
+  }
+
+  // set the initial gradient
+  ptr->gradient = initial_gradient;
+
+  // go through the list in order and call backprop() on each.
+  for (auto p : sorted) {
+    p->backprop();
+  }
+}
+
+template <class Underlying>
+requires Number<Underlying> ReverseBody<Underlying>::ReverseBody(double primal)
+    : primal{primal} {}
+
+template <class Underlying>
+requires Number<Underlying> ReverseBody<Underlying>::ReverseBody(
+    Underlying primal)
+    : primal{primal} {}
+
+template <class Underlying>
+requires Number<Underlying> ReverseBody<Underlying>::ReverseBody(
+    Underlying primal,
+    const std::list<Reverse<Underlying>>& inputs)
+    : primal{primal}, inputs{inputs} {}
+
+template <class Underlying>
+requires Number<Underlying>
+void ReverseBody<Underlying>::backprop() {}
+
+template <class Underlying>
+requires Number<Underlying> Reverse<Underlying>
+operator+(const Reverse<Underlying>& left, const Reverse<Underlying>& right) {
+  Underlying new_primal = left.ptr->primal + right.ptr->primal;
+  return Reverse<Underlying>{std::make_shared<PrecomputedGradients<Underlying>>(
+      new_primal,
+      std::list<Reverse<Underlying>>{left, right},
+      std::list<Underlying>{1, 1})};
+}
+
+template <class Underlying>
+requires Number<Underlying> Reverse<Underlying>
+operator-(const Reverse<Underlying>& left, const Reverse<Underlying>& right) {
+  return Reverse<Underlying>{std::make_shared<PrecomputedGradients<Underlying>>(
+      left.ptr->primal - right.ptr->primal,
+      std::list<Reverse<Underlying>>{left, right},
+      std::list<Underlying>{1, -1})};
+}
+
+template <class Underlying>
+requires Number<Underlying> Reverse<Underlying>
+operator-(const Reverse<Underlying>& x) {
+  return Reverse<Underlying>{std::make_shared<PrecomputedGradients<Underlying>>(
+      -x.ptr->primal,
+      std::list<Reverse<Underlying>>{x},
+      std::list<Underlying>{-1})};
+}
+
+template <class Underlying>
+requires Number<Underlying> Reverse<Underlying>
+operator*(const Reverse<Underlying>& left, const Reverse<Underlying>& right) {
+  return Reverse<Underlying>{std::make_shared<PrecomputedGradients<Underlying>>(
+      left.ptr->primal * right.ptr->primal,
+      std::list<Reverse<Underlying>>{left, right},
+      std::list<Underlying>{right.ptr->primal, left.ptr->primal})};
+}
+
+template <class Underlying>
+requires Number<Underlying> Reverse<Underlying>
+operator/(const Reverse<Underlying>& left, const Reverse<Underlying>& right) {
+  // a / b
+  Underlying new_primal = left.ptr->primal / right.ptr->primal;
+
+  return Reverse<Underlying>{std::make_shared<PrecomputedGradients<Underlying>>(
+      new_primal,
+      std::list<Reverse<Underlying>>{left, right},
+      std::list<Underlying>{
+          1 / right.ptr->primal, -new_primal / right.ptr->primal})};
+}
+
+template <class Underlying>
+requires Number<Underlying> Reverse<Underlying> pow(
+    const Reverse<Underlying>& base,
+    const Reverse<Underlying>& exponent) {
+  double power;
+  // shortcut some cases.
+  if (is_constant(exponent, power)) {
+    if (power == 0)
+      return 1;
+    if (power == 1)
+      return base;
+  }
+
+  Underlying new_primal = pow(base.ptr->primal, exponent.ptr->primal);
+
+  // Doing these gradients symbolically is too hard for my small brain.  So
+  // we'll use Num2 to get the answer.  Eventually we should come back and
+  // improve this.
+  Underlying grad1 = pow(Num2<Underlying>{base.ptr->primal, 1},
+                         Num2<Underlying>{exponent.ptr->primal})
+                         .derivative1;
+  Underlying grad2 = pow(Num2<Underlying>{base.ptr->primal},
+                         Num2<Underlying>{exponent.ptr->primal, 1})
+                         .derivative1;
+  return Reverse<Underlying>{std::make_shared<PrecomputedGradients<Underlying>>(
+      new_primal,
+      std::list<Reverse<Underlying>>{base, exponent},
+      std::list<Underlying>{grad1, grad2})};
+}
+
+template <class Underlying>
+requires Number<Underlying> Reverse<Underlying> exp(
+    const Reverse<Underlying>& x) {
+  Underlying new_primal = exp(x.ptr->primal);
+  return Reverse<Underlying>{std::make_shared<PrecomputedGradients<Underlying>>(
+      new_primal,
+      std::list<Reverse<Underlying>>{x},
+      std::list<Underlying>{new_primal})};
+}
+
+template <class Underlying>
+requires Number<Underlying> Reverse<Underlying> log(
+    const Reverse<Underlying>& x) {
+  Underlying new_primal = log(x.ptr->primal);
+  return Reverse<Underlying>{std::make_shared<PrecomputedGradients<Underlying>>(
+      new_primal,
+      std::list<Reverse<Underlying>>{x},
+      std::list<Underlying>{1 / x.ptr->primal})};
+}
+
+template <class Underlying>
+requires Number<Underlying> Reverse<Underlying> atan(
+    const Reverse<Underlying>& x) {
+  Underlying new_primal = atan(x.ptr->primal);
+  Underlying new_derivative1 = 1 / (x.ptr->primal * x.ptr->primal + 1.0f);
+  return Reverse<Underlying>{std::make_shared<PrecomputedGradients<Underlying>>(
+      new_primal,
+      std::list<Reverse<Underlying>>{x},
+      std::list<Underlying>{new_derivative1})};
+}
+
+template <class Underlying>
+requires Number<Underlying> Reverse<Underlying> lgamma(
+    const Reverse<Underlying>& x) {
+  Underlying new_primal = lgamma(x.ptr->primal);
+  Underlying new_derivative1 = polygamma(0, x.ptr->primal);
+  return Reverse<Underlying>{std::make_shared<PrecomputedGradients<Underlying>>(
+      new_primal,
+      std::list<Reverse<Underlying>>{x},
+      std::list<Underlying>{new_derivative1})};
+}
+
+template <class Underlying>
+requires Number<Underlying> Reverse<Underlying> polygamma(
+    int n,
+    const Reverse<Underlying>& x) {
+  Underlying new_primal = polygamma(n, x.ptr->primal);
+  Underlying new_derivative1 = polygamma(n + 1, x.ptr->primal);
+  return Reverse<Underlying>{std::make_shared<PrecomputedGradients<Underlying>>(
+      new_primal,
+      std::list<Reverse<Underlying>>{x},
+      std::list<Underlying>{new_derivative1})};
+}
+
+template <class Underlying>
+requires Number<Underlying> Reverse<Underlying> if_equal(
+    const Reverse<Underlying>& value,
+    const Reverse<Underlying>& comparand,
+    const Reverse<Underlying>& when_equal,
+    const Reverse<Underlying>& when_not_equal) {
+  // Note: we discard and ignore left.derivative1 and
+  // comparand->derivative1
+  Underlying new_primal = if_equal(
+      value.ptr->primal,
+      comparand.ptr->primal,
+      when_equal.ptr->primal,
+      when_not_equal.ptr->primal);
+  return Reverse<Underlying>{std::make_shared<PrecomputedGradients<Underlying>>(
+      new_primal,
+      std::list<Reverse<Underlying>>{when_equal, when_not_equal},
+      std::list<Underlying>{
+          if_equal(value.ptr->primal, comparand.ptr->primal, 1, 0),
+          if_equal(value.ptr->primal, comparand.ptr->primal, 0, 1)})};
+}
+
+template <class Underlying>
+requires Number<Underlying> Reverse<Underlying> if_less(
+    const Reverse<Underlying>& value,
+    const Reverse<Underlying>& comparand,
+    const Reverse<Underlying>& when_less,
+    const Reverse<Underlying>& when_not_less) {
+  // Note: we discard and ignore left.derivative1 and
+  // comparand->derivative1
+  Underlying new_primal = if_less(
+      value.ptr->primal,
+      comparand.ptr->primal,
+      when_less.ptr->primal,
+      when_not_less.ptr->primal);
+  return Reverse<Underlying>{std::make_shared<PrecomputedGradients<Underlying>>(
+      new_primal,
+      std::list<Reverse<Underlying>>{when_less, when_not_less},
+      std::list<Underlying>{
+          if_less(value.ptr->primal, comparand.ptr->primal, 1, 0),
+          if_less(value.ptr->primal, comparand.ptr->primal, 0, 1)})};
+}
+
+template <class Underlying>
+requires Number<Underlying>
+bool is_constant(const Reverse<Underlying>& x, double& value) {
+  if (typeid(x.ptr) == typeid(ReverseBody<Underlying>)) {
+    // this is the only class in the hierarchy that never backpropagates.
+    return is_constant(x.ptr->primal, value);
+  }
+  return false;
+}
+
+template <class Underlying>
+requires Number<Underlying>
+bool is_constant(const Reverse<Underlying>& x, const double& value) {
+  double v;
+  return is_constant(x, v) && value == v;
+}
+
+template <class Underlying>
+requires Number<Underlying> std::string to_string(
+    const Reverse<Underlying>& x) {
+  return fmt::format("[back primal={0}]", to_string(x.ptr->primal));
+}
+
+static_assert(Number<Reverse<Real>>);
+
+} // namespace beanmachine::minibmg

--- a/minibmg/tests/ad/reverse_test.cpp
+++ b/minibmg/tests/ad/reverse_test.cpp
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <random>
+#include "beanmachine/minibmg/ad/num2.h"
+#include "beanmachine/minibmg/ad/real.h"
+#include "beanmachine/minibmg/ad/reverse.h"
+#include "beanmachine/minibmg/tests/test_utils.h"
+
+using namespace ::testing;
+using namespace beanmachine::minibmg;
+
+using Back = Reverse<Real>;
+using Fwd = Num2<Real>;
+
+template <class N>
+using BinaryFunction = N (*)(N, N);
+
+// Return a vector of binary functions from (T,T) to T.
+template <class T>
+requires Number<T> std::vector<BinaryFunction<T>> functions() {
+  static std::vector<BinaryFunction<T>> result = {
+      // This list of binary functions exercises all of the operations on a
+      // Number.
+      [](T a, T b) { return a + b; },
+      [](T a, T b) { return a - b; },
+      [](T a, T b) { return a * b; },
+      [](T a, T b) { return a / b; },
+      [](T a, T b) { return pow(a, b); },
+      [](T a, T b) { return exp(a + b); },
+      [](T a, T b) { return log(a + b + 4); },
+      [](T a, T b) { return atan(a + b); },
+      [](T a, T b) { return lgamma(a + b); },
+      [](T a, T b) { return polygamma(0, a + b); },
+      [](T a, T b) { return polygamma(1, a + b); },
+      [](T a, T b) { return polygamma(2, a + b); },
+      [](T a, T b) { return polygamma(3, a + b); },
+      [](T a, T b) { return if_equal(a, a, b, a); },
+      [](T a, T b) { return if_equal(a, b, b, a); },
+      [](T a, T b) { return if_less(a, b, a, b); },
+      [](T a, T b) { return if_less(b, a, b, a); },
+      [](T a, T b) { return log(exp(a) + exp(b)); },
+      [](T a, T b) {
+        return 1.2 * a * a * a + 2.6 * a * a * b + 3.14 * a * b * b +
+            4.41 * b * b * b;
+      },
+  };
+  return result;
+}
+
+// Compare the behavior of Reverse<Real> (aka Back) to Num2<Real> (aka Fwd).
+// Assuming that Fwd is well tested and correct, this offers evidence of the
+// correctness of Back.  Both should get the same result when computing the same
+// scalar gradient.  That might not be the case for matrices, because they may
+// differ by a transpose.
+TEST(reverse_test, compare_to_num2) {
+  // Compare functions computed in reverse mode...
+  auto f1s = functions<Back>();
+
+  // To the same functions computed in forward mode.
+  auto f2s = functions<Fwd>();
+
+  // Use a random number generator with its default seed.
+  std::mt19937 g;
+
+  // Generate several doubles between -2.0 and 2.0.
+  std::uniform_real_distribution<double> unif(-2.0, 2.0);
+
+  // Test each function 5 times with different sample values
+  for (int k = 0; k < 5; k++) {
+    // For arguments a and b, we take random values for...
+    double a0 = unif(g); // a's value
+    double a1 = unif(g); // a's gradient
+    double b0 = unif(g); // b's value
+    double b1 = unif(g); // b's gradient
+
+    for (int i = 0, n = f1s.size(); i < n; i++) {
+      // df/da and df/db reverse (both at once!)
+      const auto& f1 = f1s[i];
+      Back a_back = a0;
+      Back b_back = b0;
+      Back result_back = f1(a_back, b_back);
+      Real primal_back = result_back.ptr->primal;
+      result_back.reverse(1);
+      Real dfda_back = a1 * a_back.ptr->gradient;
+      Real dfdb_back = b1 * b_back.ptr->gradient;
+
+      // compute the derivative of the result of the function with respect to
+      // its first input in forward mode
+      {
+        // df/da forward
+        const auto& f2 = f2s[i];
+        Fwd a_fwd = Fwd{a0, a1};
+        Fwd b_fwd = b0;
+        Fwd result_fwd = f2(a_fwd, b_fwd);
+        Real primal_fwd = result_fwd.primal;
+        Real dfda_fwd = result_fwd.derivative1;
+
+        EXPECT_CLOSE(primal_fwd.as_double(), primal_back.as_double());
+        EXPECT_CLOSE(dfda_fwd.as_double(), dfda_back.as_double());
+      }
+
+      // compute the derivative of the result of the function with respect to
+      // its second input in forward mode
+      {
+        // df/db forward
+        const auto& f2 = f2s[i];
+        Fwd a_fwd = a0;
+        Fwd b_fwd = Fwd{b0, b1};
+        Fwd result_fwd = f2(a_fwd, b_fwd);
+        Real primal_fwd = result_fwd.primal;
+        Real dfdb_fwd = result_fwd.derivative1;
+
+        EXPECT_CLOSE(primal_fwd.as_double(), primal_back.as_double());
+        EXPECT_CLOSE(dfdb_fwd.as_double(), dfdb_back.as_double());
+      }
+    }
+  }
+}


### PR DESCRIPTION
Summary:
Implement reverse-mode automatic differentiation (AD) for scalars.  Reverse-mode is needed for Variational Inference (VI) and multi-site Markov Chain Monte Carlo (MCMC) methods such as Hamiltonian Monte Carlo (HMC) and the No U-Turn Sampler (NUTS).

Although this is probably a high-performance implementation, the performance of reverse-mode will not likely be on the critical path of inference, as our intent is to use this implementation `Reverse` on top of symbolic nodes `Traced` - i.e. `Reverse<Traced>` - to compute gradients not numerically, but symbolically. That will produce an expression DAG which we can then optimize and generate efficient native code from.  That tightly-coded native code is what would be invoked during inference to compute the gradients (without even needing to traverse the graph).  This is a stepping-stone in that direction.

Differential Revision: D39749431

