### PR TITLE
minibmg: introduce (eventual) replacement nodes that use visitors.

### DIFF
--- a/minibmg/node.cpp
+++ b/minibmg/node.cpp
@@ -43,11 +43,6 @@ inline std::size_t hash(const std::vector<Nodep>& in_nodes) {
 
 namespace beanmachine::minibmg {
 
-std::string make_fresh_rvid() {
-  static std::atomic<long> next_rvid = 1;
-  return fmt::format("S{}", next_rvid.fetch_add(1));
-}
-
 Node::Node(
     const enum Operator op,
     const Type type,

--- a/minibmg/node2.cpp
+++ b/minibmg/node2.cpp
@@ -1,0 +1,646 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "beanmachine/minibmg/node2.h"
+#include <boost/functional/hash.hpp>
+#include <fmt/format.h>
+#include <atomic>
+#include <typeinfo>
+
+namespace {
+
+using namespace beanmachine::minibmg;
+
+inline std::size_t hash_combine(std::size_t a, std::size_t b) {
+  std::size_t seed = 0;
+  boost::hash_combine(seed, a);
+  boost::hash_combine(seed, b);
+  return seed;
+}
+
+inline std::size_t hash_combine(std::size_t a, std::size_t b, std::size_t c) {
+  std::size_t seed = 0;
+  boost::hash_combine(seed, a);
+  boost::hash_combine(seed, b);
+  boost::hash_combine(seed, c);
+  return seed;
+}
+
+inline std::size_t hash_combine(const std::vector<std::size_t>& many) {
+  std::size_t seed = 0;
+  for (auto n : many) {
+    boost::hash_combine(seed, n);
+  }
+  return seed;
+}
+
+} // namespace
+
+namespace beanmachine::minibmg {
+
+Node2::Node2(std::size_t cached_hash_value)
+    : cached_hash_value{cached_hash_value} {}
+
+Node2::~Node2() {}
+
+ScalarNode2::ScalarNode2(std::size_t cached_hash_value)
+    : Node2{cached_hash_value} {}
+
+DistributionNode2::DistributionNode2(std::size_t cached_hash_value)
+    : Node2{cached_hash_value} {}
+
+std::string make_fresh_rvid() {
+  static std::atomic<long> next_rvid = 1;
+  return fmt::format("S{}", next_rvid.fetch_add(1));
+}
+
+ScalarConstantNode2::ScalarConstantNode2(double constant_value)
+    : ScalarNode2{hash_combine(
+          std::hash<std::string>{}("ScalarConstantNode2"),
+          std::hash<double>{}(constant_value))} {}
+
+void ScalarConstantNode2::accept(Node2Visitor& visitor) const {
+  visitor.visit(this);
+}
+
+ScalarVariableNode2::ScalarVariableNode2(
+    const std::string& name,
+    const unsigned identifier)
+    : ScalarNode2{hash_combine(
+          std::hash<std::string>{}("ScalarVariableNode2"),
+          std::hash<std::string>{}(name),
+          std::hash<unsigned>{}(identifier))},
+      name{name},
+      identifier{identifier} {}
+
+void ScalarVariableNode2::accept(Node2Visitor& visitor) const {
+  visitor.visit(this);
+}
+
+ScalarSampleNode2::ScalarSampleNode2(
+    const DistributionNode2p& distribution,
+    const std::string& rvid)
+    : ScalarNode2{hash_combine(
+          std::hash<std::string>{}("ScalarSampleNode2"),
+          distribution->cached_hash_value,
+          std::hash<std::string>{}(rvid))},
+      distribution{distribution},
+      rvid{rvid} {}
+
+void ScalarSampleNode2::accept(Node2Visitor& visitor) const {
+  visitor.visit(this);
+}
+
+ScalarAddNode2::ScalarAddNode2(
+    const ScalarNode2p& left,
+    const ScalarNode2p& right)
+    : ScalarNode2{hash_combine(
+          std::hash<std::string>{}("ScalarAddNode2"),
+          left->cached_hash_value,
+          right->cached_hash_value)},
+      left{left},
+      right{right} {}
+
+void ScalarAddNode2::accept(Node2Visitor& visitor) const {
+  visitor.visit(this);
+}
+
+ScalarSubtractNode2::ScalarSubtractNode2(
+    const ScalarNode2p& left,
+    const ScalarNode2p& right)
+    : ScalarNode2{hash_combine(
+          std::hash<std::string>{}("ScalarSubtractNode2"),
+          left->cached_hash_value,
+          right->cached_hash_value)},
+      left{left},
+      right{right} {}
+
+void ScalarSubtractNode2::accept(Node2Visitor& visitor) const {
+  visitor.visit(this);
+}
+
+ScalarNegateNode2::ScalarNegateNode2(const ScalarNode2p& x)
+    : ScalarNode2{hash_combine(
+          std::hash<std::string>{}("ScalarNegateNode2"),
+          x->cached_hash_value)},
+      x{x} {}
+
+void ScalarNegateNode2::accept(Node2Visitor& visitor) const {
+  visitor.visit(this);
+}
+
+ScalarMultiplyNode2::ScalarMultiplyNode2(
+    const ScalarNode2p& left,
+    const ScalarNode2p& right)
+    : ScalarNode2{hash_combine(
+          std::hash<std::string>{}("ScalarMultiplyNode2"),
+          left->cached_hash_value,
+          right->cached_hash_value)},
+      left{left},
+      right{right} {}
+
+void ScalarMultiplyNode2::accept(Node2Visitor& visitor) const {
+  visitor.visit(this);
+}
+
+ScalarDivideNode2::ScalarDivideNode2(
+    const ScalarNode2p& left,
+    const ScalarNode2p& right)
+    : ScalarNode2{hash_combine(
+          std::hash<std::string>{}("ScalarDivideNode2"),
+          left->cached_hash_value,
+          right->cached_hash_value)},
+      left{left},
+      right{right} {}
+
+void ScalarDivideNode2::accept(Node2Visitor& visitor) const {
+  visitor.visit(this);
+}
+
+ScalarPowNode2::ScalarPowNode2(
+    const ScalarNode2p& left,
+    const ScalarNode2p& right)
+    : ScalarNode2{hash_combine(
+          std::hash<std::string>{}("ScalarPowNode2"),
+          left->cached_hash_value,
+          right->cached_hash_value)},
+      left{left},
+      right{right} {}
+
+void ScalarPowNode2::accept(Node2Visitor& visitor) const {
+  visitor.visit(this);
+}
+
+ScalarExpNode2::ScalarExpNode2(const ScalarNode2p& x)
+    : ScalarNode2{hash_combine(
+          std::hash<std::string>{}("ScalarExpNode2"),
+          x->cached_hash_value)},
+      x{x} {}
+
+void ScalarExpNode2::accept(Node2Visitor& visitor) const {
+  visitor.visit(this);
+}
+
+ScalarLogNode2::ScalarLogNode2(const ScalarNode2p& x)
+    : ScalarNode2{hash_combine(
+          std::hash<std::string>{}("ScalarLogNode2"),
+          x->cached_hash_value)},
+      x{x} {}
+
+void ScalarLogNode2::accept(Node2Visitor& visitor) const {
+  visitor.visit(this);
+}
+
+ScalarAtanNode2::ScalarAtanNode2(const ScalarNode2p& x)
+    : ScalarNode2{hash_combine(
+          std::hash<std::string>{}("ScalarAtanNode2"),
+          x->cached_hash_value)},
+      x{x} {}
+
+void ScalarAtanNode2::accept(Node2Visitor& visitor) const {
+  visitor.visit(this);
+}
+
+ScalarLgammaNode2::ScalarLgammaNode2(const ScalarNode2p& x)
+    : ScalarNode2{hash_combine(
+          std::hash<std::string>{}("ScalarLgammaNode2"),
+          x->cached_hash_value)},
+      x{x} {}
+
+void ScalarLgammaNode2::accept(Node2Visitor& visitor) const {
+  visitor.visit(this);
+}
+
+ScalarPolygammaNode2::ScalarPolygammaNode2(
+    const ScalarNode2p& n,
+    const ScalarNode2p& x)
+    : ScalarNode2{hash_combine(
+          std::hash<std::string>{}("ScalarPolygammaNode2"),
+          n->cached_hash_value,
+          x->cached_hash_value)},
+      n{n},
+      x{x} {}
+
+void ScalarPolygammaNode2::accept(Node2Visitor& visitor) const {
+  visitor.visit(this);
+}
+
+ScalarIfEqualNode2::ScalarIfEqualNode2(
+    const ScalarNode2p& a,
+    const ScalarNode2p& b,
+    const ScalarNode2p& c,
+    const ScalarNode2p& d)
+    : ScalarNode2{hash_combine(
+          {std::hash<std::string>{}("ScalarIfEqualNode2"),
+           a->cached_hash_value,
+           b->cached_hash_value,
+           c->cached_hash_value,
+           d->cached_hash_value})},
+      a{a},
+      b{b},
+      c{c},
+      d{d} {}
+
+void ScalarIfEqualNode2::accept(Node2Visitor& visitor) const {
+  visitor.visit(this);
+}
+
+ScalarIfLessNode2::ScalarIfLessNode2(
+    const ScalarNode2p& a,
+    const ScalarNode2p& b,
+    const ScalarNode2p& c,
+    const ScalarNode2p& d)
+    : ScalarNode2{hash_combine(
+          {std::hash<std::string>{}("ScalarIfLessNode2"),
+           a->cached_hash_value,
+           b->cached_hash_value,
+           c->cached_hash_value,
+           d->cached_hash_value})},
+      a{a},
+      b{b},
+      c{c},
+      d{d} {}
+
+void ScalarIfLessNode2::accept(Node2Visitor& visitor) const {
+  visitor.visit(this);
+}
+
+DistributionNormalNode2::DistributionNormalNode2(
+    const ScalarNode2p& mean,
+    const ScalarNode2p& stddev)
+    : DistributionNode2{hash_combine(
+          std::hash<std::string>{}("DistributionNormalNode2"),
+          mean->cached_hash_value,
+          stddev->cached_hash_value)},
+      mean{mean},
+      stddev{stddev} {}
+
+void DistributionNormalNode2::accept(Node2Visitor& visitor) const {
+  visitor.visit(this);
+}
+
+DistributionHalfNormalNode2::DistributionHalfNormalNode2(
+    const ScalarNode2p& stddev)
+    : DistributionNode2{hash_combine(
+          std::hash<std::string>{}("DistributionHalfNormalNode2"),
+          stddev->cached_hash_value)},
+      stddev{stddev} {}
+
+void DistributionHalfNormalNode2::accept(Node2Visitor& visitor) const {
+  visitor.visit(this);
+}
+
+DistributionBetaNode2::DistributionBetaNode2(
+    const ScalarNode2p& a,
+    const ScalarNode2p& b)
+    : DistributionNode2{hash_combine(
+          std::hash<std::string>{}("DistributionBetaNode2"),
+          a->cached_hash_value,
+          b->cached_hash_value)},
+      a{a},
+      b{b} {}
+
+void DistributionBetaNode2::accept(Node2Visitor& visitor) const {
+  visitor.visit(this);
+}
+
+DistributionBernoulliNode2::DistributionBernoulliNode2(const ScalarNode2p& prob)
+    : DistributionNode2{hash_combine(
+          std::hash<std::string>{}("DistributionBernoulliNode2"),
+          prob->cached_hash_value)},
+      prob{prob} {}
+
+void DistributionBernoulliNode2::accept(Node2Visitor& visitor) const {
+  visitor.visit(this);
+}
+
+std::vector<Node2p> in_nodes(const Node2p& n) {
+  class in_node_gatherer : public Node2Visitor {
+   public:
+    std::vector<Node2p> result;
+    void visit(const ScalarConstantNode2*) override {
+      result = {};
+    }
+    void visit(const ScalarVariableNode2*) override {
+      result = {};
+    }
+    void visit(const ScalarSampleNode2* n) override {
+      result = {n->distribution};
+    }
+    void visit(const ScalarAddNode2* n) override {
+      result = {n->left, n->right};
+    }
+    void visit(const ScalarSubtractNode2* n) override {
+      result = {n->left, n->right};
+    }
+    void visit(const ScalarNegateNode2* n) override {
+      result = {n->x};
+    }
+    void visit(const ScalarMultiplyNode2* n) override {
+      result = {n->left, n->right};
+    }
+    void visit(const ScalarDivideNode2* n) override {
+      result = {n->left, n->right};
+    }
+    void visit(const ScalarPowNode2* n) override {
+      result = {n->left, n->right};
+    }
+    void visit(const ScalarExpNode2* n) override {
+      result = {n->x};
+    }
+    void visit(const ScalarLogNode2* n) override {
+      result = {n->x};
+    }
+    void visit(const ScalarAtanNode2* n) override {
+      result = {n->x};
+    }
+    void visit(const ScalarLgammaNode2* n) override {
+      result = {n->x};
+    }
+    void visit(const ScalarPolygammaNode2* n) override {
+      result = {n->n, n->x};
+    }
+    void visit(const ScalarIfEqualNode2* n) override {
+      result = {n->a, n->b, n->c, n->d};
+    }
+    void visit(const ScalarIfLessNode2* n) override {
+      result = {n->a, n->b, n->c, n->d};
+    }
+    void visit(const DistributionNormalNode2* n) override {
+      result = {n->mean, n->stddev};
+    }
+    void visit(const DistributionHalfNormalNode2* n) override {
+      result = {n->stddev};
+    }
+    void visit(const DistributionBetaNode2* n) override {
+      result = {n->a, n->b};
+    }
+    void visit(const DistributionBernoulliNode2* n) override {
+      result = {n->prob};
+    }
+  };
+  in_node_gatherer gatherer;
+  n->accept(gatherer);
+  return std::move(gatherer.result);
+}
+
+std::size_t Node2pIdentityHash::operator()(
+    beanmachine::minibmg::Node2p const& p) const noexcept {
+  return p->cached_hash_value;
+}
+
+bool Node2pIdentityEquals::operator()(
+    const beanmachine::minibmg::Node2p& lhs,
+    const beanmachine::minibmg::Node2p& rhs) const noexcept {
+  const Node2* l = lhs.get();
+  const Node2* r = rhs.get();
+  // a node is equal to itself.
+  if (l == r) {
+    return true;
+  }
+  // equal nodes have equal hash codes and the same types
+  if (l == nullptr || r == nullptr ||
+      l->cached_hash_value != r->cached_hash_value ||
+      typeid(*l) != typeid(*r)) {
+    return false;
+  }
+
+  class EqualsTester : public Node2Visitor {
+   public:
+    const Node2* other;
+    const Node2pIdentityEquals& node_equals;
+    EqualsTester(const Node2* other, const Node2pIdentityEquals& node_equals)
+        : other{other}, node_equals{node_equals} {}
+    bool result;
+    void visit(const ScalarConstantNode2* node) override {
+      auto other = static_cast<const ScalarConstantNode2*>(this->other);
+      result = node->constant_value == other->constant_value;
+    }
+    void visit(const ScalarVariableNode2* node) override {
+      auto other = static_cast<const ScalarVariableNode2*>(this->other);
+      result =
+          node->identifier == other->identifier && node->name == other->name;
+    }
+    void visit(const ScalarSampleNode2* node) override {
+      auto other = static_cast<const ScalarSampleNode2*>(this->other);
+      result = node_equals(node->distribution, other->distribution);
+    }
+    void visit(const ScalarAddNode2* node) override {
+      auto other = static_cast<const ScalarAddNode2*>(this->other);
+      result = node_equals(node->left, other->left) &&
+          node_equals(node->right, other->right);
+    }
+    void visit(const ScalarSubtractNode2* node) override {
+      auto other = static_cast<const ScalarSubtractNode2*>(this->other);
+      result = node_equals(node->left, other->left) &&
+          node_equals(node->right, other->right);
+    }
+    void visit(const ScalarNegateNode2* node) override {
+      auto other = static_cast<const ScalarNegateNode2*>(this->other);
+      result = node_equals(node->x, other->x);
+    }
+    void visit(const ScalarMultiplyNode2* node) override {
+      auto other = static_cast<const ScalarMultiplyNode2*>(this->other);
+      result = node_equals(node->left, other->left) &&
+          node_equals(node->right, other->right);
+    }
+    void visit(const ScalarDivideNode2* node) override {
+      auto other = static_cast<const ScalarDivideNode2*>(this->other);
+      result = node_equals(node->left, other->left) &&
+          node_equals(node->right, other->right);
+    }
+    void visit(const ScalarPowNode2* node) override {
+      auto other = static_cast<const ScalarPowNode2*>(this->other);
+      result = node_equals(node->left, other->left) &&
+          node_equals(node->right, other->right);
+    }
+    void visit(const ScalarExpNode2* node) override {
+      auto other = static_cast<const ScalarExpNode2*>(this->other);
+      result = node_equals(node->x, other->x);
+    }
+    void visit(const ScalarLogNode2* node) override {
+      auto other = static_cast<const ScalarLogNode2*>(this->other);
+      result = node_equals(node->x, other->x);
+    }
+    void visit(const ScalarAtanNode2* node) override {
+      auto other = static_cast<const ScalarAtanNode2*>(this->other);
+      result = node_equals(node->x, other->x);
+    }
+    void visit(const ScalarLgammaNode2* node) override {
+      auto other = static_cast<const ScalarLgammaNode2*>(this->other);
+      result = node_equals(node->x, other->x);
+    }
+    void visit(const ScalarPolygammaNode2* node) override {
+      auto other = static_cast<const ScalarPolygammaNode2*>(this->other);
+      result = node_equals(node->n, other->n) && node_equals(node->x, other->x);
+    }
+    void visit(const ScalarIfEqualNode2* node) override {
+      auto other = static_cast<const ScalarIfEqualNode2*>(this->other);
+      result = node_equals(node->a, other->a) &&
+          node_equals(node->b, other->b) && node_equals(node->c, other->c) &&
+          node_equals(node->d, other->d);
+    }
+    void visit(const ScalarIfLessNode2* node) override {
+      auto other = static_cast<const ScalarIfLessNode2*>(this->other);
+      result = node_equals(node->a, other->a) &&
+          node_equals(node->b, other->b) && node_equals(node->c, other->c) &&
+          node_equals(node->d, other->d);
+    }
+    void visit(const DistributionNormalNode2* node) override {
+      auto other = static_cast<const DistributionNormalNode2*>(this->other);
+      result = node_equals(node->mean, other->mean) &&
+          node_equals(node->stddev, other->stddev);
+    }
+    void visit(const DistributionHalfNormalNode2* node) override {
+      auto other = static_cast<const DistributionHalfNormalNode2*>(this->other);
+      result = node_equals(node->stddev, other->stddev);
+    }
+    void visit(const DistributionBetaNode2* node) override {
+      auto other = static_cast<const DistributionBetaNode2*>(this->other);
+      result = node_equals(node->a, other->a) && node_equals(node->b, other->b);
+    }
+    void visit(const DistributionBernoulliNode2* node) override {
+      auto other = static_cast<const DistributionBernoulliNode2*>(this->other);
+      result = node_equals(node->prob, other->prob);
+    }
+  };
+
+  EqualsTester et{r, *this};
+  r->accept(et);
+  return et.result;
+}
+
+void DefaultNode2Visitor::visit(const ScalarConstantNode2* node) {
+  this->default_visit(node);
+}
+void DefaultNode2Visitor::visit(const ScalarVariableNode2* node) {
+  this->default_visit(node);
+}
+void DefaultNode2Visitor::visit(const ScalarSampleNode2* node) {
+  this->default_visit(node);
+}
+void DefaultNode2Visitor::visit(const ScalarAddNode2* node) {
+  this->default_visit(node);
+}
+void DefaultNode2Visitor::visit(const ScalarSubtractNode2* node) {
+  this->default_visit(node);
+}
+void DefaultNode2Visitor::visit(const ScalarNegateNode2* node) {
+  this->default_visit(node);
+}
+void DefaultNode2Visitor::visit(const ScalarMultiplyNode2* node) {
+  this->default_visit(node);
+}
+void DefaultNode2Visitor::visit(const ScalarDivideNode2* node) {
+  this->default_visit(node);
+}
+void DefaultNode2Visitor::visit(const ScalarPowNode2* node) {
+  this->default_visit(node);
+}
+void DefaultNode2Visitor::visit(const ScalarExpNode2* node) {
+  this->default_visit(node);
+}
+void DefaultNode2Visitor::visit(const ScalarLogNode2* node) {
+  this->default_visit(node);
+}
+void DefaultNode2Visitor::visit(const ScalarAtanNode2* node) {
+  this->default_visit(node);
+}
+void DefaultNode2Visitor::visit(const ScalarLgammaNode2* node) {
+  this->default_visit(node);
+}
+void DefaultNode2Visitor::visit(const ScalarPolygammaNode2* node) {
+  this->default_visit(node);
+}
+void DefaultNode2Visitor::visit(const ScalarIfEqualNode2* node) {
+  this->default_visit(node);
+}
+void DefaultNode2Visitor::visit(const ScalarIfLessNode2* node) {
+  this->default_visit(node);
+}
+void DefaultNode2Visitor::visit(const DistributionNormalNode2* node) {
+  this->default_visit(node);
+}
+void DefaultNode2Visitor::visit(const DistributionHalfNormalNode2* node) {
+  this->default_visit(node);
+}
+void DefaultNode2Visitor::visit(const DistributionBetaNode2* node) {
+  this->default_visit(node);
+}
+void DefaultNode2Visitor::visit(const DistributionBernoulliNode2* node) {
+  this->default_visit(node);
+}
+
+void ScalarNode2Visitor::default_visit(const Node2*) {
+  throw std::logic_error("distribution passed to a scalar visitor");
+}
+void ScalarNode2Visitor::visit(const DistributionNormalNode2* node) {
+  default_visit(node);
+}
+void ScalarNode2Visitor::visit(const DistributionHalfNormalNode2* node) {
+  default_visit(node);
+}
+void ScalarNode2Visitor::visit(const DistributionBetaNode2* node) {
+  default_visit(node);
+}
+void ScalarNode2Visitor::visit(const DistributionBernoulliNode2* node) {
+  default_visit(node);
+}
+
+void DistributionNode2Visitor::default_visit(const Node2*) {
+  throw std::logic_error("scalar passed to a distribution visitor");
+}
+void DistributionNode2Visitor::visit(const ScalarConstantNode2* node) {
+  default_visit(node);
+}
+void DistributionNode2Visitor::visit(const ScalarVariableNode2* node) {
+  default_visit(node);
+}
+void DistributionNode2Visitor::visit(const ScalarSampleNode2* node) {
+  default_visit(node);
+}
+void DistributionNode2Visitor::visit(const ScalarAddNode2* node) {
+  default_visit(node);
+}
+void DistributionNode2Visitor::visit(const ScalarSubtractNode2* node) {
+  default_visit(node);
+}
+void DistributionNode2Visitor::visit(const ScalarNegateNode2* node) {
+  default_visit(node);
+}
+void DistributionNode2Visitor::visit(const ScalarMultiplyNode2* node) {
+  default_visit(node);
+}
+void DistributionNode2Visitor::visit(const ScalarDivideNode2* node) {
+  default_visit(node);
+}
+void DistributionNode2Visitor::visit(const ScalarPowNode2* node) {
+  default_visit(node);
+}
+void DistributionNode2Visitor::visit(const ScalarExpNode2* node) {
+  default_visit(node);
+}
+void DistributionNode2Visitor::visit(const ScalarLogNode2* node) {
+  default_visit(node);
+}
+void DistributionNode2Visitor::visit(const ScalarAtanNode2* node) {
+  default_visit(node);
+}
+void DistributionNode2Visitor::visit(const ScalarLgammaNode2* node) {
+  default_visit(node);
+}
+void DistributionNode2Visitor::visit(const ScalarPolygammaNode2* node) {
+  default_visit(node);
+}
+void DistributionNode2Visitor::visit(const ScalarIfEqualNode2* node) {
+  default_visit(node);
+}
+void DistributionNode2Visitor::visit(const ScalarIfLessNode2* node) {
+  default_visit(node);
+}
+
+} // namespace beanmachine::minibmg

--- a/minibmg/node2.h
+++ b/minibmg/node2.h
@@ -1,0 +1,321 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <memory>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#pragma once
+
+namespace beanmachine::minibmg {
+
+class Node2;
+class ScalarNode2;
+class DistributionNode2;
+class Node2Visitor;
+
+using Node2p = std::shared_ptr<const Node2>;
+using ScalarNode2p = std::shared_ptr<const ScalarNode2>;
+using DistributionNode2p = std::shared_ptr<const DistributionNode2>;
+
+class Node2 {
+ public:
+  std::size_t cached_hash_value;
+  virtual void accept(Node2Visitor& visitor) const = 0;
+  virtual ~Node2();
+
+ protected:
+  explicit Node2(std::size_t cached_hash_value);
+};
+
+class ScalarNode2 : public Node2 {
+ protected:
+  explicit ScalarNode2(std::size_t cached_hash_value);
+};
+
+class DistributionNode2 : public Node2 {
+ protected:
+  explicit DistributionNode2(std::size_t cached_hash_value);
+};
+
+std::string make_fresh_rvid();
+
+class ScalarConstantNode2 : public ScalarNode2 {
+ public:
+  explicit ScalarConstantNode2(double constant_value);
+  double constant_value;
+  void accept(Node2Visitor& visitor) const override;
+};
+
+class ScalarVariableNode2 : public ScalarNode2 {
+ public:
+  ScalarVariableNode2(const std::string& name, const unsigned identifier);
+  std::string name;
+  unsigned identifier;
+  void accept(Node2Visitor& visitor) const override;
+};
+
+class ScalarSampleNode2 : public ScalarNode2 {
+ public:
+  explicit ScalarSampleNode2(
+      const DistributionNode2p& distribution,
+      const std::string& rvid = make_fresh_rvid());
+  const DistributionNode2p& distribution;
+  std::string rvid;
+  void accept(Node2Visitor& visitor) const override;
+};
+
+class ScalarAddNode2 : public ScalarNode2 {
+ public:
+  ScalarAddNode2(const ScalarNode2p& left, const ScalarNode2p& right);
+  ScalarNode2p left;
+  ScalarNode2p right;
+  void accept(Node2Visitor& visitor) const override;
+};
+
+class ScalarSubtractNode2 : public ScalarNode2 {
+ public:
+  ScalarSubtractNode2(const ScalarNode2p& left, const ScalarNode2p& right);
+  ScalarNode2p left;
+  ScalarNode2p right;
+  void accept(Node2Visitor& visitor) const override;
+};
+
+class ScalarNegateNode2 : public ScalarNode2 {
+ public:
+  explicit ScalarNegateNode2(const ScalarNode2p& x);
+  ScalarNode2p x;
+  void accept(Node2Visitor& visitor) const override;
+};
+
+class ScalarMultiplyNode2 : public ScalarNode2 {
+ public:
+  ScalarMultiplyNode2(const ScalarNode2p& left, const ScalarNode2p& right);
+  ScalarNode2p left;
+  ScalarNode2p right;
+  void accept(Node2Visitor& visitor) const override;
+};
+
+class ScalarDivideNode2 : public ScalarNode2 {
+ public:
+  ScalarDivideNode2(const ScalarNode2p& left, const ScalarNode2p& right);
+  ScalarNode2p left;
+  ScalarNode2p right;
+  void accept(Node2Visitor& visitor) const override;
+};
+
+class ScalarPowNode2 : public ScalarNode2 {
+ public:
+  ScalarPowNode2(const ScalarNode2p& left, const ScalarNode2p& right);
+  ScalarNode2p left;
+  ScalarNode2p right;
+  void accept(Node2Visitor& visitor) const override;
+};
+
+class ScalarExpNode2 : public ScalarNode2 {
+ public:
+  explicit ScalarExpNode2(const ScalarNode2p& x);
+  ScalarNode2p x;
+  void accept(Node2Visitor& visitor) const override;
+};
+
+class ScalarLogNode2 : public ScalarNode2 {
+ public:
+  explicit ScalarLogNode2(const ScalarNode2p& x);
+  ScalarNode2p x;
+  void accept(Node2Visitor& visitor) const override;
+};
+
+class ScalarAtanNode2 : public ScalarNode2 {
+ public:
+  explicit ScalarAtanNode2(const ScalarNode2p& x);
+  ScalarNode2p x;
+  void accept(Node2Visitor& visitor) const override;
+};
+
+class ScalarLgammaNode2 : public ScalarNode2 {
+ public:
+  explicit ScalarLgammaNode2(const ScalarNode2p& x);
+  ScalarNode2p x;
+  void accept(Node2Visitor& visitor) const override;
+};
+
+class ScalarPolygammaNode2 : public ScalarNode2 {
+ public:
+  ScalarPolygammaNode2(const ScalarNode2p& n, const ScalarNode2p& x);
+  ScalarNode2p n, x;
+  void accept(Node2Visitor& visitor) const override;
+};
+
+class ScalarIfEqualNode2 : public ScalarNode2 {
+ public:
+  ScalarIfEqualNode2(
+      const ScalarNode2p& a,
+      const ScalarNode2p& b,
+      const ScalarNode2p& c,
+      const ScalarNode2p& d);
+  ScalarNode2p a, b, c, d;
+  void accept(Node2Visitor& visitor) const override;
+};
+
+class ScalarIfLessNode2 : public ScalarNode2 {
+ public:
+  ScalarIfLessNode2(
+      const ScalarNode2p& a,
+      const ScalarNode2p& b,
+      const ScalarNode2p& c,
+      const ScalarNode2p& d);
+  ScalarNode2p a, b, c, d;
+  void accept(Node2Visitor& visitor) const override;
+};
+
+class DistributionNormalNode2 : public DistributionNode2 {
+ public:
+  DistributionNormalNode2(const ScalarNode2p& mean, const ScalarNode2p& stddev);
+  ScalarNode2p mean;
+  ScalarNode2p stddev;
+  void accept(Node2Visitor& visitor) const override;
+};
+
+class DistributionHalfNormalNode2 : public DistributionNode2 {
+ public:
+  explicit DistributionHalfNormalNode2(const ScalarNode2p& stddev);
+  ScalarNode2p stddev;
+  void accept(Node2Visitor& visitor) const override;
+};
+
+class DistributionBetaNode2 : public DistributionNode2 {
+ public:
+  DistributionBetaNode2(const ScalarNode2p& a, const ScalarNode2p& b);
+  ScalarNode2p a;
+  ScalarNode2p b;
+  void accept(Node2Visitor& visitor) const override;
+};
+
+class DistributionBernoulliNode2 : public DistributionNode2 {
+ public:
+  explicit DistributionBernoulliNode2(const ScalarNode2p& prob);
+  ScalarNode2p prob;
+  void accept(Node2Visitor& visitor) const override;
+};
+
+// A helper function useful when topologically sorting ScalarNode2ps (the
+// topological_sort function requires a parameter that is a function of this
+// shape).
+std::vector<Node2p> in_nodes(const Node2p& n);
+
+// Provide a good hash function so ScalarNode2p values can be used in unordered
+// maps and sets.  This treats ScalarNode2p values as semantically value-based.
+struct Node2pIdentityHash {
+  std::size_t operator()(const beanmachine::minibmg::Node2p& p) const noexcept;
+};
+
+// Provide a good equality function so ScalarNode2p values can be used in
+// unordered maps and sets.  This treats ScalarNode2p values, recursively, as
+// semantically value-based.
+struct Node2pIdentityEquals {
+  bool operator()(
+      const beanmachine::minibmg::Node2p& lhs,
+      const beanmachine::minibmg::Node2p& rhs) const noexcept;
+};
+
+// A value-based map from Node2s to T.  Used for deduplicating and
+// optimizing a graph.
+template <class T>
+using Node2ValueMap =
+    std::unordered_map<Node2p, T, Node2pIdentityHash, Node2pIdentityEquals>;
+
+// A value-based set of Node2s.
+using Node2ValueSet =
+    std::unordered_set<Node2p, Node2pIdentityHash, Node2pIdentityEquals>;
+
+// A visitor for nodes
+class Node2Visitor {
+ public:
+  virtual void visit(const ScalarConstantNode2* node) = 0;
+  virtual void visit(const ScalarVariableNode2* node) = 0;
+  virtual void visit(const ScalarSampleNode2* node) = 0;
+  virtual void visit(const ScalarAddNode2* node) = 0;
+  virtual void visit(const ScalarSubtractNode2* node) = 0;
+  virtual void visit(const ScalarNegateNode2* node) = 0;
+  virtual void visit(const ScalarMultiplyNode2* node) = 0;
+  virtual void visit(const ScalarDivideNode2* node) = 0;
+  virtual void visit(const ScalarPowNode2* node) = 0;
+  virtual void visit(const ScalarExpNode2* node) = 0;
+  virtual void visit(const ScalarLogNode2* node) = 0;
+  virtual void visit(const ScalarAtanNode2* node) = 0;
+  virtual void visit(const ScalarLgammaNode2* node) = 0;
+  virtual void visit(const ScalarPolygammaNode2* node) = 0;
+  virtual void visit(const ScalarIfEqualNode2* node) = 0;
+  virtual void visit(const ScalarIfLessNode2* node) = 0;
+  virtual void visit(const DistributionNormalNode2* node) = 0;
+  virtual void visit(const DistributionHalfNormalNode2* node) = 0;
+  virtual void visit(const DistributionBetaNode2* node) = 0;
+  virtual void visit(const DistributionBernoulliNode2* node) = 0;
+  virtual ~Node2Visitor() {}
+};
+
+// A default visitor for nodes.  Calls the default_visit method for every node
+// type except those that are overridden.
+class DefaultNode2Visitor : public Node2Visitor {
+ public:
+  virtual void default_visit(const Node2* node) = 0;
+
+  void visit(const ScalarConstantNode2* node) override;
+  void visit(const ScalarVariableNode2* node) override;
+  void visit(const ScalarSampleNode2* node) override;
+  void visit(const ScalarAddNode2* node) override;
+  void visit(const ScalarSubtractNode2* node) override;
+  void visit(const ScalarNegateNode2* node) override;
+  void visit(const ScalarMultiplyNode2* node) override;
+  void visit(const ScalarDivideNode2* node) override;
+  void visit(const ScalarPowNode2* node) override;
+  void visit(const ScalarExpNode2* node) override;
+  void visit(const ScalarLogNode2* node) override;
+  void visit(const ScalarAtanNode2* node) override;
+  void visit(const ScalarLgammaNode2* node) override;
+  void visit(const ScalarPolygammaNode2* node) override;
+  void visit(const ScalarIfEqualNode2* node) override;
+  void visit(const ScalarIfLessNode2* node) override;
+  void visit(const DistributionNormalNode2* node) override;
+  void visit(const DistributionHalfNormalNode2* node) override;
+  void visit(const DistributionBetaNode2* node) override;
+  void visit(const DistributionBernoulliNode2* node) override;
+};
+
+// A visitor for scalar nodes.  Throws an exception for distributions.
+class ScalarNode2Visitor : public Node2Visitor {
+  void default_visit(const Node2* node);
+  void visit(const DistributionNormalNode2* node) override;
+  void visit(const DistributionHalfNormalNode2* node) override;
+  void visit(const DistributionBetaNode2* node) override;
+  void visit(const DistributionBernoulliNode2* node) override;
+};
+
+// A visitor for distribution nodes.  Throws an exception for scalars.
+class DistributionNode2Visitor : public Node2Visitor {
+  void default_visit(const Node2* node);
+  void visit(const ScalarConstantNode2* node) override;
+  void visit(const ScalarVariableNode2* node) override;
+  void visit(const ScalarSampleNode2* node) override;
+  void visit(const ScalarAddNode2* node) override;
+  void visit(const ScalarSubtractNode2* node) override;
+  void visit(const ScalarNegateNode2* node) override;
+  void visit(const ScalarMultiplyNode2* node) override;
+  void visit(const ScalarDivideNode2* node) override;
+  void visit(const ScalarPowNode2* node) override;
+  void visit(const ScalarExpNode2* node) override;
+  void visit(const ScalarLogNode2* node) override;
+  void visit(const ScalarAtanNode2* node) override;
+  void visit(const ScalarLgammaNode2* node) override;
+  void visit(const ScalarPolygammaNode2* node) override;
+  void visit(const ScalarIfEqualNode2* node) override;
+  void visit(const ScalarIfLessNode2* node) override;
+};
+
+} // namespace beanmachine::minibmg


### PR DESCRIPTION
Summary:
This is the first step (step 1 below) in a series of refactoring steps that will replace minibmg nodes with a distinct node type for each operations and a visitor mechanism.

1. Introduce Node2 and Node2Visitor (without tests yet)
2. Introduce Graph2 using Node2 with json I/O (ditto)
3. Introduce Tracing2 using Node2 (ditto)
4. Introduce Eval2 (ditto)
5. Migrate tests to Node2.
6. Migrate any remaining pieces to Node2.
7. Delete Node.h and Node.cpp
8. Rename Node2 to Node and similarly for other types and files.

Differential Revision: D40390955

