### PR TITLE
minibmg: introduce (eventual) replacement for minibmg::Graph

### DIFF
--- a/minibmg/dedup2.cpp
+++ b/minibmg/dedup2.cpp
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "beanmachine/minibmg/dedup2.h"
+#include <map>
+#include <memory>
+#include <stdexcept>
+#include <unordered_map>
+#include "beanmachine/minibmg/node2.h"
+#include "beanmachine/minibmg/topological.h"
+
+namespace {
+
+using namespace beanmachine::minibmg;
+
+// Rewrite a single node by replacing all of its inputs with their deduplicated
+// counterpart.
+Node2p rewrite(Node2p node, const Node2Node2ValueMap& map) {
+  class DedupVisitor : public Node2Visitor {
+   public:
+    Node2p original;
+    const Node2Node2ValueMap& map;
+    DedupVisitor(Node2p original, const Node2Node2ValueMap& map)
+        : original{original}, map{map} {}
+    Node2p result;
+    void visit(const ScalarConstantNode2* node) {
+      result = original;
+    }
+    void visit(const ScalarVariableNode2* node) {
+      result = original;
+    }
+    void visit(const ScalarSampleNode2* node) {
+      const DistributionNode2p dist = map.at(node->distribution);
+      if (dist == node->distribution) {
+        result = original;
+      } else {
+        result = std::make_shared<ScalarSampleNode2>(dist);
+      }
+    }
+    void visit(const ScalarAddNode2* node) {
+      const ScalarNode2p left = map.at(node->left);
+      const ScalarNode2p right = map.at(node->right);
+      if (left == node->left && right == node->right) {
+        result = original;
+      } else {
+        result = std::make_shared<ScalarAddNode2>(left, right);
+      }
+    }
+    void visit(const ScalarSubtractNode2* node) {
+      const ScalarNode2p left = map.at(node->left);
+      const ScalarNode2p right = map.at(node->right);
+      if (left == node->left && right == node->right) {
+        result = original;
+      } else {
+        result = std::make_shared<ScalarSubtractNode2>(left, right);
+      }
+    }
+    void visit(const ScalarNegateNode2* node) {
+      const ScalarNode2p x = map.at(node->x);
+      if (x == node->x) {
+        result = original;
+      } else {
+        result = std::make_shared<ScalarNegateNode2>(x);
+      }
+    }
+    void visit(const ScalarMultiplyNode2* node) {
+      const ScalarNode2p left = map.at(node->left);
+      const ScalarNode2p right = map.at(node->right);
+      if (left == node->left && right == node->right) {
+        result = original;
+      } else {
+        result = std::make_shared<ScalarMultiplyNode2>(left, right);
+      }
+    }
+    void visit(const ScalarDivideNode2* node) {
+      const ScalarNode2p left = map.at(node->left);
+      const ScalarNode2p right = map.at(node->right);
+      if (left == node->left && right == node->right) {
+        result = original;
+      } else {
+        result = std::make_shared<ScalarDivideNode2>(left, right);
+      }
+    }
+    void visit(const ScalarPowNode2* node) {
+      const ScalarNode2p left = map.at(node->left);
+      const ScalarNode2p right = map.at(node->right);
+      if (left == node->left && right == node->right) {
+        result = original;
+      } else {
+        result = std::make_shared<ScalarPowNode2>(left, right);
+      }
+    }
+    void visit(const ScalarExpNode2* node) {
+      const ScalarNode2p x = map.at(node->x);
+      if (x == node->x) {
+        result = original;
+      } else {
+        result = std::make_shared<ScalarExpNode2>(x);
+      }
+    }
+    void visit(const ScalarLogNode2* node) {
+      const ScalarNode2p x = map.at(node->x);
+      if (x == node->x) {
+        result = original;
+      } else {
+        result = std::make_shared<ScalarLogNode2>(x);
+      }
+    }
+    void visit(const ScalarAtanNode2* node) {
+      const ScalarNode2p x = map.at(node->x);
+      if (x == node->x) {
+        result = original;
+      } else {
+        result = std::make_shared<ScalarAtanNode2>(x);
+      }
+    }
+    void visit(const ScalarLgammaNode2* node) {
+      const ScalarNode2p x = map.at(node->x);
+      if (x == node->x) {
+        result = original;
+      } else {
+        result = std::make_shared<ScalarLgammaNode2>(x);
+      }
+    }
+    void visit(const ScalarPolygammaNode2* node) {
+      const ScalarNode2p n = map.at(node->n);
+      const ScalarNode2p x = map.at(node->x);
+      if (n == node->n && x == node->x) {
+        result = original;
+      } else {
+        result = std::make_shared<ScalarPolygammaNode2>(n, x);
+      }
+    }
+    void visit(const ScalarIfEqualNode2* node) {
+      const ScalarNode2p a = map.at(node->a);
+      const ScalarNode2p b = map.at(node->b);
+      const ScalarNode2p c = map.at(node->c);
+      const ScalarNode2p d = map.at(node->d);
+      if (a == node->a && b == node->b && c == node->c && d == node->d) {
+        result = original;
+      } else {
+        result = std::make_shared<ScalarIfEqualNode2>(a, b, c, d);
+      }
+    }
+    void visit(const ScalarIfLessNode2* node) {
+      const ScalarNode2p a = map.at(node->a);
+      const ScalarNode2p b = map.at(node->b);
+      const ScalarNode2p c = map.at(node->c);
+      const ScalarNode2p d = map.at(node->d);
+      if (a == node->a && b == node->b && c == node->c && d == node->d) {
+        result = original;
+      } else {
+        result = std::make_shared<ScalarIfLessNode2>(a, b, c, d);
+      }
+    }
+    void visit(const DistributionNormalNode2* node) {
+      const ScalarNode2p mean = map.at(node->mean);
+      const ScalarNode2p stddev = map.at(node->stddev);
+      if (mean == node->mean && stddev == node->stddev) {
+        result = original;
+      } else {
+        result = std::make_shared<DistributionNormalNode2>(mean, stddev);
+      }
+    }
+    void visit(const DistributionHalfNormalNode2* node) {
+      const ScalarNode2p stddev = map.at(node->stddev);
+      if (stddev == node->stddev) {
+        result = original;
+      } else {
+        result = std::make_shared<DistributionHalfNormalNode2>(stddev);
+      }
+    }
+    void visit(const DistributionBetaNode2* node) {
+      const ScalarNode2p a = map.at(node->a);
+      const ScalarNode2p b = map.at(node->b);
+      if (a == node->a && b == node->b) {
+        result = original;
+      } else {
+        result = std::make_shared<DistributionBetaNode2>(a, b);
+      }
+    }
+    void visit(const DistributionBernoulliNode2* node) {
+      const ScalarNode2p prob = map.at(node->prob);
+      if (prob == node->prob) {
+        result = original;
+      } else {
+        result = std::make_shared<DistributionBernoulliNode2>(prob);
+      }
+    }
+  };
+  DedupVisitor v{node, map};
+  node->accept(v);
+  return v.result;
+}
+
+} // namespace
+
+namespace beanmachine::minibmg {
+
+// Take a set of root nodes as input, and return a map of deduplicated nodes,
+// which maps from a node in the transitive closure of the input to a
+// corresponding node in the transitive closure of the deduplicated graph.
+std::unordered_map<Node2p, Node2p> dedup_map(std::vector<Node2p> roots) {
+  // a value-based, map, which treats semantically identical nodes as the same.
+  Node2Node2ValueMap map;
+
+  // We also build a map that uses object (pointer) identity to find elements,
+  // so that operations in clients are not using recursive equality operations.
+  std::unordered_map<Node2p, Node2p> identity_map;
+
+  std::vector<Node2p> sorted;
+  if (!topological_sort<Node2p>(
+          {roots.begin(), roots.end()}, in_nodes, sorted)) {
+    throw std::invalid_argument("graph has a cycle");
+  }
+  std::reverse(sorted.begin(), sorted.end());
+  for (auto& node : sorted) {
+    if (map.contains(node)) {
+      auto mapping = map.at(node);
+      map.add(node, mapping);
+      identity_map.insert({node, mapping});
+      continue;
+    }
+    auto rewritten = rewrite(node, map);
+    map.add(node, rewritten);
+    identity_map.insert({node, rewritten});
+  }
+
+  return identity_map;
+}
+
+} // namespace beanmachine::minibmg

