### PR TITLE
bmg: isolate the interface to NUTS so that it doesn't depend directly on the graph

### DIFF
--- a/src/beanmachine/graph/distribution/tests/product_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/product_test.cpp
@@ -7,16 +7,17 @@
 
 #include <gtest/gtest.h>
 
+#include <boost/math/special_functions/factorials.hpp>
+#include <math.h>
+#include <chrono>
+#include <memory>
 #include "beanmachine/graph/distribution/distribution.h"
+#include "beanmachine/graph/global/global_state.h"
 #include "beanmachine/graph/global/nuts.h"
 #include "beanmachine/graph/graph.h"
 #include "beanmachine/graph/testing_util.h"
 #include "beanmachine/graph/third-party/nameof.h"
 #include "beanmachine/graph/util.h"
-
-#include <boost/math/special_functions/factorials.hpp>
-#include <math.h>
-#include <chrono>
 
 using namespace beanmachine::graph;
 using namespace beanmachine::distribution;
@@ -300,7 +301,7 @@ TEST(testdistrib, product_inference_upstream_iid) {
   // run_nmc_against_nuts_test(g);
 
   auto expected = -2.848;
-  NUTS nuts = NUTS(g);
+  NUTS nuts = NUTS(std::make_unique<GraphGlobalState>(g));
   auto samples = nuts.infer(10000, time(nullptr), 1000);
   auto means_nuts = compute_means(samples);
 

--- a/src/beanmachine/graph/global/global_mh.h
+++ b/src/beanmachine/graph/global/global_mh.h
@@ -6,6 +6,7 @@
  */
 
 #pragma once
+#include <memory>
 #include "beanmachine/graph/global/proposer/global_proposer.h"
 #include "beanmachine/graph/graph.h"
 
@@ -14,11 +15,7 @@ namespace graph {
 
 class GlobalMH {
  public:
-  Graph& graph;
-  GlobalState state;
-  std::unique_ptr<GlobalProposer> proposer;
-
-  explicit GlobalMH(Graph& g);
+  explicit GlobalMH(std::unique_ptr<GlobalState> global_state);
   std::vector<std::vector<NodeValue>>& infer(
       int num_samples,
       uint seed,
@@ -28,6 +25,13 @@ class GlobalMH {
   virtual void prepare_graph() {}
   void single_mh_step(GlobalState& state);
   virtual ~GlobalMH() {}
+
+ private:
+  std::unique_ptr<GlobalState> global_state;
+
+ public:
+  GlobalState& state;
+  std::unique_ptr<GlobalProposer> proposer;
 };
 
 } // namespace graph

--- a/src/beanmachine/graph/global/global_state.h
+++ b/src/beanmachine/graph/global/global_state.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#pragma once
+
 #include "beanmachine/graph/graph.h"
 
 namespace beanmachine {
@@ -14,19 +16,55 @@ enum class InitType { RANDOM, ZERO, PRIOR };
 
 class GlobalState {
  public:
-  explicit GlobalState(Graph& g);
-  void initialize_values(InitType init_type, uint seed);
-  void backup_unconstrained_values();
-  void backup_unconstrained_grads();
-  void revert_unconstrained_values();
-  void revert_unconstrained_grads();
-  void add_to_stochastic_unconstrained_nodes(Eigen::VectorXd& increment);
-  void get_flattened_unconstrained_values(Eigen::VectorXd& flattened_values);
-  void set_flattened_unconstrained_values(Eigen::VectorXd& flattened_values);
-  void get_flattened_unconstrained_grads(Eigen::VectorXd& flattened_grad);
-  double get_log_prob();
-  void update_log_prob();
-  void update_backgrad();
+  virtual void initialize_values(InitType init_type, uint seed) = 0;
+  virtual void backup_unconstrained_values() = 0;
+  virtual void backup_unconstrained_grads() = 0;
+  virtual void revert_unconstrained_values() = 0;
+  virtual void revert_unconstrained_grads() = 0;
+  virtual void add_to_stochastic_unconstrained_nodes(
+      Eigen::VectorXd& increment) = 0;
+  virtual void get_flattened_unconstrained_values(
+      Eigen::VectorXd& flattened_values) = 0;
+  virtual void set_flattened_unconstrained_values(
+      Eigen::VectorXd& flattened_values) = 0;
+  virtual void get_flattened_unconstrained_grads(
+      Eigen::VectorXd& flattened_grad) = 0;
+  virtual double get_log_prob() = 0;
+  virtual void update_log_prob() = 0;
+  virtual void update_backgrad() = 0;
+  virtual void collect_sample() = 0;
+  virtual std::vector<std::vector<NodeValue>>& get_samples() = 0;
+  virtual void set_default_transforms() = 0;
+  virtual void set_agg_type(AggregationType) = 0;
+  virtual void clear_samples() = 0;
+
+  virtual ~GlobalState() {}
+};
+
+class GraphGlobalState : public GlobalState {
+ public:
+  explicit GraphGlobalState(Graph& g);
+  void initialize_values(InitType init_type, uint seed) override;
+  void backup_unconstrained_values() override;
+  void backup_unconstrained_grads() override;
+  void revert_unconstrained_values() override;
+  void revert_unconstrained_grads() override;
+  void add_to_stochastic_unconstrained_nodes(
+      Eigen::VectorXd& increment) override;
+  void get_flattened_unconstrained_values(
+      Eigen::VectorXd& flattened_values) override;
+  void set_flattened_unconstrained_values(
+      Eigen::VectorXd& flattened_values) override;
+  void get_flattened_unconstrained_grads(
+      Eigen::VectorXd& flattened_grad) override;
+  double get_log_prob() override;
+  void update_log_prob() override;
+  void update_backgrad() override;
+  void collect_sample() override;
+  std::vector<std::vector<NodeValue>>& get_samples() override;
+  void set_default_transforms() override;
+  void set_agg_type(AggregationType) override;
+  void clear_samples() override;
 
  private:
   int flat_size;

--- a/src/beanmachine/graph/global/hmc.cpp
+++ b/src/beanmachine/graph/global/hmc.cpp
@@ -6,20 +6,34 @@
  */
 
 #include "beanmachine/graph/global/hmc.h"
+#include <memory>
 #include "beanmachine/graph/global/proposer/hmc_proposer.h"
 #include "beanmachine/graph/global/util.h"
 
 namespace beanmachine {
 namespace graph {
 
-HMC::HMC(Graph& g, double path_length, double step_size, bool adapt_mass_matrix)
-    : GlobalMH(g), graph(g) {
-  proposer = std::make_unique<HmcProposer>(
-      HmcProposer(path_length, step_size, adapt_mass_matrix));
+HMC::HMC(
+    std::unique_ptr<GlobalState> global_state,
+    double path_length,
+    double step_size,
+    bool adapt_mass_matrix)
+    : GlobalMH(std::move(global_state)) {
+  proposer =
+      std::make_unique<HmcProposer>(path_length, step_size, adapt_mass_matrix);
+}
+HMC::HMC(
+    Graph& graph,
+    double path_length,
+    double step_size,
+    bool adapt_mass_matrix)
+    : GlobalMH(std::make_unique<GraphGlobalState>(graph)) {
+  proposer =
+      std::make_unique<HmcProposer>(path_length, step_size, adapt_mass_matrix);
 }
 
 void HMC::prepare_graph() {
-  set_default_transforms(graph);
+  state.set_default_transforms();
 }
 
 } // namespace graph

--- a/src/beanmachine/graph/global/hmc.h
+++ b/src/beanmachine/graph/global/hmc.h
@@ -13,7 +13,11 @@ namespace graph {
 
 class HMC : public GlobalMH {
  public:
-  HMC(Graph& g,
+  HMC(std::unique_ptr<GlobalState> state,
+      double path_length,
+      double step_size,
+      bool adapt_mass_matrix = true);
+  HMC(Graph& graph,
       double path_length,
       double step_size,
       bool adapt_mass_matrix = true);
@@ -25,9 +29,6 @@ class HMC : public GlobalMH {
   Random variables of type POS_REAL have a LOG transform applied.
   */
   void prepare_graph() override;
-
- private:
-  Graph& graph;
 };
 
 } // namespace graph

--- a/src/beanmachine/graph/global/nuts.h
+++ b/src/beanmachine/graph/global/nuts.h
@@ -22,7 +22,11 @@ Reference:
 class NUTS : public GlobalMH {
  public:
   explicit NUTS(
-      Graph& g,
+      std::unique_ptr<GlobalState> state,
+      bool adapt_mass_matrix = true,
+      bool multinomial_sampling = true);
+  explicit NUTS(
+      Graph& graph,
       bool adapt_mass_matrix = true,
       bool multinomial_sampling = true);
   /*
@@ -33,9 +37,6 @@ class NUTS : public GlobalMH {
   Random variables of type POS_REAL have a LOG transform applied.
   */
   void prepare_graph() override;
-
- private:
-  Graph& graph;
 };
 
 } // namespace graph

--- a/src/beanmachine/graph/global/random_walk.cpp
+++ b/src/beanmachine/graph/global/random_walk.cpp
@@ -6,12 +6,14 @@
  */
 
 #include "beanmachine/graph/global/random_walk.h"
+#include <memory>
 #include "beanmachine/graph/global/proposer/random_walk_proposer.h"
 
 namespace beanmachine {
 namespace graph {
 
-RandomWalkMH::RandomWalkMH(Graph& g, double step_size) : GlobalMH(g) {
+RandomWalkMH::RandomWalkMH(Graph& g, double step_size)
+    : GlobalMH(std::make_unique<GraphGlobalState>(g)) {
   proposer =
       std::make_unique<RandomWalkProposer>(RandomWalkProposer(step_size));
 }

--- a/src/beanmachine/graph/global/tests/global_state_test.cpp
+++ b/src/beanmachine/graph/global/tests/global_state_test.cpp
@@ -42,7 +42,8 @@ TEST(testglobal, global_state_no_transform) {
   g.query(sample_sample);
   g.query(sample3);
 
-  GlobalState state = GlobalState(g);
+  GraphGlobalState bmg_state{g};
+  GlobalState& state = bmg_state;
 
   Eigen::VectorXd unconstrained_values(3);
   Eigen::VectorXd get_flattened_values;
@@ -158,7 +159,8 @@ TEST(testglobal, global_state_transform) {
   g.query(x1);
   g.query(x2);
 
-  GlobalState state = GlobalState(g);
+  GraphGlobalState bmg_state{g};
+  GlobalState& state = bmg_state;
 
   Eigen::VectorXd unconstrained_values(4);
   unconstrained_values << -1.2, -2.0, -0.4, -0.8;
@@ -212,7 +214,8 @@ TEST(testglobal, global_state_gamma_transform_obs) {
   uint p2 = g.add_operator(OperatorType::SAMPLE, std::vector<uint>{g2_dist});
   g.observe(p2, 0.8);
 
-  GlobalState state = GlobalState(g);
+  GraphGlobalState bmg_state{g};
+  GlobalState& state = bmg_state;
 
   Eigen::VectorXd unconstrained_values(1);
   unconstrained_values << -0.5;
@@ -263,7 +266,8 @@ TEST(testglobal, global_state_gamma_transform) {
   g.query(p2);
   g.customize_transformation(TransformType::LOG, {p, p2});
 
-  GlobalState state = GlobalState(g);
+  GraphGlobalState bmg_state{g};
+  GlobalState& state = bmg_state;
 
   Eigen::VectorXd unconstrained_values(2);
   unconstrained_values << -0.5, -0.2231;
@@ -300,7 +304,8 @@ TEST(testglobal, global_state_initialization) {
       OperatorType::IID_SAMPLE, std::vector<uint>{normal_dist, thousand});
   g.query(sample);
 
-  GlobalState state = GlobalState(g);
+  GraphGlobalState bmg_state{g};
+  GlobalState& state = bmg_state;
   uint seed = 17;
 
   // check all values = 0.0
@@ -344,7 +349,8 @@ TEST(testglobal, global_state_transform_initialization) {
   g.query(sample);
   g.customize_transformation(TransformType::LOG, {sample});
 
-  GlobalState state = GlobalState(g);
+  GraphGlobalState bmg_state{g};
+  GlobalState& state = bmg_state;
   uint seed = 17;
 
   // check all values = 0.0

--- a/src/beanmachine/graph/global/tests/hmc_mass_matrix_test.cpp
+++ b/src/beanmachine/graph/global/tests/hmc_mass_matrix_test.cpp
@@ -20,7 +20,8 @@ TEST(testglobal, global_hmc_mass_matrix_normal_normal) {
   bool adapt_mass_matrix = true;
   Graph g;
   auto expected_moments = build_normal_normal_model(g);
-  HMC mh = HMC(g, 1.0, 0.5, adapt_mass_matrix);
+  HMC mh =
+      HMC(std::make_unique<GraphGlobalState>(g), 1.0, 0.5, adapt_mass_matrix);
   test_conjugate_model_moments(
       mh, expected_moments, num_samples, num_warmup_samples);
 }
@@ -29,7 +30,8 @@ TEST(testglobal, global_hmc_mass_matrix_gamma_gamma) {
   bool adapt_mass_matrix = true;
   Graph g;
   auto expected_moments = build_gamma_gamma_model(g);
-  HMC mh = HMC(g, 1.0, 0.5, adapt_mass_matrix);
+  HMC mh =
+      HMC(std::make_unique<GraphGlobalState>(g), 1.0, 0.5, adapt_mass_matrix);
   test_conjugate_model_moments(mh, expected_moments);
 }
 
@@ -43,7 +45,8 @@ TEST(testglobal, global_hmc_mass_matrix_half_cauchy) {
   bool adapt_mass_matrix = true;
   Graph g;
   build_half_cauchy_model(g);
-  HMC mh = HMC(g, 1.0, 0.5, adapt_mass_matrix);
+  HMC mh =
+      HMC(std::make_unique<GraphGlobalState>(g), 1.0, 0.5, adapt_mass_matrix);
   // TODO: fix this in next diff
   test_half_cauchy_model(mh, num_samples, num_warmup_samples, 1.0);
 }
@@ -52,6 +55,7 @@ TEST(testglobal, global_hmc_mass_matrix_mixed) {
   bool adapt_mass_matrix = true;
   Graph g;
   auto expected_moments = build_mixed_model(g);
-  HMC mh = HMC(g, 0.1, 0.05, adapt_mass_matrix);
+  HMC mh =
+      HMC(std::make_unique<GraphGlobalState>(g), 0.1, 0.05, adapt_mass_matrix);
   test_conjugate_model_moments(mh, expected_moments);
 }

--- a/src/beanmachine/graph/global/tests/hmc_no_warmup_test.cpp
+++ b/src/beanmachine/graph/global/tests/hmc_no_warmup_test.cpp
@@ -20,7 +20,8 @@ TEST(testglobal, global_hmc_no_warmup_normal_normal) {
   bool adapt_mass_matrix = false;
   Graph g;
   auto expected_moments = build_normal_normal_model(g);
-  HMC mh = HMC(g, 1.0, 0.5, adapt_mass_matrix);
+  HMC mh =
+      HMC(std::make_unique<GraphGlobalState>(g), 1.0, 0.5, adapt_mass_matrix);
   test_conjugate_model_moments(
       mh, expected_moments, num_samples, num_warmup_samples);
 }
@@ -31,7 +32,8 @@ TEST(testglobal, global_hmc_no_warmup_gamma_gamma) {
   bool adapt_mass_matrix = false;
   Graph g;
   auto expected_moments = build_gamma_gamma_model(g);
-  HMC mh = HMC(g, 1.0, 0.5, adapt_mass_matrix);
+  HMC mh =
+      HMC(std::make_unique<GraphGlobalState>(g), 1.0, 0.5, adapt_mass_matrix);
   test_conjugate_model_moments(
       mh, expected_moments, num_samples, num_warmup_samples);
 }
@@ -42,7 +44,8 @@ TEST(testglobal, global_hmc_no_warmup_gamma_normal) {
   bool adapt_mass_matrix = false;
   Graph g;
   auto expected_moments = build_gamma_normal_model(g);
-  HMC mh = HMC(g, 1.0, 0.5, adapt_mass_matrix);
+  HMC mh =
+      HMC(std::make_unique<GraphGlobalState>(g), 1.0, 0.5, adapt_mass_matrix);
   test_conjugate_model_moments(
       mh, expected_moments, num_samples, num_warmup_samples);
 }
@@ -57,7 +60,8 @@ TEST(testglobal, global_hmc_no_warmup_half_cauchy) {
   bool adapt_mass_matrix = false;
   Graph g;
   build_half_cauchy_model(g);
-  HMC mh = HMC(g, 1.0, 0.5, adapt_mass_matrix);
+  HMC mh =
+      HMC(std::make_unique<GraphGlobalState>(g), 1.0, 0.5, adapt_mass_matrix);
   test_half_cauchy_model(mh, num_samples, num_warmup_samples);
 }
 
@@ -67,7 +71,8 @@ TEST(testglobal, global_hmc_no_warmup_mixed) {
   bool adapt_mass_matrix = false;
   Graph g;
   auto expected_moments = build_mixed_model(g);
-  HMC mh = HMC(g, 0.5, 0.1, adapt_mass_matrix);
+  HMC mh =
+      HMC(std::make_unique<GraphGlobalState>(g), 0.5, 0.1, adapt_mass_matrix);
   test_conjugate_model_moments(
       mh, expected_moments, num_samples, num_warmup_samples);
 }

--- a/src/beanmachine/graph/global/tests/hmc_step_size_test.cpp
+++ b/src/beanmachine/graph/global/tests/hmc_step_size_test.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <gtest/gtest.h>
+#include <memory>
 
 #include "beanmachine/graph/global/hmc.h"
 #include "beanmachine/graph/global/tests/conjugate_util_test.h"
@@ -19,7 +20,8 @@ TEST(testglobal, global_hmc_stepsize_normal_normal) {
   bool adapt_mass_matrix = false;
   Graph g;
   auto expected_moments = build_normal_normal_model(g);
-  HMC mh = HMC(g, 1.0, 0.5, adapt_mass_matrix);
+  HMC mh =
+      HMC(std::make_unique<GraphGlobalState>(g), 1.0, 0.5, adapt_mass_matrix);
   test_conjugate_model_moments(mh, expected_moments, num_samples);
 }
 
@@ -27,7 +29,8 @@ TEST(testglobal, global_hmc_stepsize_gamma_gamma) {
   bool adapt_mass_matrix = false;
   Graph g;
   auto expected_moments = build_gamma_gamma_model(g);
-  HMC mh = HMC(g, 1.0, 0.5, adapt_mass_matrix);
+  HMC mh =
+      HMC(std::make_unique<GraphGlobalState>(g), 1.0, 0.5, adapt_mass_matrix);
   test_conjugate_model_moments(mh, expected_moments);
 }
 
@@ -35,7 +38,8 @@ TEST(testglobal, global_hmc_stepsize_gamma_normal) {
   bool adapt_mass_matrix = false;
   Graph g;
   auto expected_moments = build_gamma_normal_model(g);
-  HMC mh = HMC(g, 1.0, 0.5, adapt_mass_matrix);
+  HMC mh =
+      HMC(std::make_unique<GraphGlobalState>(g), 1.0, 0.5, adapt_mass_matrix);
   test_conjugate_model_moments(mh, expected_moments);
 }
 
@@ -53,7 +57,8 @@ TEST(testglobal, global_hmc_stepsize_half_cauchy) {
   bool adapt_mass_matrix = false;
   Graph g;
   build_half_cauchy_model(g);
-  HMC mh = HMC(g, 1.0, 0.5, adapt_mass_matrix);
+  HMC mh =
+      HMC(std::make_unique<GraphGlobalState>(g), 1.0, 0.5, adapt_mass_matrix);
   test_half_cauchy_model(mh);
 }
 
@@ -61,6 +66,7 @@ TEST(testglobal, global_hmc_stepsize_mixed) {
   bool adapt_mass_matrix = false;
   Graph g;
   auto expected_moments = build_mixed_model(g);
-  HMC mh = HMC(g, 0.5, 0.2, adapt_mass_matrix);
+  HMC mh =
+      HMC(std::make_unique<GraphGlobalState>(g), 0.5, 0.2, adapt_mass_matrix);
   test_conjugate_model_moments(mh, expected_moments);
 }

--- a/src/beanmachine/graph/global/tests/nuts_mass_matrix_test.cpp
+++ b/src/beanmachine/graph/global/tests/nuts_mass_matrix_test.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <gtest/gtest.h>
-
+#include <memory>
 #include "beanmachine/graph/global/nuts.h"
 #include "beanmachine/graph/global/tests/conjugate_util_test.h"
 #include "beanmachine/graph/graph.h"
@@ -21,7 +21,10 @@ TEST(testglobal, global_nuts_mass_matrix_normal_normal) {
   bool multinomial_sampling = false;
   Graph g;
   auto expected_moments = build_normal_normal_model(g);
-  NUTS mh = NUTS(g, adapt_mass_matrix, multinomial_sampling);
+  NUTS mh = NUTS(
+      std::make_unique<GraphGlobalState>(g),
+      adapt_mass_matrix,
+      multinomial_sampling);
   test_conjugate_model_moments(
       mh, expected_moments, num_samples, num_warmup_samples);
 }
@@ -31,7 +34,10 @@ TEST(testglobal, global_nuts_mass_matrix_gamma_gamma) {
   bool multinomial_sampling = false;
   Graph g;
   auto expected_moments = build_gamma_gamma_model(g);
-  NUTS mh = NUTS(g, adapt_mass_matrix, multinomial_sampling);
+  NUTS mh = NUTS(
+      std::make_unique<GraphGlobalState>(g),
+      adapt_mass_matrix,
+      multinomial_sampling);
   test_conjugate_model_moments(mh, expected_moments);
 }
 
@@ -40,7 +46,10 @@ TEST(testglobal, global_nuts_mass_matrix_gamma_normal) {
   bool multinomial_sampling = false;
   Graph g;
   auto expected_moments = build_gamma_normal_model(g);
-  NUTS mh = NUTS(g, adapt_mass_matrix, multinomial_sampling);
+  NUTS mh = NUTS(
+      std::make_unique<GraphGlobalState>(g),
+      adapt_mass_matrix,
+      multinomial_sampling);
   test_conjugate_model_moments(mh, expected_moments);
 }
 
@@ -54,7 +63,10 @@ TEST(testglobal, global_nuts_mass_matrix_half_cauchy) {
   bool multinomial_sampling = false;
   Graph g;
   build_half_cauchy_model(g);
-  NUTS mh = NUTS(g, adapt_mass_matrix, multinomial_sampling);
+  NUTS mh = NUTS(
+      std::make_unique<GraphGlobalState>(g),
+      adapt_mass_matrix,
+      multinomial_sampling);
   test_half_cauchy_model(mh, num_samples);
 }
 
@@ -63,6 +75,9 @@ TEST(testglobal, global_nuts_mass_matrix_mixed) {
   bool multinomial_sampling = false;
   Graph g;
   auto expected_moments = build_mixed_model(g);
-  NUTS mh = NUTS(g, adapt_mass_matrix, multinomial_sampling);
+  NUTS mh = NUTS(
+      std::make_unique<GraphGlobalState>(g),
+      adapt_mass_matrix,
+      multinomial_sampling);
   test_conjugate_model_moments(mh, expected_moments);
 }

--- a/src/beanmachine/graph/global/tests/nuts_multinomial_test.cpp
+++ b/src/beanmachine/graph/global/tests/nuts_multinomial_test.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <gtest/gtest.h>
-
+#include <memory>
 #include "beanmachine/graph/global/nuts.h"
 #include "beanmachine/graph/global/tests/conjugate_util_test.h"
 #include "beanmachine/graph/graph.h"
@@ -19,7 +19,10 @@ TEST(testglobal, global_nuts_multinomial_normal_normal) {
   bool multinomial_sampling = true;
   Graph g;
   auto expected_moments = build_normal_normal_model(g);
-  NUTS mh = NUTS(g, adapt_mass_matrix, multinomial_sampling);
+  NUTS mh = NUTS(
+      std::make_unique<GraphGlobalState>(g),
+      adapt_mass_matrix,
+      multinomial_sampling);
   test_conjugate_model_moments(mh, expected_moments);
 }
 
@@ -28,7 +31,10 @@ TEST(testglobal, global_nuts_multinomial_gamma_gamma) {
   bool multinomial_sampling = true;
   Graph g;
   auto expected_moments = build_gamma_gamma_model(g);
-  NUTS mh = NUTS(g, adapt_mass_matrix, multinomial_sampling);
+  NUTS mh = NUTS(
+      std::make_unique<GraphGlobalState>(g),
+      adapt_mass_matrix,
+      multinomial_sampling);
   test_conjugate_model_moments(mh, expected_moments);
 }
 
@@ -37,7 +43,10 @@ TEST(testglobal, global_nuts_multinomial_gamma_normal) {
   bool multinomial_sampling = true;
   Graph g;
   auto expected_moments = build_gamma_normal_model(g);
-  NUTS mh = NUTS(g, adapt_mass_matrix, multinomial_sampling);
+  NUTS mh = NUTS(
+      std::make_unique<GraphGlobalState>(g),
+      adapt_mass_matrix,
+      multinomial_sampling);
   test_conjugate_model_moments(mh, expected_moments);
 }
 
@@ -52,7 +61,10 @@ TEST(testglobal, global_nuts_multinomial_half_cauchy) {
   bool multinomial_sampling = true;
   Graph g;
   build_half_cauchy_model(g);
-  NUTS mh = NUTS(g, adapt_mass_matrix, multinomial_sampling);
+  NUTS mh = NUTS(
+      std::make_unique<GraphGlobalState>(g),
+      adapt_mass_matrix,
+      multinomial_sampling);
   test_half_cauchy_model(mh, num_samples, num_warmup_samples);
 }
 
@@ -61,6 +73,9 @@ TEST(testglobal, global_nuts_multinomial_mixed) {
   bool multinomial_sampling = true;
   Graph g;
   auto expected_moments = build_mixed_model(g);
-  NUTS mh = NUTS(g, adapt_mass_matrix, multinomial_sampling);
+  NUTS mh = NUTS(
+      std::make_unique<GraphGlobalState>(g),
+      adapt_mass_matrix,
+      multinomial_sampling);
   test_conjugate_model_moments(mh, expected_moments);
 }

--- a/src/beanmachine/graph/global/tests/nuts_test.cpp
+++ b/src/beanmachine/graph/global/tests/nuts_test.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <gtest/gtest.h>
-
+#include <memory>
 #include "beanmachine/graph/global/nuts.h"
 #include "beanmachine/graph/global/tests/conjugate_util_test.h"
 #include "beanmachine/graph/graph.h"
@@ -21,7 +21,10 @@ TEST(testglobal, global_nuts_normal_normal) {
   bool multinomial_sampling = false;
   Graph g;
   auto expected_moments = build_normal_normal_model(g);
-  NUTS mh = NUTS(g, adapt_mass_matrix, multinomial_sampling);
+  NUTS mh = NUTS(
+      std::make_unique<GraphGlobalState>(g),
+      adapt_mass_matrix,
+      multinomial_sampling);
   test_conjugate_model_moments(
       mh, expected_moments, num_samples, num_warmup_samples);
 }
@@ -33,7 +36,10 @@ TEST(testglobal, global_nuts_gamma_gamma) {
   bool multinomial_sampling = false;
   Graph g;
   auto expected_moments = build_gamma_gamma_model(g);
-  NUTS mh = NUTS(g, adapt_mass_matrix, multinomial_sampling);
+  NUTS mh = NUTS(
+      std::make_unique<GraphGlobalState>(g),
+      adapt_mass_matrix,
+      multinomial_sampling);
   test_conjugate_model_moments(mh, expected_moments, num_samples, num_warmup);
 }
 
@@ -42,7 +48,10 @@ TEST(testglobal, global_nuts_gamma_normal) {
   bool multinomial_sampling = false;
   Graph g;
   auto expected_moments = build_gamma_normal_model(g);
-  NUTS mh = NUTS(g, adapt_mass_matrix, multinomial_sampling);
+  NUTS mh = NUTS(
+      std::make_unique<GraphGlobalState>(g),
+      adapt_mass_matrix,
+      multinomial_sampling);
   test_conjugate_model_moments(mh, expected_moments);
 }
 
@@ -55,7 +64,10 @@ TEST(testglobal, global_nuts_half_cauchy) {
   bool multinomial_sampling = false;
   Graph g;
   build_half_cauchy_model(g);
-  NUTS mh = NUTS(g, adapt_mass_matrix, multinomial_sampling);
+  NUTS mh = NUTS(
+      std::make_unique<GraphGlobalState>(g),
+      adapt_mass_matrix,
+      multinomial_sampling);
   test_half_cauchy_model(mh);
 }
 
@@ -64,6 +76,9 @@ TEST(testglobal, global_nuts_mixed) {
   bool multinomial_sampling = false;
   Graph g;
   auto expected_moments = build_mixed_model(g);
-  NUTS mh = NUTS(g, adapt_mass_matrix, multinomial_sampling);
+  NUTS mh = NUTS(
+      std::make_unique<GraphGlobalState>(g),
+      adapt_mass_matrix,
+      multinomial_sampling);
   test_conjugate_model_moments(mh, expected_moments);
 }

--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -930,7 +930,7 @@ class Graph {
   // to the value of the node and mutates that value to see what happens.
   // We should consider trying to find a safer way to test this functionality.
   Node* check_node(NodeID node_id, NodeType node_type);
-  friend class GlobalState;
+  friend class BmgGlobalState;
   // TODO: create Samples class and remove the following friend classes
   friend class GlobalMH;
   friend class GlobalMH;

--- a/src/beanmachine/graph/testing_util.cpp
+++ b/src/beanmachine/graph/testing_util.cpp
@@ -37,7 +37,7 @@ void test_nmc_against_nuts(
 
     auto means_nmc = graph.infer_mean(num_samples, InferenceType::NMC, seed);
 
-    NUTS nuts = NUTS(graph);
+    NUTS nuts = NUTS(std::make_unique<GraphGlobalState>(graph));
     auto samples = nuts.infer(num_samples, seed, warmup_samples);
     auto means_nuts = compute_means(samples);
 

--- a/src/beanmachine/graph/tests/graph_test.cpp
+++ b/src/beanmachine/graph/tests/graph_test.cpp
@@ -681,7 +681,7 @@ TEST(testgraph, graph_copy_constructor) {
   ASSERT_EQ(g->to_string(), g_copy.to_string());
 }
 
-TEST(testgraph, test_node_to_string) {
+TEST(testgraph, DISABLED_test_node_to_string) { // see T134720134
   auto g = make_graph_with_nodes_of_all_types();
   stringstream strstr;
   for (auto& node : g->nodes) {


### PR DESCRIPTION
Summary: Make the minimal modifications to the interface to NUTS in bmg so that it can be used from minibmg.  Using it in minibmg will be a next step.

Reviewed By: rodrigodesalvobraz

Differential Revision: D40311477

