### PR TITLE
minibmg: deduplicate nodes of a graph

### DIFF
--- a/minibmg/ad/traced_to_string.cpp
+++ b/minibmg/ad/traced_to_string.cpp
@@ -9,203 +9,26 @@
 #include <functional>
 #include <memory>
 #include <set>
+#include <sstream>
 #include "beanmachine/minibmg/ad/traced.h"
 #include "beanmachine/minibmg/minibmg.h"
+#include "beanmachine/minibmg/pretty.h"
 #include "beanmachine/minibmg/topological.h"
-
-using namespace beanmachine::minibmg;
-
-// Private helper data structures and functions used in producing a string form
-// for a Traced.
-namespace {
-
-enum class Precedence {
-  Term,
-  Product,
-  Sum,
-};
-
-struct PrintedForm {
-  PrintedForm() : string{""}, precedence{Precedence::Term} {}
-  PrintedForm(std::string string, Precedence precedence)
-      : string{string}, precedence{precedence} {}
-  PrintedForm(const PrintedForm& other)
-      : string{other.string}, precedence{other.precedence} {}
-  PrintedForm& operator=(const PrintedForm& other) = default;
-  ~PrintedForm() {}
-  std::string string;
-  Precedence precedence;
-};
-
-Precedence precedence_for_operator(Operator op) {
-  switch (op) {
-    case Operator::ADD:
-    case Operator::SUBTRACT:
-    case Operator::NEGATE:
-      return Precedence::Sum;
-    case Operator::MULTIPLY:
-    case Operator::DIVIDE:
-      return Precedence::Product;
-    default:
-      return Precedence::Term;
-  }
-}
-
-std::string string_for_operator(Operator op) {
-  switch (op) {
-    case Operator::ADD:
-      return "+";
-    case Operator::SUBTRACT:
-    case Operator::NEGATE:
-      return "-";
-    case Operator::MULTIPLY:
-      return "*";
-    case Operator::DIVIDE:
-      return "/";
-    case Operator::POW:
-      return "pow";
-    case Operator::POLYGAMMA:
-      return "polygamma";
-    case Operator::EXP:
-      return "exp";
-    case Operator::LOG:
-      return "log";
-    case Operator::ATAN:
-      return "atan";
-    case Operator::LGAMMA:
-      return "lgamma";
-    case Operator::IF_EQUAL:
-      return "if_equal";
-    case Operator::IF_LESS:
-      return "if_less";
-    default:
-      return "<program error>";
-  }
-}
-
-PrintedForm print(Nodep node, std::map<Nodep, PrintedForm>& cache) {
-  auto op = node->op;
-  switch (op) {
-    case Operator::CONSTANT: {
-      auto n = std::dynamic_pointer_cast<const ConstantNode>(node);
-      return PrintedForm{fmt::format("{}", n->value), Precedence::Term};
-    }
-    case Operator::VARIABLE: {
-      auto n = std::dynamic_pointer_cast<const VariableNode>(node);
-      auto name = (n->name.length() == 0) ? fmt::format("__{0}", n->identifier)
-                                          : n->name;
-      return PrintedForm{name, Precedence::Term};
-    }
-    case Operator::ADD:
-    case Operator::SUBTRACT:
-    case Operator::MULTIPLY:
-    case Operator::DIVIDE: {
-      auto n = std::dynamic_pointer_cast<const OperatorNode>(node);
-      auto this_precedence = precedence_for_operator(op);
-      auto this_string = string_for_operator(op);
-      auto left = cache[n->in_nodes[0]];
-      auto ls = (left.precedence > this_precedence)
-          ? fmt::format("({0})", left.string)
-          : left.string;
-      auto right = cache[n->in_nodes[1]];
-      auto rs = (right.precedence >= this_precedence)
-          ? fmt::format("({0})", right.string)
-          : right.string;
-      return PrintedForm{
-          fmt::format("{0} {1} {2}", ls, this_string, rs), this_precedence};
-    }
-    case Operator::NEGATE: {
-      auto n = std::dynamic_pointer_cast<const OperatorNode>(node);
-      auto this_precedence = precedence_for_operator(op);
-      auto right = cache[n->in_nodes[0]];
-      auto rs = (right.precedence >= this_precedence)
-          ? fmt::format("({0})", right.string)
-          : right.string;
-      return PrintedForm{fmt::format("-{0}", rs), this_precedence};
-    }
-    case Operator::POW:
-    case Operator::POLYGAMMA: {
-      auto n = std::dynamic_pointer_cast<const OperatorNode>(node);
-      auto left = cache[n->in_nodes[0]];
-      auto ls = left.string;
-      auto right = cache[n->in_nodes[1]];
-      auto rs = right.string;
-      auto this_string = string_for_operator(op);
-      return PrintedForm{
-          fmt::format("{1}({0}, {2})", ls, this_string, rs), Precedence::Term};
-    }
-    case Operator::EXP:
-    case Operator::LOG:
-    case Operator::ATAN:
-    case Operator::LGAMMA: {
-      auto n = std::dynamic_pointer_cast<const OperatorNode>(node);
-      auto this_string = string_for_operator(op);
-      auto left = cache[n->in_nodes[0]];
-      auto ls = left.string;
-      return PrintedForm{
-          fmt::format("{1}({0})", ls, this_string), Precedence::Term};
-    }
-    case Operator::IF_LESS:
-    case Operator::IF_EQUAL: {
-      auto n = std::dynamic_pointer_cast<const OperatorNode>(node);
-      auto this_string = string_for_operator(op);
-      auto left = cache[n->in_nodes[0]];
-      auto ls = left.string;
-      return PrintedForm{
-          fmt::format(
-              "{1}({0}, {2}, {3}, {4})",
-              ls,
-              this_string,
-              cache[n->in_nodes[1]].string,
-              cache[n->in_nodes[2]].string,
-              cache[n->in_nodes[3]].string),
-          Precedence::Term};
-    }
-    default: {
-      return PrintedForm{
-          fmt::format(
-              "{}:{}: not implemented: to_string(const Traced& traced)",
-              __FILE__,
-              __LINE__),
-          Precedence::Term};
-    }
-  }
-}
-
-} // namespace
 
 namespace beanmachine::minibmg {
 
-std::string to_string(const Nodep& node);
+std::string to_string(const Nodep& node) {
+  auto pretty_result = pretty_print({node});
+  std::stringstream code;
+  for (auto p : pretty_result.prelude) {
+    code << p << std::endl;
+  }
+  code << pretty_result.code[node];
+  return code.str();
+}
 
 std::string to_string(const Traced& traced) {
   return to_string(traced.node);
-}
-
-std::string to_string(const Nodep& node) {
-  auto successors = [](const Nodep& t) -> std::vector<Nodep> {
-    switch (t->op) {
-      case Operator::CONSTANT:
-      case Operator::VARIABLE:
-        return {};
-      default:
-        return std::dynamic_pointer_cast<const OperatorNode>(t)->in_nodes;
-    }
-  };
-  std::vector<Nodep> topologically_sorted;
-  bool sorted =
-      topological_sort<Nodep>({node}, successors, topologically_sorted);
-  if (!sorted) {
-    throw std::invalid_argument("cycle in graph");
-  }
-  std::reverse(topologically_sorted.begin(), topologically_sorted.end());
-  std::map<Nodep, PrintedForm> cache{};
-  for (auto n : topologically_sorted) {
-    auto p = print(n, cache);
-    cache[n] = p;
-  }
-
-  return cache[node].string;
 }
 
 } // namespace beanmachine::minibmg

