### PR TITLE
Utility class to flatten a dict of Tensors

### DIFF
--- a/src/beanmachine/ppl/inference/proposer/utils.py
+++ b/src/beanmachine/ppl/inference/proposer/utils.py
@@ -1,0 +1,45 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Dict, Generic, TypeVar
+
+import torch
+
+KeyType = TypeVar("KeyType")
+
+
+class DictToVecConverter(Generic[KeyType]):
+    """
+    A utility class to convert a dictionary of Tensors into a single flattened
+    Tensor or the other way around.
+
+    Args:
+        example_dict: A dict that will be used to determine the order of the
+        keys and the size of the flattened Tensor.
+    """
+
+    def __init__(self, example_dict: Dict[KeyType, torch.Tensor]) -> None:
+        # determine the order of the keys
+        self._keys = list(example_dict.keys())
+        # store the size of the values, which will be used when we want to
+        # reshape them back
+        self._val_shapes = [example_dict[key].shape for key in self._keys]
+        # compute the indicies that each of the entry corresponds to. e.g. for
+        # keys[0], its value will correspond to flatten_vec[idxs[0] : idxs[1]]
+        val_sizes = [example_dict[key].numel() for key in self._keys]
+        self._idxs = torch.cumsum(torch.tensor([0] + val_sizes), dim=0)
+
+    def to_vec(self, dict_in: Dict[KeyType, torch.Tensor]) -> torch.Tensor:
+        """Concatenate the entries of a dictionary to a flattened Tensor"""
+        return torch.cat([dict_in[key].flatten() for key in self._keys])
+
+    def to_dict(self, vec_in: torch.Tensor) -> Dict[KeyType, torch.Tensor]:
+        """Reconstruct a dictionary out of a flattened Tensor"""
+        retval = {}
+        for key, shape, idx_begin, idx_end in zip(
+            self._keys, self._val_shapes, self._idxs, self._idxs[1:]
+        ):
+            retval[key] = vec_in[idx_begin:idx_end].reshape(shape)
+        return retval

--- a/tests/ppl/inference/proposer/utils_test.py
+++ b/tests/ppl/inference/proposer/utils_test.py
@@ -1,0 +1,19 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from beanmachine.ppl.inference.proposer.utils import DictToVecConverter
+
+
+def test_dict_to_vec_conversion():
+    d = {"a": torch.ones((2, 5)), "b": torch.rand(5), "c": torch.tensor(3.0)}
+    converter = DictToVecConverter(example_dict=d)
+    v = converter.to_vec(d)
+    assert len(v) == 16  # 2x5 + 5 + 1
+    # applying exp on the flatten tensor is equivalent to applying it to each
+    # of the tensor in the dictionary
+    d_exp = converter.to_dict(torch.exp(v))
+    for key in d:
+        assert torch.allclose(torch.exp(d[key]), d_exp[key])


### PR DESCRIPTION
Summary:
**Note: it will be helpful to take a look at D39918894 to get some context before reviewing this diff**

This diff introduces a utility class that help converting a dictionary of torch tensors into a single flattened tensor (or the other way around). For example, given a dictionary `{"a": torch.tensor([[1.0, 2.0], [3.0, 4.0]]), "b": torch.tensor(5.0)}`, we may convert it into `tensor([1.0, 2.0, 3.0, 4.0, 5.0])`, which would allow us to easily apply computations to every entry of the dictionary without traversing it with a for loop.

This utility will be used in HMC/NUTS in D39918894. It was split into its own diff to reduce the size of each diff to make them slightly easier to review. Converting the variables in the graph into a single vector allows us to compute things like leapfrog updates and U-turn conditions without using for loop. This will not only reduce the runtime of the algorithm by a bit, but also make it easier to compute full mass matrix later on (which requires us to compute a NxN covariance matrix for the entire graph).

Reviewed By: AishwaryaSivaraman

Differential Revision: D39918887

