### PR TITLE
minibmg: Add an external Graph property observations_by_node

### DIFF
--- a/minibmg/container.cpp
+++ b/minibmg/container.cpp
@@ -14,7 +14,7 @@ Container::~Container() {
   for (auto i = _container_map.begin(), end = _container_map.end(); i != end;
        ++i) {
     const _BaseProperty* const property = i->first;
-    void* value = i->second;
+    const void* value = i->second;
     property->_delete_value(value);
   }
 }

--- a/minibmg/container.h
+++ b/minibmg/container.h
@@ -27,7 +27,7 @@ class Container {
   Container() {}
   virtual ~Container();
 
-  std::unordered_map<const _BaseProperty*, void*> _container_map;
+  std::unordered_map<const _BaseProperty*, const void*> _container_map;
 };
 
 /*
@@ -38,7 +38,7 @@ class _BaseProperty {
  public:
   _BaseProperty() {}
 
-  virtual void _delete_value(void* valuep) const = 0;
+  virtual void _delete_value(const void* valuep) const = 0;
 
   virtual ~_BaseProperty() {}
 };
@@ -69,8 +69,8 @@ template <class DerivedPropertyType, class ContainerType, class ValueType>
 class Property : public _BaseProperty {
  public:
   static ValueType* get(const ContainerType& container);
-  void _delete_value(void* valuep) const override {
-    auto vp = (ValueType*)valuep;
+  void _delete_value(const void* valuep) const override {
+    auto vp = (const ValueType*)valuep;
     delete vp;
   }
 
@@ -105,14 +105,14 @@ ValueType* Property<DerivedPropertyType, ContainerType, ValueType>::get(
   if (found != map.end()) {
     return (ValueType*)found->second;
   }
-  auto result = property->create(container);
+  ValueType* result = property->create(container);
   // We cast away const to make the map mutable.  The API is still immutable, as
   // it is not possible for a client to observe a state transition (e.g. a
   // different state at two different times). That is because the client always
   // (only) sees the value in its constructed state.
   auto& mutable_map =
-      *const_cast<std::unordered_map<const _BaseProperty*, void*>*>(&map);
-  mutable_map[property] = result;
+      *const_cast<std::unordered_map<const _BaseProperty*, const void*>*>(&map);
+  mutable_map[property] = reinterpret_cast<const void*>(result);
   return result;
 }
 

--- a/minibmg/observations_by_node.cpp
+++ b/minibmg/observations_by_node.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "beanmachine/minibmg/observations_by_node.h"
+
+namespace {
+
+using namespace beanmachine::minibmg;
+
+class ObservationByNodeProperty : public Property<
+                                      ObservationByNodeProperty,
+                                      Graph,
+                                      const std::unordered_map<Nodep, double>> {
+ public:
+  const std::unordered_map<Nodep, double>* create(
+      const Graph& g) const override {
+    return new std::unordered_map<Nodep, double>{
+        g.observations.begin(), g.observations.end()};
+  }
+  ~ObservationByNodeProperty() {}
+};
+
+} // namespace
+
+namespace beanmachine::minibmg {
+
+const std::unordered_map<Nodep, double>& observations_by_node(
+    const Graph& graph) {
+  return *ObservationByNodeProperty::get(graph);
+}
+
+} // namespace beanmachine::minibmg

--- a/minibmg/observations_by_node.h
+++ b/minibmg/observations_by_node.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <list>
+#include <unordered_set>
+#include "beanmachine/minibmg/graph.h"
+#include "beanmachine/minibmg/node.h"
+
+namespace beanmachine::minibmg {
+
+// A map from an observation node to its observed value.
+const std::unordered_map<Nodep, double>& observations_by_node(
+    const Graph& graph);
+
+} // namespace beanmachine::minibmg

--- a/minibmg/tests/observations_by_node_test.cpp
+++ b/minibmg/tests/observations_by_node_test.cpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include "beanmachine/minibmg/fluent_factory.h"
+#include "beanmachine/minibmg/graph.h"
+#include "beanmachine/minibmg/observations_by_node.h"
+
+using namespace ::testing;
+using namespace beanmachine::minibmg;
+
+TEST(observations_by_node_test, simple) {
+  Graph::FluentFactory f;
+  auto b = beta(2, 2);
+  auto s1 = sample(b);
+  auto s2 = sample(b);
+  f.observe(s1, 0.5);
+  f.observe(s2, 0.4);
+  auto g = f.build();
+  auto& obs = observations_by_node(g);
+  ASSERT_EQ(obs.size(), 2);
+  for (auto o : g.observations) {
+    ASSERT_EQ(obs.find(o.first)->second, o.second);
+  }
+}


### PR DESCRIPTION
Summary: This property will be useful during inference, to efficiently determine whether a sample node is observed, and to retrieve its observed value.

Reviewed By: rodrigodesalvobraz

Differential Revision: D39944494