--- a/minibmg/dedup.cpp
+++ b/minibmg/dedup.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "beanmachine/minibmg/dedup.h"
+#include <map>
+#include <stdexcept>
+#include <unordered_map>
+#include "beanmachine/minibmg/operator.h"
+#include "beanmachine/minibmg/topological.h"
+
+namespace {
+
+using namespace beanmachine::minibmg;
+
+// Rewrite a single node by replacing all of its inputs with their deduplicated
+// counterpart.
+Nodep rewrite(Nodep node, const NodeValueMap<Nodep>& map) {
+  switch (node->op) {
+    case Operator::CONSTANT:
+    case Operator::VARIABLE:
+      return node;
+    case Operator::SAMPLE: {
+      auto s = std::dynamic_pointer_cast<const SampleNode>(node);
+      Nodep dist = map.at(s->distribution);
+      if (dist == s->distribution) {
+        return node;
+      }
+      return std::make_shared<SampleNode>(dist, s->rvid);
+    }
+    default: {
+      auto op = std::dynamic_pointer_cast<const OperatorNode>(node);
+      std::vector<Nodep> in_nodes;
+      bool changed = false;
+      for (Nodep in_node : op->in_nodes) {
+        Nodep replacement = map.at(in_node);
+        if (replacement != in_node) {
+          changed = true;
+        }
+        in_nodes.push_back(replacement);
+      }
+      if (!changed) {
+        return node;
+      }
+      return std::make_shared<OperatorNode>(in_nodes, node->op, node->type);
+    }
+  }
+}
+
+} // namespace
+
+namespace beanmachine::minibmg {
+
+// Take a set of root nodes as input, and return a map of deduplicated nodes,
+// which maps from a node in the transitive closure of the input to a
+// corresponding node in the transitive closure of the deduplicated graph.
+std::unordered_map<Nodep, Nodep> dedup(std::vector<Nodep> roots) {
+  // a value-based, map, which treats semantically identical nodes as the same.
+  NodeValueMap<Nodep> map;
+
+  // We also build a map that uses object (pointer) identity to find elements,
+  // so that operations in clients are not using recursive equality operations.
+  std::unordered_map<Nodep, Nodep> identity_map;
+
+  std::vector<Nodep> sorted;
+  if (!topological_sort<Nodep>(
+          {roots.begin(), roots.end()}, in_nodes, sorted)) {
+    throw std::invalid_argument("graph has a cycle");
+  }
+  std::reverse(sorted.begin(), sorted.end());
+  for (auto node : sorted) {
+    auto found = map.find(node);
+    if (found != map.end()) {
+      map.insert({node, found->second});
+      identity_map.insert({node, found->second});
+      continue;
+    }
+    auto rewritten = rewrite(node, map);
+    map.insert({node, rewritten});
+    identity_map.insert({node, rewritten});
+  }
+
+  return identity_map;
+}
+
+} // namespace beanmachine::minibmg

