### PR TITLE
minibmg: generalize common subexpression elimination

### DIFF
--- a/minibmg/ad/num3.h
+++ b/minibmg/ad/num3.h
@@ -11,8 +11,11 @@
 #include <cassert>
 #include <cmath>
 #include <cstdlib>
+#include <vector>
 #include "beanmachine/minibmg/ad/number.h"
 #include "beanmachine/minibmg/ad/real.h"
+#include "beanmachine/minibmg/dedup.h"
+#include "beanmachine/minibmg/node.h"
 
 namespace beanmachine::minibmg {
 
@@ -350,5 +353,31 @@ requires Number<Underlying> std::string to_string(const Num3<Underlying>& x) {
 }
 
 static_assert(Number<Num3<Real>>);
+
+template <class Underlying>
+requires Number<Underlying>
+class DedupHelper<Num3<Underlying>> {
+  DedupHelper<Underlying> helper{};
+
+ public:
+  std::vector<Nodep> find_roots(const Num3<Underlying>& num3) const {
+    std::vector<Nodep> result = helper.find_roots(num3.primal);
+    for (auto& n : helper.find_roots(num3.derivative1)) {
+      result.push_back(n);
+    }
+    for (auto& n : helper.find_roots(num3.derivative2)) {
+      result.push_back(n);
+    }
+    return result;
+  }
+  Num3<Underlying> rewrite(
+      const Num3<Underlying>& num3,
+      const std::unordered_map<Nodep, Nodep>& map) const {
+    auto new_primal = helper.rewrite(num3.primal, map);
+    auto new_derivative1 = helper.rewrite(num3.derivative1, map);
+    auto new_derivative2 = helper.rewrite(num3.derivative2, map);
+    return {new_primal, new_derivative1, new_derivative2};
+  }
+};
 
 } // namespace beanmachine::minibmg

--- a/minibmg/ad/traced.h
+++ b/minibmg/ad/traced.h
@@ -12,6 +12,7 @@
 #include <vector>
 #include "beanmachine/minibmg/ad/number.h"
 #include "beanmachine/minibmg/ad/real.h"
+#include "beanmachine/minibmg/dedup.h"
 #include "beanmachine/minibmg/node.h"
 
 namespace beanmachine::minibmg {
@@ -71,6 +72,19 @@ bool is_constant(const Traced& x, const double& value);
 std::string to_string(const Traced& x);
 
 static_assert(Number<Traced>);
+
+template <>
+class DedupHelper<Traced> {
+ public:
+  std::vector<Nodep> find_roots(const Traced& t) const {
+    return {t.node};
+  }
+  Traced rewrite(const Traced& t, const std::unordered_map<Nodep, Nodep>& map)
+      const {
+    const auto& f = map.find(t.node);
+    return (f == map.end()) ? t : Traced(f->second);
+  }
+};
 
 } // namespace beanmachine::minibmg
 