--- a/minibmg/dedup2.h
+++ b/minibmg/dedup2.h
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <list>
+#include <memory>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+#include "beanmachine/minibmg/ad/real.h"
+#include "beanmachine/minibmg/node2.h"
+
+namespace beanmachine::minibmg {
+
+// Take a set of root nodes as input, and return a map of deduplicated nodes,
+// which maps from a node in the transitive closure of the roots to a
+// corresponding node in the transitive closure of the deduplicated graph.
+// This is used in the implementation of dedup(), but might occasionally be
+// useful in this form.
+std::unordered_map<Node2p, Node2p> dedup_map(std::vector<Node2p> roots);
+
+// In order to deduplicate data in a given data structure, the programmer must
+// specialize this template class to locate the roots contained in
+// that data structure, and to write a replacement for data structure in which
+// nodes have been deduplicated.  We provide a number of specializations for
+// data structures likely to be needed.
+template <class T>
+class DedupHelper2 {
+ public:
+  DedupHelper2() = delete;
+  // locate all of the roots.
+  std::vector<Node2p> find_roots(const T&) const;
+  // rewrite the T, given a mapping from each node to its replacement.
+  T rewrite(const T&, const std::unordered_map<Node2p, Node2p>&) const;
+};
+
+// Rewrite a data structure by deduplicating its nodes.  The programmer must
+// either provide an implementation of DedupHelper2<T> or specialize it.
+template <class T>
+T dedup2(const T& data, const DedupHelper2<T>& helper = DedupHelper2<T>{}) {
+  auto roots = helper.find_roots(data);
+  auto map = dedup_map(roots);
+  return helper.rewrite(data, map);
+}
+
+// A single node can be deduplicated
+template <>
+class DedupHelper2<Node2p> {
+ public:
+  std::vector<Node2p> find_roots(const Node2p& n) const {
+    return {n};
+  }
+  Node2p rewrite(
+      const Node2p& node,
+      const std::unordered_map<Node2p, Node2p>& map) const {
+    auto f = map.find(node);
+    return f == map.end() ? node : f->second;
+  }
+};
+
+// A vector can be deduplicated.
+template <class T>
+class DedupHelper2<std::vector<T>> {
+  DedupHelper2<T> t_helper{};
+
+ public:
+  std::vector<Node2p> find_roots(const std::vector<T>& roots) const {
+    std::vector<Node2p> result;
+    for (const auto& root : roots) {
+      auto more_roots = t_helper.find_roots(root);
+      result.push_back(more_roots.begin(), more_roots.end());
+    }
+    return result;
+  }
+  std::vector<T> rewrite(
+      const std::vector<T>& roots,
+      const std::unordered_map<Node2p, Node2p>& map) const {
+    std::vector<T> result;
+    for (const auto& root : roots) {
+      result.push_back(t_helper.rewrite(root, map));
+    }
+    return result;
+  }
+};
+
+// A list can be deduplicated
+template <class T>
+class DedupHelper2<std::list<T>> {
+  DedupHelper2<T> t_helper{};
+
+ public:
+  std::vector<Node2p> find_roots(const std::list<T>& roots) const {
+    std::vector<Node2p> result;
+    for (const auto& root : roots) {
+      auto more_roots = t_helper.find_roots(root);
+      result.push_back(more_roots.begin(), more_roots.end());
+    }
+    return result;
+  }
+  std::list<T> rewrite(
+      const std::list<T>& roots,
+      const std::unordered_map<Node2p, Node2p>& map) const {
+    std::list<T> result;
+    for (const auto& root : roots) {
+      result.push_back(t_helper.rewrite(root, map));
+    }
+    return result;
+  }
+};
+
+// A pair can be deduplicated
+template <class T, class U>
+class DedupHelper2<std::pair<T, U>> {
+  DedupHelper2<T> t_helper{};
+  DedupHelper2<U> u_helper{};
+
+ public:
+  std::vector<Node2p> find_roots(const std::pair<T, U>& root) const {
+    std::vector<Node2p> result = t_helper(root.first);
+    for (auto& r : u_helper.find_roots(root.second)) {
+      result.push_back(r);
+    }
+    return result;
+  }
+  std::pair<T, U> rewrite(
+      const std::pair<T, U>& root,
+      const std::unordered_map<Node2p, Node2p>& map) const {
+    return {
+        t_helper.rewrite(root.first, map), u_helper.rewrite(root.second, map)};
+  }
+};
+
+// A double can be deduplicated (no action)
+template <>
+class DedupHelper2<double> {
+ public:
+  std::vector<Node2p> find_roots(const double&) const {
+    return {};
+  }
+  double rewrite(const double& root, std::unordered_map<Node2p, Node2p>) const {
+    return root;
+  }
+};
+
+// A Real (wrapper around a double) can be deduplicated (no action)
+template <>
+class DedupHelper2<Real> {
+ public:
+  std::vector<Node2p> find_roots(const Real&) const {
+    return {};
+  }
+  // rewrite the T, given a mapping from each node to its replacement.
+  Real rewrite(const Real& t, const std::unordered_map<Node2p, Node2p>&) const {
+    return t;
+  }
+};
+
+} // namespace beanmachine::minibmg

