### PR TITLE
Node cloning

### DIFF
--- a/src/beanmachine/graph/distribution/distribution.h
+++ b/src/beanmachine/graph/distribution/distribution.h
@@ -20,6 +20,15 @@ class Distribution : public graph::Node {
       graph::ValueType sample_type,
       const std::vector<graph::Node*>& in_nodes);
 
+  std::unique_ptr<Node> clone() override {
+    auto result = new_distribution(dist_type, sample_type, in_nodes);
+    std::copy( // TODO: next diff will move this into new_distribution
+        in_nodes.begin(),
+        in_nodes.end(),
+        std::back_inserter(result->in_nodes));
+    return result;
+  }
+
   Distribution(graph::DistributionType dist_type, graph::AtomicType sample_type)
       : graph::Node(graph::NodeType::DISTRIBUTION),
         dist_type(dist_type),

--- a/src/beanmachine/graph/factor/factor.h
+++ b/src/beanmachine/graph/factor/factor.h
@@ -27,6 +27,15 @@ class Factor : public graph::Node {
   void backward() override {}
 
   graph::FactorType fac_type;
+
+  std::unique_ptr<Node> clone() override {
+    auto result = new_factor(fac_type, in_nodes);
+    std::copy( // TODO: next diff will move this into new_factor
+        in_nodes.begin(),
+        in_nodes.end(),
+        std::back_inserter(result->in_nodes));
+    return result;
+  }
 };
 
 } // namespace factor