--- a/minibmg/dedup.h
+++ b/minibmg/dedup.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <memory>
+#include <unordered_map>
+#include <vector>
+#include "beanmachine/minibmg/node.h"
+
+namespace beanmachine::minibmg {
+
+// Take a set of root nodes as input, and return a map of deduplicated nodes,
+// which maps from a node in the transitive closure of the roots to a
+// corresponding node in the transitive closure of the deduplicated graph.
+std::unordered_map<Nodep, Nodep> dedup(std::vector<Nodep> roots);
+
+} // namespace beanmachine::minibmg

--- a/minibmg/fluent_factory.cpp
+++ b/minibmg/fluent_factory.cpp
@@ -30,7 +30,14 @@ void Graph::FluentFactory::query(const Traced& value) {
 }
 
 Graph Graph::FluentFactory::build() {
-  return Graph{queries, observations};
+  return Graph::create(queries, observations);
+}
+
+Distribution half_normal(Value stddev) {
+  return Distribution{std::make_shared<const OperatorNode>(
+      std::vector<Nodep>{stddev.node},
+      Operator::DISTRIBUTION_HALF_NORMAL,
+      Type::DISTRIBUTION)};
 }
 
 Distribution normal(Value mean, Value stddev) {
@@ -54,8 +61,8 @@ Distribution bernoulli(Value p) {
       Type::DISTRIBUTION)};
 }
 
-Value sample(const Distribution& d) {
-  return Value{std::make_shared<SampleNode>(d.node)};
+Value sample(const Distribution& d, std::string rvid) {
+  return Value{std::make_shared<SampleNode>(d.node, rvid)};
 }
 
 } // namespace beanmachine::minibmg

--- a/minibmg/fluent_factory.h
+++ b/minibmg/fluent_factory.h
@@ -30,13 +30,15 @@ class Distribution {
   }
 };
 
+Distribution half_normal(Value stddev);
+
 Distribution normal(Value mean, Value stddev);
 
 Distribution beta(Value a, Value b);
 
 Distribution bernoulli(Value p);
 
