### PR TITLE
Revert back to using RuntimeError in detecting cholesky decomposition error

### DIFF
--- a/src/beanmachine/ppl/inference/proposer/hmc_proposer.py
+++ b/src/beanmachine/ppl/inference/proposer/hmc_proposer.py
@@ -148,7 +148,7 @@ class HMCProposer(BaseProposer):
             grads = torch.autograd.grad(pe, positions)[0]
         # We return NaN on Cholesky factorization errors which can be gracefully
         # handled by NUTS/HMC.
-        except torch.linalg.LinAlgError as e:
+        except RuntimeError as e:
             err_msg = str(e)
             if "singular U" in err_msg or "input is not positive-definite" in err_msg:
                 warnings.warn(

--- a/src/beanmachine/ppl/inference/sampler.py
+++ b/src/beanmachine/ppl/inference/sampler.py
@@ -77,7 +77,7 @@ class Sampler(Generator[World, Optional[World], None]):
                 accepted = torch.rand_like(accept_log_prob).log() < accept_log_prob
                 if accepted:
                     world = new_world
-            except torch.linalg.LinAlgError as e:
+            except RuntimeError as e:
                 if "singular U" in str(e) or "input is not positive-definite" in str(e):
                     # since it's normal to run into cholesky error during GP, instead of
                     # throwing an error, we simply skip current proposer (which is


### PR DESCRIPTION
Summary:
In D40075512 (https://github.com/facebookresearch/beanmachine/commit/ae9105f2369cfb2f8cbdc7b7f08b4c4d164129db), we changes `RuntimeError` to `torch.linalg.LinAlgError` in handling the cholesky decomposition error because the latter is more precise. However, it turns out that if we JIT compile the code (e.g. when applying NNC), then TorchScript would intercept any exception and [re-throw it as a RuntimeError](https://www.internalfb.com/code/fbsource/[dafeb921e61a372399e1b74ef3449d512ae03bfc]/fbcode/caffe2/torch/csrc/jit/runtime/interpreter.cpp?lines=824-825). As a result, let's change it back so that our GP models can still run with NNC.

(see N2553577 for an example exception)

Differential Revision: D40116106