--- a/minibmg/dedup.cpp
+++ b/minibmg/dedup.cpp
@@ -114,8 +114,8 @@ Nodep rewrite(Nodep node, const NodeValueMap<Nodep>& map) {
       auto op = std::dynamic_pointer_cast<const OperatorNode>(node);
       std::vector<Nodep> in_nodes;
       bool changed = false;
-      for (Nodep in_node : op->in_nodes) {
-        Nodep replacement = map.at(in_node);
+      for (auto& in_node : op->in_nodes) {
+        auto& replacement = map.at(in_node);
         if (replacement != in_node) {
           changed = true;
         }
@@ -136,7 +136,7 @@ namespace beanmachine::minibmg {
 // Take a set of root nodes as input, and return a map of deduplicated nodes,
 // which maps from a node in the transitive closure of the input to a
 // corresponding node in the transitive closure of the deduplicated graph.
-std::unordered_map<Nodep, Nodep> dedup(std::vector<Nodep> roots) {
+std::unordered_map<Nodep, Nodep> dedup_map(std::vector<Nodep> roots) {
   // a value-based, map, which treats semantically identical nodes as the same.
   NodeValueMap<Nodep> map;
 
@@ -150,7 +150,7 @@ std::unordered_map<Nodep, Nodep> dedup(std::vector<Nodep> roots) {
     throw std::invalid_argument("graph has a cycle");
   }
   std::reverse(sorted.begin(), sorted.end());
-  for (auto node : sorted) {
+  for (auto& node : sorted) {
     auto found = map.find(node);
     if (found != map.end()) {
       map.insert({node, found->second});

--- a/minibmg/dedup.h
+++ b/minibmg/dedup.h
@@ -7,9 +7,13 @@
 
 #pragma once
 
+#include <list>
 #include <memory>
 #include <unordered_map>
+#include <utility>
 #include <vector>
+#include "beanmachine/minibmg/ad/real.h"
+#include "beanmachine/minibmg/graph.h"
 #include "beanmachine/minibmg/node.h"
 
 namespace beanmachine::minibmg {
@@ -17,6 +21,142 @@ namespace beanmachine::minibmg {
 // Take a set of root nodes as input, and return a map of deduplicated nodes,
 // which maps from a node in the transitive closure of the roots to a
 // corresponding node in the transitive closure of the deduplicated graph.
-std::unordered_map<Nodep, Nodep> dedup(std::vector<Nodep> roots);
+std::unordered_map<Nodep, Nodep> dedup_map(std::vector<Nodep> roots);
+
+// In order to deduplicate data in a given data structure, the programmer must
+// specialize this template class to locate the roots contained in
+// that data structure, and to write a replacement for data structure in which
+// nodes have been deduplicated.  We provide a number of specializations for
+// data structures likely to be needed.
+template <class T>
+class DedupHelper {
+ public:
+  DedupHelper() = delete;
+  // locate all of the roots.
+  std::vector<Nodep> find_roots(const T&) const;
+  // rewrite the T, given a mapping from each node to its replacement.
+  T rewrite(const T&, std::unordered_map<Nodep, Nodep>) const;
+};
+
+// Rewrite a data structure by deduplicating its nodes.  The programmer must
+// either provide an implementation of DedupHelper<T> or specialize it.
+template <class T>
+T dedup(const T& data, const DedupHelper<T>& helper = DedupHelper<T>{}) {
+  auto roots = helper.find_roots(data);
+  auto map = dedup_map(roots);
+  return helper.rewrite(data, map);
+}
+
+// A single node can be deduplicated
+template <>
+class DedupHelper<Nodep> {
+ public:
+  std::vector<Nodep> find_roots(Nodep& n) const {
+    return {n};
+  }
+  Nodep rewrite(const Nodep& node, const std::unordered_map<Nodep, Nodep>& map)
+      const {
+    auto f = map.find(node);
+    return f == map.end() ? node : f->second;
+  }
+};
+
+// A vector can be deduplicated.
+template <class T>
+class DedupHelper<std::vector<T>> {
+  DedupHelper<T> t_helper{};
+
+ public:
+  std::vector<Nodep> find_roots(const std::vector<T>& roots) const {
+    std::vector<Nodep> result;
+    for (const auto& root : roots) {
+      auto more_roots = t_helper.find_roots(root);
+      result.push_back(more_roots.begin(), more_roots.end());
+    }
+    return result;
+  }
+  std::vector<T> rewrite(
+      const std::vector<T>& roots,
+      const std::unordered_map<Nodep, Nodep>& map) const {
+    std::vector<T> result;
+    for (const auto& root : roots) {
+      result.push_back(t_helper.rewrite(root, map));
+    }
+    return result;
+  }
+};
+
+// A list can be deduplicated
+template <class T>
+class DedupHelper<std::list<T>> {
+  DedupHelper<T> t_helper{};
+
+ public:
+  std::vector<Nodep> find_roots(const std::list<T>& roots) const {
+    std::vector<Nodep> result;
+    for (const auto& root : roots) {
+      auto more_roots = t_helper.find_roots(root);
+      result.push_back(more_roots.begin(), more_roots.end());
+    }
+    return result;
+  }
+  std::list<T> rewrite(
+      const std::list<T>& roots,
+      const std::unordered_map<Nodep, Nodep>& map) const {
+    std::list<T> result;
+    for (const auto& root : roots) {
+      result.push_back(t_helper.rewrite(root, map));
+    }
+    return result;
+  }
+};
+
+// A pair can be deduplicated
+template <class T, class U>
+class DedupHelper<std::pair<T, U>> {
+  DedupHelper<T> t_helper{};
+  DedupHelper<U> u_helper{};
+
+ public:
+  std::vector<Nodep> find_roots(const std::pair<T, U>& root) const {
+    std::vector<Nodep> result = t_helper(root.first);
+    for (auto& r : u_helper.find_roots(root.second)) {
+      result.push_back(r);
+    }
+    return result;
+  }
+  std::pair<T, U> rewrite(
+      const std::pair<T, U>& root,
+      const std::unordered_map<Nodep, Nodep>& map) const {
+    return {
+        t_helper.rewrite(root.first, map), u_helper.rewrite(root.second, map)};
+  }
+};
+
+// A double can be deduplicated (no action)
+template <>
+class DedupHelper<double> {
+ public:
+  std::vector<Nodep> find_roots(const double& root) const {
+    return {};
+  }
+  double rewrite(const double& root, std::unordered_map<Nodep, Nodep>) const {
+    return root;
+  }
+};
+
+// A Real (wrapper around a double) can be deduplicated (no action)
+template <>
+class DedupHelper<Real> {
+ public:
+  std::vector<Nodep> find_roots(const Real& t) const {
+    return {};
+  }
+  // rewrite the T, given a mapping from each node to its replacement.
+  Real rewrite(const Real& t, const std::unordered_map<Nodep, Nodep>& map)
+      const {
+    return t;
+  }
+};
 
 } // namespace beanmachine::minibmg

--- a/minibmg/eval.h
+++ b/minibmg/eval.h
@@ -186,4 +186,21 @@ requires Number<T> EvalResult<T> eval_graph(
   return {log_prob, queries};
 }
 
+template <class Underlying>
+requires Number<Underlying>
+class DedupHelper<EvalResult<Underlying>> {
+  DedupHelper<Underlying> helper{};
+
+ public:
+  std::vector<Nodep> find_roots(const EvalResult<Underlying>& e) const {
+    return helper.find_roots(e.log_prob);
+  }
+  EvalResult<Underlying> rewrite(
+      const EvalResult<Underlying>& e,
+      const std::unordered_map<Nodep, Nodep>& map) const {
+    auto new_log_prob = helper.rewrite(e.log_prob, map);
+    return {new_log_prob, e.queries};
+  }
+};
+
 } // namespace beanmachine::minibmg

--- a/minibmg/graph.cpp
+++ b/minibmg/graph.cpp
@@ -25,17 +25,14 @@ const std::vector<Nodep> roots(
     const std::vector<Nodep>& queries,
     const std::list<std::pair<Nodep, double>>& observations) {
   std::list<Nodep> roots;
-  for (auto n : queries) {
+  for (auto& n : queries) {
     roots.push_back(n);
   }
-  for (auto p : observations) {
+  for (auto& p : observations) {
     if (p.first->op != Operator::SAMPLE) {
       throw std::invalid_argument(fmt::format("can only observe a sample"));
     }
     roots.push_front(p.first);
-  }
-  for (auto n : queries) {
-    roots.push_back(n);
   }
   std::vector<Nodep> all_nodes;
   if (!topological_sort<Nodep>(roots, &in_nodes, all_nodes)) {
@@ -45,28 +42,56 @@ const std::vector<Nodep> roots(
   return all_nodes;
 }
 
+struct QueriesAndObservations {
+  std::vector<Nodep> queries;
+  std::list<std::pair<Nodep, double>> observations;
+  ~QueriesAndObservations() {}
+};
+
 } // namespace
 
 namespace beanmachine::minibmg {
+
+template <>
+class DedupHelper<QueriesAndObservations> {
+ public:
+  std::vector<Nodep> find_roots(const QueriesAndObservations& qo) const {
+    std::vector<Nodep> roots;
+    for (auto& q : qo.observations) {
+      roots.push_back(q.first);
+    }
+    for (auto& n : qo.queries) {
+      roots.push_back(n);
+    }
+    return roots;
+  }
+  QueriesAndObservations rewrite(
+      const QueriesAndObservations& qo,
+      const std::unordered_map<Nodep, Nodep>& map) const {
+    DedupHelper<std::vector<Nodep>> h1{};
+    DedupHelper<std::list<std::pair<Nodep, double>>> h2{};
+    return QueriesAndObservations{
+        h1.rewrite(qo.queries, map), h2.rewrite(qo.observations, map)};
+  }
+};
 
 using dynamic = folly::dynamic;
 
 Graph Graph::create(
     const std::vector<Nodep>& queries,
     const std::list<std::pair<Nodep, double>>& observations) {
-  std::vector<Nodep> all_nodes = roots(queries, observations);
+  for (auto& p : observations) {
+    if (p.first->op != Operator::SAMPLE) {
+      throw std::invalid_argument(fmt::format("can only observe a sample"));
+    }
+  }
+
+  auto qo0 = QueriesAndObservations{queries, observations};
+  auto qo1 = dedup(qo0);
+
+  std::vector<Nodep> all_nodes = roots(qo1.queries, qo1.observations);
   Graph::validate(all_nodes);
-  auto dedup_map = beanmachine::minibmg::dedup(all_nodes);
-  std::vector<Nodep> deduped_queries;
-  std::list<std::pair<Nodep, double>> deduped_observations;
-  for (auto q : queries) {
-    deduped_queries.push_back(dedup_map[q]);
-  }
-  for (auto p : observations) {
-    deduped_observations.push_back({dedup_map[p.first], p.second});
-  }
-  auto deduped_all_nodes = roots(deduped_queries, deduped_observations);
-  return Graph{deduped_all_nodes, deduped_queries, deduped_observations};
+  return Graph{all_nodes, qo1.queries, qo1.observations};
 }
 
 Graph::~Graph() {}
@@ -158,7 +183,7 @@ folly::dynamic graph_to_json(const Graph& g) {
   dynamic a = dynamic::array;
 
   unsigned long next_identifier = 0;
-  for (auto node : g) {
+  for (auto& node : g) {
     // assign node identifiers sequentially.  They are called "sequence" in the
     // generated json.
     auto identifier = next_identifier++;
@@ -184,7 +209,7 @@ folly::dynamic graph_to_json(const Graph& g) {
       default: {
         auto n = std::dynamic_pointer_cast<const OperatorNode>(node);
         dynamic in_nodes = dynamic::array;
-        for (auto pred : n->in_nodes) {
+        for (auto& pred : n->in_nodes) {
           in_nodes.push_back(node_to_identifier[pred]);
         }
         dyn_node["in_nodes"] = in_nodes;
@@ -206,7 +231,7 @@ folly::dynamic graph_to_json(const Graph& g) {
   result["observations"] = observations;
 
   dynamic queries = dynamic::array;
-  for (auto q : g.queries) {
+  for (auto& q : g.queries) {
     queries.push_back(node_to_identifier[q]);
   }
   result["queries"] = queries;
@@ -317,7 +342,7 @@ Graph json_to_graph(folly::dynamic d) {
           throw JsonError("missing in_nodes.");
         }
         std::vector<Nodep> in_nodes;
-        for (auto in_nodev : in_nodesv) {
+        for (auto& in_nodev : in_nodesv) {
           if (!in_nodev.isInt()) {
             throw JsonError("missing in_node for operator.");
           }
@@ -342,7 +367,7 @@ Graph json_to_graph(folly::dynamic d) {
   std::vector<Nodep> queries;
   auto query_nodes = d["queries"];
   if (query_nodes.isArray()) {
-    for (auto query : query_nodes) {
+    for (auto& query : query_nodes) {
       if (!query.isInt()) {
         throw JsonError("bad query value.");
       }
@@ -358,7 +383,7 @@ Graph json_to_graph(folly::dynamic d) {
   std::list<std::pair<Nodep, double>> observations;
   auto observation_nodes = d["observations"];
   if (observation_nodes.isArray()) {
-    for (auto obs : observation_nodes) {
+    for (auto& obs : observation_nodes) {
       auto node = obs["node"];
       if (!node.isInt()) {
         throw JsonError("bad observation node.");
@@ -367,8 +392,8 @@ Graph json_to_graph(folly::dynamic d) {
       if (!identifier_to_node.contains(node_i)) {
         throw JsonError(fmt::format("bad in_node {} for observation.", node_i));
       }
-      auto obs_node = identifier_to_node[node_i];
-      auto value = obs["value"];
+      auto& obs_node = identifier_to_node[node_i];
+      auto& value = obs["value"];
       if (!node.isDouble() && !node.isInt()) {
         throw JsonError("bad value for observation.");
       }


### PR DESCRIPTION
Summary: Using a trick I learned from the C++ standard template library, generalize the graph deduplication so that it can be used on any kind of data structure that contains nodes, provided there is a specialization of `DedupHelper<T>` for that type.

Differential Revision: D40194895

