### PR TITLE
Full mass matrix option for HMC & NUTS

### DIFF
--- a/src/beanmachine/ppl/inference/hmc_inference.py
+++ b/src/beanmachine/ppl/inference/hmc_inference.py
@@ -36,6 +36,7 @@ class GlobalHamiltonianMonteCarlo(BaseInference):
         initial_step_size: float = 1.0,
         adapt_step_size: bool = True,
         adapt_mass_matrix: bool = True,
+        full_mass_matrix: bool = False,
         target_accept_prob: float = 0.8,
         nnc_compile: bool = False,
     ):
@@ -43,6 +44,7 @@ class GlobalHamiltonianMonteCarlo(BaseInference):
         self.initial_step_size = initial_step_size
         self.adapt_step_size = adapt_step_size
         self.adapt_mass_matrix = adapt_mass_matrix
+        self.full_mass_matrix = full_mass_matrix
         self.target_accept_prob = target_accept_prob
         self.nnc_compile = nnc_compile
         self._proposer = None
@@ -65,6 +67,7 @@ class GlobalHamiltonianMonteCarlo(BaseInference):
                 self.initial_step_size,
                 self.adapt_step_size,
                 self.adapt_mass_matrix,
+                self.full_mass_matrix,
                 self.target_accept_prob,
                 self.nnc_compile,
             )
@@ -96,6 +99,7 @@ class SingleSiteHamiltonianMonteCarlo(BaseInference):
         initial_step_size: float = 1.0,
         adapt_step_size: bool = True,
         adapt_mass_matrix: bool = True,
+        full_mass_matrix: bool = False,
         target_accept_prob: float = 0.8,
         nnc_compile: bool = True,
     ):
@@ -103,6 +107,7 @@ class SingleSiteHamiltonianMonteCarlo(BaseInference):
         self.initial_step_size = initial_step_size
         self.adapt_step_size = adapt_step_size
         self.adapt_mass_matrix = adapt_mass_matrix
+        self.full_mass_matrix = full_mass_matrix
         self.target_accept_prob = target_accept_prob
         self.nnc_compile = nnc_compile
         self._proposers = {}
@@ -127,6 +132,7 @@ class SingleSiteHamiltonianMonteCarlo(BaseInference):
                     self.initial_step_size,
                     self.adapt_step_size,
                     self.adapt_mass_matrix,
+                    self.full_mass_matrix,
                     self.target_accept_prob,
                     self.nnc_compile,
                 )

--- a/src/beanmachine/ppl/inference/nuts_inference.py
+++ b/src/beanmachine/ppl/inference/nuts_inference.py
@@ -45,6 +45,7 @@ class GlobalNoUTurnSampler(BaseInference):
         initial_step_size: float = 1.0,
         adapt_step_size: bool = True,
         adapt_mass_matrix: bool = True,
+        full_mass_matrix: bool = False,
         multinomial_sampling: bool = True,
         target_accept_prob: float = 0.8,
         nnc_compile: bool = True,
@@ -54,6 +55,7 @@ class GlobalNoUTurnSampler(BaseInference):
         self.initial_step_size = initial_step_size
         self.adapt_step_size = adapt_step_size
         self.adapt_mass_matrix = adapt_mass_matrix
+        self.full_mass_matrix = full_mass_matrix
         self.multinomial_sampling = multinomial_sampling
         self.target_accept_prob = target_accept_prob
         self.nnc_compile = nnc_compile
@@ -78,6 +80,7 @@ class GlobalNoUTurnSampler(BaseInference):
                 self.initial_step_size,
                 self.adapt_step_size,
                 self.adapt_mass_matrix,
+                self.full_mass_matrix,
                 self.multinomial_sampling,
                 self.target_accept_prob,
                 self.nnc_compile,
@@ -118,6 +121,7 @@ class SingleSiteNoUTurnSampler(BaseInference):
         initial_step_size: float = 1.0,
         adapt_step_size: bool = True,
         adapt_mass_matrix: bool = True,
+        full_mass_matrix: bool = False,
         multinomial_sampling: bool = True,
         target_accept_prob: float = 0.8,
         nnc_compile: bool = False,
@@ -127,6 +131,7 @@ class SingleSiteNoUTurnSampler(BaseInference):
         self.initial_step_size = initial_step_size
         self.adapt_step_size = adapt_step_size
         self.adapt_mass_matrix = adapt_mass_matrix
+        self.full_mass_matrix = full_mass_matrix
         self.multinomial_sampling = multinomial_sampling
         self.target_accept_prob = target_accept_prob
         self.nnc_compile = nnc_compile
@@ -153,6 +158,7 @@ class SingleSiteNoUTurnSampler(BaseInference):
                     self.initial_step_size,
                     self.adapt_step_size,
                     self.adapt_mass_matrix,
+                    self.full_mass_matrix,
                     self.multinomial_sampling,
                     self.target_accept_prob,
                     self.nnc_compile,

--- a/src/beanmachine/ppl/inference/proposer/nuts_proposer.py
+++ b/src/beanmachine/ppl/inference/proposer/nuts_proposer.py
@@ -80,6 +80,7 @@ class NUTSProposer(HMCProposer):
         initial_step_size: float = 1.0,
         adapt_step_size: bool = True,
         adapt_mass_matrix: bool = True,
+        full_mass_matrix: bool = False,
         multinomial_sampling: bool = True,
         target_accept_prob: float = 0.8,
         nnc_compile: bool = True,
@@ -93,6 +94,7 @@ class NUTSProposer(HMCProposer):
             initial_step_size=initial_step_size,
             adapt_step_size=adapt_step_size,
             adapt_mass_matrix=adapt_mass_matrix,
+            full_mass_matrix=full_mass_matrix,
             target_accept_prob=target_accept_prob,
             nnc_compile=False,  # we will use NNC at NUTS level, not at HMC level
         )
@@ -111,7 +113,7 @@ class NUTSProposer(HMCProposer):
         sum_momentums: torch.Tensor,
     ) -> torch.Tensor:
         """The generalized U-turn condition, as described in [2] Appendix 4.2"""
-        rho = mass_inv * sum_momentums
+        rho = self._scale_r(sum_momentums, mass_inv)
         return (torch.dot(left_momentums, rho) <= 0) or (
             torch.dot(right_momentums, rho) <= 0
         )


### PR DESCRIPTION
Summary:
This diff add the full mass matrix option (also known as the [dense metric](https://mc-stan.org/docs/reference-manual/hmc-algorithm-parameters.html#euclidean-metric)) to HMC and NUTS. We already had a lot of the required infra set up, so there are only a few main changes in this diff:
1. We store the diagonal mass matrix as a vector of length `(N)` whereas the full mass matrix has size `(N, N)`. This will affect how we scale the momentums, which is refactored into its own `scale_r` method.
2. Since the initial momentums need to be draw from [MultiNormal0, M)](https://mc-stan.org/docs/reference-manual/hamiltonian-monte-carlo.html#auxiliary-momentum-variable), the `MultivariateNormal` distribution in PyTorch is used here.
3. HMC and NUTS will still use the diagonal mass matrix by default, similar to the other PPLs.

Differential Revision: D32632103