--- a/minibmg/graph.cpp
+++ b/minibmg/graph.cpp
@@ -245,10 +245,7 @@ folly::dynamic graph_to_json(const Graph& g) {
   return result;
 }
 
-JsonError::JsonError(const std::string& message) : message(message) {}
-
 Graph json_to_graph(folly::dynamic d) {
-  Graph::Factory gf;
   // Nodes are identified by a "sequence" number appearing in json.
   // They are arbitrary numbers.  The only requirement is that they
   // are distinct.  They are used to identify nodes in the json.

--- a/minibmg/graph2.cpp
+++ b/minibmg/graph2.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "beanmachine/minibmg/graph2.h"
+#include <list>
+#include <stdexcept>
+#include <vector>
+#include "beanmachine/minibmg/dedup2.h"
+#include "beanmachine/minibmg/topological.h"
+
+namespace {
+
+using namespace beanmachine::minibmg;
+
+const std::vector<Node2p> roots(
+    const std::vector<Node2p>& queries,
+    const std::list<std::pair<Node2p, double>>& observations) {
+  std::list<Node2p> roots;
+  for (auto& n : queries) {
+    roots.push_back(n);
+  }
+  for (auto& p : observations) {
+    if (typeid(p.first.get()) != typeid(ScalarSampleNode2*)) {
+      throw std::invalid_argument(fmt::format("can only observe a sample"));
+    }
+    roots.push_front(p.first);
+  }
+  std::vector<Node2p> all_nodes;
+  if (!topological_sort<Node2p>(roots, &in_nodes, all_nodes)) {
+    throw std::invalid_argument("graph has a cycle");
+  }
+  std::reverse(all_nodes.begin(), all_nodes.end());
+  return all_nodes;
+}
+
+struct QueriesAndObservations {
+  std::vector<Node2p> queries;
+  std::list<std::pair<Node2p, double>> observations;
+  ~QueriesAndObservations() {}
+};
+
+} // namespace
+
+namespace beanmachine::minibmg {
+
+template <>
+class DedupHelper2<QueriesAndObservations> {
+ public:
+  std::vector<Node2p> find_roots(const QueriesAndObservations& qo) const {
+    std::vector<Node2p> roots;
+    for (auto& q : qo.observations) {
+      roots.push_back(q.first);
+    }
+    for (auto& n : qo.queries) {
+      roots.push_back(n);
+    }
+    return roots;
+  }
+  QueriesAndObservations rewrite(
+      const QueriesAndObservations& qo,
+      const std::unordered_map<Node2p, Node2p>& map) const {
+    DedupHelper2<std::vector<Node2p>> h1{};
+    DedupHelper2<std::list<std::pair<Node2p, double>>> h2{};
+    return QueriesAndObservations{
+        h1.rewrite(qo.queries, map), h2.rewrite(qo.observations, map)};
+  }
+};
+
+using dynamic = folly::dynamic;
+
+Graph2 Graph2::create(
+    const std::vector<Node2p>& queries,
+    const std::list<std::pair<Node2p, double>>& observations) {
+  for (auto& p : observations) {
+    if (typeid(p.first.get()) != typeid(ScalarSampleNode2*)) {
+      throw std::invalid_argument(fmt::format("can only observe a sample"));
+    }
+  }
+
+  auto qo0 = QueriesAndObservations{queries, observations};
+  auto qo1 = dedup2(qo0);
+
+  std::vector<Node2p> all_nodes = roots(qo1.queries, qo1.observations);
+  return Graph2{all_nodes, qo1.queries, qo1.observations};
+}
+
+Graph2::~Graph2() {}
+
+Graph2::Graph2(
+    const std::vector<Node2p>& nodes,
+    const std::vector<Node2p>& queries,
+    const std::list<std::pair<Node2p, double>>& observations)
+    : nodes{nodes}, queries{queries}, observations{observations} {}
+
+} // namespace beanmachine::minibmg

--- a/minibmg/graph2.h
+++ b/minibmg/graph2.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/json.h>
+#include <list>
+#include "beanmachine/minibmg/graph_properties/container.h"
+#include "beanmachine/minibmg/node2.h"
+
+namespace beanmachine::minibmg {
+
+class Graph2 : public Container {
+ public:
+  // produces a graph by computing the transitive closure of the input queries
+  // and observations and topologically sorting the set of nodes so reached.
+  // valudates that the list of nodes so reached forms a valid graph, and
+  // returns that graph.  Throws an exception if the nodes do not form a valid
+  // graph.
+  static Graph2 create(
+      const std::vector<Node2p>& queries,
+      const std::list<std::pair<Node2p, double>>& observations);
+  ~Graph2();
+
+  // Implement the iterator pattern so clients can iterate over the nodes.
+  inline auto begin() const {
+    return nodes.begin();
+  }
+  inline auto end() const {
+    return nodes.end();
+  }
+  inline Node2p operator[](int index) const {
+    return nodes[index];
+  }
+  inline int size() const {
+    return nodes.size();
+  }
+
+  // All of the nodes, in a topologically sorted order such that a node can only
+  // be used as an input in subsequent (and not previous) nodes.
+  const std::vector<Node2p> nodes;
+
+  // Queries of the model.  These are nodes whose values are sampled by
+  // inference.
+  const std::vector<Node2p> queries;
+
+  // Observations of the model.  These are SAMPLE nodes in the model whose
+  // values are known.
+  const std::list<std::pair<Node2p, double>> observations;
+
+ private:
+  // A private constructor that forms a graph without validation.
+  // Used internally.  All exposed graphs should be validated.
+  Graph2(
+      const std::vector<Node2p>& nodes,
+      const std::vector<Node2p>& queries,
+      const std::list<std::pair<Node2p, double>>& observations);
+
+ public:
+  // A factory for making graphs, like the bmg API used by Beanstalk
+  class Factory;
+
+  // A more natural factory for making graphs, using operator overloading.
+  class FluidFactory;
+};
+
+// Exception to throw when json_to_graph fails.
+class JsonError : public std::exception {
+ public:
+  explicit JsonError(const std::string& message);
+  const std::string message;
+};
+
+folly::dynamic graph_to_json2(const Graph2& g);
+Graph2 json2_to_graph(folly::dynamic d); // throw (JsonError)
+
+} // namespace beanmachine::minibmg

--- a/minibmg/json2.cpp
+++ b/minibmg/json2.cpp
@@ -1,0 +1,430 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <folly/json.h>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <string_view>
+#include "beanmachine/minibmg/graph2.h"
+
+namespace {
+
+inline constexpr auto hash_djb2a(const std::string_view sv) {
+  unsigned long hash{5381};
+  for (unsigned char c : sv) {
+    hash = ((hash << 5) + hash) ^ c;
+  }
+  return hash;
+}
+
+inline constexpr auto operator"" _sh(const char* str, size_t len) {
+  return hash_djb2a(std::string_view{str, len});
+}
+
+} // namespace
+
+namespace beanmachine::minibmg {
+
+using dynamic = folly::dynamic;
+
+JsonError::JsonError(const std::string& message) : message(message) {}
+
+folly::dynamic graph2_to_json(const Graph2& g) {
+  std::unordered_map<Node2p, unsigned long> node_to_identifier;
+  dynamic result = dynamic::object;
+  result["comment"] = "created by graph_to_json";
+  dynamic a = dynamic::array;
+
+  unsigned long next_identifier = 0;
+  for (auto& node : g) {
+    // assign node identifiers sequentially.  They are called "sequence" in the
+    // generated json.
+    auto identifier = next_identifier++;
+    node_to_identifier[node] = identifier;
+    dynamic dyn_node = dynamic::object;
+    dyn_node["sequence"] = identifier;
+
+    class JsonNodeWriterVisitor : public Node2Visitor {
+     public:
+      JsonNodeWriterVisitor(dynamic& dyn_node) : dyn_node{dyn_node} {}
+      dynamic& dyn_node;
+      void visit(const ScalarConstantNode2* node) override {
+        dyn_node["operator"] = "CONSTANT";
+        dyn_node["value"] = node->constant_value;
+      }
+      void visit(const ScalarVariableNode2* node) override {
+        dyn_node["operator"] = "VARIABLE";
+        dyn_node["name"] = node->name;
+        dyn_node["identifier"] = node->identifier;
+      }
+      void visit(const ScalarSampleNode2* node) override {
+        dyn_node["operator"] = "SAMPLE";
+      }
+      void visit(const ScalarAddNode2* node) override {
+        dyn_node["operator"] = "ADD";
+      }
+      void visit(const ScalarSubtractNode2* node) override {
+        dyn_node["operator"] = "SUBTRACT";
+      }
+      void visit(const ScalarNegateNode2* node) override {
+        dyn_node["operator"] = "NEGATE";
+      }
+      void visit(const ScalarMultiplyNode2* node) override {
+        dyn_node["operator"] = "MULTIPLY";
+      }
+      void visit(const ScalarDivideNode2* node) override {
+        dyn_node["operator"] = "DIVIDE";
+      }
+      void visit(const ScalarPowNode2* node) override {
+        dyn_node["operator"] = "POW";
+      }
+      void visit(const ScalarExpNode2* node) override {
+        dyn_node["operator"] = "EXP";
+      }
+      void visit(const ScalarLogNode2* node) override {
+        dyn_node["operator"] = "LOG";
+      }
+      void visit(const ScalarAtanNode2* node) override {
+        dyn_node["operator"] = "ATAN";
+      }
+      void visit(const ScalarLgammaNode2* node) override {
+        dyn_node["operator"] = "LGAMMA";
+      }
+      void visit(const ScalarPolygammaNode2* node) override {
+        dyn_node["operator"] = "POLYGAMMA";
+      }
+      void visit(const ScalarIfEqualNode2* node) override {
+        dyn_node["operator"] = "IF_EQUAL";
+      }
+      void visit(const ScalarIfLessNode2* node) override {
+        dyn_node["operator"] = "IF_LESS";
+      }
+      void visit(const DistributionNormalNode2* node) override {
+        dyn_node["operator"] = "DISTRIBUTION_NORMAL";
+      }
+      void visit(const DistributionHalfNormalNode2* node) override {
+        dyn_node["operator"] = "DISTRIBUTION_HALF_NORMAL";
+      }
+      void visit(const DistributionBetaNode2* node) override {
+        dyn_node["operator"] = "DISTRIBUTION_BETA";
+      }
+      void visit(const DistributionBernoulliNode2* node) override {
+        dyn_node["operator"] = "DISTRIBUTION_BERNOULLI";
+      }
+    };
+
+    JsonNodeWriterVisitor v{dyn_node};
+    node->accept(v);
+    auto in = in_nodes(node);
+    if (in.size() > 0) {
+      dynamic in_nodes = dynamic::array;
+      for (auto& n : in) {
+        in_nodes.push_back(node_to_identifier[n]);
+      }
+      dyn_node["in_nodes"] = in_nodes;
+    }
+
+    a.push_back(dyn_node);
+  }
+  result["nodes"] = a;
+
+  dynamic observations = dynamic::array;
+  for (auto& q : g.observations) {
+    dynamic d = dynamic::object;
+    auto id = node_to_identifier[q.first];
+    d["node"] = id;
+    d["value"] = q.second;
+    observations.push_back(d);
+  }
+  result["observations"] = observations;
+
+  dynamic queries = dynamic::array;
+  for (auto& q : g.queries) {
+    queries.push_back(node_to_identifier[q]);
+  }
+  result["queries"] = queries;
+
+  return result;
+}
+
+Graph2 json_to_graph2(folly::dynamic d) {
+  // Nodes are identified by a "sequence" number appearing in json.
+  // They are arbitrary numbers.  The only requirement is that they
+  // are distinct.  They are used to identify nodes in the json.
+  // This map is used to identify the specific node when it is
+  // referenced in the json.
+  std::unordered_map<int, Node2p> identifier_to_node;
+
+  auto json_nodes = d["nodes"];
+  if (!json_nodes.isArray()) {
+    throw JsonError("missing \"nodes\" property");
+  }
+  for (auto json_node : json_nodes) {
+    auto identifierv = json_node["sequence"];
+    if (!identifierv.isInt()) {
+      throw JsonError("missing sequence number.");
+    }
+    auto identifier = identifierv.asInt();
+
+    auto opv = json_node["operator"];
+    if (!opv.isString()) {
+      throw JsonError("missing operator.");
+    }
+
+    std::vector<Node2p> in_nodes{};
+    switch (hash_djb2a(opv.asString())) {
+      case "CONSTANT"_sh:
+      case "VARIABLE"_sh:
+        // in_nodes not expected.
+        break;
+      default:
+        auto in_nodesv = json_node["in_nodes"];
+        if (!in_nodesv.isArray()) {
+          throw JsonError("missing in_nodes.");
+        }
+        std::vector<Node2p> in_nodes;
+        for (auto& in_nodev : in_nodesv) {
+          if (!in_nodev.isInt()) {
+            throw JsonError("missing in_node for operator.");
+          }
+          auto in_node_i = in_nodev.asInt();
+          if (!identifier_to_node.contains(in_node_i)) {
+            throw JsonError("bad in_node for operator.");
+          }
+          auto in_node = identifier_to_node[in_node_i];
+          in_nodes.push_back(in_node);
+        }
+        break;
+    }
+
+    Node2p node;
+    switch (hash_djb2a(opv.asString())) {
+      case "CONSTANT"_sh: {
+        auto valuev = json_node["value"];
+        double value;
+        if (valuev.isInt()) {
+          value = valuev.asInt();
+        } else if (valuev.isDouble()) {
+          value = valuev.asDouble();
+        } else {
+          throw JsonError("bad value for constant.");
+        }
+        node = std::make_shared<const ScalarConstantNode2>(value);
+      } break;
+      case "VARIABLE"_sh: {
+        auto namev = json_node["name"];
+        std::string name = "";
+        if (namev.isString()) {
+          name = namev.asString();
+        } else {
+          throw JsonError("bad name for variable.");
+        }
+        auto variable_indexv = json_node["variable_index"];
+        if (!variable_indexv.isInt()) {
+          throw JsonError("bad variable_index for variable.");
+        }
+        auto variable_index = (unsigned)variable_indexv.asInt();
+        node =
+            std::make_shared<const ScalarVariableNode2>(name, variable_index);
+      } break;
+      case "ADD"_sh: {
+        if (in_nodes.size() != 2) {
+          throw JsonError("bad in_node for operator.");
+        }
+        node = std::make_shared<ScalarAddNode2>(
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[1]));
+      } break;
+      case "SUBTRACT"_sh: {
+        if (in_nodes.size() != 2) {
+          throw JsonError("bad in_node for operator.");
+        }
+        node = std::make_shared<ScalarSubtractNode2>(
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[1]));
+      } break;
+      case "NEGATE"_sh: {
+        if (in_nodes.size() != 1) {
+          throw JsonError("bad in_node for operator.");
+        }
+        node = std::make_shared<ScalarNegateNode2>(
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]));
+      } break;
+      case "MULTIPLY"_sh: {
+        if (in_nodes.size() != 2) {
+          throw JsonError("bad in_node for operator.");
+        }
+        node = std::make_shared<ScalarMultiplyNode2>(
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[1]));
+      } break;
+      case "DIVIDE"_sh: {
+        if (in_nodes.size() != 2) {
+          throw JsonError("bad in_node for operator.");
+        }
+        node = std::make_shared<ScalarDivideNode2>(
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[1]));
+      } break;
+      case "POW"_sh: {
+        if (in_nodes.size() != 2) {
+          throw JsonError("bad in_node for operator.");
+        }
+        node = std::make_shared<ScalarPowNode2>(
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[1]));
+      } break;
+      case "EXP"_sh: {
+        if (in_nodes.size() != 1) {
+          throw JsonError("bad in_node for operator.");
+        }
+        node = std::make_shared<ScalarExpNode2>(
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]));
+      } break;
+      case "LOG"_sh: {
+        if (in_nodes.size() != 1) {
+          throw JsonError("bad in_node for operator.");
+        }
+        node = std::make_shared<ScalarLogNode2>(
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]));
+      } break;
+      case "ATAN"_sh: {
+        if (in_nodes.size() != 1) {
+          throw JsonError("bad in_node for operator.");
+        }
+        node = std::make_shared<ScalarAtanNode2>(
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]));
+      } break;
+      case "LGAMMA"_sh: {
+        if (in_nodes.size() != 1) {
+          throw JsonError("bad in_node for operator.");
+        }
+        node = std::make_shared<ScalarLgammaNode2>(
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]));
+      } break;
+      case "POLYGAMMA"_sh: {
+        if (in_nodes.size() != 2) {
+          throw JsonError("bad in_node for operator.");
+        }
+        node = std::make_shared<ScalarPolygammaNode2>(
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[1]));
+      } break;
+      case "IF_EQUAL"_sh: {
+        if (in_nodes.size() != 4) {
+          throw JsonError("bad in_node for operator.");
+        }
+        node = std::make_shared<ScalarIfEqualNode2>(
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[1]),
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[2]),
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[3]));
+      } break;
+      case "IF_LESS"_sh: {
+        if (in_nodes.size() != 4) {
+          throw JsonError("bad in_node for operator.");
+        }
+        node = std::make_shared<ScalarIfLessNode2>(
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[1]),
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[2]),
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[3]));
+      } break;
+      case "DISTRIBUTION_NORMAL"_sh: {
+        if (in_nodes.size() != 2) {
+          throw JsonError("bad in_node for operator.");
+        }
+        node = std::make_shared<DistributionNormalNode2>(
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[1]));
+      } break;
+      case "DISTRIBUTION_HALF_NORMAL"_sh: {
+        if (in_nodes.size() != 1) {
+          throw JsonError("bad in_node for operator.");
+        }
+        node = std::make_shared<DistributionHalfNormalNode2>(
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]));
+        break;
+
+      } break;
+      case "DISTRIBUTION_BETA"_sh: {
+        if (in_nodes.size() != 2) {
+          throw JsonError("bad in_node for operator.");
+        }
+        node = std::make_shared<DistributionBetaNode2>(
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[1]));
+      } break;
+      case "DISTRIBUTION_BERNOULLI"_sh: {
+        if (in_nodes.size() != 1) {
+          throw JsonError("bad in_node for operator.");
+        }
+        node = std::make_shared<DistributionBernoulliNode2>(
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]));
+      } break;
+      case "SAMPLE"_sh: {
+        if (in_nodes.size() != 1) {
+          throw JsonError("bad in_node for operator.");
+        }
+        node = std::make_shared<ScalarSampleNode2>(
+            std::dynamic_pointer_cast<const DistributionNode2>(in_nodes[0]));
+      } break;
+      default:
+        throw JsonError("operator unknown: " + opv.asString());
+        break;
+    }
+
+    if (identifier_to_node.contains(identifier)) {
+      throw JsonError(fmt::format("duplicate node ID {}.", identifier));
+    }
+
+    identifier_to_node[identifier] = node;
+  }
+
+  std::vector<Node2p> queries;
+  auto query_nodes = d["queries"];
+  if (query_nodes.isArray()) {
+    for (auto& query : query_nodes) {
+      if (!query.isInt()) {
+        throw JsonError("bad query value.");
+      }
+      auto query_i = query.asInt();
+      if (!identifier_to_node.contains(query_i)) {
+        throw JsonError(fmt::format("bad in_node {} for query.", query_i));
+      }
+      auto query_node = identifier_to_node[query_i];
+      queries.push_back(query_node);
+    }
+  }
+
+  std::list<std::pair<Node2p, double>> observations;
+  auto observation_nodes = d["observations"];
+  if (observation_nodes.isArray()) {
+    for (auto& obs : observation_nodes) {
+      auto node = obs["node"];
+      if (!node.isInt()) {
+        throw JsonError("bad observation node.");
+      }
+      auto node_i = node.asInt();
+      if (!identifier_to_node.contains(node_i)) {
+        throw JsonError(fmt::format("bad in_node {} for observation.", node_i));
+      }
+      auto& obs_node = identifier_to_node[node_i];
+      auto& value = obs["value"];
+      if (!node.isDouble() && !node.isInt()) {
+        throw JsonError("bad value for observation.");
+      }
+      auto value_d = value.asDouble();
+      observations.push_back(std::pair{obs_node, value_d});
+    }
+  }
+
+  return Graph2::create(queries, observations);
+}
+
+} // namespace beanmachine::minibmg

