### PR TITLE
Passing in-nodes all the way to `Node` constructor

### DIFF
--- a/src/beanmachine/graph/distribution/bernoulli.cpp
+++ b/src/beanmachine/graph/distribution/bernoulli.cpp
@@ -16,7 +16,7 @@ namespace distribution {
 Bernoulli::Bernoulli(
     graph::ValueType sample_type,
     const std::vector<graph::Node*>& in_nodes)
-    : Distribution(graph::DistributionType::BERNOULLI, sample_type) {
+    : Distribution(graph::DistributionType::BERNOULLI, sample_type, in_nodes) {
   if (sample_type != graph::AtomicType::BOOLEAN) {
     throw std::invalid_argument("Bernoulli produces boolean valued samples");
   }

--- a/src/beanmachine/graph/distribution/bernoulli_logit.cpp
+++ b/src/beanmachine/graph/distribution/bernoulli_logit.cpp
@@ -22,7 +22,7 @@ using namespace graph;
 BernoulliLogit::BernoulliLogit(
     ValueType sample_type,
     const std::vector<Node*>& in_nodes)
-    : Distribution(DistributionType::BERNOULLI_LOGIT, sample_type) {
+    : Distribution(DistributionType::BERNOULLI_LOGIT, sample_type, in_nodes) {
   // a BernoulliLogit distribution has one parent which is a real value
   if (in_nodes.size() != 1) {
     throw std::invalid_argument(

--- a/src/beanmachine/graph/distribution/bernoulli_noisy_or.cpp
+++ b/src/beanmachine/graph/distribution/bernoulli_noisy_or.cpp
@@ -31,7 +31,10 @@ static inline double log1mexpm(double x) {
 BernoulliNoisyOr::BernoulliNoisyOr(
     graph::ValueType sample_type,
     const std::vector<graph::Node*>& in_nodes)
-    : Distribution(graph::DistributionType::BERNOULLI_NOISY_OR, sample_type) {
+    : Distribution(
+          graph::DistributionType::BERNOULLI_NOISY_OR,
+          sample_type,
+          in_nodes) {
   if (sample_type != graph::AtomicType::BOOLEAN) {
     throw std::invalid_argument(
         "BernoulliNoisyOr produces boolean valued samples");

--- a/src/beanmachine/graph/distribution/beta.cpp
+++ b/src/beanmachine/graph/distribution/beta.cpp
@@ -17,7 +17,7 @@ namespace distribution {
 Beta::Beta(
     graph::ValueType sample_type,
     const std::vector<graph::Node*>& in_nodes)
-    : Distribution(graph::DistributionType::BETA, sample_type) {
+    : Distribution(graph::DistributionType::BETA, sample_type, in_nodes) {
   // a Beta has two parents which are real numbers and it outputs a probability
   if (sample_type != graph::AtomicType::PROBABILITY) {
     throw std::invalid_argument("Beta produces probability samples");

--- a/src/beanmachine/graph/distribution/bimixture.cpp
+++ b/src/beanmachine/graph/distribution/bimixture.cpp
@@ -61,7 +61,7 @@ namespace distribution {
 using namespace graph;
 
 Bimixture::Bimixture(ValueType sample_type, const std::vector<Node*>& in_nodes)
-    : Distribution(DistributionType::BIMIXTURE, sample_type) {
+    : Distribution(DistributionType::BIMIXTURE, sample_type, in_nodes) {
   // a Bimixture distribution has three parents:
   // [the probability of sampling from Dist_1, node for Dist_1, node for Dist_2]
   if (in_nodes.size() != 3) {

--- a/src/beanmachine/graph/distribution/binomial.cpp
+++ b/src/beanmachine/graph/distribution/binomial.cpp
@@ -18,7 +18,7 @@ namespace distribution {
 Binomial::Binomial(
     graph::ValueType sample_type,
     const std::vector<graph::Node*>& in_nodes)
-    : Distribution(graph::DistributionType::BINOMIAL, sample_type) {
+    : Distribution(graph::DistributionType::BINOMIAL, sample_type, in_nodes) {
   // a Binomial has two parents -- natural, probability and outputs a natural
   if (sample_type != graph::AtomicType::NATURAL) {
     throw std::invalid_argument("Binomial produces natural number samples");

--- a/src/beanmachine/graph/distribution/categorical.cpp
+++ b/src/beanmachine/graph/distribution/categorical.cpp
@@ -16,7 +16,10 @@ namespace distribution {
 Categorical::Categorical(
     graph::ValueType sample_type,
     const std::vector<graph::Node*>& in_nodes)
-    : Distribution(graph::DistributionType::CATEGORICAL, sample_type) {
+    : Distribution(
+          graph::DistributionType::CATEGORICAL,
+          sample_type,
+          in_nodes) {
   if (sample_type != graph::AtomicType::NATURAL) {
     throw std::invalid_argument("Categorical produces natural valued samples");
   }

--- a/src/beanmachine/graph/distribution/cauchy.cpp
+++ b/src/beanmachine/graph/distribution/cauchy.cpp
@@ -18,7 +18,7 @@ namespace distribution {
 using namespace graph;
 
 Cauchy::Cauchy(ValueType sample_type, const std::vector<Node*>& in_nodes)
-    : Distribution(DistributionType::CAUCHY, sample_type) {
+    : Distribution(DistributionType::CAUCHY, sample_type, in_nodes) {
   // a Cauchy distribution has two parents - a location and a scale which are
   // positive reals
   if (in_nodes.size() != 2) {

--- a/src/beanmachine/graph/distribution/dirichlet.cpp
+++ b/src/beanmachine/graph/distribution/dirichlet.cpp
@@ -17,7 +17,7 @@ namespace distribution {
 Dirichlet::Dirichlet(
     graph::ValueType sample_type,
     const std::vector<graph::Node*>& in_nodes)
-    : Distribution(graph::DistributionType::DIRICHLET, sample_type) {
+    : Distribution(graph::DistributionType::DIRICHLET, sample_type, in_nodes) {
   // a Dirichlet has one parent which is a positive real matrix
   // and outputs a col simplex matrix
   if (sample_type.atomic_type != graph::AtomicType::PROBABILITY) {

--- a/src/beanmachine/graph/distribution/distribution.h
+++ b/src/beanmachine/graph/distribution/distribution.h
@@ -20,6 +20,15 @@ class Distribution : public graph::Node {
       graph::ValueType sample_type,
       const std::vector<graph::Node*>& in_nodes);
 
+  std::unique_ptr<Node> clone() override {
+    auto result = new_distribution(dist_type, sample_type, in_nodes);
+    std::copy( // TODO: next diff will move this into new_distribution
+        in_nodes.begin(),
+        in_nodes.end(),
+        std::back_inserter(result->in_nodes));
+    return result;
+  }
+
   Distribution(graph::DistributionType dist_type, graph::AtomicType sample_type)
       : graph::Node(graph::NodeType::DISTRIBUTION),
         dist_type(dist_type),

--- a/src/beanmachine/graph/distribution/distribution.h
+++ b/src/beanmachine/graph/distribution/distribution.h
@@ -29,12 +29,18 @@ class Distribution : public graph::Node {
     return result;
   }
 
-  Distribution(graph::DistributionType dist_type, graph::AtomicType sample_type)
-      : graph::Node(graph::NodeType::DISTRIBUTION),
+  Distribution(
+      graph::DistributionType dist_type,
+      graph::AtomicType sample_type,
+      const std::vector<Node*>& in_nodes)
+      : graph::Node(graph::NodeType::DISTRIBUTION, in_nodes),
         dist_type(dist_type),
         sample_type(sample_type) {}
-  Distribution(graph::DistributionType dist_type, graph::ValueType sample_type)
-      : graph::Node(graph::NodeType::DISTRIBUTION),
+  Distribution(
+      graph::DistributionType dist_type,
+      graph::ValueType sample_type,
+      const std::vector<Node*>& in_nodes)
+      : graph::Node(graph::NodeType::DISTRIBUTION, in_nodes),
         dist_type(dist_type),
         sample_type(sample_type) {}
   graph::NodeValue sample(std::mt19937& gen) const;

--- a/src/beanmachine/graph/distribution/dummy_marginal.cpp
+++ b/src/beanmachine/graph/distribution/dummy_marginal.cpp
@@ -15,7 +15,10 @@ namespace beanmachine {
 namespace distribution {
 
 DummyMarginal::DummyMarginal(std::unique_ptr<graph::SubGraph> subgraph_ptr)
-    : Distribution(graph::DistributionType::DUMMY, graph::AtomicType::REAL) {
+    : Distribution(
+          graph::DistributionType::DUMMY,
+          graph::AtomicType::REAL,
+          in_nodes) {
   this->subgraph_ptr = std::move(subgraph_ptr);
 }
 

--- a/src/beanmachine/graph/distribution/flat.cpp
+++ b/src/beanmachine/graph/distribution/flat.cpp
@@ -15,7 +15,7 @@ namespace distribution {
 using namespace graph;
 
 Flat::Flat(AtomicType sample_type, const std::vector<Node*>& in_nodes)
-    : Distribution(DistributionType::FLAT, sample_type) {
+    : Distribution(DistributionType::FLAT, sample_type, in_nodes) {
   // a Flat distribution has no parents
   if (in_nodes.size() != 0) {
     throw std::invalid_argument("Flat distribution has no parents");
@@ -23,7 +23,7 @@ Flat::Flat(AtomicType sample_type, const std::vector<Node*>& in_nodes)
 }
 
 Flat::Flat(ValueType sample_type, const std::vector<Node*>& in_nodes)
-    : Distribution(DistributionType::FLAT, sample_type) {
+    : Distribution(DistributionType::FLAT, sample_type, in_nodes) {
   // a Flat distribution has no parents
   if (in_nodes.size() != 0) {
     throw std::invalid_argument("Flat distribution has no parents");

--- a/src/beanmachine/graph/distribution/gamma.cpp
+++ b/src/beanmachine/graph/distribution/gamma.cpp
@@ -20,7 +20,7 @@ namespace distribution {
 using namespace graph;
 
 Gamma::Gamma(ValueType sample_type, const std::vector<Node*>& in_nodes)
-    : Distribution(DistributionType::GAMMA, sample_type) {
+    : Distribution(DistributionType::GAMMA, sample_type, in_nodes) {
   // a Gamma distribution has two parents:
   // shape -> positive real; rate -> positive real
   if (sample_type != AtomicType::POS_REAL) {

--- a/src/beanmachine/graph/distribution/geometric.cpp
+++ b/src/beanmachine/graph/distribution/geometric.cpp
@@ -16,7 +16,7 @@ namespace distribution {
 Geometric::Geometric(
     graph::ValueType sample_type,
     const std::vector<graph::Node*>& in_nodes)
-    : Distribution(graph::DistributionType::GEOMETRIC, sample_type) {
+    : Distribution(graph::DistributionType::GEOMETRIC, sample_type, in_nodes) {
   if (sample_type != graph::AtomicType::NATURAL) {
     throw std::invalid_argument("Geometric produces natural valued samples");
   }

--- a/src/beanmachine/graph/distribution/half_cauchy.cpp
+++ b/src/beanmachine/graph/distribution/half_cauchy.cpp
@@ -21,7 +21,7 @@ using namespace graph;
 HalfCauchy::HalfCauchy(
     ValueType sample_type,
     const std::vector<Node*>& in_nodes)
-    : Distribution(DistributionType::HALF_CAUCHY, sample_type) {
+    : Distribution(DistributionType::HALF_CAUCHY, sample_type, in_nodes) {
   // a HalfCauchy distribution has one parent a scale which is positive real
   if (in_nodes.size() != 1) {
     throw std::invalid_argument(

--- a/src/beanmachine/graph/distribution/half_normal.cpp
+++ b/src/beanmachine/graph/distribution/half_normal.cpp
@@ -21,7 +21,7 @@ using namespace graph;
 Half_Normal::Half_Normal(
     ValueType sample_type,
     const std::vector<Node*>& in_nodes)
-    : Distribution(DistributionType::HALF_NORMAL, sample_type) {
+    : Distribution(DistributionType::HALF_NORMAL, sample_type, in_nodes) {
   // a Half_Normal distribution has one parent
   // sigma -> positive real
   if (in_nodes.size() != 1) {

--- a/src/beanmachine/graph/distribution/lkj_cholesky.cpp
+++ b/src/beanmachine/graph/distribution/lkj_cholesky.cpp
@@ -25,7 +25,7 @@ using namespace graph;
 LKJCholesky::LKJCholesky(
     graph::ValueType sample_type,
     const std::vector<Node*>& in_nodes)
-    : Distribution(DistributionType::LKJ_CHOLESKY, sample_type) {
+    : Distribution(DistributionType::LKJ_CHOLESKY, sample_type, in_nodes) {
   // an LKJ distribution has one parent, the concentration/shape parameter of
   // the distribution
   if (in_nodes.size() != 1) {

--- a/src/beanmachine/graph/distribution/log_normal.cpp
+++ b/src/beanmachine/graph/distribution/log_normal.cpp
@@ -19,7 +19,7 @@ namespace distribution {
 using namespace graph;
 
 LogNormal::LogNormal(ValueType sample_type, const std::vector<Node*>& in_nodes)
-    : Distribution(DistributionType::LOG_NORMAL, sample_type) {
+    : Distribution(DistributionType::LOG_NORMAL, sample_type, in_nodes) {
   // a Log Normal distribution has two parents
   // mean of logarithm distribution -> real,
   // standard deviation of logarithm distribution -> positive real

--- a/src/beanmachine/graph/distribution/multivariate_normal.cpp
+++ b/src/beanmachine/graph/distribution/multivariate_normal.cpp
@@ -16,7 +16,10 @@ namespace distribution {
 MultivariateNormal::MultivariateNormal(
     graph::ValueType sample_type,
     const std::vector<graph::Node*>& in_nodes)
-    : Distribution(graph::DistributionType::MULTIVARIATE_NORMAL, sample_type) {
+    : Distribution(
+          graph::DistributionType::MULTIVARIATE_NORMAL,
+          sample_type,
+          in_nodes) {
   // a multivariate normal has two parents which are a mean vector and a
   // covariance matrix
   // it outputs a (col) broadcast matrix

--- a/src/beanmachine/graph/distribution/normal.cpp
+++ b/src/beanmachine/graph/distribution/normal.cpp
@@ -20,7 +20,7 @@ namespace distribution {
 using namespace graph;
 
 Normal::Normal(ValueType sample_type, const std::vector<Node*>& in_nodes)
-    : Distribution(DistributionType::NORMAL, sample_type) {
+    : Distribution(DistributionType::NORMAL, sample_type, in_nodes) {
   // a Normal distribution has two parents
   // mean -> real, sigma -> positive real
   if (in_nodes.size() != 2) {

--- a/src/beanmachine/graph/distribution/poisson.cpp
+++ b/src/beanmachine/graph/distribution/poisson.cpp
@@ -19,7 +19,7 @@ namespace distribution {
 Poisson::Poisson(
     graph::ValueType sample_type,
     const std::vector<graph::Node*>& in_nodes)
-    : Distribution(graph::DistributionType::POISSON, sample_type) {
+    : Distribution(graph::DistributionType::POISSON, sample_type, in_nodes) {
   if (sample_type != graph::AtomicType::NATURAL) {
     throw std::invalid_argument("Poisson produces natural valued samples");
   }

--- a/src/beanmachine/graph/distribution/product.cpp
+++ b/src/beanmachine/graph/distribution/product.cpp
@@ -55,11 +55,17 @@ ValueType get_unique_sample_type(const vector<Node*>& in_nodes) {
 //////////////// Product methods
 
 Product::Product(const vector<Node*>& in_nodes)
-    : Distribution(DistributionType::PRODUCT, get_unique_sample_type(in_nodes)),
+    : Distribution(
+          DistributionType::PRODUCT,
+          get_unique_sample_type(in_nodes),
+          in_nodes),
       in_distributions(vector_dynamic_cast<Distribution>(in_nodes)) {}
 
 Product::Product(AtomicType sample_type, const vector<Node*>& in_nodes)
-    : Distribution(DistributionType::PRODUCT, get_unique_sample_type(in_nodes)),
+    : Distribution(
+          DistributionType::PRODUCT,
+          get_unique_sample_type(in_nodes),
+          in_nodes),
       in_distributions(vector_dynamic_cast<Distribution>(in_nodes)) {
   check_required_sample_type_against_sample_type_from_parents(sample_type);
 }

--- a/src/beanmachine/graph/distribution/student_t.cpp
+++ b/src/beanmachine/graph/distribution/student_t.cpp
@@ -31,7 +31,7 @@ namespace distribution {
 using namespace graph;
 
 StudentT::StudentT(ValueType sample_type, const std::vector<Node*>& in_nodes)
-    : Distribution(DistributionType::STUDENT_T, sample_type) {
+    : Distribution(DistributionType::STUDENT_T, sample_type, in_nodes) {
   // a StudentT distribution has three parents
   // n (degrees of freedom) > 0 ; l (location) -> real; scale -> positive real
   if (in_nodes.size() != 3) {

--- a/src/beanmachine/graph/distribution/tabular.cpp
+++ b/src/beanmachine/graph/distribution/tabular.cpp
@@ -18,7 +18,7 @@ namespace distribution {
 Tabular::Tabular(
     graph::ValueType sample_type,
     const std::vector<graph::Node*>& in_nodes)
-    : Distribution(graph::DistributionType::TABULAR, sample_type) {
+    : Distribution(graph::DistributionType::TABULAR, sample_type, in_nodes) {
   // check the sample datatype
   if (sample_type != graph::AtomicType::BOOLEAN) {
     throw std::invalid_argument("Tabular supports only boolean valued samples");

--- a/src/beanmachine/graph/factor/exp_product.cpp
+++ b/src/beanmachine/graph/factor/exp_product.cpp
@@ -15,7 +15,7 @@ namespace beanmachine {
 namespace factor {
 
 ExpProduct::ExpProduct(const std::vector<graph::Node*>& in_nodes)
-    : Factor(graph::FactorType::EXP_PRODUCT) {
+    : Factor(graph::FactorType::EXP_PRODUCT, in_nodes) {
   // an ExpProduct factor must have at least one parent
   if (in_nodes.size() < 1) {
     throw std::invalid_argument(

--- a/src/beanmachine/graph/factor/factor.h
+++ b/src/beanmachine/graph/factor/factor.h
@@ -27,6 +27,15 @@ class Factor : public graph::Node {
   void backward() override {}
 
   graph::FactorType fac_type;
+
+  std::unique_ptr<Node> clone() override {
+    auto result = new_factor(fac_type, in_nodes);
+    std::copy( // TODO: next diff will move this into new_factor
+        in_nodes.begin(),
+        in_nodes.end(),
+        std::back_inserter(result->in_nodes));
+    return result;
+  }
 };
 
 } // namespace factor

--- a/src/beanmachine/graph/factor/factor.h
+++ b/src/beanmachine/graph/factor/factor.h
@@ -17,8 +17,10 @@ class Factor : public graph::Node {
   static std::unique_ptr<Factor> new_factor(
       graph::FactorType fac_type,
       const std::vector<graph::Node*>& in_nodes);
-  explicit Factor(graph::FactorType fac_type)
-      : graph::Node(graph::NodeType::FACTOR), fac_type(fac_type) {}
+  explicit Factor(
+      graph::FactorType fac_type,
+      const std::vector<Node*>& in_nodes)
+      : graph::Node(graph::NodeType::FACTOR, in_nodes), fac_type(fac_type) {}
   bool is_stochastic() const override {
     return true;
   }

--- a/src/beanmachine/graph/graph.cpp
+++ b/src/beanmachine/graph/graph.cpp
@@ -572,16 +572,21 @@ std::vector<Node*> Graph::convert_parent_ids(
   return parent_nodes;
 }
 
+uint Graph::add_node(std::unique_ptr<Node> node) {
+  uint index = static_cast<uint>(nodes.size());
+  node->index = index;
+  nodes.push_back(std::move(node));
+  return index;
+}
+
 uint Graph::add_node(std::unique_ptr<Node> node, std::vector<uint> parents) {
-  // Maintain the in/out nodes of this node and its parents
+  // Update the in/out nodes of this node and its parents
   for (uint paridx : parents) {
     Node* parent = nodes[paridx].get();
     parent->out_nodes.push_back(node.get());
     node->in_nodes.push_back(parent);
   }
-  uint index = node->index = static_cast<uint>(nodes.size());
-  nodes.push_back(std::move(node));
-  return index;
+  return add_node(std::move(node));
 }
 
 std::function<uint(uint)> Graph::remove_node(uint node_id) {
@@ -1277,6 +1282,12 @@ void Graph::reindex_nodes() {
 Graph::Graph(const Graph& other) {
   // This copy constructor does not copy the inference results (if available)
   // from the source graph.
+  *this = other;
+}
+
+Graph& Graph::operator=(const Graph& other) {
+  // This copy assignment operator does not copy the inference results
+  // (if available) from the source graph.
   for (uint i = 0; i < static_cast<uint>(other.nodes.size()); i++) {
     Node* node = other.nodes[i].get();
     std::vector<uint> parent_ids = get_parent_ids(node->in_nodes);
@@ -1314,6 +1325,8 @@ Graph::Graph(const Graph& other) {
   master_graph = other.master_graph;
   agg_type = other.agg_type;
   agg_samples = other.agg_samples;
+
+  return *this;
 }
 
 void Graph::_compute_evaluation_and_inference_readiness_data() {
@@ -1519,6 +1532,58 @@ double Graph::compute_log_prob_of(const std::vector<Node*>& sto_nodes) {
     log_prob += node->log_prob();
   }
   return log_prob;
+}
+
+bool same_type(const Node& node1, const Node& node2) {
+  using namespace distribution;
+  using namespace oper;
+  using namespace factor;
+
+  try {
+    auto& dist1 = dynamic_cast<const Distribution&>(node1);
+    try {
+      auto& dist2 = dynamic_cast<const Distribution&>(node2);
+      return dist1.dist_type == dist2.dist_type;
+    } catch (std::bad_cast&) {
+      return false;
+    }
+  } catch (std::bad_cast&) {
+    try {
+      auto& operator1 = dynamic_cast<const Operator&>(node1);
+      try {
+        auto& operator2 = dynamic_cast<const Operator&>(node2);
+        return operator1.op_type == operator2.op_type;
+      } catch (std::bad_cast&) {
+        return false;
+      }
+    } catch (std::bad_cast&) {
+      try {
+        auto& factor1 = dynamic_cast<const Factor&>(node1);
+        try {
+          auto& factor2 = dynamic_cast<const Factor&>(node2);
+          return factor1.fac_type == factor2.fac_type;
+        } catch (std::bad_cast&) {
+          return false;
+        }
+      } catch (std::bad_cast&) {
+        try {
+          auto& constant1 = dynamic_cast<const ConstNode&>(node1);
+          try {
+            auto& constant2 = dynamic_cast<const ConstNode&>(node2);
+            return constant1.value == constant2.value;
+          } catch (std::bad_cast&) {
+            return false;
+          }
+        } catch (std::bad_cast&) {
+          return false;
+        }
+      }
+    }
+  }
+}
+
+bool are_equal(const Node& node1, const Node& node2) {
+  return same_type(node1, node2) and node1.in_nodes == node2.in_nodes;
 }
 
 } // namespace graph

--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -484,10 +484,13 @@ class Node {
 
   /*** Constructors and destructor ***/
 
-  Node() {}
-  explicit Node(NodeType node_type)
+  // NOLINTNEXTLINE(clang-diagnostic-unused-parameter)
+  explicit Node(const std::vector<Node*>& in_nodes) {}
+  // NOLINTNEXTLINE(clang-diagnostic-unused-parameter)
+  Node(NodeType node_type, const std::vector<Node*>& in_nodes)
       : node_type(node_type), grad1(0), grad2(0) {}
-  Node(NodeType node_type, NodeValue value)
+  // NOLINTNEXTLINE(clang-diagnostic-unused-parameter)
+  Node(NodeType node_type, NodeValue value, const std::vector<Node*>& in_nodes)
       : node_type(node_type), value(value), grad1(0), grad2(0) {}
   virtual ~Node() {}
 
@@ -603,7 +606,7 @@ class Node {
 
 class ConstNode : public Node {
  public:
-  explicit ConstNode(NodeValue value) : Node(NodeType::CONSTANT, value) {}
+  explicit ConstNode(NodeValue value) : Node(NodeType::CONSTANT, value, {}) {}
   void eval(std::mt19937& /* unused */) override {}
   ~ConstNode() override {}
   std::unique_ptr<Node> clone() override {

--- a/src/beanmachine/graph/operator/controlop.cpp
+++ b/src/beanmachine/graph/operator/controlop.cpp
@@ -11,7 +11,7 @@ namespace beanmachine {
 namespace oper {
 
 IfThenElse::IfThenElse(const std::vector<graph::Node*>& in_nodes)
-    : Operator(graph::OperatorType::IF_THEN_ELSE) {
+    : Operator(graph::OperatorType::IF_THEN_ELSE, in_nodes) {
   if (in_nodes.size() != 3) {
     throw std::invalid_argument(
         "operator IF_THEN_ELSE requires exactly three parents");
@@ -38,7 +38,7 @@ void IfThenElse::eval(std::mt19937& /* gen */) {
 }
 
 Choice::Choice(const std::vector<graph::Node*>& in_nodes)
-    : Operator(graph::OperatorType::CHOICE) {
+    : Operator(graph::OperatorType::CHOICE, in_nodes) {
   if (in_nodes.size() < 2) {
     throw std::invalid_argument(
         "operator CHOICE requires at least two parents");

--- a/src/beanmachine/graph/operator/linalgop.cpp
+++ b/src/beanmachine/graph/operator/linalgop.cpp
@@ -33,7 +33,7 @@ namespace beanmachine {
 namespace oper {
 
 Transpose::Transpose(const std::vector<graph::Node*>& in_nodes)
-    : Operator(graph::OperatorType::TRANSPOSE) {
+    : Operator(graph::OperatorType::TRANSPOSE, in_nodes) {
   if (in_nodes.size() != 1) {
     throw std::invalid_argument("TRANSPOSE requires one parent node");
   }
@@ -57,7 +57,7 @@ void Transpose::eval(std::mt19937& /* gen */) {
 }
 
 MatrixMultiply::MatrixMultiply(const std::vector<graph::Node*>& in_nodes)
-    : Operator(graph::OperatorType::MATRIX_MULTIPLY) {
+    : Operator(graph::OperatorType::MATRIX_MULTIPLY, in_nodes) {
   if (in_nodes.size() != 2) {
     throw std::invalid_argument("MATRIX_MULTIPLY requires two parent nodes");
   }
@@ -100,7 +100,7 @@ void MatrixMultiply::eval(std::mt19937& /* gen */) {
 // implement the desired functionality
 
 MatrixScale::MatrixScale(const std::vector<graph::Node*>& in_nodes)
-    : Operator(graph::OperatorType::MATRIX_SCALE) {
+    : Operator(graph::OperatorType::MATRIX_SCALE, in_nodes) {
   if (in_nodes.size() != 2) {
     throw std::invalid_argument("MATRIX_SCALE requires two parent nodes");
   }
@@ -160,7 +160,7 @@ void MatrixScale::eval(std::mt19937& /* gen */) {
 
 ElementwiseMultiply::ElementwiseMultiply(
     const std::vector<graph::Node*>& in_nodes)
-    : Operator(graph::OperatorType::ELEMENTWISE_MULTIPLY) {
+    : Operator(graph::OperatorType::ELEMENTWISE_MULTIPLY, in_nodes) {
   if (in_nodes.size() != 2) {
     throw std::invalid_argument(
         "ELEMENTWISE_MULTIPLY requires two parent nodes");
@@ -196,7 +196,7 @@ void ElementwiseMultiply::eval(std::mt19937& /* gen */) {
 }
 
 MatrixAdd::MatrixAdd(const std::vector<graph::Node*>& in_nodes)
-    : Operator(graph::OperatorType::MATRIX_ADD) {
+    : Operator(graph::OperatorType::MATRIX_ADD, in_nodes) {
   if (in_nodes.size() != 2) {
     throw std::invalid_argument("MATRIX_ADD requires two parent nodes");
   }
@@ -234,7 +234,7 @@ void MatrixAdd::eval(std::mt19937& /* gen */) {
 }
 
 MatrixNegate::MatrixNegate(const std::vector<graph::Node*>& in_nodes)
-    : Operator(graph::OperatorType::MATRIX_NEGATE) {
+    : Operator(graph::OperatorType::MATRIX_NEGATE, in_nodes) {
   if (in_nodes.size() != 1) {
     throw std::invalid_argument("MATRIX_NEGATE requires one parent node");
   }
@@ -270,7 +270,7 @@ void MatrixNegate::eval(std::mt19937& /* gen */) {
 }
 
 Index::Index(const std::vector<graph::Node*>& in_nodes)
-    : Operator(graph::OperatorType::INDEX) {
+    : Operator(graph::OperatorType::INDEX, in_nodes) {
   if (in_nodes.size() != 2) {
     throw std::invalid_argument("INDEX requires two parent nodes");
   }
@@ -317,7 +317,7 @@ void Index::eval(std::mt19937& /* gen */) {
 }
 
 ColumnIndex::ColumnIndex(const std::vector<graph::Node*>& in_nodes)
-    : Operator(graph::OperatorType::COLUMN_INDEX) {
+    : Operator(graph::OperatorType::COLUMN_INDEX, in_nodes) {
   if (in_nodes.size() != 2) {
     throw std::invalid_argument("COLUMN_INDEX requires two parent nodes");
   }
@@ -364,7 +364,7 @@ void ColumnIndex::eval(std::mt19937& /* gen */) {
 }
 
 BroadcastAdd::BroadcastAdd(const std::vector<graph::Node*>& in_nodes)
-    : Operator(graph::OperatorType::BROADCAST_ADD) {
+    : Operator(graph::OperatorType::BROADCAST_ADD, in_nodes) {
   if (in_nodes.size() != 2) {
     throw std::invalid_argument("BROADCAST_ADD requires two parent nodes");
   }
@@ -395,7 +395,7 @@ void BroadcastAdd::eval(std::mt19937& /* gen */) {
 }
 
 Cholesky::Cholesky(const std::vector<graph::Node*>& in_nodes)
-    : Operator(graph::OperatorType::CHOLESKY) {
+    : Operator(graph::OperatorType::CHOLESKY, in_nodes) {
   if (in_nodes.size() != 1) {
     throw std::invalid_argument("CHOLESKY requires one parent node");
   }
@@ -426,7 +426,7 @@ void Cholesky::eval(std::mt19937& /* gen */) {
 }
 
 MatrixExp::MatrixExp(const std::vector<graph::Node*>& in_nodes)
-    : Operator(graph::OperatorType::MATRIX_EXP) {
+    : Operator(graph::OperatorType::MATRIX_EXP, in_nodes) {
   if (in_nodes.size() != 1) {
     throw std::invalid_argument("MATRIX_EXP requires one parent node");
   }
@@ -456,7 +456,7 @@ void MatrixExp::eval(std::mt19937& /* gen */) {
 }
 
 MatrixSum::MatrixSum(const std::vector<graph::Node*>& in_nodes)
-    : Operator(graph::OperatorType::MATRIX_SUM) {
+    : Operator(graph::OperatorType::MATRIX_SUM, in_nodes) {
   if (in_nodes.size() != 1) {
     throw std::invalid_argument("MATRIX_SUM requires one parent node");
   }
@@ -481,7 +481,7 @@ void MatrixSum::eval(std::mt19937& /* gen */) {
 }
 
 MatrixLog::MatrixLog(const std::vector<graph::Node*>& in_nodes)
-    : Operator(graph::OperatorType::MATRIX_LOG) {
+    : Operator(graph::OperatorType::MATRIX_LOG, in_nodes) {
   if (in_nodes.size() != 1) {
     throw std::invalid_argument("MATRIX_LOG requires one parent node");
   }
@@ -510,7 +510,7 @@ void MatrixLog::eval(std::mt19937& /* gen */) {
 }
 
 MatrixLog1p::MatrixLog1p(const std::vector<graph::Node*>& in_nodes)
-    : Operator(graph::OperatorType::MATRIX_LOG1P) {
+    : Operator(graph::OperatorType::MATRIX_LOG1P, in_nodes) {
   if (in_nodes.size() != 1) {
     throw std::invalid_argument("MATRIX_LOG1P requires one parent node");
   }
@@ -539,7 +539,7 @@ void MatrixLog1p::eval(std::mt19937& /* gen */) {
 }
 
 MatrixLog1mexp::MatrixLog1mexp(const std::vector<graph::Node*>& in_nodes)
-    : Operator(graph::OperatorType::MATRIX_LOG1MEXP) {
+    : Operator(graph::OperatorType::MATRIX_LOG1MEXP, in_nodes) {
   if (in_nodes.size() != 1) {
     throw std::invalid_argument("MATRIX_LOG1MEXP requires one parent node");
   }
@@ -565,7 +565,7 @@ void MatrixLog1mexp::eval(std::mt19937& /* gen */) {
 }
 
 MatrixPhi::MatrixPhi(const std::vector<graph::Node*>& in_nodes)
-    : Operator(graph::OperatorType::MATRIX_PHI) {
+    : Operator(graph::OperatorType::MATRIX_PHI, in_nodes) {
   if (in_nodes.size() != 1) {
     throw std::invalid_argument("MATRIX_PHI requires one parent node");
   }
@@ -591,7 +591,7 @@ void MatrixPhi::eval(std::mt19937& /* gen */) {
 }
 
 MatrixComplement::MatrixComplement(const std::vector<graph::Node*>& in_nodes)
-    : Operator(graph::OperatorType::MATRIX_COMPLEMENT) {
+    : Operator(graph::OperatorType::MATRIX_COMPLEMENT, in_nodes) {
   if (in_nodes.size() != 1) {
     throw std::invalid_argument("MATRIX_COMPLEMENT requires one parent node");
   }

--- a/src/beanmachine/graph/operator/multiaryop.cpp
+++ b/src/beanmachine/graph/operator/multiaryop.cpp
@@ -118,7 +118,7 @@ void LogSumExp::eval(std::mt19937& /* gen */) {
 }
 
 Pow::Pow(const std::vector<graph::Node*>& in_nodes)
-    : Operator(graph::OperatorType::POW) {
+    : Operator(graph::OperatorType::POW, in_nodes) {
   if (in_nodes.size() != 2) {
     throw std::invalid_argument("operator POW requires 2 parents");
   }
@@ -169,7 +169,7 @@ void Pow::eval(std::mt19937& /* gen */) {
 }
 
 ToMatrix::ToMatrix(const std::vector<graph::Node*>& in_nodes)
-    : Operator(graph::OperatorType::TO_MATRIX) {
+    : Operator(graph::OperatorType::TO_MATRIX, in_nodes) {
   if (in_nodes.size() < 3) {
     throw std::invalid_argument(
         "operator TO_MATRIX requires number of rows (m), number of columns (n), "
@@ -254,7 +254,7 @@ void ToMatrix::eval(std::mt19937& /* gen */) {
 }
 
 Broadcast::Broadcast(const std::vector<graph::Node*>& in_nodes)
-    : Operator(graph::OperatorType::BROADCAST) {
+    : Operator(graph::OperatorType::BROADCAST, in_nodes) {
   if (in_nodes.size() != 3) {
     throw std::invalid_argument(
         "operator BROADCAST requires number of rows (m), number of columns (n), "
@@ -353,7 +353,7 @@ void Broadcast::eval(std::mt19937& /* gen */) {
 }
 
 FillMatrix::FillMatrix(const std::vector<graph::Node*>& in_nodes)
-    : Operator(graph::OperatorType::FILL_MATRIX) {
+    : Operator(graph::OperatorType::FILL_MATRIX, in_nodes) {
   if (in_nodes.size() != 3) {
     throw std::invalid_argument(
         "operator FILL_MATRIX requires number of rows (m), number of columns (n), "
@@ -410,7 +410,7 @@ void FillMatrix::eval(std::mt19937& /* gen */) {
 }
 
 LogProb::LogProb(const std::vector<graph::Node*>& in_nodes)
-    : Operator(graph::OperatorType::LOG_PROB) {
+    : Operator(graph::OperatorType::LOG_PROB, in_nodes) {
   if (in_nodes.size() != 2) {
     throw std::invalid_argument("operator LOG_PROB requires two input nodes");
   }

--- a/src/beanmachine/graph/operator/multiaryop.h
+++ b/src/beanmachine/graph/operator/multiaryop.h
@@ -18,7 +18,7 @@ class MultiaryOperator : public Operator {
   MultiaryOperator(
       graph::OperatorType op_type,
       const std::vector<graph::Node*>& in_nodes)
-      : Operator(op_type) {
+      : Operator(op_type, in_nodes) {
     if (in_nodes.size() < 2) {
       throw std::invalid_argument(
           "expecting at least two parents for operator " +

--- a/src/beanmachine/graph/operator/operator.cpp
+++ b/src/beanmachine/graph/operator/operator.cpp
@@ -14,27 +14,38 @@
 namespace beanmachine {
 namespace oper {
 
+using namespace std;
+
+unique_ptr<graph::Node> Operator::clone() {
+  auto result = OperatorFactory::create_op(op_type, in_nodes);
+  std::copy( // TODO: next diff will move this into create_op
+      in_nodes.begin(),
+      in_nodes.end(),
+      std::back_inserter(result->in_nodes));
+  return result;
+}
+
 double Operator::log_prob() const {
-  throw std::runtime_error("log_prob is only defined for sample or iid sample");
+  throw runtime_error("log_prob is only defined for sample or iid sample");
 }
 
 void Operator::gradient_log_prob(
     const graph::Node* target_node,
     double& /* grad1 */,
     double& /* grad2 */) const {
-  throw std::runtime_error(
+  throw runtime_error(
       "gradient_log_prob is only defined for sample or iid sample");
 }
 
-void Operator::eval(std::mt19937& /* gen */) {
-  throw std::runtime_error(
+void Operator::eval(mt19937& /* gen */) {
+  throw runtime_error(
       "internal error: unexpected operator type " +
       std::to_string(static_cast<int>(op_type)) + " at node_id " +
       std::to_string(index));
 }
 
 void Operator::compute_gradients() {
-  throw std::runtime_error(
+  throw runtime_error(
       "internal error: unexpected operator type " +
       std::to_string(static_cast<int>(op_type)) + " at node_id " +
       std::to_string(index));
@@ -52,27 +63,27 @@ bool OperatorFactory::register_op(
   return false;
 }
 
-std::unique_ptr<Operator> OperatorFactory::create_op(
+unique_ptr<Operator> OperatorFactory::create_op(
     const graph::OperatorType op_type,
-    const std::vector<graph::Node*>& in_nodes) {
+    const vector<graph::Node*>& in_nodes) {
   int op_id = static_cast<int>(op_type);
   // Check OperatorFactory::factories_are_registered here to deactivate compiler
   // optimization on unused static is_registered variables.
   if (!OperatorFactory::factories_are_registered) {
-    throw std::runtime_error(
-        "internal error: unregistered operator type " + std::to_string(op_id));
+    throw runtime_error(
+        "internal error: unregistered operator type " + to_string(op_id));
   }
   auto iter = OperatorFactory::op_map().find(op_id);
   if (iter != OperatorFactory::op_map().end()) {
     return iter->second(in_nodes);
   }
-  throw std::runtime_error(
-      "internal error: unregistered operator type " + std::to_string(op_id));
+  throw runtime_error(
+      "internal error: unregistered operator type " + to_string(op_id));
   return nullptr;
 }
 
-std::map<int, OperatorFactory::builder_type>& OperatorFactory::op_map() {
-  static std::map<int, OperatorFactory::builder_type> operator_map;
+map<int, OperatorFactory::builder_type>& OperatorFactory::op_map() {
+  static map<int, OperatorFactory::builder_type> operator_map;
   return operator_map;
 }
 

--- a/src/beanmachine/graph/operator/operator.h
+++ b/src/beanmachine/graph/operator/operator.h
@@ -8,7 +8,6 @@
 #pragma once
 #include <map>
 
-#include "beanmachine/graph/distribution/distribution.h"
 #include "beanmachine/graph/graph.h"
 
 namespace beanmachine {
@@ -19,6 +18,7 @@ class Operator : public graph::Node {
   explicit Operator(graph::OperatorType op_type)
       : graph::Node(graph::NodeType::OPERATOR), op_type(op_type) {}
   ~Operator() override {}
+  std::unique_ptr<Node> clone() override;
   bool is_stochastic() const override {
     return false;
   }

--- a/src/beanmachine/graph/operator/operator.h
+++ b/src/beanmachine/graph/operator/operator.h
@@ -15,8 +15,10 @@ namespace oper {
 
 class Operator : public graph::Node {
  public:
-  explicit Operator(graph::OperatorType op_type)
-      : graph::Node(graph::NodeType::OPERATOR), op_type(op_type) {}
+  explicit Operator(
+      graph::OperatorType op_type,
+      const std::vector<Node*>& in_nodes)
+      : graph::Node(graph::NodeType::OPERATOR, in_nodes), op_type(op_type) {}
   ~Operator() override {}
   std::unique_ptr<Node> clone() override;
   bool is_stochastic() const override {

--- a/src/beanmachine/graph/operator/stochasticop.cpp
+++ b/src/beanmachine/graph/operator/stochasticop.cpp
@@ -139,7 +139,7 @@ void IIdSample::_backward(bool skip_observed) {
 }
 
 Sample::Sample(const std::vector<graph::Node*>& in_nodes)
-    : StochasticOperator(graph::OperatorType::SAMPLE) {
+    : StochasticOperator(graph::OperatorType::SAMPLE, in_nodes) {
   if (in_nodes.size() != 1) {
     throw std::invalid_argument("operator SAMPLE requires a single parent");
   }
@@ -163,7 +163,7 @@ Sample::Sample(const std::vector<graph::Node*>& in_nodes)
 }
 
 IIdSample::IIdSample(const std::vector<graph::Node*>& in_nodes)
-    : StochasticOperator(graph::OperatorType::IID_SAMPLE) {
+    : StochasticOperator(graph::OperatorType::IID_SAMPLE, in_nodes) {
   uint in_degree = static_cast<uint>(in_nodes.size());
   if (in_degree != 2 and in_degree != 3) {
     throw std::invalid_argument("operator IID_SAMPLE requires 2 or 3 parents");

--- a/src/beanmachine/graph/operator/stochasticop.h
+++ b/src/beanmachine/graph/operator/stochasticop.h
@@ -6,6 +6,7 @@
  */
 
 #pragma once
+#include "beanmachine/graph/distribution/distribution.h"
 #include "beanmachine/graph/graph.h"
 #include "beanmachine/graph/operator/operator.h"
 #include "beanmachine/graph/transform/transform.h"

--- a/src/beanmachine/graph/operator/stochasticop.h
+++ b/src/beanmachine/graph/operator/stochasticop.h
@@ -16,8 +16,11 @@ namespace oper {
 
 class StochasticOperator : public Operator {
  public:
-  explicit StochasticOperator(graph::OperatorType op_type)
-      : Operator(op_type), transform_type(graph::TransformType::NONE) {}
+  explicit StochasticOperator(
+      graph::OperatorType op_type,
+      const std::vector<Node*>& in_nodes)
+      : Operator(op_type, in_nodes),
+        transform_type(graph::TransformType::NONE) {}
   ~StochasticOperator() override {}
 
   void eval(std::mt19937& gen) override {

--- a/src/beanmachine/graph/operator/unaryop.h
+++ b/src/beanmachine/graph/operator/unaryop.h
@@ -18,7 +18,7 @@ class UnaryOperator : public Operator {
   UnaryOperator(
       graph::OperatorType op_type,
       const std::vector<graph::Node*>& in_nodes)
-      : Operator(op_type) {
+      : Operator(op_type, in_nodes) {
     if (in_nodes.size() != 1) {
       throw std::invalid_argument(
           "expecting exactly a single parent for unary operator " +

--- a/src/beanmachine/graph/testing_util.cpp
+++ b/src/beanmachine/graph/testing_util.cpp
@@ -6,22 +6,27 @@
  */
 
 #include <iostream>
+#include <typeinfo>
 
+#include "beanmachine/graph/distribution/distribution.h"
+#include "beanmachine/graph/factor/factor.h"
 #include "beanmachine/graph/global/nuts.h"
 #include "beanmachine/graph/graph.h"
+#include "beanmachine/graph/operator/operator.h"
 #include "beanmachine/graph/testing_util.h"
 
 namespace beanmachine::util {
 
 using namespace std;
+using namespace graph;
 
 void test_nmc_against_nuts(
-    graph::Graph& graph,
+    Graph& graph,
     int num_rounds,
     int num_samples,
     int warmup_samples,
-    std::function<unsigned()> seed_getter,
-    std::function<void(double, double)> tester) {
+    function<unsigned()> seed_getter,
+    function<void(double, double)> tester) {
   if (graph.queries.empty()) {
     throw invalid_argument(
         "test_nmc_against_nuts requires at least one query in graph.");
@@ -30,10 +35,9 @@ void test_nmc_against_nuts(
   for (int i = 0; i != num_rounds; i++) {
     auto seed = seed_getter();
 
-    auto means_nmc =
-        graph.infer_mean(num_samples, graph::InferenceType::NMC, seed);
+    auto means_nmc = graph.infer_mean(num_samples, InferenceType::NMC, seed);
 
-    graph::NUTS nuts = graph::NUTS(graph);
+    NUTS nuts = NUTS(graph);
     auto samples = nuts.infer(num_samples, seed, warmup_samples);
     auto means_nuts = compute_means(samples);
 
@@ -54,9 +58,7 @@ void test_nmc_against_nuts(
        << endl;
 }
 
-double compute_mean_at_index(
-    std::vector<std::vector<graph::NodeValue>> samples,
-    std::size_t index) {
+double compute_mean_at_index(vector<vector<NodeValue>> samples, size_t index) {
   double mean = 0;
   for (size_t i = 0; i < samples.size(); i++) {
     assert(samples[i].size() > index);
@@ -67,13 +69,12 @@ double compute_mean_at_index(
   return mean;
 }
 
-std::vector<double> compute_means(
-    std::vector<std::vector<graph::NodeValue>> samples) {
+vector<double> compute_means(vector<vector<NodeValue>> samples) {
   if (samples.empty()) {
-    return std::vector<double>();
+    return vector<double>();
   }
   auto num_dims = samples[0].size();
-  auto means = std::vector<double>(num_dims);
+  auto means = vector<double>(num_dims);
   for (size_t i = 0; i != num_dims; i++) {
     means[i] = compute_mean_at_index(samples, i);
   }

--- a/src/beanmachine/graph/tests/graph_test.cpp
+++ b/src/beanmachine/graph/tests/graph_test.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <array>
+#include <iostream>
 #include <stdexcept>
 #include <tuple>
 
@@ -15,10 +16,12 @@
 #include "beanmachine/graph/distribution/distribution.h"
 #include "beanmachine/graph/factor/factor.h"
 #include "beanmachine/graph/operator/operator.h"
+#include "beanmachine/graph/util.h"
 
 using namespace beanmachine;
 using namespace std;
 using namespace graph;
+using namespace util;
 
 void populate_arithmetic_graph(unique_ptr<Graph>& g) {
   /*
@@ -669,6 +672,25 @@ TEST(testgraph, graph_copy_constructor) {
   ASSERT_EQ(g->to_string(), g_copy.to_string());
 }
 
+TEST(testgraph, test_node_cloning) {
+  auto g = make_graph_with_nodes_of_all_types();
+
+  Graph original_g_copy(*g);
+
+  // Duplicate all nodes
+  auto original_size = g->nodes.size();
+  for (auto node_id : range(original_size)) {
+    auto& node = g->nodes[node_id];
+    uint clone_id = g->duplicate(node);
+  }
+
+  for (auto node_id : range(original_size)) {
+    auto& original_node = g->nodes[node_id];
+    auto& clone_node = g->nodes[node_id + original_size];
+    ASSERT_TRUE(are_equal(*original_node, *clone_node));
+  }
+}
+
 TEST(testgraph, full_log_prob) {
   Graph g;
   uint a = g.add_constant_pos_real(5.0);
@@ -755,7 +777,8 @@ TEST(testgraph, bad_observations) {
   EXPECT_THROW(g.observe(o_sample_natural, nat_matrix), invalid_argument);
   EXPECT_THROW(g.observe(o_sample_natural, real_matrix), invalid_argument);
 
-  // Observe a natural(2, 1) to be a bool, double, natural, and (1, 2) matrices
+  // Observe a natural(2, 1) to be a bool, double, natural, and (1, 2)
+  // matrices
   uint o_iid_nat = g.add_operator(
       OperatorType::IID_SAMPLE,
       vector<uint>{d_binomial, c_natural_2, c_natural_1});

--- a/src/beanmachine/graph/util.h
+++ b/src/beanmachine/graph/util.h
@@ -11,6 +11,7 @@
 #include <cmath>
 
 #include <boost/iterator/transform_iterator.hpp>
+#include <boost/range/irange.hpp>
 #include <Eigen/Dense>
 #include <algorithm>
 #include <map>
@@ -305,6 +306,25 @@ class EnumClassIterable {
     return val != i.val;
   }
 };
+
+/*
+ * Iterables over integer ranges.
+ * Source: https://codereview.stackexchange.com/a/52217
+ */
+template <class Integer>
+decltype(auto) range(Integer first, Integer last) {
+  return boost::irange(first, last);
+}
+
+template <class Integer, class StepSize>
+decltype(auto) range(Integer first, Integer last, StepSize step_size) {
+  return boost::irange(first, last, step_size);
+}
+
+template <class Integer>
+decltype(auto) range(Integer last) {
+  return boost::irange(static_cast<Integer>(0), last);
+}
 
 } // namespace util
 } // namespace beanmachine


### PR DESCRIPTION
Summary:
This diff simply wires things so that `Node`'s constructors receive the in-nodes as parameters.

This diff does not change any functionality because this new parameter is ignored. The next diff will use this parameter to wire `Node::in_nodes` and `Node::out_nodes` in `Node`'s constructors, as opposed to how it is currently done in `Graph::add_node`.

This will prevent badly surprising effects like passing in-nodes to `create_op` or `new_distribution` only to find out the created node does not have those in-nodes (because they are added later by `Graph::add_node`).

The two diffs are separated so that the numerous (but uninteresting) lines of this diff do not obscure the real functionality changes (in the next diff).

Differential Revision: D39797437

