### PR TITLE
Vectorize NUTS & HMC internal computations

### DIFF
--- a/src/beanmachine/ppl/inference/proposer/utils.py
+++ b/src/beanmachine/ppl/inference/proposer/utils.py
@@ -1,0 +1,45 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Dict, Generic, TypeVar
+
+import torch
+
+KeyType = TypeVar("KeyType")
+
+
+class DictToVecConverter(Generic[KeyType]):
+    """
+    A utility class to convert a dictionary of Tensors into a single flattened
+    Tensor or the other way around.
+
+    Args:
+        example_dict: A dict that will be used to determine the order of the
+        keys and the size of the flattened Tensor.
+    """
+
+    def __init__(self, example_dict: Dict[KeyType, torch.Tensor]) -> None:
+        # determine the order of the keys
+        self._keys = list(example_dict.keys())
+        # store the size of the values, which will be used when we want to
+        # reshape them back
+        self._val_shapes = [example_dict[key].shape for key in self._keys]
+        # compute the indicies that each of the entry corresponds to. e.g. for
+        # keys[0], its value will correspond to flatten_vec[idxs[0] : idxs[1]]
+        val_sizes = [example_dict[key].numel() for key in self._keys]
+        self._idxs = torch.cumsum(torch.tensor([0] + val_sizes), dim=0)
+
+    def to_vec(self, dict_in: Dict[KeyType, torch.Tensor]) -> torch.Tensor:
+        """Concatenate the entries of a dictionary to a flattened Tensor"""
+        return torch.cat([dict_in[key].flatten() for key in self._keys])
+
+    def to_dict(self, vec_in: torch.Tensor) -> Dict[KeyType, torch.Tensor]:
+        """Reconstruct a dictionary out of a flattened Tensor"""
+        retval = {}
+        for key, shape, idx_begin, idx_end in zip(
+            self._keys, self._val_shapes, self._idxs, self._idxs[1:]
+        ):
+            retval[key] = vec_in[idx_begin:idx_end].reshape(shape)
+        return retval

--- a/src/beanmachine/ppl/inference/proposer/utils.py
+++ b/src/beanmachine/ppl/inference/proposer/utils.py
@@ -29,7 +29,7 @@ class DictToVecConverter(Generic[KeyType]):
         # compute the indicies that each of the entry corresponds to. e.g. for
         # keys[0], its value will correspond to flatten_vec[idxs[0] : idxs[1]]
         val_sizes = [example_dict[key].numel() for key in self._keys]
-        self._idxs = torch.cumsum(torch.tensor([0] + val_sizes), dim=0)
+        self._idxs = list(torch.cumsum(torch.tensor([0] + val_sizes), dim=0))
 
     def to_vec(self, dict_in: Dict[KeyType, torch.Tensor]) -> torch.Tensor:
         """Concatenate the entries of a dictionary to a flattened Tensor"""

--- a/tests/ppl/inference/proposer/hmc_proposer_test.py
+++ b/tests/ppl/inference/proposer/hmc_proposer_test.py
@@ -41,10 +41,8 @@ def test_potential_grads(hmc):
     pe, pe_grad = hmc._potential_grads(hmc._positions)
     assert isinstance(pe, torch.Tensor)
     assert pe.numel() == 1
-    for node, z in hmc._positions.items():
-        assert node in pe_grad
-        assert isinstance(pe_grad[node], torch.Tensor)
-        assert pe_grad[node].shape == z.shape
+    assert isinstance(pe_grad, torch.Tensor)
+    assert pe_grad.shape == hmc._positions.shape
 
 
 def test_kinetic_grads(hmc):
@@ -53,10 +51,8 @@ def test_kinetic_grads(hmc):
     assert isinstance(ke, torch.Tensor)
     assert ke.numel() == 1
     ke_grad = hmc._kinetic_grads(momentums, hmc._mass_inv)
-    for node, z in hmc._positions.items():
-        assert node in ke_grad
-        assert isinstance(ke_grad[node], torch.Tensor)
-        assert len(ke_grad[node]) == z.numel()
+    assert isinstance(ke_grad, torch.Tensor)
+    assert ke_grad.shape == hmc._positions.shape
 
 
 def test_leapfrog_step(hmc):
@@ -65,8 +61,8 @@ def test_leapfrog_step(hmc):
     new_positions, new_momentums, pe, pe_grad = hmc._leapfrog_step(
         hmc._positions, momentums, step_size, hmc._mass_inv
     )
-    assert momentums == new_momentums
-    assert new_positions == hmc._positions
+    assert torch.allclose(momentums, new_momentums)
+    assert torch.allclose(hmc._positions, new_positions)
 
 
 @pytest.mark.parametrize(

--- a/tests/ppl/inference/proposer/utils_test.py
+++ b/tests/ppl/inference/proposer/utils_test.py
@@ -1,0 +1,19 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from beanmachine.ppl.inference.proposer.utils import DictToVecConverter
+
+
+def test_dict_to_vec_conversion():
+    d = {"a": torch.ones((2, 5)), "b": torch.rand(5), "c": torch.tensor(3.0)}
+    converter = DictToVecConverter(example_dict=d)
+    v = converter.to_vec(d)
+    assert len(v) == 16  # 2x5 + 5 + 1
+    # applying exp on the flatten tensor is equivalent to applying it to each
+    # of the tensor in the dictionary
+    d_exp = converter.to_dict(torch.exp(v))
+    for key in d:
+        assert torch.allclose(torch.exp(d[key]), d_exp[key])


### PR DESCRIPTION
Summary:
HMC and NUTS are "global" methods where we compute values for the entire graph at once. Currently, this is being done in BM by keeping the core parameters (positions, momentums, and inverse mass matrices) as a dictionaries and looping over them when we compute new values.

In this diff, we are going to represent the values in the graphs into a single flattened tensor, so that we can get rid of most of the for loops in the body of HMC and NUTS. Note that to compute potential energy (i.e. the joint log prob), we still have to "unflatten" the vector back into a dictionary to get the value for each of the node, but because this part is being JIT compiled, the change in this diff should still make the algorithms more efficient.

The change in this diff will also make it much easier to add the full mass matrix option to HMC and NUTS later on, because to compute the covariance matrix between every nodes in the graph, we will have to flatten the values anyway.

Differential Revision: D39918894