--- a/minibmg/node2.h
+++ b/minibmg/node2.h
@@ -226,6 +226,30 @@ struct Node2pIdentityEquals {
 
 // A value-based map from Node2s to T.  Used for deduplicating and
 // optimizing a graph.
+class Node2Node2ValueMap {
+ public:
+  ~Node2Node2ValueMap() {}
+  ScalarNode2p at(const ScalarNode2p& p) const {
+    return std::dynamic_pointer_cast<const ScalarNode2>(map.at(p));
+  }
+  DistributionNode2p at(const DistributionNode2p& p) const {
+    return std::dynamic_pointer_cast<const DistributionNode2>(map.at(p));
+  }
+  Node2p at(const Node2p& p) const {
+    return map.at(p);
+  }
+  bool contains(const Node2p& p) const {
+    return map.contains(p);
+  }
+  void add(const Node2p& key, const Node2p& value) {
+    map.insert({key, value});
+  }
+
+ private:
+  std::unordered_map<Node2p, Node2p, Node2pIdentityHash, Node2pIdentityEquals>
+      map;
+};
+
 template <class T>
 using Node2ValueMap =
     std::unordered_map<Node2p, T, Node2pIdentityHash, Node2pIdentityEquals>;


### PR DESCRIPTION
Summary:
This is the second step (step 2 below) in a series of refactoring steps that will replace minibmg nodes with a distinct node type for each operations and a visitor mechanism.  The idea is that we will write replacements for all of the parts of minibmg using the new paradigm, and then switch over the tests to the new code.

1. Introduce Node2 and Node2Visitor (without tests yet)
2. Introduce Graph2 using Node2 with json I/O (ditto)
3. Introduce Tracing2 using Node2 (ditto)
4. Introduce Eval2 (ditto)
5. Migrate tests to Node2.
6. Migrate any remaining pieces to Node2.
7. Delete Node.h and Node.cpp and other things that have been replaced.
8. Rename Node2 to Node and similarly for other types and files.

Differential Revision: D40396732