--- a/src/beanmachine/graph/operator/operator.cpp
+++ b/src/beanmachine/graph/operator/operator.cpp
@@ -14,27 +14,38 @@
 namespace beanmachine {
 namespace oper {
 
+using namespace std;
+
+unique_ptr<graph::Node> Operator::clone() {
+  auto result = OperatorFactory::create_op(op_type, in_nodes);
+  std::copy( // TODO: next diff will move this into create_op
+      in_nodes.begin(),
+      in_nodes.end(),
+      std::back_inserter(result->in_nodes));
+  return result;
+}
+
 double Operator::log_prob() const {
-  throw std::runtime_error("log_prob is only defined for sample or iid sample");
+  throw runtime_error("log_prob is only defined for sample or iid sample");
 }
 
 void Operator::gradient_log_prob(
     const graph::Node* target_node,
     double& /* grad1 */,
     double& /* grad2 */) const {
-  throw std::runtime_error(
+  throw runtime_error(
       "gradient_log_prob is only defined for sample or iid sample");
 }
 
-void Operator::eval(std::mt19937& /* gen */) {
-  throw std::runtime_error(
+void Operator::eval(mt19937& /* gen */) {
+  throw runtime_error(
       "internal error: unexpected operator type " +
       std::to_string(static_cast<int>(op_type)) + " at node_id " +
       std::to_string(index));
 }
 
 void Operator::compute_gradients() {
-  throw std::runtime_error(
+  throw runtime_error(
       "internal error: unexpected operator type " +
       std::to_string(static_cast<int>(op_type)) + " at node_id " +
       std::to_string(index));
@@ -52,27 +63,27 @@ bool OperatorFactory::register_op(
   return false;
 }
 
-std::unique_ptr<Operator> OperatorFactory::create_op(
+unique_ptr<Operator> OperatorFactory::create_op(
     const graph::OperatorType op_type,
-    const std::vector<graph::Node*>& in_nodes) {
+    const vector<graph::Node*>& in_nodes) {
   int op_id = static_cast<int>(op_type);
   // Check OperatorFactory::factories_are_registered here to deactivate compiler
   // optimization on unused static is_registered variables.
   if (!OperatorFactory::factories_are_registered) {
-    throw std::runtime_error(
-        "internal error: unregistered operator type " + std::to_string(op_id));
+    throw runtime_error(
+        "internal error: unregistered operator type " + to_string(op_id));
   }
   auto iter = OperatorFactory::op_map().find(op_id);
   if (iter != OperatorFactory::op_map().end()) {
     return iter->second(in_nodes);
   }
-  throw std::runtime_error(
-      "internal error: unregistered operator type " + std::to_string(op_id));
+  throw runtime_error(
+      "internal error: unregistered operator type " + to_string(op_id));
   return nullptr;
 }
 
-std::map<int, OperatorFactory::builder_type>& OperatorFactory::op_map() {
-  static std::map<int, OperatorFactory::builder_type> operator_map;
+map<int, OperatorFactory::builder_type>& OperatorFactory::op_map() {
+  static map<int, OperatorFactory::builder_type> operator_map;
   return operator_map;
 }
 

--- a/src/beanmachine/graph/operator/operator.h
+++ b/src/beanmachine/graph/operator/operator.h
@@ -8,7 +8,6 @@
 #pragma once
 #include <map>
 
-#include "beanmachine/graph/distribution/distribution.h"
 #include "beanmachine/graph/graph.h"
 
 namespace beanmachine {
@@ -19,6 +18,7 @@ class Operator : public graph::Node {
   explicit Operator(graph::OperatorType op_type)
       : graph::Node(graph::NodeType::OPERATOR), op_type(op_type) {}
   ~Operator() override {}
+  std::unique_ptr<Node> clone() override;
   bool is_stochastic() const override {
     return false;
   }

--- a/src/beanmachine/graph/operator/stochasticop.h
+++ b/src/beanmachine/graph/operator/stochasticop.h
@@ -6,6 +6,7 @@
  */
 
 #pragma once
+#include "beanmachine/graph/distribution/distribution.h"
 #include "beanmachine/graph/graph.h"
 #include "beanmachine/graph/operator/operator.h"
 #include "beanmachine/graph/transform/transform.h"

--- a/src/beanmachine/graph/testing_util.cpp
+++ b/src/beanmachine/graph/testing_util.cpp
@@ -6,22 +6,27 @@
  */
 
 #include <iostream>
+#include <typeinfo>
 
+#include "beanmachine/graph/distribution/distribution.h"
+#include "beanmachine/graph/factor/factor.h"
 #include "beanmachine/graph/global/nuts.h"
 #include "beanmachine/graph/graph.h"
+#include "beanmachine/graph/operator/operator.h"
 #include "beanmachine/graph/testing_util.h"
 
 namespace beanmachine::util {
 
 using namespace std;
+using namespace graph;
 
 void test_nmc_against_nuts(
-    graph::Graph& graph,
+    Graph& graph,
     int num_rounds,
     int num_samples,
     int warmup_samples,
-    std::function<unsigned()> seed_getter,
-    std::function<void(double, double)> tester) {
+    function<unsigned()> seed_getter,
+    function<void(double, double)> tester) {
   if (graph.queries.empty()) {
     throw invalid_argument(
         "test_nmc_against_nuts requires at least one query in graph.");
@@ -30,10 +35,9 @@ void test_nmc_against_nuts(
   for (int i = 0; i != num_rounds; i++) {
     auto seed = seed_getter();
 
-    auto means_nmc =
-        graph.infer_mean(num_samples, graph::InferenceType::NMC, seed);
+    auto means_nmc = graph.infer_mean(num_samples, InferenceType::NMC, seed);
 
-    graph::NUTS nuts = graph::NUTS(graph);
+    NUTS nuts = NUTS(graph);
     auto samples = nuts.infer(num_samples, seed, warmup_samples);
     auto means_nuts = compute_means(samples);
 
@@ -54,9 +58,7 @@ void test_nmc_against_nuts(
        << endl;
 }
 
-double compute_mean_at_index(
-    std::vector<std::vector<graph::NodeValue>> samples,
-    std::size_t index) {
+double compute_mean_at_index(vector<vector<NodeValue>> samples, size_t index) {
   double mean = 0;
   for (size_t i = 0; i < samples.size(); i++) {
     assert(samples[i].size() > index);
@@ -67,13 +69,12 @@ double compute_mean_at_index(
   return mean;
 }
 
-std::vector<double> compute_means(
-    std::vector<std::vector<graph::NodeValue>> samples) {
+vector<double> compute_means(vector<vector<NodeValue>> samples) {
   if (samples.empty()) {
-    return std::vector<double>();
+    return vector<double>();
   }
   auto num_dims = samples[0].size();
-  auto means = std::vector<double>(num_dims);
+  auto means = vector<double>(num_dims);
   for (size_t i = 0; i != num_dims; i++) {
     means[i] = compute_mean_at_index(samples, i);
   }

--- a/src/beanmachine/graph/tests/graph_test.cpp
+++ b/src/beanmachine/graph/tests/graph_test.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <array>
+#include <iostream>
 #include <stdexcept>
 #include <tuple>
 
@@ -15,10 +16,12 @@
 #include "beanmachine/graph/distribution/distribution.h"
 #include "beanmachine/graph/factor/factor.h"
 #include "beanmachine/graph/operator/operator.h"
+#include "beanmachine/graph/util.h"
 
 using namespace beanmachine;
 using namespace std;
 using namespace graph;
+using namespace util;
 
 void populate_arithmetic_graph(unique_ptr<Graph>& g) {
   /*
@@ -676,6 +679,25 @@ TEST(testgraph, graph_copy_constructor) {
   ASSERT_EQ(g->to_string(), g_copy.to_string());
 }
 
+TEST(testgraph, test_node_cloning) {
+  auto g = make_graph_with_nodes_of_all_types();
+
+  Graph original_g_copy(*g);
+
+  // Duplicate all nodes
+  auto original_size = g->nodes.size();
+  for (auto node_id : range(original_size)) {
+    auto& node = g->nodes[node_id];
+    uint clone_id = g->duplicate(node);
+  }
+
+  for (auto node_id : range(original_size)) {
+    auto& original_node = g->nodes[node_id];
+    auto& clone_node = g->nodes[node_id + original_size];
+    ASSERT_TRUE(are_equal(*original_node, *clone_node));
+  }
+}
+
 TEST(testgraph, full_log_prob) {
   Graph g;
   uint a = g.add_constant_pos_real(5.0);
@@ -762,7 +784,8 @@ TEST(testgraph, bad_observations) {
   EXPECT_THROW(g.observe(o_sample_natural, nat_matrix), invalid_argument);
   EXPECT_THROW(g.observe(o_sample_natural, real_matrix), invalid_argument);
 
-  // Observe a natural(2, 1) to be a bool, double, natural, and (1, 2) matrices
+  // Observe a natural(2, 1) to be a bool, double, natural, and (1, 2)
+  // matrices
   uint o_iid_nat = g.add_operator(
       OperatorType::IID_SAMPLE,
       vector<uint>{d_binomial, c_natural_2, c_natural_1});

--- a/src/beanmachine/graph/util.h
+++ b/src/beanmachine/graph/util.h
@@ -11,6 +11,7 @@
 #include <cmath>
 
 #include <boost/iterator/transform_iterator.hpp>
+#include <boost/range/irange.hpp>
 #include <Eigen/Dense>
 #include <algorithm>
 #include <map>
@@ -305,6 +306,25 @@ class EnumClassIterable {
     return val != i.val;
   }
 };
+
+/*
+ * Iterables over integer ranges.
+ * Source: https://codereview.stackexchange.com/a/52217
+ */
+template <class Integer>
+decltype(auto) range(Integer first, Integer last) {
+  return boost::irange(first, last);
+}
+
+template <class Integer, class StepSize>
+decltype(auto) range(Integer first, Integer last, StepSize step_size) {
+  return boost::irange(first, last, step_size);
+}
+
+template <class Integer>
+decltype(auto) range(Integer last) {
+  return boost::irange(static_cast<Integer>(0), last);
+}
 
 } // namespace util
 } // namespace beanmachine


### PR DESCRIPTION
Summary:
Introduces `Node::clone()` and `Graph::duplicate(unique_str<Node>)` so graphs can be rewritten.

To test the result of cloning, added `same_type(const Node&, const Node&)` and `are_equal(const Node&, const Node&)` functions.

Cleaned up some code by using namespaces, and introduced a `range` function in `util.h` similar to Python's `range` to make loops over integers more readable.

Differential Revision: D39797237