-Value sample(const Distribution& d);
+Value sample(const Distribution& d, std::string rvid = make_fresh_rvid());
 
 class Graph::FluentFactory {
  public:

--- a/minibmg/graph.h
+++ b/minibmg/graph.h
@@ -21,7 +21,7 @@ class Graph : public Container {
   // valudates that the list of nodes so reached forms a valid graph, and
   // returns that graph.  Throws an exception if the nodes do not form a valid
   // graph.
-  Graph(
+  static Graph create(
       const std::vector<Nodep>& queries,
       const std::list<std::pair<Nodep, double>>& observations);
   ~Graph();

--- a/minibmg/node.cpp
+++ b/minibmg/node.cpp
@@ -32,7 +32,11 @@ inline std::size_t hash_combine(std::size_t a, std::size_t b, std::size_t c) {
 }
 
 inline std::size_t hash(const std::vector<Nodep>& in_nodes) {
-  return boost::hash_range(in_nodes.begin(), in_nodes.end());
+  std::size_t seed = 0;
+  for (auto n : in_nodes) {
+    boost::hash_combine(seed, n->cached_hash_value);
+  }
+  return seed;
 }
 
 } // namespace
@@ -91,6 +95,62 @@ std::vector<Nodep> in_nodes(const Nodep& n) {
       return {std::dynamic_pointer_cast<const SampleNode>(n)->distribution};
     default:
       return std::dynamic_pointer_cast<const OperatorNode>(n)->in_nodes;
+  }
+}
+
+std::size_t NodepIdentityHash::operator()(
+    beanmachine::minibmg::Nodep const& p) const noexcept {
+  return p->cached_hash_value;
+}
+
+bool NodepIdentityEquals::operator()(
+    const beanmachine::minibmg::Nodep& lhs,
+    const beanmachine::minibmg::Nodep& rhs) const noexcept {
+  using namespace beanmachine::minibmg;
+  const Node* l = lhs.get();
+  const Node* r = rhs.get();
+  // a node is equal to itself.
+  if (l == r) {
+    return true;
+  }
+  // equal nodes have equal hash codes and equal operators.
+  if (l == nullptr || r == nullptr ||
+      l->cached_hash_value != r->cached_hash_value || l->op != r->op) {
+    return false;
+  }
+  switch (l->op) {
+    case Operator::VARIABLE: {
+      const VariableNode* vl = dynamic_cast<const VariableNode*>(l);
+      const VariableNode* vr = dynamic_cast<const VariableNode*>(r);
+      return vl->name == vr->name && vl->identifier == vr->identifier;
+    }
+    case Operator::CONSTANT: {
+      double cl = dynamic_cast<const ConstantNode*>(l)->value;
+      double cr = dynamic_cast<const ConstantNode*>(r)->value;
+      return std::isnan(cl) ? std::isnan(cr) : cl == cr;
+    }
+    case Operator::SAMPLE: {
+      const SampleNode* sl = dynamic_cast<const SampleNode*>(l);
+      const SampleNode* sr = dynamic_cast<const SampleNode*>(r);
+      return sl->rvid == sr->rvid &&
+          this->operator()(sl->distribution, sr->distribution);
+    }
+    default: {
+      const OperatorNode* lo = dynamic_cast<const OperatorNode*>(l);
+      const OperatorNode* ro = dynamic_cast<const OperatorNode*>(r);
+      if (lo->in_nodes.size() != ro->in_nodes.size()) {
+        return false;
+      }
+      auto it1 = lo->in_nodes.begin();
+      auto it2 = ro->in_nodes.begin();
+      for (; it1 != lo->in_nodes.end() && it2 != ro->in_nodes.end();
+           it1++, it2++) {
+        if (!this->operator()(*it1, *it2)) {
+          return false;
+        }
+      }
+      return true;
+    }
   }
 }
 

--- a/minibmg/node.h
+++ b/minibmg/node.h
@@ -12,6 +12,7 @@
 #include <cstddef>
 #include <functional>
 #include <memory>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 #include "beanmachine/minibmg/operator.h"
@@ -71,69 +72,28 @@ class SampleNode : public Node {
 
 std::vector<Nodep> in_nodes(const Nodep& n);
 
-} // namespace beanmachine::minibmg
-
 // Provide a good hash function so Nodep values can be used in unordered maps
 // and sets.  This treats Nodep values as semantically value-based.
-template <>
-struct std::hash<beanmachine::minibmg::Nodep> {
-  std::size_t operator()(beanmachine::minibmg::Nodep const& p) const noexcept {
-    return p->cached_hash_value;
-  }
+struct NodepIdentityHash {
+  std::size_t operator()(beanmachine::minibmg::Nodep const& p) const noexcept;
 };
 
 // Provide a good equality function so Nodep values can be used in unordered
 // maps and sets.  This treats Nodep values, recursively, as semantically
 // value-based.
-template <>
-struct std::equal_to<beanmachine::minibmg::Nodep> {
+struct NodepIdentityEquals {
   bool operator()(
       const beanmachine::minibmg::Nodep& lhs,
-      const beanmachine::minibmg::Nodep& rhs) const {
-    using namespace beanmachine::minibmg;
-    const Node* l = lhs.get();
-    const Node* r = rhs.get();
-    // a node is equal to itself.
-    if (l == r) {
-      return true;
-    }
-    // equal nodes have equal hash codes and equal operators.
-    if (l->cached_hash_value != r->cached_hash_value || l->op != r->op) {
-      return false;
-    }
-    switch (l->op) {
-      case Operator::VARIABLE: {
-        const VariableNode* vl = dynamic_cast<const VariableNode*>(l);
-        const VariableNode* vr = dynamic_cast<const VariableNode*>(r);
-        return vl->name == vr->name && vl->identifier == vr->identifier;
-      }
-      case Operator::CONSTANT: {
-        double cl = dynamic_cast<const ConstantNode*>(l)->value;
-        double cr = dynamic_cast<const ConstantNode*>(r)->value;
-        return std::isnan(cl) ? std::isnan(cr) : cl == cr;
-      }
-      case Operator::SAMPLE: {
-        const SampleNode* sl = dynamic_cast<const SampleNode*>(l);
-        const SampleNode* sr = dynamic_cast<const SampleNode*>(r);
-        return sl->rvid == sr->rvid &&
-            this->operator()(sl->distribution, sr->distribution);
-      }
-      default: {
-        const OperatorNode* lo = dynamic_cast<const OperatorNode*>(l);
-        const OperatorNode* ro = dynamic_cast<const OperatorNode*>(r);
-        if (lo->in_nodes.size() != ro->in_nodes.size()) {
-          return false;
-        }
-        auto it1 = lo->in_nodes.begin();
-        auto it2 = ro->in_nodes.begin();
-        for (; it1 != lo->in_nodes.end() && it2 != ro->in_nodes.end();
-             it1++, it2++) {
-          if (!this->operator()(*it1, *it2)) {
-            return false;
-          }
-        }
-        return true;
-      }
-    }
-  }
+      const beanmachine::minibmg::Nodep& rhs) const noexcept;
 };
+
+// A value-based map from nodes to T.  Used for deduplicating a graph.
+template <class T>
+using NodeValueMap =
+    std::unordered_map<Nodep, T, NodepIdentityHash, NodepIdentityEquals>;
+
+// A value-based set of nodes.
+using NodeValueSet =
+    std::unordered_set<Nodep, NodepIdentityHash, NodepIdentityEquals>;
+
+} // namespace beanmachine::minibmg

--- a/minibmg/operator.h
+++ b/minibmg/operator.h
@@ -20,7 +20,7 @@ enum class Operator {
   // Result: the given constant value (REAL)
   CONSTANT,
 
-  // A scalar variable.  Used for symbolid auto-differentiation (AD).
+  // A scalar variable.  Used for symbolic auto-differentiation (AD).
   VARIABLE,
 
   // Add two scalars.

--- a/minibmg/pretty.cpp
+++ b/minibmg/pretty.cpp
@@ -1,0 +1,293 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "beanmachine/minibmg/pretty.h"
+#include <map>
+#include <sstream>
+#include <stdexcept>
+#include <unordered_map>
+#include "beanmachine/minibmg/node.h"
+#include "beanmachine/minibmg/topological.h"
+#include "operator.h"
+
+// Private helper data structures and functions used in producing a string form
+// for a Traced.
+namespace {
+
+using namespace beanmachine::minibmg;
+
+enum class Precedence {
+  Term,
+  Product,
+  Sum,
+};
+
+struct PrintedForm {
+  std::string string;
+  Precedence precedence;
+
+  PrintedForm() : string{""}, precedence{Precedence::Term} {}
+  PrintedForm(std::string string, Precedence precedence)
+      : string{string}, precedence{precedence} {}
+  PrintedForm(const PrintedForm& other)
+      : string{other.string}, precedence{other.precedence} {}
+  PrintedForm& operator=(const PrintedForm& other) = default;
+  ~PrintedForm() {}
+};
+
+Precedence precedence_for_operator(Operator op) {
+  switch (op) {
+    case Operator::ADD:
+    case Operator::SUBTRACT:
+    case Operator::NEGATE:
+      return Precedence::Sum;
+    case Operator::MULTIPLY:
+    case Operator::DIVIDE:
+      return Precedence::Product;
+    default:
+      return Precedence::Term;
+  }
+}
+
+std::string string_for_operator(Operator op) {
+  switch (op) {
+    case Operator::ADD:
+      return "+";
+    case Operator::SUBTRACT:
+    case Operator::NEGATE:
+      return "-";
+    case Operator::MULTIPLY:
+      return "*";
+    case Operator::DIVIDE:
+      return "/";
+    case Operator::POW:
+      return "pow";
+    case Operator::POLYGAMMA:
+      return "polygamma";
+    case Operator::EXP:
+      return "exp";
+    case Operator::LOG:
+      return "log";
+    case Operator::ATAN:
+      return "atan";
+    case Operator::LGAMMA:
+      return "lgamma";
+    case Operator::IF_EQUAL:
+      return "if_equal";
+    case Operator::IF_LESS:
+      return "if_less";
+    default:
+      return "<program error>";
+  }
+}
+
+PrintedForm print(Nodep node, std::map<Nodep, PrintedForm>& cache) {
+  auto op = node->op;
+  switch (op) {
+    case Operator::CONSTANT: {
+      auto n = std::dynamic_pointer_cast<const ConstantNode>(node);
+      return PrintedForm{fmt::format("{}", n->value), Precedence::Term};
+    }
+    case Operator::VARIABLE: {
+      auto n = std::dynamic_pointer_cast<const VariableNode>(node);
+      auto name = (n->name.length() == 0) ? fmt::format("__{0}", n->identifier)
+                                          : n->name;
+      return PrintedForm{name, Precedence::Term};
+    }
+    case Operator::ADD:
+    case Operator::SUBTRACT:
+    case Operator::MULTIPLY:
+    case Operator::DIVIDE: {
+      auto n = std::dynamic_pointer_cast<const OperatorNode>(node);
+      auto this_precedence = precedence_for_operator(op);
+      auto operator_name = string_for_operator(op);
+      auto left = cache[n->in_nodes[0]];
+      auto ls = (left.precedence > this_precedence)
+          ? fmt::format("({0})", left.string)
+          : left.string;
+      auto right = cache[n->in_nodes[1]];
+      auto rs = (right.precedence >= this_precedence)
+          ? fmt::format("({0})", right.string)
+          : right.string;
+      return PrintedForm{
+          fmt::format("{0} {1} {2}", ls, operator_name, rs), this_precedence};
+    }
+    case Operator::NEGATE: {
+      auto n = std::dynamic_pointer_cast<const OperatorNode>(node);
+      auto this_precedence = precedence_for_operator(op);
+      auto right = cache[n->in_nodes[0]];
+      auto rs = (right.precedence >= this_precedence)
+          ? fmt::format("({0})", right.string)
+          : right.string;
+      return PrintedForm{fmt::format("-{0}", rs), this_precedence};
+    }
+    case Operator::POW:
+    case Operator::POLYGAMMA: {
+      auto n = std::dynamic_pointer_cast<const OperatorNode>(node);
+      auto left = cache[n->in_nodes[0]];
+      auto ls = left.string;
+      auto right = cache[n->in_nodes[1]];
+      auto rs = right.string;
+      auto operator_name = string_for_operator(op);
+      return PrintedForm{
+          fmt::format("{0}({1}, {2})", operator_name, ls, rs),
+          Precedence::Term};
+    }
+    case Operator::EXP:
+    case Operator::LOG:
+    case Operator::ATAN:
+    case Operator::LGAMMA: {
+      auto n = std::dynamic_pointer_cast<const OperatorNode>(node);
+      auto operator_name = string_for_operator(op);
+      auto left = cache[n->in_nodes[0]];
+      auto ls = left.string;
+      return PrintedForm{
+          fmt::format("{0}({1})", operator_name, ls), Precedence::Term};
+    }
+    case Operator::IF_LESS:
+    case Operator::IF_EQUAL: {
+      auto n = std::dynamic_pointer_cast<const OperatorNode>(node);
+      auto operator_name = string_for_operator(op);
+      auto left = cache[n->in_nodes[0]];
+      auto ls = left.string;
+      return PrintedForm{
+          fmt::format(
+              "{0}({1}, {2}, {3}, {4})",
+              operator_name,
+              ls,
+              cache[n->in_nodes[1]].string,
+              cache[n->in_nodes[2]].string,
+              cache[n->in_nodes[3]].string),
+          Precedence::Term};
+    }
+    case Operator::DISTRIBUTION_BERNOULLI: {
+      auto n = std::dynamic_pointer_cast<const OperatorNode>(node);
+      return PrintedForm{
+          fmt::format("{0}({1})", "bernoulli", cache[n->in_nodes[0]].string),
+          Precedence::Term};
+    }
+    case Operator::DISTRIBUTION_BETA: {
+      auto n = std::dynamic_pointer_cast<const OperatorNode>(node);
+      return PrintedForm{
+          fmt::format(
+              "{0}({1}, {2})",
+              "beta",
+              cache[n->in_nodes[0]].string,
+              cache[n->in_nodes[1]].string),
+          Precedence::Term};
+    }
+    case Operator::DISTRIBUTION_HALF_NORMAL: {
+      auto n = std::dynamic_pointer_cast<const OperatorNode>(node);
+      return PrintedForm{
+          fmt::format("{0}({1})", "half_normal", cache[n->in_nodes[0]].string),
+          Precedence::Term};
+    }
+    case Operator::DISTRIBUTION_NORMAL: {
+      auto n = std::dynamic_pointer_cast<const OperatorNode>(node);
+      return PrintedForm{
+          fmt::format(
+              "{0}({1}, {2})",
+              "normal",
+              cache[n->in_nodes[0]].string,
+              cache[n->in_nodes[1]].string),
+          Precedence::Term};
+    }
+    case Operator::SAMPLE: {
+      auto n = std::dynamic_pointer_cast<const SampleNode>(node);
+      return PrintedForm{
+          fmt::format(
+              "{0}({1}, \"{2}\")",
+              "sample",
+              cache[n->distribution].string,
+              n->rvid),
+          Precedence::Term};
+    }
+    default: {
+      return PrintedForm{
+          fmt::format(
+              "{}:{}: not implemented: to_string(const Traced& traced) for operator {}",
+              __FILE__,
+              __LINE__,
+              to_string(op)),
+          Precedence::Term};
+    }
+  }
+}
+
+} // namespace
+
+namespace beanmachine::minibmg {
+
+// Pretty-print a set of Nodes.  Returns a PrettyResult.
+const PrettyResult pretty_print(std::vector<Nodep> roots) {
+  std::map<Nodep, unsigned> counts =
+      count_predecessors<Nodep>({roots.begin(), roots.end()}, in_nodes);
+  // count the roots as uses too, so that they get put into a variable if
+  // also used elsewhere.
+  for (auto n : roots) {
+    counts[n]++;
+  }
+
+  std::vector<Nodep> sorted;
+  if (!topological_sort<Nodep>(
+          {roots.begin(), roots.end()}, in_nodes, sorted)) {
+    throw std::logic_error("nodes have a cycle");
+  }
+  reverse(sorted.begin(), sorted.end());
+
+  std::map<Nodep, PrintedForm> cache;
+  std::vector<std::string> prelude;
+  unsigned next_temp = 1;
+  for (auto n : sorted) {
+    PrintedForm p = print(n, cache);
+    if (counts[n] > 1 && n->op != Operator::VARIABLE) {
+      std::string temp = fmt::format("temp_{}", next_temp++);
+      std::string assignment = fmt::format("auto {} = {};", temp, p.string);
+      prelude.push_back(assignment);
+      p = {temp, Precedence::Term};
+    }
+    cache[n] = p;
+  }
+
+  std::unordered_map<Nodep, std::string> code;
+  for (auto p : cache) {
+    code[p.first] = p.second.string;
+  }
+
+  return PrettyResult{prelude, code};
+}
+
+// Pretty-print a graph into the code that would need to be written using the
+// fluid factory to reproduce it.  Assumes the graph has already been
+// deduplicated.
+std::string pretty_print(const Graph& graph) {
+  std::vector<Nodep> roots;
+  for (auto p : graph.observations) {
+    roots.push_back(p.first);
+  }
+  for (auto n : graph.queries) {
+    roots.push_back(n);
+  }
+  auto pretty_result = pretty_print(roots);
+  std::stringstream code;
+  for (auto p : pretty_result.prelude) {
+    code << p << std::endl;
+  }
+  code << "Graph::FluentFactory fac;" << std::endl;
+  for (auto q : graph.queries) {
+    code << fmt::format("fac.query({});", pretty_result.code[q]) << std::endl;
+  }
+  for (auto o : graph.observations) {
+    code << fmt::format(
+                "fac.observe({}, {});", pretty_result.code[o.first], o.second)
+         << std::endl;
+  }
+
+  return code.str();
+}
+
+} // namespace beanmachine::minibmg

--- a/minibmg/pretty.h
+++ b/minibmg/pretty.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include "beanmachine/minibmg/graph.h"
+#include "beanmachine/minibmg/node.h"
+
+namespace beanmachine::minibmg {
+
+struct PrettyResult {
+  // a set of variable assignments that are prelude to the expressions for the
+  // nodes.  These assignments are for shared intermediate results.
+  std::vector<std::string> prelude;
+
+  // For each remaining root, the expression for computing it, with identifiers
+  // referring to variables declared in the prelude for shared values.
+  std::unordered_map<Nodep, std::string> code;
+};
+
+// Pretty-print a set of Nodes.  Returns a PrettyResult.
+const PrettyResult pretty_print(std::vector<Nodep> roots);
+
+// Pretty-print a graph into the code that would need to be written using the
+// fluid factory to reproduce it.
+std::string pretty_print(const Graph& graph);
+
+} // namespace beanmachine::minibmg

--- a/minibmg/tests/ad/traced_test.cpp
+++ b/minibmg/tests/ad/traced_test.cpp
@@ -62,16 +62,16 @@ TEST(traced_test, simple6) {
 }
 
 // Show what happens when the computation graph is a dag instead of a tree.
-// In that case we unfortunately repeat code in the to_string form.
-// We will fix that later (T128357330).
 TEST(traced_test, dag) {
   Traced x = Traced::variable("x", 0);
   auto t1 = x + x;
   auto t2 = t1 + t1;
   auto t3 = t2 + t2;
-  // As a small consolation, at least it is minimally parenthesized to preserve
-  // order of operations.
-  ASSERT_EQ("x + x + (x + x) + (x + x + (x + x))", to_string(t3));
+  std::string expected_result =
+      R":(auto temp_1 = x + x;
+auto temp_2 = temp_1 + temp_1;
+temp_2 + temp_2):";
+  ASSERT_EQ(expected_result, to_string(t3));
 }
 
 TEST(traced_test, derivative1) {

--- a/minibmg/tests/fluent_factory_test.cpp
+++ b/minibmg/tests/fluent_factory_test.cpp
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 #include "beanmachine/minibmg/fluent_factory.h"
 #include "beanmachine/minibmg/graph.h"
+#include "beanmachine/minibmg/pretty.h"
 
 using namespace ::testing;
 using namespace beanmachine::minibmg;
@@ -28,39 +29,41 @@ std::string raw_json = R"({
       "value": 2
     },
     {
-      "operator": "CONSTANT",
+      "in_nodes": [
+        0,
+        0
+      ],
+      "operator": "DISTRIBUTION_BETA",
       "sequence": 1,
-      "type": "REAL",
-      "value": 2
+      "type": "DISTRIBUTION"
     },
     {
       "in_nodes": [
-        1,
         1
       ],
-      "operator": "DISTRIBUTION_BETA",
+      "operator": "SAMPLE",
       "sequence": 2,
-      "type": "DISTRIBUTION"
+      "type": "REAL"
     },
     {
       "in_nodes": [
         2
       ],
-      "operator": "SAMPLE",
+      "operator": "DISTRIBUTION_BERNOULLI",
       "sequence": 3,
-      "type": "REAL"
+      "type": "DISTRIBUTION"
     },
     {
       "in_nodes": [
         3
       ],
-      "operator": "DISTRIBUTION_BERNOULLI",
+      "operator": "SAMPLE",
       "sequence": 4,
-      "type": "DISTRIBUTION"
+      "type": "REAL"
     },
     {
       "in_nodes": [
-        4
+        3
       ],
       "operator": "SAMPLE",
       "sequence": 5,
@@ -68,7 +71,7 @@ std::string raw_json = R"({
     },
     {
       "in_nodes": [
-        4
+        3
       ],
       "operator": "SAMPLE",
       "sequence": 6,
@@ -76,7 +79,7 @@ std::string raw_json = R"({
     },
     {
       "in_nodes": [
-        4
+        3
       ],
       "operator": "SAMPLE",
       "sequence": 7,
@@ -84,22 +87,18 @@ std::string raw_json = R"({
     },
     {
       "in_nodes": [
-        4
+        3
       ],
       "operator": "SAMPLE",
       "sequence": 8,
       "type": "REAL"
-    },
-    {
-      "in_nodes": [
-        4
-      ],
-      "operator": "SAMPLE",
-      "sequence": 9,
-      "type": "REAL"
     }
   ],
   "observations": [
+    {
+      "node": 4,
+      "value": 1
+    },
     {
       "node": 5,
       "value": 1
@@ -110,19 +109,15 @@ std::string raw_json = R"({
     },
     {
       "node": 7,
-      "value": 1
+      "value": 0
     },
     {
       "node": 8,
       "value": 0
-    },
-    {
-      "node": 9,
-      "value": 0
     }
   ],
   "queries": [
-    3
+    2
   ]
 })";
 
