### PR TITLE
Add LKJ Cholesky to pybindings

### DIFF
--- a/src/beanmachine/graph/pybindings.cpp
+++ b/src/beanmachine/graph/pybindings.cpp
@@ -120,7 +120,8 @@ PYBIND11_MODULE(graph, module) {
       .value("CATEGORICAL", DistributionType::CATEGORICAL)
       .value("POISSON", DistributionType::POISSON)
       .value("PRODUCT", DistributionType::PRODUCT)
-      .value("GEOMETRIC", DistributionType::GEOMETRIC);
+      .value("GEOMETRIC", DistributionType::GEOMETRIC)
+      .value("LKJ_CHOLESKY", DistributionType::LKJ_CHOLESKY);
 
   py::enum_<FactorType>(module, "FactorType")
       .value("EXP_PRODUCT", FactorType::EXP_PRODUCT);


### PR DESCRIPTION
Summary: Forgot this when adding LKJ Cholesky, which caused issues for BMGInference in python

Reviewed By: rodrigodesalvobraz

Differential Revision: D39829602

