### PR TITLE
minibmg: add RVID to the sample operation

### DIFF
--- a/minibmg/eval.h
+++ b/minibmg/eval.h
@@ -125,8 +125,8 @@ void eval_graph(
         if (obsp != observations.end()) {
           value = obsp->second;
         } else {
-          auto sample = std::dynamic_pointer_cast<const OperatorNode>(node);
-          Nodep in0 = sample->in_nodes[0];
+          auto sample = std::dynamic_pointer_cast<const SampleNode>(node);
+          Nodep in0 = sample->distribution;
           auto dist = std::dynamic_pointer_cast<const OperatorNode>(in0);
           std::function<double(unsigned)> get_parameter = [&](unsigned i) {
             return data[dist->in_nodes[i]].as_double();

--- a/minibmg/factory.cpp
+++ b/minibmg/factory.cpp
@@ -6,7 +6,9 @@
  */
 
 #include "beanmachine/minibmg/factory.h"
+#include <memory>
 #include <stdexcept>
+#include "node.h"
 
 namespace beanmachine::minibmg {
 
@@ -150,6 +152,15 @@ NodeId Graph::Factory::add_variable(
     const std::string& name,
     const unsigned variable_index) {
   auto new_node = std::make_shared<VariableNode>(name, variable_index);
+  return add_node(new_node);
+}
+
+NodeId Graph::Factory::add_sample(NodeId distribution) {
+  auto parent_node = identifer_to_node[distribution];
+  if (parent_node == nullptr) {
+    throw std::invalid_argument("Reference to nonexistent node.");
+  }
+  auto new_node = std::make_shared<SampleNode>(parent_node);
   return add_node(new_node);
 }
 

--- a/minibmg/factory.h
+++ b/minibmg/factory.h
@@ -63,6 +63,7 @@ class Graph::Factory {
  public:
   NodeId add_constant(double value);
   NodeId add_operator(enum Operator op, std::vector<NodeId> parents);
+  NodeId add_sample(NodeId distribution);
 
   // Add an observation to the graph.  The sample must identify a SAMPLE node.
   void add_observation(NodeId sample, double value);

--- a/minibmg/fluent_factory.cpp
+++ b/minibmg/fluent_factory.cpp
@@ -55,8 +55,7 @@ Distribution bernoulli(Value p) {
 }
 
 Value sample(const Distribution& d) {
-  return Value{std::make_shared<OperatorNode>(
-      std::vector<Nodep>{d.node}, Operator::SAMPLE, Type::REAL)};
+  return Value{std::make_shared<SampleNode>(d.node)};
 }
 
 } // namespace beanmachine::minibmg

--- a/minibmg/graph.cpp
+++ b/minibmg/graph.cpp
@@ -9,25 +9,17 @@
 #include <fmt/core.h>
 #include <folly/json.h>
 #include <algorithm>
+#include <memory>
 #include <unordered_map>
 #include "beanmachine/minibmg/factory.h"
 #include "beanmachine/minibmg/topological.h"
 #include "graph.h"
+#include "node.h"
 #include "operator.h"
 
 namespace {
 
 using namespace beanmachine::minibmg;
-
-std::vector<Nodep> successors(const Nodep& n) {
-  switch (n->op) {
-    case Operator::CONSTANT:
-    case Operator::VARIABLE:
-      return {};
-    default:
-      return std::dynamic_pointer_cast<const OperatorNode>(n)->in_nodes;
-  }
-}
 
 const std::vector<Nodep> roots(
     const std::vector<Nodep>& queries,
@@ -46,7 +38,7 @@ const std::vector<Nodep> roots(
     roots.push_back(n);
   }
   std::vector<Nodep> all_nodes;
-  if (!topological_sort<Nodep>(roots, &successors, all_nodes)) {
+  if (!topological_sort<Nodep>(roots, &in_nodes, all_nodes)) {
     throw std::invalid_argument("graph has a cycle");
   }
   std::reverse(all_nodes.begin(), all_nodes.end());
@@ -106,6 +98,20 @@ void Graph::validate(std::vector<Nodep> nodes) {
       case Operator::VARIABLE:
         break;
 
+      case Operator::SAMPLE: {
+        auto op = std::dynamic_pointer_cast<const SampleNode>(node);
+        Nodep distribution = op->distribution;
+        if (!seen.count(distribution)) {
+          throw std::invalid_argument(
+              fmt::format("Node {0} has a parent not previously seen", i));
+        }
+        if (distribution->type != Type::DISTRIBUTION) {
+          throw std::invalid_argument(fmt::format(
+              "Node {0} (SAMPLE) should have a DISTRIBUTION input", i));
+        }
+        break;
+      }
+
       // Check other operators.
       default: {
         auto op = std::dynamic_pointer_cast<const OperatorNode>(node);
@@ -128,6 +134,7 @@ void Graph::validate(std::vector<Nodep> nodes) {
                 to_string(parent_types[j])));
           }
         }
+        break;
       }
     }
 
@@ -158,6 +165,13 @@ folly::dynamic graph_to_json(const Graph& g) {
         break;
       }
       // TODO: case Operator::VARIABLE:
+      case Operator::SAMPLE: {
+        auto n = std::dynamic_pointer_cast<const SampleNode>(node);
+        dynamic in_nodes = dynamic::array;
+        in_nodes.push_back(node_to_identifier[n->distribution]);
+        dyn_node["in_nodes"] = in_nodes;
+        break;
+      }
       default: {
         auto n = std::dynamic_pointer_cast<const OperatorNode>(node);
         dynamic in_nodes = dynamic::array;
@@ -265,6 +279,26 @@ Graph json_to_graph(folly::dynamic d) {
         }
         auto variable_index = (unsigned)variable_indexv.asInt();
         node = std::make_shared<const VariableNode>(name, variable_index);
+        break;
+      }
+      case Operator::SAMPLE: {
+        auto in_nodesv = json_node["in_nodes"];
+        if (!in_nodesv.isArray()) {
+          throw JsonError("missing in_nodes.");
+        }
+        if (in_nodesv.size() != 1) {
+          throw JsonError("sample requires one input node.");
+        }
+        auto in_nodev = in_nodesv[0];
+        if (!in_nodev.isInt()) {
+          throw JsonError("missing in_node for operator.");
+        }
+        auto in_node_i = in_nodev.asInt();
+        if (!identifier_to_node.contains(in_node_i)) {
+          throw JsonError("bad in_node for operator.");
+        }
+        auto in_node = identifier_to_node[in_node_i];
+        node = std::make_shared<const SampleNode>(in_node, identifier);
         break;
       }
       default: {

--- a/minibmg/node.cpp
+++ b/minibmg/node.cpp
@@ -6,7 +6,17 @@
  */
 
 #include "beanmachine/minibmg/node.h"
+#include <atomic>
 #include <stdexcept>
+
+namespace {
+
+std::atomic<long> next_rvid = 1;
+long make_fresh_rvid() {
+  return next_rvid.fetch_add(1);
+}
+
+} // namespace
 
 namespace beanmachine::minibmg {
 
@@ -22,6 +32,7 @@ OperatorNode::OperatorNode(
   switch (op) {
     case Operator::CONSTANT:
     case Operator::VARIABLE:
+    case Operator::SAMPLE:
       throw std::invalid_argument(
           "OperatorNode cannot be used for " + to_string(op) + ".");
     default:;
@@ -35,5 +46,27 @@ VariableNode::VariableNode(const std::string& name, const unsigned identifier)
     : Node{Operator::VARIABLE, Type::REAL},
       name{name},
       identifier{identifier} {}
+
+SampleNode::SampleNode(Nodep distribution)
+    : Node{Operator::SAMPLE, Type::REAL},
+      distribution{distribution},
+      rvid{make_fresh_rvid()} {}
+
+SampleNode::SampleNode(Nodep distribution, long rvid)
+    : Node{Operator::SAMPLE, Type::REAL},
+      distribution{distribution},
+      rvid{rvid} {}
+
+std::vector<Nodep> in_nodes(const Nodep& n) {
+  switch (n->op) {
+    case Operator::CONSTANT:
+    case Operator::VARIABLE:
+      return {};
+    case Operator::SAMPLE:
+      return {std::dynamic_pointer_cast<const SampleNode>(n)->distribution};
+    default:
+      return std::dynamic_pointer_cast<const OperatorNode>(n)->in_nodes;
+  }
+}
 
 } // namespace beanmachine::minibmg

--- a/minibmg/node.h
+++ b/minibmg/node.h
@@ -55,4 +55,15 @@ class VariableNode : public Node {
   unsigned identifier;
 };
 
+class SampleNode : public Node {
+ public:
+  explicit SampleNode(Nodep distribution);
+  explicit SampleNode(Nodep distribution, long rvid);
+  Nodep distribution;
+  // We assign a distinct ID to each sample operation in a model
+  long rvid;
+};
+
+std::vector<Nodep> in_nodes(const Nodep& n);
+
 } // namespace beanmachine::minibmg

--- a/minibmg/out_nodes.cpp
+++ b/minibmg/out_nodes.cpp
@@ -34,20 +34,9 @@ class Out_Nodes_Property
     Out_Nodes_Data* data = new Out_Nodes_Data{};
     for (auto node : g) {
       data->node_map[node] = std::list<Nodep>{};
-      switch (node->op) {
-        case Operator::CONSTANT:
-        case Operator::VARIABLE:
-          // these nodes do not have inputs.
-          break;
-        default: {
-          // the rest are operator nodes.
-          auto opnode = std::dynamic_pointer_cast<const OperatorNode>(node);
-          for (auto in_node : opnode->in_nodes) {
-            auto& predecessor_out_set = data->for_node(in_node);
-            predecessor_out_set.push_back(node);
-          }
-          break;
-        }
+      for (auto in_node : in_nodes(node)) {
+        auto& predecessor_out_set = data->for_node(in_node);
+        predecessor_out_set.push_back(node);
       }
     }
 

--- a/minibmg/tests/eval_test.cpp
+++ b/minibmg/tests/eval_test.cpp
@@ -49,7 +49,7 @@ TEST(eval_test, sample1) {
   auto k0 = fac.add_constant(expected_mean);
   auto k1 = fac.add_constant(expected_stdev);
   auto normal0 = fac.add_operator(Operator::DISTRIBUTION_NORMAL, {k0, k1});
-  auto sample0 = fac.add_operator(Operator::SAMPLE, {normal0});
+  auto sample0 = fac.add_sample(normal0);
   fac.add_query(sample0); // add a root to the graph.
   auto graph = fac.build();
   // We create a new random number generator with its default (deterministic)

--- a/minibmg/tests/minibmg_test.cpp
+++ b/minibmg/tests/minibmg_test.cpp
@@ -27,7 +27,7 @@ TEST(test_minibmg, basic_building_1) {
   ASSERT_ID(k56, 3);
   auto beta = gf.add_operator(Operator::DISTRIBUTION_BETA, {plus, k56});
   ASSERT_ID(beta, 4);
-  auto sample = gf.add_operator(Operator::SAMPLE, {beta});
+  auto sample = gf.add_sample(beta);
   ASSERT_ID(sample, 5);
   gf.add_observation(sample, 7.8);
   auto query = gf.add_query(sample);
@@ -48,7 +48,7 @@ TEST(test_minibmg, dead_code_dropped) {
   ASSERT_ID(k56, 3);
   auto beta = gf.add_operator(Operator::DISTRIBUTION_BETA, {k34, k56});
   ASSERT_ID(beta, 4);
-  auto sample = gf.add_operator(Operator::SAMPLE, {beta});
+  auto sample = gf.add_sample(beta);
   ASSERT_ID(sample, 5);
   gf.add_observation(sample, 7.8);
   auto query = gf.add_query(sample);

--- a/minibmg/tests/out_nodes_test.cpp
+++ b/minibmg/tests/out_nodes_test.cpp
@@ -20,7 +20,7 @@ TEST(out_nodes_test, simple) {
   auto plus = gf.add_operator(Operator::ADD, {k12, k34});
   auto k56 = gf.add_constant(5.6);
   auto beta = gf.add_operator(Operator::DISTRIBUTION_BETA, {plus, k56});
-  auto sample = gf.add_operator(Operator::SAMPLE, {beta});
+  auto sample = gf.add_sample(beta);
   gf.add_observation(sample, 7.8);
   /* auto query_ = */ gf.add_query(sample);
   Graph g = gf.build();


### PR DESCRIPTION
Summary:
Soon we will be adding a deduplication facility to minibmg.  Unfortunately, distinct samples from the same distribution appear to be duplicate operations, but because samples are nondeterministic they are actually distinct operations.  To make each sample node distinct, we add a random variable identifier.

Most clients of the graph will have no need to pay attention to the identifier.

Differential Revision: D39888681

