### PR TITLE
Adaptation fixes

### DIFF
--- a/src/beanmachine/ppl/inference/proposer/hmc_proposer.py
+++ b/src/beanmachine/ppl/inference/proposer/hmc_proposer.py
@@ -148,8 +148,7 @@ class HMCProposer(BaseProposer):
             grads = torch.autograd.grad(pe, positions)[0]
         # We return NaN on Cholesky factorization errors which can be gracefully
         # handled by NUTS/HMC.
-        # TODO: Change to torch.linalg.LinAlgError when in release.
-        except RuntimeError as e:
+        except torch.linalg.LinAlgError as e:
             err_msg = str(e)
             if "singular U" in err_msg or "input is not positive-definite" in err_msg:
                 warnings.warn(
@@ -328,6 +327,7 @@ class HMCProposer(BaseProposer):
                     self._mass_matrix_adapter.finalize()
 
                     if self.adapt_step_size:
+                        self.step_size = self._step_size_adapter.finalize()
                         self.step_size = self._find_reasonable_step_size(
                             self.step_size,
                             self._positions,

--- a/src/beanmachine/ppl/inference/sampler.py
+++ b/src/beanmachine/ppl/inference/sampler.py
@@ -77,13 +77,14 @@ class Sampler(Generator[World, Optional[World], None]):
                 accepted = torch.rand_like(accept_log_prob).log() < accept_log_prob
                 if accepted:
                     world = new_world
-            except RuntimeError as e:
+            except torch.linalg.LinAlgError as e:
                 if "singular U" in str(e) or "input is not positive-definite" in str(e):
                     # since it's normal to run into cholesky error during GP, instead of
                     # throwing an error, we simply skip current proposer (which is
                     # equivalent to a rejection) and will retry in the next iteration
                     warnings.warn(f"Proposal rejected: {e}", RuntimeWarning)
-                    continue
+                    accepted = False
+                    accept_log_prob = -torch.inf
                 else:
                     raise e
 


### PR DESCRIPTION
Summary:
This diff contains several fixes to the adaptations phase:

1. For HMC/NUTS, at the end of an [adaptation window](https://mc-stan.org/docs/reference-manual/hmc-algorithm-parameters.html#automatic-parameter-tuning), we need to update the step size with the dual-averaged value first before calling `_find_reasonable_step_size`  and reset the adapter.
2. In sampler.py, when running into cholesky decomposition error, we shouldn't just `continue` to the next iteration. Instead, the remaining adaptation procedures should still be run
3. Updated `RuntimeError` to `torch.linalg.LinAlgError` which is more precise

Reviewed By: CactusWin

Differential Revision: D40075512

