### PR TITLE
minibmg: implement an abstraction of the graph for use by inference

### DIFF
--- a/minibmg/ad/reverse.h
+++ b/minibmg/ad/reverse.h
@@ -39,6 +39,9 @@ class Reverse {
   Reverse<Underlying>& operator=(const Reverse<Underlying>& other);
   double as_double() const;
   void reverse(double initial_adjoint);
+  Underlying adjoint() {
+    return ptr->adjoint;
+  }
 };
 
 template <class Underlying>
@@ -78,6 +81,13 @@ requires Number<Underlying> Reverse<Underlying>::Reverse(
     std::shared_ptr<ReverseBody<Underlying>> body)
     : ptr{body} {}
 
+template <class Underlying>
+requires Number<Underlying> Reverse<Underlying>
+&Reverse<Underlying>::operator=(const Reverse<Underlying>& other) {
+  this->ptr = other.ptr;
+  return *this;
+}
+
 // This implementation of ReverseBody<Underlying> permits the precomputation of
 // the local derivative, and simply multiplies during the reverse phase to
 // implement the chain rule.  Although not necessarily storage efficient for
@@ -114,7 +124,7 @@ requires Number<Underlying> Reverse<Underlying>::Reverse(
 template <class Underlying>
 requires Number<Underlying>
 double Reverse<Underlying>::as_double() const {
-  return ptr->as_double();
+  return ptr->primal.as_double();
 }
 
 template <class Underlying>

--- a/minibmg/container.cpp
+++ b/minibmg/container.cpp
@@ -14,7 +14,7 @@ Container::~Container() {
   for (auto i = _container_map.begin(), end = _container_map.end(); i != end;
        ++i) {
     const _BaseProperty* const property = i->first;
-    void* value = i->second;
+    const void* value = i->second;
     property->_delete_value(value);
   }
 }

--- a/minibmg/container.h
+++ b/minibmg/container.h
@@ -27,7 +27,7 @@ class Container {
   Container() {}
   virtual ~Container();
 
-  std::unordered_map<const _BaseProperty*, void*> _container_map;
+  std::unordered_map<const _BaseProperty*, const void*> _container_map;
 };
 
 /*
@@ -38,7 +38,7 @@ class _BaseProperty {
  public:
   _BaseProperty() {}
 
-  virtual void _delete_value(void* valuep) const = 0;
+  virtual void _delete_value(const void* valuep) const = 0;
 
   virtual ~_BaseProperty() {}
 };
@@ -69,8 +69,8 @@ template <class DerivedPropertyType, class ContainerType, class ValueType>
 class Property : public _BaseProperty {
  public:
   static ValueType* get(const ContainerType& container);
-  void _delete_value(void* valuep) const override {
-    auto vp = (ValueType*)valuep;
+  void _delete_value(const void* valuep) const override {
+    auto vp = (const ValueType*)valuep;
     delete vp;
   }
 
@@ -105,14 +105,14 @@ ValueType* Property<DerivedPropertyType, ContainerType, ValueType>::get(
   if (found != map.end()) {
     return (ValueType*)found->second;
   }
-  auto result = property->create(container);
+  ValueType* result = property->create(container);
   // We cast away const to make the map mutable.  The API is still immutable, as
   // it is not possible for a client to observe a state transition (e.g. a
   // different state at two different times). That is because the client always
   // (only) sees the value in its constructed state.
   auto& mutable_map =
-      *const_cast<std::unordered_map<const _BaseProperty*, void*>*>(&map);
-  mutable_map[property] = result;
+      *const_cast<std::unordered_map<const _BaseProperty*, const void*>*>(&map);
+  mutable_map[property] = reinterpret_cast<const void*>(result);
   return result;
 }
 

--- a/minibmg/eval.h
+++ b/minibmg/eval.h
@@ -8,32 +8,14 @@
 #pragma once
 
 #include <fmt/format.h>
+#include <memory>
 #include <random>
 #include "beanmachine/minibmg/distribution/distribution.h"
 #include "beanmachine/minibmg/distribution/make_distribution.h"
 #include "beanmachine/minibmg/eval_error.h"
 #include "beanmachine/minibmg/graph.h"
 #include "beanmachine/minibmg/node.h"
-
-namespace {
-
-using namespace beanmachine::minibmg;
-
-template <class T>
-T get(const std::unordered_map<Nodep, T>& map, Nodep id) {
-  auto t = map.find(id);
-  if (t == map.end()) {
-    throw EvalError(fmt::format("Missing data for node"));
-  }
-  return t->second;
-}
-
-template <class T>
-void put(std::unordered_map<Nodep, T>& map, Nodep id, const T& value) {
-  map[id] = value;
-}
-
-} // namespace
+#include "beanmachine/minibmg/observations_by_node.h"
 
 namespace beanmachine::minibmg {
 
@@ -71,50 +53,100 @@ eval_operator(Operator op, std::function<N(unsigned)> get_value) {
   }
 }
 
-// Evaluating an entire graph, returning an array of doubles that contains, for
-// each scalar-valued node at graph index i, the evaluated value of that node at
-// the corresponding index in the returned value.  The caller is responsible for
-// freeing the returned array.
 template <class T>
 requires Number<T>
-void eval_graph(
+struct EvalResult {
+  // The log probability of the overall computation.
+  T log_prob;
+
+  // The value of the queries.
+  std::vector<double> queries;
+};
+
+template <class T>
+requires Number<T>
+struct SampledValue {
+  T constrained;
+  T unconstrained;
+  T log_prob;
+};
+
+template <class T>
+requires Number<T> SampledValue<T> sample_from_distribution(
+    const Distribution<T>& distribution,
+    std::mt19937& gen) {
+  auto transformation = distribution.transformation();
+  if (transformation == nullptr) {
+    T constrained = distribution.sample(gen);
+    T unconstrained = constrained;
+    T log_prob = distribution.log_prob(constrained);
+    return {constrained, unconstrained, log_prob};
+  } else {
+    T constrained = distribution.sample(gen);
+    T unconstrained = transformation->call(constrained);
+    T log_prob = distribution.log_prob(constrained);
+    // Transforming the log_prob is on hold until I understand the math.
+    // log_prob = transformation->transform_log_prob(constrained, log_prob);
+    return {constrained, unconstrained, log_prob};
+  }
+}
+
+// Evaluating an entire graph, producing into `data` a map of doubles that
+// contains, for each scalar-valued node at graph index i, the evaluated value
+// of that node at the corresponding index in the returned value.  Also returns
+// the log probability of the samples.  The sampler function, if passed, is used
+// to sample from the distribution.  It should return the sample in both
+// constrained and unconstrained spaces, and a log_prob value with respect to
+// its distribution transformed to the unconstrained space.
+template <class T>
+requires Number<T> EvalResult<T> eval_graph(
     const Graph& graph,
     std::mt19937& gen,
     std::function<T(const std::string& name, const unsigned identifier)>
         read_variable,
-    std::unordered_map<Nodep, T>& data) {
-  // Copy observations into a map for easy access.
-  std::unordered_map<Nodep, double> observations;
+    std::unordered_map<Nodep, T>& data,
+    bool run_queries = false,
+    bool eval_log_prob = false,
+    std::function<
+        SampledValue<T>(const Distribution<T>& distribution, std::mt19937& gen)>
+        sampler = sample_from_distribution<T>) {
   std::unordered_map<Nodep, std::shared_ptr<const Distribution<T>>>
       distributions;
-  for (auto p : graph.observations) {
-    observations[p.first] = p.second;
-  }
-  int n = graph.size();
-  for (int i = 0; i < n; i++) {
-    Nodep node = graph[i];
+
+  auto& obs_by_node = observations_by_node(graph);
+  T log_prob = 0;
+  for (auto node : graph) {
     switch (node->op) {
+        // only need to handle SAMPLE here.
+        // if a node is queried or reused, save it in data or distributions.
       case Operator::VARIABLE: {
         auto v = std::dynamic_pointer_cast<const VariableNode>(node);
-        put(data, node, read_variable(v->name, v->identifier));
+        data[node] = read_variable(v->name, v->identifier);
         break;
       }
       case Operator::CONSTANT: {
         auto c = std::dynamic_pointer_cast<const ConstantNode>(node);
-        put(data, node, T{c->value});
+        data[node] = c->value;
         break;
       }
       case Operator::SAMPLE: {
-        auto obsp = observations.find(node);
-        double value;
-        if (obsp != observations.end()) {
-          value = obsp->second;
+        auto obsp = obs_by_node.find(node);
+        auto sample_node = std::dynamic_pointer_cast<const SampleNode>(node);
+        auto dist_node = sample_node->distribution;
+        auto dist = distributions[dist_node];
+        if (obsp != obs_by_node.end()) {
+          auto value = data[node] = obsp->second;
+          if (eval_log_prob) {
+            T logp = dist->log_prob(value);
+            log_prob = log_prob + logp;
+          }
         } else {
-          auto sample = std::dynamic_pointer_cast<const SampleNode>(node);
-          auto dist = distributions[sample->distribution];
-          value = dist->sample(gen);
+          auto sampled_value = sampler(*dist, gen);
+          data[node] = sampled_value.constrained;
+          if (eval_log_prob) {
+            log_prob = log_prob + sampled_value.log_prob;
+          }
         }
-        put(data, node, T{value});
         break;
       }
       case Operator::NO_OPERATOR: {
@@ -131,8 +163,7 @@ void eval_graph(
             break;
           }
           case Type::REAL: {
-            T result = eval_operator<T>(node->op, get_parameter);
-            put(data, node, result);
+            data[node] = eval_operator<T>(node->op, get_parameter);
             break;
           }
           default: {
@@ -143,6 +174,16 @@ void eval_graph(
       }
     }
   }
+
+  std::vector<double> queries;
+  if (run_queries) {
+    for (auto q : graph.queries) {
+      auto d = data.find(q);
+      double value = (d == data.end()) ? 0 : d->second.as_double();
+      queries.push_back(value);
+    }
+  }
+  return {log_prob, queries};
 }
 
 } // namespace beanmachine::minibmg

--- a/minibmg/fluent_factory.cpp
+++ b/minibmg/fluent_factory.cpp
@@ -33,35 +33,35 @@ Graph Graph::FluentFactory::build() {
   return Graph::create(queries, observations);
 }
 
-Distribution half_normal(Value stddev) {
-  return Distribution{std::make_shared<const OperatorNode>(
+FluentDistribution half_normal(Value stddev) {
+  return FluentDistribution{std::make_shared<const OperatorNode>(
       std::vector<Nodep>{stddev.node},
       Operator::DISTRIBUTION_HALF_NORMAL,
       Type::DISTRIBUTION)};
 }
 
-Distribution normal(Value mean, Value stddev) {
-  return Distribution{std::make_shared<const OperatorNode>(
+FluentDistribution normal(Value mean, Value stddev) {
+  return FluentDistribution{std::make_shared<const OperatorNode>(
       std::vector<Nodep>{mean.node, stddev.node},
       Operator::DISTRIBUTION_NORMAL,
       Type::DISTRIBUTION)};
 }
 
-Distribution beta(Value a, Value b) {
-  return Distribution{std::make_shared<OperatorNode>(
+FluentDistribution beta(Value a, Value b) {
+  return FluentDistribution{std::make_shared<OperatorNode>(
       std::vector<Nodep>{a.node, b.node},
       Operator::DISTRIBUTION_BETA,
       Type::DISTRIBUTION)};
 }
 
-Distribution bernoulli(Value p) {
-  return Distribution{std::make_shared<OperatorNode>(
+FluentDistribution bernoulli(Value p) {
+  return FluentDistribution{std::make_shared<OperatorNode>(
       std::vector<Nodep>{p.node},
       Operator::DISTRIBUTION_BERNOULLI,
       Type::DISTRIBUTION)};
 }
 
-Value sample(const Distribution& d, std::string rvid) {
+Value sample(const FluentDistribution& d, std::string rvid) {
   return Value{std::make_shared<SampleNode>(d.node, rvid)};
 }
 

--- a/minibmg/fluent_factory.h
+++ b/minibmg/fluent_factory.h
@@ -17,10 +17,10 @@ namespace beanmachine::minibmg {
 using Value = Traced;
 
 // For distributions
-class Distribution {
+class FluentDistribution {
  public:
   Nodep node;
-  /* implicit */ Distribution(Nodep node) : node{node} {
+  /* implicit */ FluentDistribution(Nodep node) : node{node} {
     if (node->type != Type::DISTRIBUTION) {
       throw std::invalid_argument("node is not a value");
     }
@@ -30,15 +30,15 @@ class Distribution {
   }
 };
 
-Distribution half_normal(Value stddev);
+FluentDistribution half_normal(Value stddev);
 
-Distribution normal(Value mean, Value stddev);
+FluentDistribution normal(Value mean, Value stddev);
 
-Distribution beta(Value a, Value b);
+FluentDistribution beta(Value a, Value b);
 
-Distribution bernoulli(Value p);
+FluentDistribution bernoulli(Value p);
 
-Value sample(const Distribution& d, std::string rvid = make_fresh_rvid());
+Value sample(const FluentDistribution& d, std::string rvid = make_fresh_rvid());
 
 class Graph::FluentFactory {
  public:

--- a/minibmg/inference/hmc_world.cpp
+++ b/minibmg/inference/hmc_world.cpp
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "beanmachine/minibmg/inference/hmc_world.h"
+#include <memory>
+#include <random>
+#include <unordered_set>
+#include "beanmachine/minibmg/ad/real.h"
+#include "beanmachine/minibmg/ad/reverse.h"
+#include "beanmachine/minibmg/distribution/distribution.h"
+#include "beanmachine/minibmg/eval.h"
+#include "beanmachine/minibmg/graph.h"
+#include "beanmachine/minibmg/node.h"
+#include "beanmachine/minibmg/observations_by_node.h"
+#include "beanmachine/minibmg/operator.h"
+
+namespace {
+
+using namespace beanmachine::minibmg;
+
+class HMCWorld0 : public HMCWorld {
+ private:
+  const Graph& graph;
+  std::unordered_set<Nodep> unobserved_samples;
+
+ public:
+  HMCWorld0(const Graph& graph);
+
+  unsigned num_unobserved_samples() const override;
+
+  HMCWorldEvalResult evaluate(
+      const std::vector<double>& proposed_unconstrained_values) const override;
+
+  std::vector<double> queries(
+      const std::vector<double>& proposed_unconstrained_values) const override;
+};
+
+HMCWorld0::HMCWorld0(const Graph& graph) : graph{graph} {
+  // we identify the set of unobserved samples by...
+  for (auto node : graph.nodes) {
+    // ...counting the samples...
+    if (node->op == Operator::SAMPLE) {
+      unobserved_samples.insert(node);
+    }
+  }
+  // and subtracting the observed ones.
+  for (auto p : graph.observations) {
+    unobserved_samples.erase(p.first);
+  }
+}
+
+unsigned HMCWorld0::num_unobserved_samples() const {
+  return unobserved_samples.size();
+}
+
+template <class T>
+requires Number<T> EvalResult<T> evaluate_internal(
+    const Graph& graph,
+    const std::vector<double>& proposed_unconstrained_values,
+    std::unordered_map<Nodep, T>& data,
+    std::mt19937& gen,
+    bool run_queries,
+    bool eval_log_prob) {
+  unsigned next_sample = 0;
+
+  // Here is our function for producing an unobserved sample.  We consume the
+  // data provided by the caller, transforming it if necessary.
+  std::function<SampledValue<T>(
+      const Distribution<T>& distribution, std::mt19937& gen)>
+      sample_from_distribution = [&](const Distribution<T>& distribution,
+                                     std::mt19937& gen) -> SampledValue<T> {
+    T unconstrained = proposed_unconstrained_values[next_sample++];
+    auto transform = distribution.transformation();
+    if (transform == nullptr) {
+      T constrained = unconstrained;
+      T logp = eval_log_prob ? distribution.log_prob(constrained) : 0;
+      return {constrained, unconstrained, logp};
+    } else {
+      T constrained = transform->inverse(unconstrained);
+      T logp = eval_log_prob ? distribution.log_prob(constrained) : 0;
+      //
+      // We avoid the transform here because it may change the location of the
+      // highest likelihood value.  For example, with a beta(7, 5), the peak is
+      // at X=0.6.  However, when viewed in the transformed space with the
+      // log_prob value also transformed, the peak occurs at a value
+      // corresponding to X=0.625.  I need help understanding what to do here.
+      // For now we just avoid transforming the log_prob value.
+      //
+      // // logp = transform->transform_log_prob(constrained, logp);
+      return {constrained, unconstrained, logp};
+    }
+  };
+
+  // we don't need to read "variables" from a graph because there is no
+  // such concept as a variable in Bean Machine.
+  auto read_variable = [](const std::string& name,
+                          const unsigned identifier) -> T {
+    throw std::logic_error("Bean Machine models should not contain variables");
+  };
+
+  // evaluate the graph.
+  return eval_graph<T>(
+      graph,
+      gen,
+      read_variable,
+      data,
+      run_queries,
+      eval_log_prob,
+      sample_from_distribution);
+}
+
+HMCWorldEvalResult HMCWorld0::evaluate(
+    const std::vector<double>& proposed_unconstrained_values) const {
+  using T = Reverse<Real>;
+  std::unordered_map<Nodep, T> data;
+  std::mt19937 gen;
+
+  // evaluate the graph and its log_prob in reverse mode
+  auto eval_result = evaluate_internal<T>(
+      graph,
+      proposed_unconstrained_values,
+      data,
+      gen,
+      /* run_queries = */ false,
+      /* eval_log_prob = */ true);
+
+  // extract the gradients for the unobserved samples.
+  eval_result.log_prob.reverse(1);
+  std::vector<double> gradients;
+  auto& obs = observations_by_node(graph);
+  for (auto node : graph) {
+    if (node->op == Operator::SAMPLE && !obs.contains(node)) {
+      // we found an unobserved sample.  Add its gradient to the result.
+      auto found = data.find(node);
+      auto grad =
+          (found == data.end()) ? 0 : found->second.adjoint().as_double();
+      gradients.push_back(grad);
+    }
+  }
+
+  return HMCWorldEvalResult{
+      eval_result.log_prob.as_double(), std::move(gradients)};
+}
+
+std::vector<double> HMCWorld0::queries(
+    const std::vector<double>& proposed_unconstrained_values) const {
+  // In order to evaluate the queries, we evaluate the graph without computing
+  // gradients.
+  using T = Real;
+
+  std::unordered_map<Nodep, T> data;
+  std::mt19937 gen;
+
+  // evaluate the graph and its log_prob using real numbers
+  auto eval_result = evaluate_internal<T>(
+      graph,
+      proposed_unconstrained_values,
+      data,
+      gen,
+      /* run_queries = */ true,
+      /* eval_log_prob = */ false);
+
+  return eval_result.queries;
+}
+
+} // namespace
+
+namespace beanmachine::minibmg {
+
+std::unique_ptr<const HMCWorld> hmc_world_0(const Graph& graph) {
+  return std::make_unique<HMCWorld0>(graph);
+}
+
+} // namespace beanmachine::minibmg

--- a/minibmg/inference/hmc_world.h
+++ b/minibmg/inference/hmc_world.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <array>
+#include <memory>
+#include <vector>
+#include "beanmachine/minibmg/graph.h"
+
+namespace beanmachine::minibmg {
+
+// The result of calling HMCWorld::evaluate
+struct HMCWorldEvalResult;
+
+// This interface defines an abstraction of a graph containing exactly and only
+// what is needed for some inference methods, such as gradient ascent
+// evaluation of the maximum likelihood, HMC, and NUTS.  The premise of this API
+// is that the model being abstracted contains no unobserved samples from
+// discrete distributions.  The distributions are assumed to be
+// supported over the full range of real numbers; the implementation of this
+// interface is expected to ensure this by transforming the distributions and
+// their samples if necessary.
+class HMCWorld {
+ public:
+  // The total number of samples appearing in the model that are NOT observed.
+  virtual unsigned num_unobserved_samples() const = 0;
+
+  // Given proposed assigned values for all of the onobserved samples in the
+  // model (transformed, if necessary, so that they are unconstrained -
+  // supported over the real numbers), compute the log probability of the model
+  // with that assignment, as well as the the first derivative of the log
+  // probability with respect to each of the proposed values.  The input vector
+  // is required to be of a size that is equal to the return value of
+  // num_unobserved_samples.
+  virtual HMCWorldEvalResult evaluate(
+      const std::vector<double>& proposed_unconstrained_values) const = 0;
+
+  // Given proposed assigned values for all of the onobserved samples in the
+  // model (as in evaluate), compute the value of queried nodes in the model.
+  // Queried values are returned in the untransformed space.  The input
+  // vector is required to be of a size that is equal to the return value of
+  // num_unobserved_samples.
+  virtual std::vector<double> queries(
+      const std::vector<double>& proposed_unconstrained_values) const = 0;
+
+  virtual ~HMCWorld() {}
+};
+
+struct HMCWorldEvalResult {
+  // The computed log probability of a given assignment to the samples in a
+  // model.
+  double log_prob;
+
+  // The derivative of the log probability with respect to each of the
+  // unobserved samples in a model.
+  std::vector<double> gradients;
+};
+
+// produce an abstraction of the graph for use by inference.  This
+// implementation performs its work by evaluating the graph node by node on
+// demand.  You can think of this as an interpreter for the graph.
+std::unique_ptr<const HMCWorld> hmc_world_0(const Graph& graph);
+
+// produce an abstraction of the graph for use by inference.  This
+// implementation performs its work by evaluating the graph symbolically,
+// optimizing the symbolic form, and cacheing it for later use.  Then it
+// evaluates the optimized expression graph when needed.  You can think of this
+// as a bytecode compiler and bytecode interpreter for the graph.
+std::unique_ptr<const HMCWorld> hmc_world_1(const Graph& graph);
+
+// produce an abstraction of the graph for use by inference.  This
+// implementation performs its work by evaluating the graph symbolically,
+// optimizing the symbolic form, generating native machine code from that, and
+// cacheing that code for later use.  Then it calls the generated native code
+// when needed.  This can be considered a JIT compiler for the graph.
+std::unique_ptr<const HMCWorld> hmc_world_2(const Graph& graph);
+
+} // namespace beanmachine::minibmg

--- a/minibmg/inference/mle_inference.cpp
+++ b/minibmg/inference/mle_inference.cpp
@@ -1,0 +1,39 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "beanmachine/minibmg/inference/mle_inference.h"
+#include <iostream>
+#include <vector>
+#include "beanmachine/minibmg/graph.h"
+#include "beanmachine/minibmg/inference/hmc_world.h"
+
+namespace beanmachine::minibmg {
+
+std::vector<double> mle_inference_0(
+    const Graph& graph,
+    double learning_rate,
+    int num_rounds,
+    std::vector<double> initial_proposals,
+    bool print_progress) {
+  auto abstraction = hmc_world_0(graph);
+  int num_samples = abstraction->num_unobserved_samples();
+
+  std::vector<double> proposals = initial_proposals;
+  proposals.resize(num_samples);
+
+  for (int round = 0; round < num_rounds; round++) {
+    auto result = abstraction->evaluate(proposals);
+    if (print_progress) {
+      std::cout << fmt::format(
+          "log_prob: {} inferred: {}\n",
+          result.log_prob,
+          abstraction->queries(proposals)[0]);
+    }
+    for (int samp = 0; samp < num_samples; samp++) {
+      proposals[samp] += result.gradients[samp] * learning_rate;
+    }
+  }
+
+  return abstraction->queries(proposals);
+}
+
+} // namespace beanmachine::minibmg

--- a/minibmg/inference/mle_inference.h
+++ b/minibmg/inference/mle_inference.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <memory>
+#include <vector>
+#include "beanmachine/minibmg/graph.h"
+
+namespace beanmachine::minibmg {
+
+/*
+ * A hacked-together and totally inadequate inference method that computes a
+ * local maxima of the log probability, mainly provided for testing `hmc_world`.
+ * I hope that's what "MLE" inference means (Maximum Likelihood Estimation)
+ * otherwise I'll be totally embarrased.  This implementation is not adaptive;
+ * it requires you to set the learning rate and number of rounds.  In practice
+ * appropriate values for these vary wildly from application to application.
+ * Perhaps someday we will do a better job of inferring them by computing the
+ * second derivative, utilizing momentum, checking for convergence, and/or
+ * something else.
+ *
+ * This is version zero (0) because it exercises `hmc_world_0()`.  In the future
+ * we'll exercise more advanced versions of that method.
+ */
+std::vector<double> mle_inference_0(
+    const Graph& graph,
+    double learning_rate = 0.1,
+    int num_rounds = 25,
+    std::vector<double> initial_proposals = std::vector<double>{},
+    bool print_progress = false);
+
+} // namespace beanmachine::minibmg

--- a/minibmg/observations_by_node.cpp
+++ b/minibmg/observations_by_node.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "beanmachine/minibmg/observations_by_node.h"
+
+namespace {
+
+using namespace beanmachine::minibmg;
+
+class ObservationByNodeProperty : public Property<
+                                      ObservationByNodeProperty,
+                                      Graph,
+                                      const std::unordered_map<Nodep, double>> {
+ public:
+  const std::unordered_map<Nodep, double>* create(
+      const Graph& g) const override {
+    return new std::unordered_map<Nodep, double>{
+        g.observations.begin(), g.observations.end()};
+  }
+  ~ObservationByNodeProperty() {}
+};
+
+} // namespace
+
+namespace beanmachine::minibmg {
+
+const std::unordered_map<Nodep, double>& observations_by_node(
+    const Graph& graph) {
+  return *ObservationByNodeProperty::get(graph);
+}
+
+} // namespace beanmachine::minibmg

--- a/minibmg/observations_by_node.h
+++ b/minibmg/observations_by_node.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <list>
+#include <unordered_set>
+#include "beanmachine/minibmg/graph.h"
+#include "beanmachine/minibmg/node.h"
+
+namespace beanmachine::minibmg {
+
+// A map from an observation node to its observed value.
+const std::unordered_map<Nodep, double>& observations_by_node(
+    const Graph& graph);
+
+} // namespace beanmachine::minibmg

--- a/minibmg/operator.h
+++ b/minibmg/operator.h
@@ -63,8 +63,7 @@ enum class Operator {
   // Result: REAL
   LGAMMA,
 
-  // The polygamma(x, n) function.  polygamma(x, 0) is also known as digamma(x)
-  // Note the order of parameters.
+  // The polygamma(n, x) function.  polygamma(0, x) is also known as digamma(x)
   // Result: REAL
   POLYGAMMA,
 

--- a/minibmg/tests/inference/mle_inference_test.cpp
+++ b/minibmg/tests/inference/mle_inference_test.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <memory>
+#include "beanmachine/minibmg/fluent_factory.h"
+#include "beanmachine/minibmg/inference/hmc_world.h"
+#include "beanmachine/minibmg/inference/mle_inference.h"
+
+using namespace ::testing;
+using namespace beanmachine::minibmg;
+
+TEST(mle_inference_test, coin_flipping) {
+  // Take a familiar-looking model and run gradient descent to confirm that we
+  // get the expected value.
+  Graph::FluentFactory f;
+  auto d = beta(2, 2);
+  auto s = sample(d);
+  auto bn = bernoulli(s);
+  f.observe(sample(bn), 1);
+  f.observe(sample(bn), 1);
+  f.observe(sample(bn), 0);
+  f.query(s);
+
+  auto inference_result = mle_inference_0(f.build());
+
+  auto s_expected = 0.6;
+  auto s_inferred = inference_result[0];
+
+  ASSERT_NEAR(s_inferred, s_expected, 1e-7);
+}
+
+TEST(mle_inference_test, sqrt) {
+  // Compute the square root of two using the the technique of "observing a
+  // functional"
+  // (https://fb.workplace.com/groups/pplxfn/permalink/3245784932349729/).
+  Graph::FluentFactory f;
+  auto n1 = normal(1, 1e7);
+  auto sqrt = sample(n1);
+  auto two = sqrt * sqrt;
+  auto n2 = normal(two, 1);
+  f.observe(sample(n2), 2);
+  f.query(sqrt);
+
+  const double learning_rate = 0.1;
+  std::vector<double> initial_proposals{1.0};
+  auto inference_result = mle_inference_0(
+      f.build(),
+      /* learning_rate= */ learning_rate,
+      /* num_rounds= */ 25,
+      /* initial_proposals= */ initial_proposals);
+
+  auto s_expected = std::sqrt(2.0);
+  auto s_inferred = inference_result[0];
+
+  ASSERT_NEAR(s_inferred, s_expected, 1e-7);
+}
+
+TEST(mle_inference_test, normal) {
+  // Test inference in the absence of observations.
+  Graph::FluentFactory f;
+  auto n = normal(2, 3);
+  f.query(sample(n));
+  // Learning rate set by trial and error
+  const double learning_rate = 5;
+  auto inference_result =
+      mle_inference_0(f.build(), /* learning_rate= */ learning_rate);
+
+  auto s_expected = 2.0;
+  auto s_inferred = inference_result[0];
+
+  ASSERT_NEAR(s_inferred, s_expected, 1e-7);
+}
+
+TEST(mle_inference_test, beta) {
+  // Test inference in the absence of observations.
+  Graph::FluentFactory f;
+  double a = 7;
+  double b = 5;
+  auto n = beta(a, b);
+  auto s = sample(n);
+  f.query(s);
+
+  // From https://en.wikipedia.org/wiki/Beta_distribution
+  // The mode of a Beta distributed random variable X with α, β > 1 is the most
+  // likely value of the distribution (corresponding to the peak in the PDF),
+  // and is given by the following expression: (α - 1)/(α + β - 2).
+  double mode = (a - 1) / (a + b - 2);
+  auto s_expected = mode;
+
+  auto inference_result = mle_inference_0(f.build());
+  auto s_inferred = inference_result[0];
+
+  ASSERT_NEAR(s_inferred, s_expected, 1e-7);
+}

--- a/minibmg/tests/observations_by_node_test.cpp
+++ b/minibmg/tests/observations_by_node_test.cpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include "beanmachine/minibmg/fluent_factory.h"
+#include "beanmachine/minibmg/graph.h"
+#include "beanmachine/minibmg/observations_by_node.h"
+
+using namespace ::testing;
+using namespace beanmachine::minibmg;
+
+TEST(observations_by_node_test, simple) {
+  Graph::FluentFactory f;
+  auto b = beta(2, 2);
+  auto s1 = sample(b);
+  auto s2 = sample(b);
+  f.observe(s1, 0.5);
+  f.observe(s2, 0.4);
+  auto g = f.build();
+  auto& obs = observations_by_node(g);
+  ASSERT_EQ(obs.size(), 2);
+  for (auto o : g.observations) {
+    ASSERT_EQ(obs.find(o.first)->second, o.second);
+  }
+}

--- a/minibmg/topological.h
+++ b/minibmg/topological.h
@@ -37,14 +37,13 @@ std::map<T, unsigned> count_predecessors_internal(
     counted.insert(node);
     nodes.push_back(node);
 
-    if (predecessor_counts.find(node) == predecessor_counts.end()) {
+    if (!predecessor_counts.contains(node)) {
       predecessor_counts[node] = 0;
     }
 
     for (auto succ : successors(node)) {
       to_count.push_back(succ);
-      auto found = predecessor_counts.find(succ);
-      if (found == predecessor_counts.end()) {
+      if (!predecessor_counts.contains(succ)) {
         predecessor_counts[succ] = 1;
       } else {
         predecessor_counts[succ] = predecessor_counts[succ] + 1;


### PR DESCRIPTION
Summary:
Implements an API that summarizes a graph into the operations needed for MLE, HMC, and NUTS.  Also provides a tiny implementation of MLE using gradient ascent to test it.

See also https://www.internalfb.com/taskgraph?t=123566192 for future planned work on minibmg.

Differential Revision: D40079038

