### PR TITLE
Fix NUTS handling of matrix data

### DIFF
--- a/src/beanmachine/graph/global/global_state.cpp
+++ b/src/beanmachine/graph/global/global_state.cpp
@@ -180,7 +180,10 @@ void GraphGlobalState::set_flattened_unconstrained_values(
       value->_double = flattened_values[i];
       i++;
     } else {
+      int rows = static_cast<int>(value->_matrix.rows());
+      int cols = static_cast<int>(value->_matrix.cols());
       value->_matrix = flattened_values.segment(i, value->_matrix.size());
+      value->_matrix.resize(rows, cols);
       i += static_cast<int>(value->_matrix.size());
     }
 

--- a/src/beanmachine/graph/global/tests/nuts_matrix_test.cpp
+++ b/src/beanmachine/graph/global/tests/nuts_matrix_test.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include "beanmachine/graph/graph.h"
+
+using namespace beanmachine;
+using namespace graph;
+TEST(testglobal, nuts_matrix_test) {
+  // A very basic test which confirms that NUTS runs without crashing
+  // on matrix samples. It makes no guarantees of sample validity.
+
+  Graph g;
+  auto one = g.add_constant_pos_real(1.0);
+  auto lkj_chol_dist = g.add_distribution(
+      DistributionType::LKJ_CHOLESKY,
+      ValueType(VariableType::BROADCAST_MATRIX, AtomicType::REAL, 3, 3),
+      std::vector<uint>{one});
+  auto cov_llt =
+      g.add_operator(OperatorType::SAMPLE, std::vector<uint>{lkj_chol_dist});
+  g.query(cov_llt);
+  auto samples = g.infer(2, InferenceType::NUTS);
+  auto sample = samples[0][0];
+  assert(sample._matrix.rows() == 3);
+  assert(sample._matrix.cols() == 3);
+}


### PR DESCRIPTION
Summary: Previously, NUTS had an issue where matrix node values would be set to flattened data during inference. This fixes the issue and adds a simple test which makes sure NUTS runs on matrix samples without crashing (though no guarantees of good samples yet).

Reviewed By: AishwaryaSivaraman

Differential Revision: D40393310

