### PR TITLE
minibmg: local expression rewriter/optimizer

### DIFF
--- a/minibmg/dedup.cpp
+++ b/minibmg/dedup.cpp
@@ -9,91 +9,13 @@
 #include <map>
 #include <stdexcept>
 #include <unordered_map>
+#include "beanmachine/minibmg/node.h"
 #include "beanmachine/minibmg/operator.h"
 #include "beanmachine/minibmg/topological.h"
 
 namespace {
 
 using namespace beanmachine::minibmg;
-
-// Provide a good hash function so Nodep values can be used in unordered maps
-// and sets.  This treats Nodep values as semantically value-based.
-struct NodepIdentityHash {
-  std::size_t operator()(beanmachine::minibmg::Nodep const& p) const noexcept;
-};
-
-// Provide a good equality function so Nodep values can be used in unordered
-// maps and sets.  This treats Nodep values, recursively, as semantically
-// value-based.
-struct NodepIdentityEquals {
-  bool operator()(
-      const beanmachine::minibmg::Nodep& lhs,
-      const beanmachine::minibmg::Nodep& rhs) const noexcept;
-};
-
-// A value-based map from nodes to T.  Used for deduplicating a graph.
-template <class T>
-using NodeValueMap =
-    std::unordered_map<Nodep, T, NodepIdentityHash, NodepIdentityEquals>;
-
-// A value-based set of nodes.
-using NodeValueSet =
-    std::unordered_set<Nodep, NodepIdentityHash, NodepIdentityEquals>;
-
-std::size_t NodepIdentityHash::operator()(
-    beanmachine::minibmg::Nodep const& p) const noexcept {
-  return p->cached_hash_value;
-}
-
-bool NodepIdentityEquals::operator()(
-    const beanmachine::minibmg::Nodep& lhs,
-    const beanmachine::minibmg::Nodep& rhs) const noexcept {
-  const Node* l = lhs.get();
-  const Node* r = rhs.get();
-  // a node is equal to itself.
-  if (l == r) {
-    return true;
-  }
-  // equal nodes have equal hash codes and equal operators.
-  if (l == nullptr || r == nullptr ||
-      l->cached_hash_value != r->cached_hash_value || l->op != r->op) {
-    return false;
-  }
-  switch (l->op) {
-    case Operator::VARIABLE: {
-      const VariableNode* vl = dynamic_cast<const VariableNode*>(l);
-      const VariableNode* vr = dynamic_cast<const VariableNode*>(r);
-      return vl->name == vr->name && vl->identifier == vr->identifier;
-    }
-    case Operator::CONSTANT: {
-      double cl = dynamic_cast<const ConstantNode*>(l)->value;
-      double cr = dynamic_cast<const ConstantNode*>(r)->value;
-      return std::isnan(cl) ? std::isnan(cr) : cl == cr;
-    }
-    case Operator::SAMPLE: {
-      const SampleNode* sl = dynamic_cast<const SampleNode*>(l);
-      const SampleNode* sr = dynamic_cast<const SampleNode*>(r);
-      return sl->rvid == sr->rvid &&
-          this->operator()(sl->distribution, sr->distribution);
-    }
-    default: {
-      const OperatorNode* lo = dynamic_cast<const OperatorNode*>(l);
-      const OperatorNode* ro = dynamic_cast<const OperatorNode*>(r);
-      if (lo->in_nodes.size() != ro->in_nodes.size()) {
-        return false;
-      }
-      auto it1 = lo->in_nodes.begin();
-      auto it2 = ro->in_nodes.begin();
-      for (; it1 != lo->in_nodes.end() && it2 != ro->in_nodes.end();
-           it1++, it2++) {
-        if (!this->operator()(*it1, *it2)) {
-          return false;
-        }
-      }
-      return true;
-    }
-  }
-}
 
 // Rewrite a single node by replacing all of its inputs with their deduplicated
 // counterpart.
@@ -115,7 +37,7 @@ Nodep rewrite(Nodep node, const NodeValueMap<Nodep>& map) {
       std::vector<Nodep> in_nodes;
       bool changed = false;
       for (auto& in_node : op->in_nodes) {
-        auto& replacement = map.at(in_node);
+        auto replacement = map.at(in_node);
         if (replacement != in_node) {
           changed = true;
         }

--- a/minibmg/dedup.h
+++ b/minibmg/dedup.h
@@ -21,6 +21,8 @@ namespace beanmachine::minibmg {
 // Take a set of root nodes as input, and return a map of deduplicated nodes,
 // which maps from a node in the transitive closure of the roots to a
 // corresponding node in the transitive closure of the deduplicated graph.
+// This is used in the implementation of dedup(), but might occasionally be
+// useful in this form.
 std::unordered_map<Nodep, Nodep> dedup_map(std::vector<Nodep> roots);
 
 // In order to deduplicate data in a given data structure, the programmer must
@@ -35,7 +37,7 @@ class DedupHelper {
   // locate all of the roots.
   std::vector<Nodep> find_roots(const T&) const;
   // rewrite the T, given a mapping from each node to its replacement.
-  T rewrite(const T&, std::unordered_map<Nodep, Nodep>) const;
+  T rewrite(const T&, const std::unordered_map<Nodep, Nodep>&) const;
 };
 
 // Rewrite a data structure by deduplicating its nodes.  The programmer must
@@ -51,7 +53,7 @@ T dedup(const T& data, const DedupHelper<T>& helper = DedupHelper<T>{}) {
 template <>
 class DedupHelper<Nodep> {
  public:
-  std::vector<Nodep> find_roots(Nodep& n) const {
+  std::vector<Nodep> find_roots(const Nodep& n) const {
     return {n};
   }
   Nodep rewrite(const Nodep& node, const std::unordered_map<Nodep, Nodep>& map)

--- a/minibmg/localopt.cpp
+++ b/minibmg/localopt.cpp
@@ -1,0 +1,354 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "beanmachine/minibmg/localopt.h"
+#include <memory>
+#include <unordered_map>
+#include "beanmachine/minibmg/node.h"
+#include "beanmachine/minibmg/operator.h"
+#include "beanmachine/minibmg/topological.h"
+
+namespace {
+
+using namespace beanmachine::minibmg;
+double k(Nodep node) {
+  return std::dynamic_pointer_cast<const ConstantNode>(node)->value;
+}
+
+NodepIdentityEquals same{};
+
+Nodep make_operator(Operator op, std::vector<Nodep> in_nodes) {
+  return std::make_shared<OperatorNode>(in_nodes, op, Type::REAL);
+}
+
+} // namespace
+
+namespace beanmachine::minibmg {
+
+Nodep rewrite_node(const Nodep& node, NodeValueMap<Nodep>& map);
+
+// This is a temporary hack to perform some local optimizations on the a graph
+// node. Ultimately, these should be organized into a rewriter based on tree
+// automata, which will make the rewriters much easier to maintain and much
+// faster.  For now we hand-implement a few rules by brute force.  The one-line
+// comment before each transformation shows what the rule would look like in a
+// hypothetical rewriting system.
+Nodep rewrite_one(const Nodep& node, NodeValueMap<Nodep>& map) {
+  // A semantically equivalent node was already rewritten.
+  if (auto found = map.find(node); found != map.end()) {
+    return found->second;
+  }
+  switch (node->op) {
+    case Operator::ADD: {
+      auto op = std::dynamic_pointer_cast<const OperatorNode>(node);
+      // {k1 + k2, k3}, // constant fold
+      auto left = map.at(op->in_nodes[0]);
+      auto right = map.at(op->in_nodes[1]);
+      if (left->op == Operator::CONSTANT && right->op == Operator::CONSTANT) {
+        return std::make_shared<ConstantNode>(k(left) + k(right));
+      }
+      // {0 + x, x},
+      if (left->op == Operator::CONSTANT && k(left) == 0) {
+        return right;
+      }
+      // {x + 0, x},
+      if (right->op == Operator::CONSTANT && k(right) == 0) {
+        return left;
+      }
+      // {x + x, 2 * x},
+      if (same(left, right)) {
+        auto two = rewrite_node(std::make_shared<ConstantNode>(2), map);
+        return make_operator(Operator::MULTIPLY, {two, left});
+      }
+      if (left == op->in_nodes[0] && right == op->in_nodes[1]) {
+        return node;
+      }
+      return make_operator(Operator::ADD, {left, right});
+    }
+
+    case Operator::SUBTRACT: {
+      auto op = std::dynamic_pointer_cast<const OperatorNode>(node);
+      auto left = map.at(op->in_nodes[0]);
+      auto right = map.at(op->in_nodes[1]);
+      // {k1 - k2, k3}, // constant fold
+      if (left->op == Operator::CONSTANT && right->op == Operator::CONSTANT) {
+        return std::make_shared<ConstantNode>(k(left) - k(right));
+      }
+      // {0 - x, -x},
+      if (left->op == Operator::CONSTANT && k(left) == 0) {
+        return make_operator(Operator::NEGATE, {right});
+      }
+      // {x - 0, x},
+      if (right->op == Operator::CONSTANT && k(right) == 0) {
+        return left;
+      }
+      // {x - x, 0},
+      if (same(left, right)) {
+        return std::make_shared<ConstantNode>(0);
+      }
+      if (left == op->in_nodes[0] && right == op->in_nodes[1]) {
+        return node;
+      }
+      return make_operator(Operator::SUBTRACT, {left, right});
+    }
+
+    case Operator::NEGATE: {
+      auto op = std::dynamic_pointer_cast<const OperatorNode>(node);
+      auto x = map.at(op->in_nodes[0]);
+      // {-k, k3}, // constant fold
+      if (x->op == Operator::CONSTANT) {
+        return std::make_shared<ConstantNode>(-k(x));
+      }
+      // {--x, x},
+      if (x->op == Operator::NEGATE) {
+        return std::dynamic_pointer_cast<const OperatorNode>(x)->in_nodes[0];
+      }
+      if (x == op->in_nodes[0]) {
+        return node;
+      }
+      return make_operator(Operator::NEGATE, {x});
+    }
+
+    case Operator::MULTIPLY: {
+      auto op = std::dynamic_pointer_cast<const OperatorNode>(node);
+      auto left = map.at(op->in_nodes[0]);
+      auto right = map.at(op->in_nodes[1]);
+      // {k1 * k2, k3}, // constant fold
+      if (left->op == Operator::CONSTANT && right->op == Operator::CONSTANT) {
+        return std::make_shared<ConstantNode>(k(left) * k(right));
+      }
+      // {0 * x, 0},
+      if (left->op == Operator::CONSTANT && k(left) == 0) {
+        return left;
+      }
+      // {-1 * x, -x},
+      if (left->op == Operator::CONSTANT && k(left) == -1) {
+        return make_operator(Operator::NEGATE, {right});
+      }
+      // {1 * x, x},
+      if (left->op == Operator::CONSTANT && k(left) == 1) {
+        return right;
+      }
+      // {x * 0, 0},
+      if (right->op == Operator::CONSTANT && k(right) == 0) {
+        return right;
+      }
+      // {x * 1, x},
+      if (right->op == Operator::CONSTANT && k(right) == 1) {
+        return left;
+      }
+      // {k1 * (k2 * x), k3 * x },
+      if (left->op == Operator::CONSTANT && right->op == Operator::MULTIPLY) {
+        auto rop = std::dynamic_pointer_cast<const OperatorNode>(node);
+        if (rop->in_nodes[0]->op == Operator::CONSTANT) {
+          auto k3 = rewrite_node(
+              std::make_shared<ConstantNode>(k(left) * k(rop->in_nodes[0])),
+              map);
+          return make_operator(Operator::MULTIPLY, {k3, rop->in_nodes[1]});
+        }
+      }
+      if (left == op->in_nodes[0] && right == op->in_nodes[1]) {
+        return node;
+      }
+      return make_operator(Operator::MULTIPLY, {left, right});
+    }
+
+    case Operator::DIVIDE: {
+      auto op = std::dynamic_pointer_cast<const OperatorNode>(node);
+      auto left = map.at(op->in_nodes[0]);
+      auto right = map.at(op->in_nodes[1]);
+      // {k1 / k2, k3}, // constant fold
+      if (left->op == Operator::CONSTANT && right->op == Operator::CONSTANT) {
+        return std::make_shared<ConstantNode>(k(left) / k(right));
+      }
+      // {x / k, (1/k) * x},
+      if (right->op == Operator::CONSTANT) {
+        auto k3 =
+            rewrite_node(std::make_shared<ConstantNode>(1 / k(right)), map);
+        return make_operator(Operator::MULTIPLY, {k3, left});
+      }
+      if (left == op->in_nodes[0] && right == op->in_nodes[1]) {
+        return node;
+      }
+      return make_operator(Operator::DIVIDE, {left, right});
+    }
+
+    case Operator::POW: {
+      auto op = std::dynamic_pointer_cast<const OperatorNode>(node);
+      auto left = map.at(op->in_nodes[0]);
+      auto right = map.at(op->in_nodes[1]);
+      // {pow(k1, k2), k3}, // constant fold
+      if (left->op == Operator::CONSTANT && right->op == Operator::CONSTANT) {
+        auto k3 = std::pow(k(left), k(right));
+        return std::make_shared<ConstantNode>(k3);
+      }
+      // {pow(x, 1), x},
+      if (right->op == Operator::CONSTANT && k(right) == 1) {
+        return left;
+      }
+      if (left == op->in_nodes[0] && right == op->in_nodes[1]) {
+        return node;
+      }
+      return make_operator(Operator::POW, {left, right});
+    }
+
+    case Operator::EXP: {
+      auto op = std::dynamic_pointer_cast<const OperatorNode>(node);
+      auto x = map.at(op->in_nodes[0]);
+      // {exp(k), k3}, // constant fold
+      if (x->op == Operator::CONSTANT) {
+        return std::make_shared<ConstantNode>(std::exp(k(x)));
+      }
+      // {exp(log(x)), x},
+      if (x->op == Operator::LOG) {
+        return std::dynamic_pointer_cast<const OperatorNode>(x)->in_nodes[0];
+      }
+      if (x == op->in_nodes[0]) {
+        return node;
+      }
+      return make_operator(Operator::EXP, {x});
+    }
+
+    case Operator::LOG: {
+      auto op = std::dynamic_pointer_cast<const OperatorNode>(node);
+      auto x = map.at(op->in_nodes[0]);
+      // {log(k), k3}, // constant fold
+      if (x->op == Operator::CONSTANT) {
+        return std::make_shared<ConstantNode>(std::log(k(x)));
+      }
+      // {log(exp(x)), x},
+      if (x->op == Operator::EXP) {
+        return std::dynamic_pointer_cast<const OperatorNode>(x)->in_nodes[0];
+      }
+      if (x == op->in_nodes[0]) {
+        return node;
+      }
+      return make_operator(Operator::LOG, {x});
+    }
+
+    case Operator::ATAN: {
+      auto op = std::dynamic_pointer_cast<const OperatorNode>(node);
+      auto x = map.at(op->in_nodes[0]);
+      // {atan(k), k3}, // constant fold
+      if (x->op == Operator::CONSTANT) {
+        return std::make_shared<ConstantNode>(std::atan(k(x)));
+      }
+      if (x == op->in_nodes[0]) {
+        return node;
+      }
+      return make_operator(Operator::ATAN, {x});
+    }
+
+    case Operator::LGAMMA: {
+      auto op = std::dynamic_pointer_cast<const OperatorNode>(node);
+      auto x = map.at(op->in_nodes[0]);
+      // {lgamma(k), k3}, // constant fold
+      if (x->op == Operator::CONSTANT) {
+        return std::make_shared<ConstantNode>(std::lgamma(k(x)));
+      }
+      if (x == op->in_nodes[0]) {
+        return node;
+      }
+      return make_operator(Operator::LGAMMA, {x});
+    }
+
+    case Operator::POLYGAMMA: {
+      auto op = std::dynamic_pointer_cast<const OperatorNode>(node);
+      auto left = map.at(op->in_nodes[0]);
+      auto right = map.at(op->in_nodes[1]);
+      // {polygamma(k1, k2), k3}, // constant fold
+      if (left->op == Operator::CONSTANT && right->op == Operator::CONSTANT) {
+        auto value = boost::math::polygamma(k(left), k(right));
+        return std::make_shared<ConstantNode>(value);
+      }
+      if (left == op->in_nodes[0] && right == op->in_nodes[1]) {
+        return node;
+      }
+      return make_operator(Operator::POLYGAMMA, {left, right});
+    }
+
+    default:
+      break;
+  }
+
+  return node;
+}
+
+// The following method may be useful in debugging the problematic case
+// that the rewrite_one method returns nested nodes that it does not
+// place in the map. It is commented out in normal use, but when the
+// optimizer throws an exception because a node is not in the map, this
+// will likely be helpful in finding the problem.
+bool check_children(const Nodep& node, NodeValueMap<Nodep>& map) {
+  if (auto op = std::dynamic_pointer_cast<const OperatorNode>(node)) {
+    for (auto& in : op->in_nodes) {
+      if (!map.contains(in) || map.at(in) == nullptr) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+// An intermediate method placed into the call-chain just to make debugging
+// easier.
+inline Nodep rewrite_one_internal(const Nodep& node, NodeValueMap<Nodep>& map) {
+  return rewrite_one(node, map);
+}
+
+// Call the rewriter repeatedly on a node until a fixed-point is reached, and
+// then place the result in the node-value-based map.
+Nodep rewrite_node(const Nodep& node, NodeValueMap<Nodep>& map) {
+  // check_children(node, map);
+  Nodep rewritten = node;
+  while (true) {
+    const Nodep n = rewrite_one_internal(rewritten, map);
+    if (same(n, rewritten)) {
+      rewritten = n;
+      break;
+    }
+    if (n == nullptr) {
+      throw std::logic_error("rewriter should not return nullptr");
+    }
+    map[rewritten] = n;
+    rewritten = n;
+  }
+  if (auto found = map.find(node);
+      found == map.end() || !same(rewritten, found->second)) {
+    if (rewritten == nullptr) {
+      throw std::logic_error("rewriter should not return nullptr");
+    }
+    map[node] = rewritten;
+  }
+  map[rewritten] = rewritten;
+  return rewritten;
+}
+
+std::unordered_map<Nodep, Nodep> opt_map(std::vector<Nodep> roots) {
+  std::vector<Nodep> sorted;
+  if (!topological_sort<Nodep>(
+          {roots.begin(), roots.end()}, in_nodes, sorted)) {
+    throw std::invalid_argument("graph has a cycle");
+  }
+  std::reverse(sorted.begin(), sorted.end());
+
+  // a value-based, map, which treats semantically identical nodes as the same.
+  NodeValueMap<Nodep> map;
+  for (auto& node : sorted) {
+    rewrite_node(node, map);
+  }
+
+  // We also build a map that uses object (pointer) identity to find elements,
+  // so that operations in clients are not using recursive equality operations.
+  std::unordered_map<Nodep, Nodep> identity_map;
+  for (auto& node : sorted) {
+    identity_map.insert({node, map.at(node)});
+  }
+  return identity_map;
+}
+
+} // namespace beanmachine::minibmg

--- a/minibmg/localopt.h
+++ b/minibmg/localopt.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "beanmachine/minibmg/dedup.h"
+
+namespace beanmachine::minibmg {
+
+// Take a set of root nodes as input, and return a map of (locally) optimized
+// nodes, which maps from a node in the transitive closure of the roots to a
+// corresponding node in the transitive closure of the optimized graph.
+// This is used in the implementation of opt(), but might occasionally be
+// useful in this form.
+std::unordered_map<Nodep, Nodep> opt_map(std::vector<Nodep> roots);
+
+// See dedup.h
+template <class T>
+class DedupHelper;
+
+// Rewrite a data structure by "optimizing" its nodes, applying local
+// transformations that are expected to improve runtime required to evaluate it.
+template <class T>
+T opt(const T& data, const DedupHelper<T>& helper = DedupHelper<T>{}) {
+  auto roots = helper.find_roots(data);
+  auto map = opt_map(roots);
+  return helper.rewrite(data, map);
+}
+
+} // namespace beanmachine::minibmg

--- a/minibmg/node.h
+++ b/minibmg/node.h
@@ -70,6 +70,34 @@ class SampleNode : public Node {
   std::string rvid;
 };
 
+// A helper function useful when topologically sorting nodes (the
+// topological_sort function requires a parameter that is a function of this
+// shape).
 std::vector<Nodep> in_nodes(const Nodep& n);
+
+// Provide a good hash function so Nodep values can be used in unordered maps
+// and sets.  This treats Nodep values as semantically value-based.
+struct NodepIdentityHash {
+  std::size_t operator()(beanmachine::minibmg::Nodep const& p) const noexcept;
+};
+
+// Provide a good equality function so Nodep values can be used in unordered
+// maps and sets.  This treats Nodep values, recursively, as semantically
+// value-based.
+struct NodepIdentityEquals {
+  bool operator()(
+      const beanmachine::minibmg::Nodep& lhs,
+      const beanmachine::minibmg::Nodep& rhs) const noexcept;
+};
+
+// A value-based map from nodes to T.  Used for deduplicating and optimizing a
+// graph.
+template <class T>
+using NodeValueMap =
+    std::unordered_map<Nodep, T, NodepIdentityHash, NodepIdentityEquals>;
+
+// A value-based set of nodes.
+using NodeValueSet =
+    std::unordered_set<Nodep, NodepIdentityHash, NodepIdentityEquals>;
 
 } // namespace beanmachine::minibmg

--- a/minibmg/pretty.cpp
+++ b/minibmg/pretty.cpp
@@ -43,11 +43,11 @@ Precedence precedence_for_operator(Operator op) {
   switch (op) {
     case Operator::ADD:
     case Operator::SUBTRACT:
-    case Operator::NEGATE:
       return Precedence::Sum;
     case Operator::MULTIPLY:
     case Operator::DIVIDE:
       return Precedence::Product;
+    case Operator::NEGATE:
     default:
       return Precedence::Term;
   }
@@ -121,7 +121,7 @@ PrintedForm print(Nodep node, std::map<Nodep, PrintedForm>& cache) {
       auto n = std::dynamic_pointer_cast<const OperatorNode>(node);
       auto this_precedence = precedence_for_operator(op);
       auto right = cache[n->in_nodes[0]];
-      auto rs = (right.precedence >= this_precedence)
+      auto rs = (right.precedence > this_precedence)
           ? fmt::format("({0})", right.string)
           : right.string;
       return PrintedForm{fmt::format("-{0}", rs), this_precedence};

--- a/minibmg/tests/eval_test.cpp
+++ b/minibmg/tests/eval_test.cpp
@@ -5,10 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <gtest/gtest.h>
-
 #include <beanmachine/minibmg/minibmg.h>
 #include <beanmachine/minibmg/tests/test_utils.h>
+#include <gtest/gtest.h>
 #include <random>
 #include "beanmachine/minibmg/ad/num2.h"
 #include "beanmachine/minibmg/ad/num3.h"

--- a/minibmg/tests/localopt_test.cpp
+++ b/minibmg/tests/localopt_test.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <sstream>
+#include <unordered_map>
+#include "beanmachine/minibmg/ad/num3.h"
+#include "beanmachine/minibmg/ad/traced.h"
+#include "beanmachine/minibmg/eval.h"
+#include "beanmachine/minibmg/fluent_factory.h"
+#include "beanmachine/minibmg/graph.h"
+#include "beanmachine/minibmg/localopt.h"
+#include "beanmachine/minibmg/pretty.h"
+
+using namespace ::testing;
+using namespace ::beanmachine::minibmg;
+
+template <class T>
+requires Number<T> T logit(const T& x) {
+  return log(x / (1 - x));
+}
+
+TEST(localopt_test, symbolic_derivatives) {
+  Graph::FluentFactory fac;
+  auto f = beta(2, 2);
+  auto s = sample(f);
+  fac.query(s);
+  auto c = bernoulli(s);
+  fac.observe(sample(c), 1);
+  fac.observe(sample(c), 1);
+  fac.observe(sample(c), 0);
+  Graph graph = fac.build();
+
+  // Locate the node of interest.
+  Nodep rv = graph.queries[0];
+
+  // evaluate the graph's log prob, and its first and second derivatives.
+  using T = Num3<Traced>;
+  std::mt19937 gen;
+  std::function<T(const std::string&, const unsigned int)> read_variable =
+      [](const std::string& name, const unsigned int id) -> T {
+    return Traced::variable(name, id);
+  };
+  std::unordered_map<Nodep, T> data;
+  std::function<SampledValue<T>(
+      const Distribution<T>& distribution, std::mt19937& gen)>
+      sampler = [](const Distribution<T>& distribution,
+                   std::mt19937&) -> SampledValue<T> {
+    auto constrained = T{Traced::variable("rvid.constrained", 0), 1, 0};
+    auto unconstrained = distribution.transformation()->call(constrained);
+    auto log_prob = distribution.log_prob(constrained);
+    return SampledValue<T>{constrained, unconstrained, log_prob};
+  };
+  auto eval_result = eval_graph(
+      graph,
+      gen,
+      read_variable,
+      data,
+      /* run_queries= */ false,
+      /* eval_log_prob= */ true,
+      /* sampler= */ sampler);
+
+  eval_result = opt(eval_result);
+  auto log_prob = eval_result.log_prob.primal.node;
+  auto d1 = eval_result.log_prob.derivative1.node;
+  auto d2 = eval_result.log_prob.derivative2.node;
+  std::vector<Nodep> roots = {log_prob, d1, d2};
+  auto print_result = pretty_print(roots);
+
+  std::stringstream printed;
+  for (auto a : print_result.prelude) {
+    printed << a << std::endl;
+  }
+
+  printed << "log_prob = ";
+  printed << print_result.code[log_prob] << std::endl;
+  printed << "d1 = ";
+  printed << print_result.code[d1] << std::endl;
+  printed << "d2 = ";
+  printed << print_result.code[d2] << std::endl;
+
+  auto expected = R"(auto temp_1 = -pow(rvid.constrained, -2);
+auto temp_2 = 1 - rvid.constrained;
+auto temp_3 = -pow(temp_2, -2);
+auto temp_4 = 1 / rvid.constrained;
+auto temp_5 = -1 / temp_2;
+auto temp_6 = log(rvid.constrained);
+auto temp_7 = log(temp_2);
+log_prob = temp_6 + temp_7 + 1.791759469228055 + temp_6 + temp_6 + temp_7
+d1 = temp_4 + temp_5 + temp_4 + temp_4 + temp_5
+d2 = temp_1 + temp_3 + temp_1 + temp_1 + temp_3
+)";
+  ASSERT_EQ(printed.str(), expected);
+}


### PR DESCRIPTION
Summary:
A local rewriter for graphs that performs a number of simple, local algebraic transformations to simplify the graph.  This is mainly useful after forming a symbolic derivative, as AD can produce lots of inefficient and redundant code.

Currently, the individual transformations are performed by brute force.  Later, we should add a tree automaton implementation so that each transformation would be just a single line of code (something like the comment that precedes the code for each transformation).

Reviewed By: CactusWin

Differential Revision: D40200074