@@ -142,6 +137,109 @@ TEST(fluent_factory_test, simple_test) {
   auto graph = fac.build();
   auto json = folly::toPrettyJson(beanmachine::minibmg::graph_to_json(graph));
   ASSERT_EQ(raw_json, json);
+}
+
+TEST(fluent_factory_test, deduplication_01) {
+  Graph::FluentFactory fac;
+  auto b = beta(2, 2);
+  auto s = sample(b, "S0");
+  auto r = bernoulli(s);
+
+  fac.observe(sample(r, "S1"), 1);
+  fac.observe(sample(r, "S2"), 1);
+  fac.observe(sample(r, "S3"), 1);
+  fac.observe(sample(r, "S4"), 0);
+  fac.observe(sample(r, "S5"), 0);
+  fac.query(s);
+
+  auto r2 = bernoulli(s);
+
+  fac.observe(sample(r2, "S6"), 1);
+  fac.observe(sample(r2, "S7"), 1);
+  fac.observe(sample(r2, "S8"), 1);
+  fac.observe(sample(r2, "S9"), 0);
+  fac.observe(sample(r2, "S10"), 0);
+
+  auto graph = fac.build();
+  auto pretty = pretty_print(graph);
+  auto expected = R"+(auto temp_1 = 2;
+auto temp_2 = sample(beta(temp_1, temp_1), "S0");
+auto temp_3 = bernoulli(temp_2);
+Graph::FluentFactory fac;
+fac.query(temp_2);
+fac.observe(sample(temp_3, "S1"), 1);
+fac.observe(sample(temp_3, "S2"), 1);
+fac.observe(sample(temp_3, "S3"), 1);
+fac.observe(sample(temp_3, "S4"), 0);
+fac.observe(sample(temp_3, "S5"), 0);
+fac.observe(sample(temp_3, "S6"), 1);
+fac.observe(sample(temp_3, "S7"), 1);
+fac.observe(sample(temp_3, "S8"), 1);
+fac.observe(sample(temp_3, "S9"), 0);
+fac.observe(sample(temp_3, "S10"), 0);
+)+";
+  ASSERT_EQ(expected, pretty);
+}
+
+TEST(fluent_factory_test, deduplication_02) {
+  Value final = 0;
+  for (int i = 0; i < 2; i++) {
+    auto t1 = beta(2, 2);
+    auto t2 = sample(t1, "S0") + sample(t1, "S1");
+    auto t3 = t2 + t2;
+    auto t4 = t3 - t2;
+    auto t5 = -(t4 + t3);
+    auto t6 = t5 * t4;
+    auto t7 = t6 / t5;
+    auto t8 = pow(t7, t6);
+    auto t9 = exp(t8 + t7);
+    auto t10 = log(t9 + t8);
+    auto t11 = atan(t10 + t9);
+    auto t12 = lgamma(t11 + t10);
+    auto t13 = polygamma(2, t11 + t12);
+    auto t14 = if_equal(t13, t12, t11, t10);
+    auto t15 = if_less(t14, t13, t12, t11);
+    auto t16 = normal(t15, t14);
+    auto t17 = sample(t16, "S2") + sample(t16, "S3");
+    auto t18 = half_normal(t17);
+    auto t19 = sample(t18, "S4") + sample(t18, "S5");
+    // note using the same sample twice here.
+    auto t20 = bernoulli(sample(t1, "S6"));
+    auto t21 = bernoulli(sample(t1, "S6"));
+    auto t22 = sample(t20, "S7") + sample(t20, "S8");
+    auto t23 = t22 + t19 + t17 + t15;
+    final = final + t23;
+  }
+
+  Graph::FluentFactory fac;
+  fac.query(final);
+  auto graph = fac.build();
+  auto pretty = pretty_print(graph);
+  auto expected = R"+(auto temp_1 = 2;
+auto temp_2 = beta(temp_1, temp_1);
+auto temp_3 = bernoulli(sample(temp_2, "S6"));
+auto temp_4 = sample(temp_2, "S0") + sample(temp_2, "S1");
+auto temp_5 = temp_4 + temp_4;
+auto temp_6 = temp_5 - temp_4;
+auto temp_7 = -(temp_6 + temp_5);
+auto temp_8 = temp_7 * temp_6;
+auto temp_9 = temp_8 / temp_7;
+auto temp_10 = pow(temp_9, temp_8);
+auto temp_11 = exp(temp_10 + temp_9);
+auto temp_12 = log(temp_11 + temp_10);
+auto temp_13 = atan(temp_12 + temp_11);
+auto temp_14 = lgamma(temp_13 + temp_12);
+auto temp_15 = polygamma(temp_1, temp_13 + temp_14);
+auto temp_16 = if_equal(temp_15, temp_14, temp_13, temp_12);
+auto temp_17 = if_less(temp_16, temp_15, temp_14, temp_13);
+auto temp_18 = normal(temp_17, temp_16);
+auto temp_19 = sample(temp_18, "S2") + sample(temp_18, "S3");
+auto temp_20 = half_normal(temp_19);
+auto temp_21 = sample(temp_3, "S7") + sample(temp_3, "S8") + (sample(temp_20, "S4") + sample(temp_20, "S5")) + temp_19 + temp_17;
+Graph::FluentFactory fac;
+fac.query(temp_21 + temp_21);
+)+";
+  ASSERT_EQ(expected, pretty);
 }
 
 } // namespace fluent_factory_test


### PR DESCRIPTION
Summary:
Deduplicate a graph bottom-up.  This is easier now that we have Nodep offering efficient hash code and equality.  It is possible that we will want to improve performance in the future by cacheing the results of some equality tests so that they are not so recursive.

We have stopped specializing the `std::` hash and equality functors, because we don't want to impose value semantics in all clients.  Instead we offer `NodeValueSet` (a value-based set of nodes) and `NodeValueMap<T>` (a value-based map from `Nodep` to `T`).

Differential Revision: D39909501

