### PR TITLE
minibmg: implement factories for Graph2

### DIFF
--- a/minibmg/ad/traced2.cpp
+++ b/minibmg/ad/traced2.cpp
@@ -121,9 +121,8 @@ bool is_constant(const Traced2& x, const double& value) {
   return is_constant(x, v) && v == value;
 }
 
-std::string to_string(const Traced2& x) {
-  return fmt::format(
-      "{}:{}: to_string(Traced2) not implemented", __FILE__, __LINE__);
+std::string to_string(const Traced2& traced) {
+  return to_string(traced.node);
 }
 
 } // namespace beanmachine::minibmg

--- a/minibmg/ad/traced2.cpp
+++ b/minibmg/ad/traced2.cpp
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "beanmachine/minibmg/ad/traced2.h"
+#include <functional>
+#include <memory>
+#include <set>
+#include <vector>
+#include "beanmachine/minibmg/ad/real.h"
+#include "beanmachine/minibmg/eval_error.h"
+#include "beanmachine/minibmg/node2.h"
+
+namespace beanmachine::minibmg {
+
+double Traced2::as_double() const {
+  double value;
+  if (is_constant(node, value)) {
+    return value;
+  }
+
+  throw EvalError("constant value expected but found " + to_string(*this));
+}
+
+// We perform some optimizations during construction.
+// It might be better to do no optimizations at this point and have a tree
+// rewriter that can be reused, but for now this is a simpler approach.
+Traced2 operator+(const Traced2& left, const Traced2& right) {
+  ScalarNode2p result = std::make_shared<ScalarAddNode2>(left.node, right.node);
+  return result;
+}
+
+Traced2 operator-(const Traced2& left, const Traced2& right) {
+  ScalarNode2p result =
+      std::make_shared<ScalarSubtractNode2>(left.node, right.node);
+  return result;
+}
+
+Traced2 operator-(const Traced2& x) {
+  ScalarNode2p result = std::make_shared<ScalarNegateNode2>(x.node);
+  return result;
+}
+
+Traced2 operator*(const Traced2& left, const Traced2& right) {
+  ScalarNode2p result =
+      std::make_shared<ScalarMultiplyNode2>(left.node, right.node);
+  return result;
+}
+
+Traced2 operator/(const Traced2& left, const Traced2& right) {
+  ScalarNode2p result =
+      std::make_shared<ScalarDivideNode2>(left.node, right.node);
+  return result;
+}
+
+Traced2 pow(const Traced2& base, const Traced2& exponent) {
+  ScalarNode2p result =
+      std::make_shared<ScalarPowNode2>(base.node, exponent.node);
+  return result;
+}
+
+Traced2 exp(const Traced2& x) {
+  ScalarNode2p result = std::make_shared<ScalarExpNode2>(x.node);
+  return result;
+}
+
+Traced2 log(const Traced2& x) {
+  ScalarNode2p result = std::make_shared<ScalarLogNode2>(x.node);
+  return result;
+}
+
+Traced2 atan(const Traced2& x) {
+  ScalarNode2p result = std::make_shared<ScalarAtanNode2>(x.node);
+  return result;
+}
+
+Traced2 lgamma(const Traced2& x) {
+  ScalarNode2p result = std::make_shared<ScalarLgammaNode2>(x.node);
+  return result;
+}
+
+Traced2 polygamma(const int n, const Traced2& x) {
+  ScalarNode2p nn = std::make_shared<ScalarConstantNode2>(n);
+  ScalarNode2p result = std::make_shared<ScalarPolygammaNode2>(nn, x.node);
+  return result;
+}
+
+Traced2 if_equal(
+    const Traced2& value,
+    const Traced2& comparand,
+    const Traced2& when_equal,
+    const Traced2& when_not_equal) {
+  ScalarNode2p result = std::make_shared<ScalarIfEqualNode2>(
+      value.node, comparand.node, when_equal.node, when_not_equal.node);
+  return result;
+}
+
+Traced2 if_less(
+    const Traced2& value,
+    const Traced2& comparand,
+    const Traced2& when_less,
+    const Traced2& when_not_less) {
+  ScalarNode2p result = std::make_shared<ScalarIfLessNode2>(
+      value.node, comparand.node, when_less.node, when_not_less.node);
+  return result;
+}
+
+bool is_constant(const Traced2& x, double& value) {
+  if (auto xnode = dynamic_cast<const ScalarConstantNode2*>(x.node.get())) {
+    value = xnode->constant_value;
+    return true;
+  }
+  return false;
+}
+
+bool is_constant(const Traced2& x, const double& value) {
+  double v;
+  return is_constant(x, v) && v == value;
+}
+
+std::string to_string(const Traced2& x) {
+  return fmt::format(
+      "{}:{}: to_string(Traced2) not implemented", __FILE__, __LINE__);
+}
+
+} // namespace beanmachine::minibmg

--- a/minibmg/ad/traced2.h
+++ b/minibmg/ad/traced2.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <memory>
+#include <stdexcept>
+#include <unordered_map>
+#include <vector>
+#include "beanmachine/minibmg/ad/number.h"
+#include "beanmachine/minibmg/ad/real.h"
+#include "beanmachine/minibmg/dedup2.h"
+#include "beanmachine/minibmg/node2.h"
+
+namespace beanmachine::minibmg {
+
+/*
+An implementation of the Number concept that simply builds an expression tree
+(actually, a DAG: directed acyclic graph) representing the computation
+performed.  This is also used for the fluent factory.
+ */
+class Traced2 {
+ public:
+  ScalarNode2p node;
+
+  /* implicit */ inline Traced2(ScalarNode2p node) : node{node} {}
+  /* implicit */ inline Traced2(double value)
+      : node{std::make_shared<ScalarConstantNode2>(value)} {}
+  /* implicit */ inline Traced2(Real value)
+      : node{std::make_shared<ScalarConstantNode2>(value.as_double())} {}
+
+  static Traced2 variable(const std::string& name, const unsigned identifier) {
+    return Traced2{std::make_shared<ScalarVariableNode2>(name, identifier)};
+  }
+
+  double as_double() const;
+};
+
+Traced2 operator+(const Traced2& left, const Traced2& right);
+Traced2 operator-(const Traced2& left, const Traced2& right);
+Traced2 operator-(const Traced2& x);
+Traced2 operator*(const Traced2& left, const Traced2& right);
+Traced2 operator/(const Traced2& left, const Traced2& right);
+Traced2 pow(const Traced2& base, const Traced2& exponent);
+Traced2 exp(const Traced2& x);
+Traced2 log(const Traced2& x);
+Traced2 atan(const Traced2& x);
+Traced2 lgamma(const Traced2& x);
+Traced2 polygamma(int n, const Traced2& other);
+Traced2 if_equal(
+    const Traced2& value,
+    const Traced2& comparand,
+    const Traced2& when_equal,
+    const Traced2& when_not_equal);
+Traced2 if_less(
+    const Traced2& value,
+    const Traced2& comparand,
+    const Traced2& when_less,
+    const Traced2& when_not_less);
+bool is_constant(const Traced2& x, double& value);
+bool is_constant(const Traced2& x, const double& value);
+std::string to_string(const Traced2& x);
+
+static_assert(Number<Traced2>);
+
+template <>
+class DedupHelper2<Traced2> {
+ public:
+  std::vector<Node2p> find_roots(const Traced2& t) const {
+    return {t.node};
+  }
+  Traced2 rewrite(
+      const Traced2& t,
+      const std::unordered_map<Node2p, Node2p>& map) const {
+    const auto& f = map.find(t.node);
+    return (f == map.end())
+        ? t
+        : Traced2(std::dynamic_pointer_cast<const ScalarNode2>(f->second));
+  }
+};
+
+} // namespace beanmachine::minibmg
+
+// We want to use Traced2 values in (unordered) maps and sets, so we need a good
+// comparison function.  We delegate to the underlying node pointer for
+// that comparison.
+template <>
+struct ::std::less<beanmachine::minibmg::Traced2> {
+  bool operator()(
+      const beanmachine::minibmg::Traced2& lhs,
+      const beanmachine::minibmg::Traced2& rhs) const {
+    static const auto x = ::std::less<beanmachine::minibmg::ScalarNode2p>{};
+    return x(lhs.node, rhs.node);
+  }
+};

--- a/minibmg/dedup2.cpp
+++ b/minibmg/dedup2.cpp
@@ -35,7 +35,7 @@ class DedupVisitor : public Node2Visitor {
     if (dist == node->distribution) {
       result = original;
     } else {
-      result = std::make_shared<ScalarSampleNode2>(dist);
+      result = std::make_shared<ScalarSampleNode2>(dist, node->rvid);
     }
   }
   void visit(const ScalarAddNode2* node) override {

--- a/minibmg/dedup2.cpp
+++ b/minibmg/dedup2.cpp
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "beanmachine/minibmg/dedup2.h"
+#include <map>
+#include <memory>
+#include <stdexcept>
+#include <unordered_map>
+#include "beanmachine/minibmg/node2.h"
+#include "beanmachine/minibmg/topological.h"
+
+namespace {
+
+using namespace beanmachine::minibmg;
+
+class DedupVisitor : public Node2Visitor {
+ public:
+  Node2p original;
+  const Node2Node2ValueMap& map;
+  DedupVisitor(Node2p original, const Node2Node2ValueMap& map)
+      : original{original}, map{map} {}
+  Node2p result;
+  void visit(const ScalarConstantNode2*) override {
+    result = original;
+  }
+  void visit(const ScalarVariableNode2*) override {
+    result = original;
+  }
+  void visit(const ScalarSampleNode2* node) override {
+    const DistributionNode2p dist = map.at(node->distribution);
+    if (dist == node->distribution) {
+      result = original;
+    } else {
+      result = std::make_shared<ScalarSampleNode2>(dist);
+    }
+  }
+  void visit(const ScalarAddNode2* node) override {
+    const ScalarNode2p left = map.at(node->left);
+    const ScalarNode2p right = map.at(node->right);
+    if (left == node->left && right == node->right) {
+      result = original;
+    } else {
+      result = std::make_shared<ScalarAddNode2>(left, right);
+    }
+  }
+  void visit(const ScalarSubtractNode2* node) override {
+    const ScalarNode2p left = map.at(node->left);
+    const ScalarNode2p right = map.at(node->right);
+    if (left == node->left && right == node->right) {
+      result = original;
+    } else {
+      result = std::make_shared<ScalarSubtractNode2>(left, right);
+    }
+  }
+  void visit(const ScalarNegateNode2* node) override {
+    const ScalarNode2p x = map.at(node->x);
+    if (x == node->x) {
+      result = original;
+    } else {
+      result = std::make_shared<ScalarNegateNode2>(x);
+    }
+  }
+  void visit(const ScalarMultiplyNode2* node) override {
+    const ScalarNode2p left = map.at(node->left);
+    const ScalarNode2p right = map.at(node->right);
+    if (left == node->left && right == node->right) {
+      result = original;
+    } else {
+      result = std::make_shared<ScalarMultiplyNode2>(left, right);
+    }
+  }
+  void visit(const ScalarDivideNode2* node) override {
+    const ScalarNode2p left = map.at(node->left);
+    const ScalarNode2p right = map.at(node->right);
+    if (left == node->left && right == node->right) {
+      result = original;
+    } else {
+      result = std::make_shared<ScalarDivideNode2>(left, right);
+    }
+  }
+  void visit(const ScalarPowNode2* node) override {
+    const ScalarNode2p left = map.at(node->left);
+    const ScalarNode2p right = map.at(node->right);
+    if (left == node->left && right == node->right) {
+      result = original;
+    } else {
+      result = std::make_shared<ScalarPowNode2>(left, right);
+    }
+  }
+  void visit(const ScalarExpNode2* node) override {
+    const ScalarNode2p x = map.at(node->x);
+    if (x == node->x) {
+      result = original;
+    } else {
+      result = std::make_shared<ScalarExpNode2>(x);
+    }
+  }
+  void visit(const ScalarLogNode2* node) override {
+    const ScalarNode2p x = map.at(node->x);
+    if (x == node->x) {
+      result = original;
+    } else {
+      result = std::make_shared<ScalarLogNode2>(x);
+    }
+  }
+  void visit(const ScalarAtanNode2* node) override {
+    const ScalarNode2p x = map.at(node->x);
+    if (x == node->x) {
+      result = original;
+    } else {
+      result = std::make_shared<ScalarAtanNode2>(x);
+    }
+  }
+  void visit(const ScalarLgammaNode2* node) override {
+    const ScalarNode2p x = map.at(node->x);
+    if (x == node->x) {
+      result = original;
+    } else {
+      result = std::make_shared<ScalarLgammaNode2>(x);
+    }
+  }
+  void visit(const ScalarPolygammaNode2* node) override {
+    const ScalarNode2p n = map.at(node->n);
+    const ScalarNode2p x = map.at(node->x);
+    if (n == node->n && x == node->x) {
+      result = original;
+    } else {
+      result = std::make_shared<ScalarPolygammaNode2>(n, x);
+    }
+  }
+  void visit(const ScalarIfEqualNode2* node) override {
+    const ScalarNode2p a = map.at(node->a);
+    const ScalarNode2p b = map.at(node->b);
+    const ScalarNode2p c = map.at(node->c);
+    const ScalarNode2p d = map.at(node->d);
+    if (a == node->a && b == node->b && c == node->c && d == node->d) {
+      result = original;
+    } else {
+      result = std::make_shared<ScalarIfEqualNode2>(a, b, c, d);
+    }
+  }
+  void visit(const ScalarIfLessNode2* node) override {
+    const ScalarNode2p a = map.at(node->a);
+    const ScalarNode2p b = map.at(node->b);
+    const ScalarNode2p c = map.at(node->c);
+    const ScalarNode2p d = map.at(node->d);
+    if (a == node->a && b == node->b && c == node->c && d == node->d) {
+      result = original;
+    } else {
+      result = std::make_shared<ScalarIfLessNode2>(a, b, c, d);
+    }
+  }
+  void visit(const DistributionNormalNode2* node) override {
+    const ScalarNode2p mean = map.at(node->mean);
+    const ScalarNode2p stddev = map.at(node->stddev);
+    if (mean == node->mean && stddev == node->stddev) {
+      result = original;
+    } else {
+      result = std::make_shared<DistributionNormalNode2>(mean, stddev);
+    }
+  }
+  void visit(const DistributionHalfNormalNode2* node) override {
+    const ScalarNode2p stddev = map.at(node->stddev);
+    if (stddev == node->stddev) {
+      result = original;
+    } else {
+      result = std::make_shared<DistributionHalfNormalNode2>(stddev);
+    }
+  }
+  void visit(const DistributionBetaNode2* node) override {
+    const ScalarNode2p a = map.at(node->a);
+    const ScalarNode2p b = map.at(node->b);
+    if (a == node->a && b == node->b) {
+      result = original;
+    } else {
+      result = std::make_shared<DistributionBetaNode2>(a, b);
+    }
+  }
+  void visit(const DistributionBernoulliNode2* node) override {
+    const ScalarNode2p prob = map.at(node->prob);
+    if (prob == node->prob) {
+      result = original;
+    } else {
+      result = std::make_shared<DistributionBernoulliNode2>(prob);
+    }
+  }
+};
+
+// Rewrite a single node by replacing all of its inputs with their deduplicated
+// counterpart.
+Node2p rewrite(Node2p node, const Node2Node2ValueMap& map) {
+  DedupVisitor v{node, map};
+  node->accept(v);
+  return v.result;
+}
+
+} // namespace
+
+namespace beanmachine::minibmg {
+
+// Take a set of root nodes as input, and return a map of deduplicated nodes,
+// which maps from a node in the transitive closure of the input to a
+// corresponding node in the transitive closure of the deduplicated graph.
+std::unordered_map<Node2p, Node2p> dedup_map(std::vector<Node2p> roots) {
+  // a value-based, map, which treats semantically identical nodes as the same.
+  Node2Node2ValueMap map;
+
+  // We also build a map that uses object (pointer) identity to find elements,
+  // so that operations in clients are not using recursive equality operations.
+  std::unordered_map<Node2p, Node2p> identity_map;
+
+  std::vector<Node2p> sorted;
+  if (!topological_sort<Node2p>(
+          {roots.begin(), roots.end()}, in_nodes, sorted)) {
+    throw std::invalid_argument("graph has a cycle");
+  }
+  std::reverse(sorted.begin(), sorted.end());
+  for (auto& node : sorted) {
+    if (map.contains(node)) {
+      auto mapping = map.at(node);
+      map.add(node, mapping);
+      identity_map.insert({node, mapping});
+      continue;
+    }
+    auto rewritten = rewrite(node, map);
+    map.add(node, rewritten);
+    identity_map.insert({node, rewritten});
+  }
+
+  return identity_map;
+}
+
+} // namespace beanmachine::minibmg

--- a/minibmg/dedup2.h
+++ b/minibmg/dedup2.h
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <list>
+#include <memory>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+#include "beanmachine/minibmg/ad/real.h"
+#include "beanmachine/minibmg/node2.h"
+
+namespace beanmachine::minibmg {
+
+// Take a set of root nodes as input, and return a map of deduplicated nodes,
+// which maps from a node in the transitive closure of the roots to a
+// corresponding node in the transitive closure of the deduplicated graph.
+// This is used in the implementation of dedup(), but might occasionally be
+// useful in this form.
+std::unordered_map<Node2p, Node2p> dedup_map(std::vector<Node2p> roots);
+
+// In order to deduplicate data in a given data structure, the programmer must
+// specialize this template class to locate the roots contained in
+// that data structure, and to write a replacement for data structure in which
+// nodes have been deduplicated.  We provide a number of specializations for
+// data structures likely to be needed.
+template <class T>
+class DedupHelper2 {
+ public:
+  DedupHelper2() = delete;
+  // locate all of the roots.
+  std::vector<Node2p> find_roots(const T&) const;
+  // rewrite the T, given a mapping from each node to its replacement.
+  T rewrite(const T&, const std::unordered_map<Node2p, Node2p>&) const;
+};
+
+// Rewrite a data structure by deduplicating its nodes.  The programmer must
+// either provide an implementation of DedupHelper2<T> or specialize it.
+template <class T>
+T dedup2(const T& data, const DedupHelper2<T>& helper = DedupHelper2<T>{}) {
+  auto roots = helper.find_roots(data);
+  auto map = dedup_map(roots);
+  return helper.rewrite(data, map);
+}
+
+// A single node can be deduplicated
+template <>
+class DedupHelper2<Node2p> {
+ public:
+  std::vector<Node2p> find_roots(const Node2p& n) const {
+    return {n};
+  }
+  Node2p rewrite(
+      const Node2p& node,
+      const std::unordered_map<Node2p, Node2p>& map) const {
+    auto f = map.find(node);
+    return f == map.end() ? node : f->second;
+  }
+};
+
+// A vector can be deduplicated.
+template <class T>
+class DedupHelper2<std::vector<T>> {
+  DedupHelper2<T> t_helper{};
+
+ public:
+  std::vector<Node2p> find_roots(const std::vector<T>& roots) const {
+    std::vector<Node2p> result;
+    for (const auto& root : roots) {
+      auto more_roots = t_helper.find_roots(root);
+      result.push_back(more_roots.begin(), more_roots.end());
+    }
+    return result;
+  }
+  std::vector<T> rewrite(
+      const std::vector<T>& roots,
+      const std::unordered_map<Node2p, Node2p>& map) const {
+    std::vector<T> result;
+    for (const auto& root : roots) {
+      result.push_back(t_helper.rewrite(root, map));
+    }
+    return result;
+  }
+};
+
+// A list can be deduplicated
+template <class T>
+class DedupHelper2<std::list<T>> {
+  DedupHelper2<T> t_helper{};
+
+ public:
+  std::vector<Node2p> find_roots(const std::list<T>& roots) const {
+    std::vector<Node2p> result;
+    for (const auto& root : roots) {
+      auto more_roots = t_helper.find_roots(root);
+      result.push_back(more_roots.begin(), more_roots.end());
+    }
+    return result;
+  }
+  std::list<T> rewrite(
+      const std::list<T>& roots,
+      const std::unordered_map<Node2p, Node2p>& map) const {
+    std::list<T> result;
+    for (const auto& root : roots) {
+      result.push_back(t_helper.rewrite(root, map));
+    }
+    return result;
+  }
+};
+
+// A pair can be deduplicated
+template <class T, class U>
+class DedupHelper2<std::pair<T, U>> {
+  DedupHelper2<T> t_helper{};
+  DedupHelper2<U> u_helper{};
+
+ public:
+  std::vector<Node2p> find_roots(const std::pair<T, U>& root) const {
+    std::vector<Node2p> result = t_helper(root.first);
+    for (auto& r : u_helper.find_roots(root.second)) {
+      result.push_back(r);
+    }
+    return result;
+  }
+  std::pair<T, U> rewrite(
+      const std::pair<T, U>& root,
+      const std::unordered_map<Node2p, Node2p>& map) const {
+    return {
+        t_helper.rewrite(root.first, map), u_helper.rewrite(root.second, map)};
+  }
+};
+
+// A double can be deduplicated (no action)
+template <>
+class DedupHelper2<double> {
+ public:
+  std::vector<Node2p> find_roots(const double&) const {
+    return {};
+  }
+  double rewrite(const double& root, std::unordered_map<Node2p, Node2p>) const {
+    return root;
+  }
+};
+
+// A Real (wrapper around a double) can be deduplicated (no action)
+template <>
+class DedupHelper2<Real> {
+ public:
+  std::vector<Node2p> find_roots(const Real&) const {
+    return {};
+  }
+  // rewrite the T, given a mapping from each node to its replacement.
+  Real rewrite(const Real& t, const std::unordered_map<Node2p, Node2p>&) const {
+    return t;
+  }
+};
+
+} // namespace beanmachine::minibmg

--- a/minibmg/fluid_factory.cpp
+++ b/minibmg/fluid_factory.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "beanmachine/minibmg/fluid_factory.h"
+#include <memory>
+#include <stdexcept>
+#include "beanmachine/minibmg/distribution/normal.h"
+
+namespace beanmachine::minibmg {
+
+FluidDistribution::FluidDistribution(DistributionNode2p node) : node{node} {}
+
+const FluidDistribution half_normal(Value2 stddev) {
+  DistributionNode2p node =
+      std::make_shared<const DistributionHalfNormalNode2>(stddev.node);
+  return node;
+}
+
+const FluidDistribution normal(Value2 mean, Value2 stddev) {
+  DistributionNode2p node =
+      std::make_shared<const DistributionNormalNode2>(mean.node, stddev.node);
+  return node;
+}
+
+const FluidDistribution beta(Value2 a, Value2 b) {
+  DistributionNode2p node =
+      std::make_shared<const DistributionBetaNode2>(a.node, b.node);
+  return node;
+}
+
+const FluidDistribution bernoulli(Value2 p) {
+  DistributionNode2p node =
+      std::make_shared<const DistributionBernoulliNode2>(p.node);
+  return node;
+}
+
+Value2 sample(const FluidDistribution& d, std::string rvid) {
+  ScalarNode2p node = std::make_shared<const ScalarSampleNode2>(d.node, rvid);
+  return node;
+}
+
+void Graph2::FluidFactory::observe(const Value2& sample, double value) {
+  auto node = sample.node;
+  if (!dynamic_cast<const ScalarSampleNode2*>(node.get())) {
+    throw std::invalid_argument("can only observe a sample");
+  }
+  for (const auto& n : observations) {
+    if (n.first == node) {
+      throw std::invalid_argument("sample already observed");
+    }
+  }
+  observations.push_back({node, value});
+}
+
+unsigned Graph2::FluidFactory::query(const Value2& value) {
+  auto result = queries.size();
+  queries.push_back(value.node);
+  return result;
+}
+
+Graph2 Graph2::FluidFactory::build() {
+  return Graph2::create(queries, observations);
+}
+
+} // namespace beanmachine::minibmg

--- a/minibmg/fluid_factory.h
+++ b/minibmg/fluid_factory.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "beanmachine/minibmg/ad/traced2.h"
+#include "beanmachine/minibmg/graph2.h"
+#include "beanmachine/minibmg/node2.h"
+
+namespace beanmachine::minibmg {
+
+// For values
+using Value2 = Traced2;
+
+// For distributions
+class FluidDistribution {
+ public:
+  DistributionNode2p node;
+  /* implicit */ FluidDistribution(DistributionNode2p node);
+};
+
+const FluidDistribution half_normal(Value2 stddev);
+const FluidDistribution normal(Value2 mean, Value2 stddev);
+const FluidDistribution beta(Value2 a, Value2 b);
+const FluidDistribution bernoulli(Value2 p);
+
+Value2 sample(const FluidDistribution& d, std::string rvid = make_fresh_rvid());
+
+class Graph2::FluidFactory {
+ public:
+  void observe(const Traced2& sample, double value);
+  unsigned query(const Traced2& value);
+  Graph2 build();
+
+ private:
+  std::vector<Node2p> queries;
+  std::list<std::pair<Node2p, double>> observations;
+};
+
+} // namespace beanmachine::minibmg

--- a/minibmg/graph.cpp
+++ b/minibmg/graph.cpp
@@ -245,6 +245,8 @@ folly::dynamic graph_to_json(const Graph& g) {
   return result;
 }
 
+JsonError::JsonError(const std::string& message) : message(message) {}
+
 Graph json_to_graph(folly::dynamic d) {
   // Nodes are identified by a "sequence" number appearing in json.
   // They are arbitrary numbers.  The only requirement is that they

--- a/minibmg/graph.cpp
+++ b/minibmg/graph.cpp
@@ -245,10 +245,7 @@ folly::dynamic graph_to_json(const Graph& g) {
   return result;
 }
 
-JsonError::JsonError(const std::string& message) : message(message) {}
-
 Graph json_to_graph(folly::dynamic d) {
-  Graph::Factory gf;
   // Nodes are identified by a "sequence" number appearing in json.
   // They are arbitrary numbers.  The only requirement is that they
   // are distinct.  They are used to identify nodes in the json.

--- a/minibmg/graph2.cpp
+++ b/minibmg/graph2.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "beanmachine/minibmg/graph2.h"
+#include <list>
+#include <stdexcept>
+#include <vector>
+#include "beanmachine/minibmg/dedup2.h"
+#include "beanmachine/minibmg/topological.h"
+
+namespace {
+
+using namespace beanmachine::minibmg;
+
+const std::vector<Node2p> roots(
+    const std::vector<Node2p>& queries,
+    const std::list<std::pair<Node2p, double>>& observations) {
+  std::list<Node2p> roots;
+  for (auto& n : queries) {
+    roots.push_back(n);
+  }
+  for (auto& p : observations) {
+    if (typeid(p.first.get()) != typeid(ScalarSampleNode2*)) {
+      throw std::invalid_argument(fmt::format("can only observe a sample"));
+    }
+    roots.push_front(p.first);
+  }
+  std::vector<Node2p> all_nodes;
+  if (!topological_sort<Node2p>(roots, &in_nodes, all_nodes)) {
+    throw std::invalid_argument("graph has a cycle");
+  }
+  std::reverse(all_nodes.begin(), all_nodes.end());
+  return all_nodes;
+}
+
+struct QueriesAndObservations {
+  std::vector<Node2p> queries;
+  std::list<std::pair<Node2p, double>> observations;
+  ~QueriesAndObservations() {}
+};
+
+} // namespace
+
+namespace beanmachine::minibmg {
+
+template <>
+class DedupHelper2<QueriesAndObservations> {
+ public:
+  std::vector<Node2p> find_roots(const QueriesAndObservations& qo) const {
+    std::vector<Node2p> roots;
+    for (auto& q : qo.observations) {
+      roots.push_back(q.first);
+    }
+    for (auto& n : qo.queries) {
+      roots.push_back(n);
+    }
+    return roots;
+  }
+  QueriesAndObservations rewrite(
+      const QueriesAndObservations& qo,
+      const std::unordered_map<Node2p, Node2p>& map) const {
+    DedupHelper2<std::vector<Node2p>> h1{};
+    DedupHelper2<std::list<std::pair<Node2p, double>>> h2{};
+    return QueriesAndObservations{
+        h1.rewrite(qo.queries, map), h2.rewrite(qo.observations, map)};
+  }
+};
+
+using dynamic = folly::dynamic;
+
+Graph2 Graph2::create(
+    const std::vector<Node2p>& queries,
+    const std::list<std::pair<Node2p, double>>& observations) {
+  for (auto& p : observations) {
+    if (typeid(p.first.get()) != typeid(ScalarSampleNode2*)) {
+      throw std::invalid_argument(fmt::format("can only observe a sample"));
+    }
+  }
+
+  auto qo0 = QueriesAndObservations{queries, observations};
+  auto qo1 = dedup2(qo0);
+
+  std::vector<Node2p> all_nodes = roots(qo1.queries, qo1.observations);
+  return Graph2{all_nodes, qo1.queries, qo1.observations};
+}
+
+Graph2::~Graph2() {}
+
+Graph2::Graph2(
+    const std::vector<Node2p>& nodes,
+    const std::vector<Node2p>& queries,
+    const std::list<std::pair<Node2p, double>>& observations)
+    : nodes{nodes}, queries{queries}, observations{observations} {}
+
+} // namespace beanmachine::minibmg

--- a/minibmg/graph2.cpp
+++ b/minibmg/graph2.cpp
@@ -7,6 +7,7 @@
 
 #include "beanmachine/minibmg/graph2.h"
 #include <list>
+#include <memory>
 #include <stdexcept>
 #include <vector>
 #include "beanmachine/minibmg/dedup2.h"
@@ -24,7 +25,7 @@ const std::vector<Node2p> roots(
     roots.push_back(n);
   }
   for (auto& p : observations) {
-    if (typeid(p.first.get()) != typeid(ScalarSampleNode2*)) {
+    if (!std::dynamic_pointer_cast<const ScalarSampleNode2>(p.first)) {
       throw std::invalid_argument(fmt::format("can only observe a sample"));
     }
     roots.push_front(p.first);
@@ -76,7 +77,7 @@ Graph2 Graph2::create(
     const std::vector<Node2p>& queries,
     const std::list<std::pair<Node2p, double>>& observations) {
   for (auto& p : observations) {
-    if (typeid(p.first.get()) != typeid(ScalarSampleNode2*)) {
+    if (!std::dynamic_pointer_cast<const ScalarSampleNode2>(p.first)) {
       throw std::invalid_argument(fmt::format("can only observe a sample"));
     }
   }

--- a/minibmg/graph2.h
+++ b/minibmg/graph2.h
@@ -69,9 +69,9 @@ class Graph2 : public Container {
 };
 
 // Exception to throw when json_to_graph fails.
-class JsonError : public std::exception {
+class JsonError2 : public std::exception {
  public:
-  explicit JsonError(const std::string& message);
+  explicit JsonError2(const std::string& message);
   const std::string message;
 };
 

--- a/minibmg/graph2.h
+++ b/minibmg/graph2.h
@@ -75,7 +75,7 @@ class JsonError2 : public std::exception {
   const std::string message;
 };
 
-folly::dynamic graph_to_json2(const Graph2& g);
-Graph2 json2_to_graph(folly::dynamic d); // throw (JsonError)
+folly::dynamic graph_to_json(const Graph2& g);
+Graph2 json_to_graph2(folly::dynamic d); // throw (JsonError)
 
 } // namespace beanmachine::minibmg

--- a/minibmg/graph2.h
+++ b/minibmg/graph2.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/json.h>
+#include <list>
+#include "beanmachine/minibmg/graph_properties/container.h"
+#include "beanmachine/minibmg/node2.h"
+
+namespace beanmachine::minibmg {
+
+class Graph2 : public Container {
+ public:
+  // produces a graph by computing the transitive closure of the input queries
+  // and observations and topologically sorting the set of nodes so reached.
+  // valudates that the list of nodes so reached forms a valid graph, and
+  // returns that graph.  Throws an exception if the nodes do not form a valid
+  // graph.
+  static Graph2 create(
+      const std::vector<Node2p>& queries,
+      const std::list<std::pair<Node2p, double>>& observations);
+  ~Graph2();
+
+  // Implement the iterator pattern so clients can iterate over the nodes.
+  inline auto begin() const {
+    return nodes.begin();
+  }
+  inline auto end() const {
+    return nodes.end();
+  }
+  inline Node2p operator[](int index) const {
+    return nodes[index];
+  }
+  inline int size() const {
+    return nodes.size();
+  }
+
+  // All of the nodes, in a topologically sorted order such that a node can only
+  // be used as an input in subsequent (and not previous) nodes.
+  const std::vector<Node2p> nodes;
+
+  // Queries of the model.  These are nodes whose values are sampled by
+  // inference.
+  const std::vector<Node2p> queries;
+
+  // Observations of the model.  These are SAMPLE nodes in the model whose
+  // values are known.
+  const std::list<std::pair<Node2p, double>> observations;
+
+ private:
+  // A private constructor that forms a graph without validation.
+  // Used internally.  All exposed graphs should be validated.
+  Graph2(
+      const std::vector<Node2p>& nodes,
+      const std::vector<Node2p>& queries,
+      const std::list<std::pair<Node2p, double>>& observations);
+
+ public:
+  // A factory for making graphs, like the bmg API used by Beanstalk
+  class Factory;
+
+  // A more natural factory for making graphs, using operator overloading.
+  class FluidFactory;
+};
+
+// Exception to throw when json_to_graph fails.
+class JsonError : public std::exception {
+ public:
+  explicit JsonError(const std::string& message);
+  const std::string message;
+};
+
+folly::dynamic graph_to_json2(const Graph2& g);
+Graph2 json2_to_graph(folly::dynamic d); // throw (JsonError)
+
+} // namespace beanmachine::minibmg

--- a/minibmg/graph2_factory.cpp
+++ b/minibmg/graph2_factory.cpp
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "beanmachine/minibmg/graph2_factory.h"
+#include <memory>
+#include <stdexcept>
+#include "beanmachine/minibmg/node2.h"
+
+namespace beanmachine::minibmg {
+
+Node2Identifier::Node2Identifier(unsigned long value) : value{value} {}
+
+unsigned long Node2Identifier::_value() const {
+  return value;
+}
+
+ScalarNode2Identifier::ScalarNode2Identifier(unsigned long value)
+    : Node2Identifier{value} {}
+
+ScalarSampleNode2Identifier::ScalarSampleNode2Identifier(unsigned long value)
+    : ScalarNode2Identifier{value} {}
+
+DistributionNode2Identifier::DistributionNode2Identifier(unsigned long value)
+    : Node2Identifier{value} {}
+
+ScalarNode2Id Graph2::Factory::constant(double value) {
+  ScalarNode2p result = std::make_shared<ScalarConstantNode2>(value);
+  return add_node(result);
+}
+ScalarNode2Id Graph2::Factory::variable(
+    const std::string& name,
+    const unsigned identifier) {
+  ScalarNode2p result = std::make_shared<ScalarVariableNode2>(name, identifier);
+  return add_node(result);
+}
+ScalarSampleNode2Id Graph2::Factory::sample(
+    DistributionNode2Id distribution,
+    const std::string& rvid) {
+  auto result = std::make_shared<ScalarSampleNode2>(map[distribution], rvid);
+  return add_node(result);
+}
+ScalarNode2Id Graph2::Factory::add(ScalarNode2Id left, ScalarNode2Id right) {
+  ScalarNode2p result = std::make_shared<ScalarAddNode2>(map[left], map[right]);
+  return add_node(result);
+}
+ScalarNode2Id Graph2::Factory::subtract(
+    ScalarNode2Id left,
+    ScalarNode2Id right) {
+  ScalarNode2p result =
+      std::make_shared<ScalarSubtractNode2>(map[left], map[right]);
+  return add_node(result);
+}
+ScalarNode2Id Graph2::Factory::negate(ScalarNode2Id x) {
+  ScalarNode2p result = std::make_shared<ScalarNegateNode2>(map[x]);
+  return add_node(result);
+}
+ScalarNode2Id Graph2::Factory::multiply(
+    ScalarNode2Id left,
+    ScalarNode2Id right) {
+  ScalarNode2p result =
+      std::make_shared<ScalarMultiplyNode2>(map[left], map[right]);
+  return add_node(result);
+}
+ScalarNode2Id Graph2::Factory::divide(ScalarNode2Id left, ScalarNode2Id right) {
+  ScalarNode2p result =
+      std::make_shared<ScalarDivideNode2>(map[left], map[right]);
+  return add_node(result);
+}
+ScalarNode2Id Graph2::Factory::pow(ScalarNode2Id left, ScalarNode2Id right) {
+  ScalarNode2p result = std::make_shared<ScalarPowNode2>(map[left], map[right]);
+  return add_node(result);
+}
+ScalarNode2Id Graph2::Factory::exp(ScalarNode2Id x) {
+  ScalarNode2p result = std::make_shared<ScalarExpNode2>(map[x]);
+  return add_node(result);
+}
+ScalarNode2Id Graph2::Factory::log(ScalarNode2Id x) {
+  ScalarNode2p result = std::make_shared<ScalarLogNode2>(map[x]);
+  return add_node(result);
+}
+ScalarNode2Id Graph2::Factory::atan(ScalarNode2Id x) {
+  ScalarNode2p result = std::make_shared<ScalarAtanNode2>(map[x]);
+  return add_node(result);
+}
+ScalarNode2Id Graph2::Factory::lgamma(ScalarNode2Id x) {
+  ScalarNode2p result = std::make_shared<ScalarLgammaNode2>(map[x]);
+  return add_node(result);
+}
+ScalarNode2Id Graph2::Factory::polygamma(int n, ScalarNode2Id x) {
+  ScalarNode2p k = std::make_shared<ScalarConstantNode2>(n);
+  ScalarNode2p result = std::make_shared<ScalarPolygammaNode2>(k, map[x]);
+  return add_node(result);
+}
+ScalarNode2Id Graph2::Factory::if_equal(
+    ScalarNode2Id a,
+    ScalarNode2Id b,
+    ScalarNode2Id c,
+    ScalarNode2Id d) {
+  ScalarNode2p result =
+      std::make_shared<ScalarIfEqualNode2>(map[a], map[b], map[c], map[d]);
+  return add_node(result);
+}
+ScalarNode2Id Graph2::Factory::if_less(
+    ScalarNode2Id a,
+    ScalarNode2Id b,
+    ScalarNode2Id c,
+    ScalarNode2Id d) {
+  ScalarNode2p result =
+      std::make_shared<ScalarIfLessNode2>(map[a], map[b], map[c], map[d]);
+  return add_node(result);
+}
+DistributionNode2Id Graph2::Factory::normal(
+    ScalarNode2Id mean,
+    ScalarNode2Id stddev) {
+  DistributionNode2p result =
+      std::make_shared<DistributionNormalNode2>(map[mean], map[stddev]);
+  return add_node(result);
+}
+DistributionNode2Id Graph2::Factory::half_normal(ScalarNode2Id stddev) {
+  DistributionNode2p result =
+      std::make_shared<DistributionHalfNormalNode2>(map[stddev]);
+  return add_node(result);
+}
+DistributionNode2Id Graph2::Factory::beta(ScalarNode2Id a, ScalarNode2Id b) {
+  DistributionNode2p result =
+      std::make_shared<DistributionBetaNode2>(map[a], map[b]);
+  return add_node(result);
+}
+DistributionNode2Id Graph2::Factory::bernoulli(ScalarNode2Id prob) {
+  DistributionNode2p result =
+      std::make_shared<DistributionBernoulliNode2>(map[prob]);
+  return add_node(result);
+}
+
+void Graph2::Factory::observe(ScalarNode2Id sample, double value) {
+  observations.push_back({map[sample], value});
+}
+
+ScalarNode2Id Graph2::Factory::add_node(ScalarNode2p node) {
+  auto id = std::make_shared<ScalarNode2Identifier>(next_identifier++);
+  identifer_to_node[id] = node;
+  node_to_identifier[node] = id;
+  return id;
+}
+DistributionNode2Id Graph2::Factory::add_node(DistributionNode2p node) {
+  auto id = std::make_shared<DistributionNode2Identifier>(next_identifier++);
+  identifer_to_node[id] = node;
+  node_to_identifier[node] = id;
+  return id;
+}
+ScalarSampleNode2Id Graph2::Factory::add_node(
+    std::shared_ptr<ScalarSampleNode2> node) {
+  auto id = std::make_shared<ScalarSampleNode2Identifier>(next_identifier++);
+  identifer_to_node[id] = node;
+  node_to_identifier[node] = id;
+  return id;
+}
+
+unsigned Graph2::Factory::query(ScalarNode2Id value) {
+  unsigned result = queries.size();
+  queries.push_back(map[value]);
+  return result;
+}
+
+Node2p Graph2::Factory::operator[](const Node2Id& node_id) const {
+  return identifer_to_node.at(node_id);
+}
+ScalarNode2p Graph2::Factory::operator[](const ScalarNode2Id& node_id) const {
+  return std::dynamic_pointer_cast<const ScalarNode2>(
+      identifer_to_node.at(node_id));
+}
+DistributionNode2p Graph2::Factory::operator[](
+    const DistributionNode2Id& node_id) const {
+  return std::dynamic_pointer_cast<const DistributionNode2>(
+      identifer_to_node.at(node_id));
+}
+
+Graph2 Graph2::Factory::build() {
+  if (built) {
+    throw std::invalid_argument("Graph has already been built");
+  }
+  built = true;
+  auto result = Graph2::create(queries, observations);
+
+  // TODO: Update the identifier_to_node map to reflect the set of dedulplicated
+  // nodes in the graph.  This permits the caller to continue using this
+  // factory to map node identifiers to nodes in the now deduplicated graph.
+  identifer_to_node.clear();
+  node_to_identifier.clear();
+
+  return result;
+}
+
+} // namespace beanmachine::minibmg

--- a/minibmg/graph2_factory.h
+++ b/minibmg/graph2_factory.h
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <list>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+#include "beanmachine/minibmg/graph2.h"
+
+namespace beanmachine::minibmg {
+
+class Node2;
+
+// An opaque identifier for a node.
+class Node2Identifier {
+ public:
+  Node2Identifier() = delete;
+  explicit Node2Identifier(unsigned long value);
+  unsigned long _value() const;
+
+ private:
+  unsigned long value;
+};
+using Node2Id = std::shared_ptr<Node2Identifier>;
+
+class ScalarNode2Identifier : public Node2Identifier {
+ public:
+  explicit ScalarNode2Identifier(unsigned long value);
+};
+using ScalarNode2Id = std::shared_ptr<ScalarNode2Identifier>;
+
+class ScalarSampleNode2Identifier : public ScalarNode2Identifier {
+ public:
+  explicit ScalarSampleNode2Identifier(unsigned long value);
+};
+using ScalarSampleNode2Id = std::shared_ptr<ScalarSampleNode2Identifier>;
+
+class DistributionNode2Identifier : public Node2Identifier {
+ public:
+  explicit DistributionNode2Identifier(unsigned long value);
+};
+using DistributionNode2Id = std::shared_ptr<DistributionNode2Identifier>;
+
+} // namespace beanmachine::minibmg
+
+// Make Node2Id values usable as a key in a hash table.
+template <>
+struct std::hash<beanmachine::minibmg::Node2Id> {
+  std::size_t operator()(
+      const beanmachine::minibmg::Node2Id& n) const noexcept {
+    return (std::size_t)n->_value();
+  }
+};
+
+// Make Node2Id values printable using format.
+template <>
+struct fmt::formatter<beanmachine::minibmg::Node2Id>
+    : fmt::formatter<std::string> {
+  auto format(const beanmachine::minibmg::Node2Id& n, format_context& ctx) {
+    return formatter<std::string>::format(fmt::format("{}", n->_value()), ctx);
+  }
+};
+
+namespace beanmachine::minibmg {
+
+class Graph2::Factory {
+ public:
+  ScalarNode2Id constant(double value);
+  ScalarNode2Id variable(const std::string& name, const unsigned identifier);
+  ScalarSampleNode2Id sample(
+      DistributionNode2Id distribution,
+      const std::string& rvid = make_fresh_rvid());
+  ScalarNode2Id add(ScalarNode2Id left, ScalarNode2Id right);
+  ScalarNode2Id subtract(ScalarNode2Id left, ScalarNode2Id right);
+  ScalarNode2Id negate(ScalarNode2Id x);
+  ScalarNode2Id multiply(ScalarNode2Id left, ScalarNode2Id right);
+  ScalarNode2Id divide(ScalarNode2Id left, ScalarNode2Id right);
+  ScalarNode2Id pow(ScalarNode2Id left, ScalarNode2Id right);
+  ScalarNode2Id exp(ScalarNode2Id x);
+  ScalarNode2Id log(ScalarNode2Id x);
+  ScalarNode2Id atan(ScalarNode2Id x);
+  ScalarNode2Id lgamma(ScalarNode2Id x);
+  ScalarNode2Id polygamma(int n, ScalarNode2Id x);
+  ScalarNode2Id
+  if_equal(ScalarNode2Id a, ScalarNode2Id b, ScalarNode2Id c, ScalarNode2Id d);
+  ScalarNode2Id
+  if_less(ScalarNode2Id a, ScalarNode2Id b, ScalarNode2Id c, ScalarNode2Id d);
+  DistributionNode2Id normal(ScalarNode2Id mean, ScalarNode2Id stddev);
+  DistributionNode2Id half_normal(ScalarNode2Id stddev);
+  DistributionNode2Id beta(ScalarNode2Id a, ScalarNode2Id b);
+  DistributionNode2Id bernoulli(ScalarNode2Id prob);
+
+  void observe(ScalarNode2Id sample, double value);
+  unsigned query(ScalarNode2Id value);
+
+  Node2p operator[](const Node2Id& node_id) const;
+  ScalarNode2p operator[](const ScalarNode2Id& node_id) const;
+  DistributionNode2p operator[](const DistributionNode2Id& node_id) const;
+
+  Graph2 build();
+  ~Factory();
+
+ private:
+  Graph2::Factory& map = *this;
+  bool built = false;
+  std::unordered_map<Node2Id, Node2p> identifer_to_node;
+  std::unordered_map<Node2p, Node2Id> node_to_identifier;
+  std::vector<Node2p> queries;
+  std::list<std::pair<Node2p, double>> observations;
+  unsigned long next_identifier = 0;
+
+  ScalarNode2Id add_node(ScalarNode2p node);
+  DistributionNode2Id add_node(DistributionNode2p node);
+  ScalarSampleNode2Id add_node(std::shared_ptr<ScalarSampleNode2> node);
+};
+
+} // namespace beanmachine::minibmg

--- a/minibmg/json2.cpp
+++ b/minibmg/json2.cpp
@@ -1,0 +1,428 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <folly/json.h>
+#include <memory>
+#include <string>
+#include <string_view>
+#include "beanmachine/minibmg/graph2.h"
+
+namespace {
+
+using namespace beanmachine::minibmg;
+using dynamic = folly::dynamic;
+
+inline constexpr auto hash_djb2a(const std::string_view sv) {
+  unsigned long hash{5381};
+  for (unsigned char c : sv) {
+    hash = ((hash << 5) + hash) ^ c;
+  }
+  return hash;
+}
+
+inline constexpr auto operator"" _sh(const char* str, size_t len) {
+  return hash_djb2a(std::string_view{str, len});
+}
+
+class JsonNodeWriterVisitor : public Node2Visitor {
+ public:
+  explicit JsonNodeWriterVisitor(dynamic& dyn_node) : dyn_node{dyn_node} {}
+  dynamic& dyn_node;
+  void visit(const ScalarConstantNode2* node) override {
+    dyn_node["operator"] = "CONSTANT";
+    dyn_node["value"] = node->constant_value;
+  }
+  void visit(const ScalarVariableNode2* node) override {
+    dyn_node["operator"] = "VARIABLE";
+    dyn_node["name"] = node->name;
+    dyn_node["identifier"] = node->identifier;
+  }
+  void visit(const ScalarSampleNode2*) override {
+    dyn_node["operator"] = "SAMPLE";
+  }
+  void visit(const ScalarAddNode2*) override {
+    dyn_node["operator"] = "ADD";
+  }
+  void visit(const ScalarSubtractNode2*) override {
+    dyn_node["operator"] = "SUBTRACT";
+  }
+  void visit(const ScalarNegateNode2*) override {
+    dyn_node["operator"] = "NEGATE";
+  }
+  void visit(const ScalarMultiplyNode2*) override {
+    dyn_node["operator"] = "MULTIPLY";
+  }
+  void visit(const ScalarDivideNode2*) override {
+    dyn_node["operator"] = "DIVIDE";
+  }
+  void visit(const ScalarPowNode2*) override {
+    dyn_node["operator"] = "POW";
+  }
+  void visit(const ScalarExpNode2*) override {
+    dyn_node["operator"] = "EXP";
+  }
+  void visit(const ScalarLogNode2*) override {
+    dyn_node["operator"] = "LOG";
+  }
+  void visit(const ScalarAtanNode2*) override {
+    dyn_node["operator"] = "ATAN";
+  }
+  void visit(const ScalarLgammaNode2*) override {
+    dyn_node["operator"] = "LGAMMA";
+  }
+  void visit(const ScalarPolygammaNode2*) override {
+    dyn_node["operator"] = "POLYGAMMA";
+  }
+  void visit(const ScalarIfEqualNode2*) override {
+    dyn_node["operator"] = "IF_EQUAL";
+  }
+  void visit(const ScalarIfLessNode2*) override {
+    dyn_node["operator"] = "IF_LESS";
+  }
+  void visit(const DistributionNormalNode2*) override {
+    dyn_node["operator"] = "DISTRIBUTION_NORMAL";
+  }
+  void visit(const DistributionHalfNormalNode2*) override {
+    dyn_node["operator"] = "DISTRIBUTION_HALF_NORMAL";
+  }
+  void visit(const DistributionBetaNode2*) override {
+    dyn_node["operator"] = "DISTRIBUTION_BETA";
+  }
+  void visit(const DistributionBernoulliNode2*) override {
+    dyn_node["operator"] = "DISTRIBUTION_BERNOULLI";
+  }
+};
+
+} // namespace
+
+namespace beanmachine::minibmg {
+
+JsonError::JsonError(const std::string& message) : message(message) {}
+
+folly::dynamic graph2_to_json(const Graph2& g) {
+  std::unordered_map<Node2p, unsigned long> node_to_identifier;
+  dynamic result = dynamic::object;
+  result["comment"] = "created by graph_to_json";
+  dynamic a = dynamic::array;
+
+  unsigned long next_identifier = 0;
+  for (auto& node : g) {
+    // assign node identifiers sequentially.  They are called "sequence" in the
+    // generated json.
+    auto identifier = next_identifier++;
+    node_to_identifier[node] = identifier;
+    dynamic dyn_node = dynamic::object;
+    dyn_node["sequence"] = identifier;
+    JsonNodeWriterVisitor v{dyn_node};
+    node->accept(v);
+    auto in = in_nodes(node);
+    if (in.size() > 0) {
+      dynamic in_nodes = dynamic::array;
+      for (auto& n : in) {
+        in_nodes.push_back(node_to_identifier[n]);
+      }
+      dyn_node["in_nodes"] = in_nodes;
+    }
+
+    a.push_back(dyn_node);
+  }
+  result["nodes"] = a;
+
+  dynamic observations = dynamic::array;
+  for (auto& q : g.observations) {
+    dynamic d = dynamic::object;
+    auto id = node_to_identifier[q.first];
+    d["node"] = id;
+    d["value"] = q.second;
+    observations.push_back(d);
+  }
+  result["observations"] = observations;
+
+  dynamic queries = dynamic::array;
+  for (auto& q : g.queries) {
+    queries.push_back(node_to_identifier[q]);
+  }
+  result["queries"] = queries;
+
+  return result;
+}
+
+Graph2 json_to_graph2(folly::dynamic d) {
+  // Nodes are identified by a "sequence" number appearing in json.
+  // They are arbitrary numbers.  The only requirement is that they
+  // are distinct.  They are used to identify nodes in the json.
+  // This map is used to identify the specific node when it is
+  // referenced in the json.
+  std::unordered_map<int, Node2p> identifier_to_node;
+
+  auto json_nodes = d["nodes"];
+  if (!json_nodes.isArray()) {
+    throw JsonError("missing \"nodes\" property");
+  }
+  for (auto json_node : json_nodes) {
+    auto identifierv = json_node["sequence"];
+    if (!identifierv.isInt()) {
+      throw JsonError("missing sequence number.");
+    }
+    auto identifier = identifierv.asInt();
+
+    auto opv = json_node["operator"];
+    if (!opv.isString()) {
+      throw JsonError("missing operator.");
+    }
+
+    std::vector<Node2p> in_nodes{};
+    switch (hash_djb2a(opv.asString())) {
+      case "CONSTANT"_sh:
+      case "VARIABLE"_sh:
+        // in_nodes ignored
+        break;
+      default:
+        auto in_nodesv = json_node["in_nodes"];
+        if (!in_nodesv.isArray()) {
+          throw JsonError("missing in_nodes.");
+        }
+        for (auto& in_nodev : in_nodesv) {
+          if (!in_nodev.isInt()) {
+            throw JsonError("missing in_node for operator.");
+          }
+          auto in_node_i = in_nodev.asInt();
+          if (!identifier_to_node.contains(in_node_i)) {
+            throw JsonError("bad in_node for operator.");
+          }
+          auto in_node = identifier_to_node[in_node_i];
+          in_nodes.push_back(in_node);
+        }
+        break;
+    }
+
+    Node2p node;
+    switch (hash_djb2a(opv.asString())) {
+      case "CONSTANT"_sh: {
+        auto valuev = json_node["value"];
+        double value;
+        if (valuev.isInt()) {
+          value = valuev.asInt();
+        } else if (valuev.isDouble()) {
+          value = valuev.asDouble();
+        } else {
+          throw JsonError("bad value for constant.");
+        }
+        node = std::make_shared<const ScalarConstantNode2>(value);
+      } break;
+      case "VARIABLE"_sh: {
+        auto namev = json_node["name"];
+        std::string name = "";
+        if (namev.isString()) {
+          name = namev.asString();
+        } else {
+          throw JsonError("bad name for variable.");
+        }
+        auto variable_indexv = json_node["variable_index"];
+        if (!variable_indexv.isInt()) {
+          throw JsonError("bad variable_index for variable.");
+        }
+        auto variable_index = (unsigned)variable_indexv.asInt();
+        node =
+            std::make_shared<const ScalarVariableNode2>(name, variable_index);
+      } break;
+      case "ADD"_sh: {
+        if (in_nodes.size() != 2) {
+          throw JsonError("bad in_node for operator.");
+        }
+        node = std::make_shared<ScalarAddNode2>(
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[1]));
+      } break;
+      case "SUBTRACT"_sh: {
+        if (in_nodes.size() != 2) {
+          throw JsonError("bad in_node for operator.");
+        }
+        node = std::make_shared<ScalarSubtractNode2>(
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[1]));
+      } break;
+      case "NEGATE"_sh: {
+        if (in_nodes.size() != 1) {
+          throw JsonError("bad in_node for operator.");
+        }
+        node = std::make_shared<ScalarNegateNode2>(
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]));
+      } break;
+      case "MULTIPLY"_sh: {
+        if (in_nodes.size() != 2) {
+          throw JsonError("bad in_node for operator.");
+        }
+        node = std::make_shared<ScalarMultiplyNode2>(
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[1]));
+      } break;
+      case "DIVIDE"_sh: {
+        if (in_nodes.size() != 2) {
+          throw JsonError("bad in_node for operator.");
+        }
+        node = std::make_shared<ScalarDivideNode2>(
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[1]));
+      } break;
+      case "POW"_sh: {
+        if (in_nodes.size() != 2) {
+          throw JsonError("bad in_node for operator.");
+        }
+        node = std::make_shared<ScalarPowNode2>(
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[1]));
+      } break;
+      case "EXP"_sh: {
+        if (in_nodes.size() != 1) {
+          throw JsonError("bad in_node for operator.");
+        }
+        node = std::make_shared<ScalarExpNode2>(
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]));
+      } break;
+      case "LOG"_sh: {
+        if (in_nodes.size() != 1) {
+          throw JsonError("bad in_node for operator.");
+        }
+        node = std::make_shared<ScalarLogNode2>(
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]));
+      } break;
+      case "ATAN"_sh: {
+        if (in_nodes.size() != 1) {
+          throw JsonError("bad in_node for operator.");
+        }
+        node = std::make_shared<ScalarAtanNode2>(
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]));
+      } break;
+      case "LGAMMA"_sh: {
+        if (in_nodes.size() != 1) {
+          throw JsonError("bad in_node for operator.");
+        }
+        node = std::make_shared<ScalarLgammaNode2>(
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]));
+      } break;
+      case "POLYGAMMA"_sh: {
+        if (in_nodes.size() != 2) {
+          throw JsonError("bad in_node for operator.");
+        }
+        node = std::make_shared<ScalarPolygammaNode2>(
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[1]));
+      } break;
+      case "IF_EQUAL"_sh: {
+        if (in_nodes.size() != 4) {
+          throw JsonError("bad in_node for operator.");
+        }
+        node = std::make_shared<ScalarIfEqualNode2>(
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[1]),
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[2]),
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[3]));
+      } break;
+      case "IF_LESS"_sh: {
+        if (in_nodes.size() != 4) {
+          throw JsonError("bad in_node for operator.");
+        }
+        node = std::make_shared<ScalarIfLessNode2>(
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[1]),
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[2]),
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[3]));
+      } break;
+      case "DISTRIBUTION_NORMAL"_sh: {
+        if (in_nodes.size() != 2) {
+          throw JsonError("bad in_node for operator.");
+        }
+        node = std::make_shared<DistributionNormalNode2>(
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[1]));
+      } break;
+      case "DISTRIBUTION_HALF_NORMAL"_sh: {
+        if (in_nodes.size() != 1) {
+          throw JsonError("bad in_node for operator.");
+        }
+        node = std::make_shared<DistributionHalfNormalNode2>(
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]));
+        break;
+
+      } break;
+      case "DISTRIBUTION_BETA"_sh: {
+        if (in_nodes.size() != 2) {
+          throw JsonError("bad in_node for operator.");
+        }
+        node = std::make_shared<DistributionBetaNode2>(
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[1]));
+      } break;
+      case "DISTRIBUTION_BERNOULLI"_sh: {
+        if (in_nodes.size() != 1) {
+          throw JsonError("bad in_node for operator.");
+        }
+        node = std::make_shared<DistributionBernoulliNode2>(
+            std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]));
+      } break;
+      case "SAMPLE"_sh: {
+        if (in_nodes.size() != 1) {
+          throw JsonError("bad in_node for operator.");
+        }
+        node = std::make_shared<ScalarSampleNode2>(
+            std::dynamic_pointer_cast<const DistributionNode2>(in_nodes[0]));
+      } break;
+      default:
+        throw JsonError("operator unknown: " + opv.asString());
+        break;
+    }
+
+    if (identifier_to_node.contains(identifier)) {
+      throw JsonError(fmt::format("duplicate node ID {}.", identifier));
+    }
+
+    identifier_to_node[identifier] = node;
+  }
+
+  std::vector<Node2p> queries;
+  auto query_nodes = d["queries"];
+  if (query_nodes.isArray()) {
+    for (auto& query : query_nodes) {
+      if (!query.isInt()) {
+        throw JsonError("bad query value.");
+      }
+      auto query_i = query.asInt();
+      if (!identifier_to_node.contains(query_i)) {
+        throw JsonError(fmt::format("bad in_node {} for query.", query_i));
+      }
+      auto query_node = identifier_to_node[query_i];
+      queries.push_back(query_node);
+    }
+  }
+
+  std::list<std::pair<Node2p, double>> observations;
+  auto observation_nodes = d["observations"];
+  if (observation_nodes.isArray()) {
+    for (auto& obs : observation_nodes) {
+      auto node = obs["node"];
+      if (!node.isInt()) {
+        throw JsonError("bad observation node.");
+      }
+      auto node_i = node.asInt();
+      if (!identifier_to_node.contains(node_i)) {
+        throw JsonError(fmt::format("bad in_node {} for observation.", node_i));
+      }
+      auto& obs_node = identifier_to_node[node_i];
+      auto& value = obs["value"];
+      if (!node.isDouble() && !node.isInt()) {
+        throw JsonError("bad value for observation.");
+      }
+      auto value_d = value.asDouble();
+      observations.push_back(std::pair{obs_node, value_d});
+    }
+  }
+
+  return Graph2::create(queries, observations);
+}
+
+} // namespace beanmachine::minibmg

--- a/minibmg/json2.cpp
+++ b/minibmg/json2.cpp
@@ -103,7 +103,7 @@ namespace beanmachine::minibmg {
 
 JsonError2::JsonError2(const std::string& message) : message(message) {}
 
-folly::dynamic graph2_to_json(const Graph2& g) {
+folly::dynamic graph_to_json(const Graph2& g) {
   std::unordered_map<Node2p, unsigned long> node_to_identifier;
   dynamic result = dynamic::object;
   result["comment"] = "created by graph_to_json";

--- a/minibmg/json2.cpp
+++ b/minibmg/json2.cpp
@@ -101,7 +101,7 @@ class JsonNodeWriterVisitor : public Node2Visitor {
 
 namespace beanmachine::minibmg {
 
-JsonError::JsonError(const std::string& message) : message(message) {}
+JsonError2::JsonError2(const std::string& message) : message(message) {}
 
 folly::dynamic graph2_to_json(const Graph2& g) {
   std::unordered_map<Node2p, unsigned long> node_to_identifier;
@@ -161,18 +161,18 @@ Graph2 json_to_graph2(folly::dynamic d) {
 
   auto json_nodes = d["nodes"];
   if (!json_nodes.isArray()) {
-    throw JsonError("missing \"nodes\" property");
+    throw JsonError2("missing \"nodes\" property");
   }
   for (auto json_node : json_nodes) {
     auto identifierv = json_node["sequence"];
     if (!identifierv.isInt()) {
-      throw JsonError("missing sequence number.");
+      throw JsonError2("missing sequence number.");
     }
     auto identifier = identifierv.asInt();
 
     auto opv = json_node["operator"];
     if (!opv.isString()) {
-      throw JsonError("missing operator.");
+      throw JsonError2("missing operator.");
     }
 
     std::vector<Node2p> in_nodes{};
@@ -184,15 +184,15 @@ Graph2 json_to_graph2(folly::dynamic d) {
       default:
         auto in_nodesv = json_node["in_nodes"];
         if (!in_nodesv.isArray()) {
-          throw JsonError("missing in_nodes.");
+          throw JsonError2("missing in_nodes.");
         }
         for (auto& in_nodev : in_nodesv) {
           if (!in_nodev.isInt()) {
-            throw JsonError("missing in_node for operator.");
+            throw JsonError2("missing in_node for operator.");
           }
           auto in_node_i = in_nodev.asInt();
           if (!identifier_to_node.contains(in_node_i)) {
-            throw JsonError("bad in_node for operator.");
+            throw JsonError2("bad in_node for operator.");
           }
           auto in_node = identifier_to_node[in_node_i];
           in_nodes.push_back(in_node);
@@ -210,7 +210,7 @@ Graph2 json_to_graph2(folly::dynamic d) {
         } else if (valuev.isDouble()) {
           value = valuev.asDouble();
         } else {
-          throw JsonError("bad value for constant.");
+          throw JsonError2("bad value for constant.");
         }
         node = std::make_shared<const ScalarConstantNode2>(value);
       } break;
@@ -220,11 +220,11 @@ Graph2 json_to_graph2(folly::dynamic d) {
         if (namev.isString()) {
           name = namev.asString();
         } else {
-          throw JsonError("bad name for variable.");
+          throw JsonError2("bad name for variable.");
         }
         auto variable_indexv = json_node["variable_index"];
         if (!variable_indexv.isInt()) {
-          throw JsonError("bad variable_index for variable.");
+          throw JsonError2("bad variable_index for variable.");
         }
         auto variable_index = (unsigned)variable_indexv.asInt();
         node =
@@ -232,7 +232,7 @@ Graph2 json_to_graph2(folly::dynamic d) {
       } break;
       case "ADD"_sh: {
         if (in_nodes.size() != 2) {
-          throw JsonError("bad in_node for operator.");
+          throw JsonError2("bad in_node for operator.");
         }
         node = std::make_shared<ScalarAddNode2>(
             std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
@@ -240,7 +240,7 @@ Graph2 json_to_graph2(folly::dynamic d) {
       } break;
       case "SUBTRACT"_sh: {
         if (in_nodes.size() != 2) {
-          throw JsonError("bad in_node for operator.");
+          throw JsonError2("bad in_node for operator.");
         }
         node = std::make_shared<ScalarSubtractNode2>(
             std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
@@ -248,14 +248,14 @@ Graph2 json_to_graph2(folly::dynamic d) {
       } break;
       case "NEGATE"_sh: {
         if (in_nodes.size() != 1) {
-          throw JsonError("bad in_node for operator.");
+          throw JsonError2("bad in_node for operator.");
         }
         node = std::make_shared<ScalarNegateNode2>(
             std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]));
       } break;
       case "MULTIPLY"_sh: {
         if (in_nodes.size() != 2) {
-          throw JsonError("bad in_node for operator.");
+          throw JsonError2("bad in_node for operator.");
         }
         node = std::make_shared<ScalarMultiplyNode2>(
             std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
@@ -263,7 +263,7 @@ Graph2 json_to_graph2(folly::dynamic d) {
       } break;
       case "DIVIDE"_sh: {
         if (in_nodes.size() != 2) {
-          throw JsonError("bad in_node for operator.");
+          throw JsonError2("bad in_node for operator.");
         }
         node = std::make_shared<ScalarDivideNode2>(
             std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
@@ -271,7 +271,7 @@ Graph2 json_to_graph2(folly::dynamic d) {
       } break;
       case "POW"_sh: {
         if (in_nodes.size() != 2) {
-          throw JsonError("bad in_node for operator.");
+          throw JsonError2("bad in_node for operator.");
         }
         node = std::make_shared<ScalarPowNode2>(
             std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
@@ -279,35 +279,35 @@ Graph2 json_to_graph2(folly::dynamic d) {
       } break;
       case "EXP"_sh: {
         if (in_nodes.size() != 1) {
-          throw JsonError("bad in_node for operator.");
+          throw JsonError2("bad in_node for operator.");
         }
         node = std::make_shared<ScalarExpNode2>(
             std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]));
       } break;
       case "LOG"_sh: {
         if (in_nodes.size() != 1) {
-          throw JsonError("bad in_node for operator.");
+          throw JsonError2("bad in_node for operator.");
         }
         node = std::make_shared<ScalarLogNode2>(
             std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]));
       } break;
       case "ATAN"_sh: {
         if (in_nodes.size() != 1) {
-          throw JsonError("bad in_node for operator.");
+          throw JsonError2("bad in_node for operator.");
         }
         node = std::make_shared<ScalarAtanNode2>(
             std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]));
       } break;
       case "LGAMMA"_sh: {
         if (in_nodes.size() != 1) {
-          throw JsonError("bad in_node for operator.");
+          throw JsonError2("bad in_node for operator.");
         }
         node = std::make_shared<ScalarLgammaNode2>(
             std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]));
       } break;
       case "POLYGAMMA"_sh: {
         if (in_nodes.size() != 2) {
-          throw JsonError("bad in_node for operator.");
+          throw JsonError2("bad in_node for operator.");
         }
         node = std::make_shared<ScalarPolygammaNode2>(
             std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
@@ -315,7 +315,7 @@ Graph2 json_to_graph2(folly::dynamic d) {
       } break;
       case "IF_EQUAL"_sh: {
         if (in_nodes.size() != 4) {
-          throw JsonError("bad in_node for operator.");
+          throw JsonError2("bad in_node for operator.");
         }
         node = std::make_shared<ScalarIfEqualNode2>(
             std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
@@ -325,7 +325,7 @@ Graph2 json_to_graph2(folly::dynamic d) {
       } break;
       case "IF_LESS"_sh: {
         if (in_nodes.size() != 4) {
-          throw JsonError("bad in_node for operator.");
+          throw JsonError2("bad in_node for operator.");
         }
         node = std::make_shared<ScalarIfLessNode2>(
             std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
@@ -335,7 +335,7 @@ Graph2 json_to_graph2(folly::dynamic d) {
       } break;
       case "DISTRIBUTION_NORMAL"_sh: {
         if (in_nodes.size() != 2) {
-          throw JsonError("bad in_node for operator.");
+          throw JsonError2("bad in_node for operator.");
         }
         node = std::make_shared<DistributionNormalNode2>(
             std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
@@ -343,7 +343,7 @@ Graph2 json_to_graph2(folly::dynamic d) {
       } break;
       case "DISTRIBUTION_HALF_NORMAL"_sh: {
         if (in_nodes.size() != 1) {
-          throw JsonError("bad in_node for operator.");
+          throw JsonError2("bad in_node for operator.");
         }
         node = std::make_shared<DistributionHalfNormalNode2>(
             std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]));
@@ -352,7 +352,7 @@ Graph2 json_to_graph2(folly::dynamic d) {
       } break;
       case "DISTRIBUTION_BETA"_sh: {
         if (in_nodes.size() != 2) {
-          throw JsonError("bad in_node for operator.");
+          throw JsonError2("bad in_node for operator.");
         }
         node = std::make_shared<DistributionBetaNode2>(
             std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
@@ -360,25 +360,25 @@ Graph2 json_to_graph2(folly::dynamic d) {
       } break;
       case "DISTRIBUTION_BERNOULLI"_sh: {
         if (in_nodes.size() != 1) {
-          throw JsonError("bad in_node for operator.");
+          throw JsonError2("bad in_node for operator.");
         }
         node = std::make_shared<DistributionBernoulliNode2>(
             std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]));
       } break;
       case "SAMPLE"_sh: {
         if (in_nodes.size() != 1) {
-          throw JsonError("bad in_node for operator.");
+          throw JsonError2("bad in_node for operator.");
         }
         node = std::make_shared<ScalarSampleNode2>(
             std::dynamic_pointer_cast<const DistributionNode2>(in_nodes[0]));
       } break;
       default:
-        throw JsonError("operator unknown: " + opv.asString());
+        throw JsonError2("operator unknown: " + opv.asString());
         break;
     }
 
     if (identifier_to_node.contains(identifier)) {
-      throw JsonError(fmt::format("duplicate node ID {}.", identifier));
+      throw JsonError2(fmt::format("duplicate node ID {}.", identifier));
     }
 
     identifier_to_node[identifier] = node;
@@ -389,11 +389,11 @@ Graph2 json_to_graph2(folly::dynamic d) {
   if (query_nodes.isArray()) {
     for (auto& query : query_nodes) {
       if (!query.isInt()) {
-        throw JsonError("bad query value.");
+        throw JsonError2("bad query value.");
       }
       auto query_i = query.asInt();
       if (!identifier_to_node.contains(query_i)) {
-        throw JsonError(fmt::format("bad in_node {} for query.", query_i));
+        throw JsonError2(fmt::format("bad in_node {} for query.", query_i));
       }
       auto query_node = identifier_to_node[query_i];
       queries.push_back(query_node);
@@ -406,16 +406,17 @@ Graph2 json_to_graph2(folly::dynamic d) {
     for (auto& obs : observation_nodes) {
       auto node = obs["node"];
       if (!node.isInt()) {
-        throw JsonError("bad observation node.");
+        throw JsonError2("bad observation node.");
       }
       auto node_i = node.asInt();
       if (!identifier_to_node.contains(node_i)) {
-        throw JsonError(fmt::format("bad in_node {} for observation.", node_i));
+        throw JsonError2(
+            fmt::format("bad in_node {} for observation.", node_i));
       }
       auto& obs_node = identifier_to_node[node_i];
       auto& value = obs["value"];
       if (!node.isDouble() && !node.isInt()) {
-        throw JsonError("bad value for observation.");
+        throw JsonError2("bad value for observation.");
       }
       auto value_d = value.asDouble();
       observations.push_back(std::pair{obs_node, value_d});

--- a/minibmg/node2.cpp
+++ b/minibmg/node2.cpp
@@ -10,6 +10,7 @@
 #include <fmt/format.h>
 #include <atomic>
 #include <typeinfo>
+#include "beanmachine/minibmg/pretty2.h"
 
 namespace {
 
@@ -46,6 +47,16 @@ Node2::Node2(std::size_t cached_hash_value)
     : cached_hash_value{cached_hash_value} {}
 
 Node2::~Node2() {}
+
+std::string to_string(const Node2p& node) {
+  auto pretty_result = pretty_print({node});
+  std::stringstream code;
+  for (auto p : pretty_result.prelude) {
+    code << p << std::endl;
+  }
+  code << pretty_result.code[node];
+  return code.str();
+}
 
 ScalarNode2::ScalarNode2(std::size_t cached_hash_value)
     : Node2{cached_hash_value} {}

--- a/minibmg/node2.h
+++ b/minibmg/node2.h
@@ -226,13 +226,37 @@ struct Node2pIdentityEquals {
 
 // A value-based map from Node2s to T.  Used for deduplicating and
 // optimizing a graph.
-template <class T>
-using Node2ValueMap =
-    std::unordered_map<Node2p, T, Node2pIdentityHash, Node2pIdentityEquals>;
+class Node2Node2ValueMap {
+ public:
+  ~Node2Node2ValueMap() {}
+  ScalarNode2p at(const ScalarNode2p& p) const {
+    return std::dynamic_pointer_cast<const ScalarNode2>(map.at(p));
+  }
+  DistributionNode2p at(const DistributionNode2p& p) const {
+    return std::dynamic_pointer_cast<const DistributionNode2>(map.at(p));
+  }
+  Node2p at(const Node2p& p) const {
+    return map.at(p);
+  }
+  bool contains(const Node2p& p) const {
+    return map.contains(p);
+  }
+  void add(const Node2p& key, const Node2p& value) {
+    map.insert({key, value});
+  }
 
-// A value-based set of Node2s.
-using Node2ValueSet =
-    std::unordered_set<Node2p, Node2pIdentityHash, Node2pIdentityEquals>;
+ private:
+  std::unordered_map<Node2p, Node2p, Node2pIdentityHash, Node2pIdentityEquals>
+      map;
+};
+
+// template <class T>
+// using Node2ValueMap =
+//     std::unordered_map<Node2p, T, Node2pIdentityHash, Node2pIdentityEquals>;
+
+// // A value-based set of Node2s.
+// using Node2ValueSet =
+//     std::unordered_set<Node2p, Node2pIdentityHash, Node2pIdentityEquals>;
 
 // A visitor for nodes
 class Node2Visitor {

--- a/minibmg/node2.h
+++ b/minibmg/node2.h
@@ -65,7 +65,7 @@ class ScalarSampleNode2 : public ScalarNode2 {
   explicit ScalarSampleNode2(
       const DistributionNode2p& distribution,
       const std::string& rvid = make_fresh_rvid());
-  const DistributionNode2p& distribution;
+  const DistributionNode2p distribution;
   std::string rvid;
   void accept(Node2Visitor& visitor) const override;
 };

--- a/minibmg/pretty2.cpp
+++ b/minibmg/pretty2.cpp
@@ -89,25 +89,25 @@ class PrintedFormVisitor : public Node2Visitor {
   }
   void visit(const ScalarMultiplyNode2* node) override {
     auto left = cache[node->left];
-    auto ls = (left.precedence > Precedence::Term)
+    auto ls = (left.precedence > Precedence::Product)
         ? fmt::format("({})", left.string)
         : left.string;
     auto right = cache[node->right];
-    const auto& rs = (right.precedence >= Precedence::Term)
+    const auto& rs = (right.precedence >= Precedence::Product)
         ? fmt::format("({})", right.string)
         : right.string;
-    result = {fmt::format("{} * {}", ls, rs), Precedence::Term};
+    result = {fmt::format("{} * {}", ls, rs), Precedence::Product};
   }
   void visit(const ScalarDivideNode2* node) override {
     auto left = cache[node->left];
-    auto ls = (left.precedence > Precedence::Term)
+    auto ls = (left.precedence > Precedence::Product)
         ? fmt::format("({})", left.string)
         : left.string;
     auto right = cache[node->right];
-    const auto& rs = (right.precedence >= Precedence::Term)
+    const auto& rs = (right.precedence >= Precedence::Product)
         ? fmt::format("({})", right.string)
         : right.string;
-    result = {fmt::format("{} / {}", ls, rs), Precedence::Term};
+    result = {fmt::format("{} / {}", ls, rs), Precedence::Product};
   }
   void visit(const ScalarPowNode2* node) override {
     result = {
@@ -248,7 +248,7 @@ std::string pretty_print(const Graph2& graph) {
   for (auto p : pretty_result.prelude) {
     code << p << std::endl;
   }
-  code << "Graph::FluentFactory fac;" << std::endl;
+  code << "Graph::FluidFactory fac;" << std::endl;
   for (auto q : graph.queries) {
     code << fmt::format("fac.query({});", pretty_result.code[q]) << std::endl;
   }

--- a/minibmg/pretty2.cpp
+++ b/minibmg/pretty2.cpp
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "beanmachine/minibmg/pretty2.h"
+#include <map>
+#include <sstream>
+#include <stdexcept>
+#include <unordered_map>
+#include "beanmachine/minibmg/node2.h"
+#include "beanmachine/minibmg/topological.h"
+
+// Private helper data structures and functions used in producing a string form
+// for a Traced.
+namespace {
+
+using namespace beanmachine::minibmg;
+
+enum class Precedence {
+  Term,
+  Product,
+  Sum,
+};
+
+struct PrintedForm {
+  std::string string;
+  Precedence precedence;
+
+  PrintedForm() : string{""}, precedence{Precedence::Term} {}
+  PrintedForm(std::string string, Precedence precedence)
+      : string{string}, precedence{precedence} {}
+  PrintedForm(const PrintedForm& other)
+      : string{other.string}, precedence{other.precedence} {}
+  PrintedForm& operator=(const PrintedForm& other) = default;
+  ~PrintedForm() {}
+};
+
+class PrintedFormVisitor : public Node2Visitor {
+ public:
+  std::map<Node2p, PrintedForm>& cache;
+  explicit PrintedFormVisitor(std::map<Node2p, PrintedForm>& cache)
+      : cache{cache} {}
+  PrintedForm result;
+  void visit(const ScalarConstantNode2* node) override {
+    result = {fmt::format("{}", node->constant_value), Precedence::Term};
+  }
+  void visit(const ScalarVariableNode2* node) override {
+    const auto& name = (node->name.length() == 0)
+        ? fmt::format("__{}", node->identifier)
+        : node->name;
+    result = {name, Precedence::Term};
+  }
+  void visit(const ScalarSampleNode2* node) override {
+    auto name = fmt::format(
+        "sample({}, \"{}\")", cache[node->distribution].string, node->rvid);
+    result = {name, Precedence::Term};
+  }
+  void visit(const ScalarAddNode2* node) override {
+    auto left = cache[node->left];
+    auto ls = (left.precedence > Precedence::Sum)
+        ? fmt::format("({})", left.string)
+        : left.string;
+    auto right = cache[node->right];
+    const auto& rs = (right.precedence >= Precedence::Sum)
+        ? fmt::format("({})", right.string)
+        : right.string;
+    result = {fmt::format("{} + {}", ls, rs), Precedence::Sum};
+  }
+  void visit(const ScalarSubtractNode2* node) override {
+    auto left = cache[node->left];
+    auto ls = (left.precedence > Precedence::Sum)
+        ? fmt::format("({})", left.string)
+        : left.string;
+    auto right = cache[node->right];
+    const auto& rs = (right.precedence >= Precedence::Sum)
+        ? fmt::format("({})", right.string)
+        : right.string;
+    result = {fmt::format("{} - {}", ls, rs), Precedence::Sum};
+  }
+  void visit(const ScalarNegateNode2* node) override {
+    auto right = cache[node->x];
+    auto rs = (right.precedence > Precedence::Term)
+        ? fmt::format("({})", right.string)
+        : right.string;
+    result = {fmt::format("-{}", rs), Precedence::Term};
+  }
+  void visit(const ScalarMultiplyNode2* node) override {
+    auto left = cache[node->left];
+    auto ls = (left.precedence > Precedence::Term)
+        ? fmt::format("({})", left.string)
+        : left.string;
+    auto right = cache[node->right];
+    const auto& rs = (right.precedence >= Precedence::Term)
+        ? fmt::format("({})", right.string)
+        : right.string;
+    result = {fmt::format("{} * {}", ls, rs), Precedence::Term};
+  }
+  void visit(const ScalarDivideNode2* node) override {
+    auto left = cache[node->left];
+    auto ls = (left.precedence > Precedence::Term)
+        ? fmt::format("({})", left.string)
+        : left.string;
+    auto right = cache[node->right];
+    const auto& rs = (right.precedence >= Precedence::Term)
+        ? fmt::format("({})", right.string)
+        : right.string;
+    result = {fmt::format("{} / {}", ls, rs), Precedence::Term};
+  }
+  void visit(const ScalarPowNode2* node) override {
+    result = {
+        fmt::format(
+            "pow({}, {})", cache[node->left].string, cache[node->right].string),
+        Precedence::Term};
+  }
+  void visit(const ScalarExpNode2* node) override {
+    result = {fmt::format("exp({})", cache[node->x].string), Precedence::Term};
+  }
+  void visit(const ScalarLogNode2* node) override {
+    result = {fmt::format("log({})", cache[node->x].string), Precedence::Term};
+  }
+  void visit(const ScalarAtanNode2* node) override {
+    result = {fmt::format("atan({})", cache[node->x].string), Precedence::Term};
+  }
+  void visit(const ScalarLgammaNode2* node) override {
+    result = {
+        fmt::format("lgamma({})", cache[node->x].string), Precedence::Term};
+  }
+  void visit(const ScalarPolygammaNode2* node) override {
+    result = {
+        fmt::format(
+            "polygamma({}, {})", cache[node->n].string, cache[node->x].string),
+        Precedence::Term};
+  }
+  void visit(const ScalarIfEqualNode2* node) override {
+    result = {
+        fmt::format(
+            "if_equal({}, {}, {}, {})",
+            cache[node->a].string,
+            cache[node->b].string,
+            cache[node->c].string,
+            cache[node->d].string),
+        Precedence::Term};
+  }
+  void visit(const ScalarIfLessNode2* node) override {
+    result = {
+        fmt::format(
+            "if_less({}, {}, {}, {})",
+            cache[node->a].string,
+            cache[node->b].string,
+            cache[node->c].string,
+            cache[node->d].string),
+        Precedence::Term};
+  }
+  void visit(const DistributionNormalNode2* node) override {
+    result = {
+        fmt::format(
+            "normal({}, {})",
+            cache[node->mean].string,
+            cache[node->stddev].string),
+        Precedence::Term};
+  }
+  void visit(const DistributionHalfNormalNode2* node) override {
+    result = {
+        fmt::format("half_normal({})", cache[node->stddev].string),
+        Precedence::Term};
+  }
+  void visit(const DistributionBetaNode2* node) override {
+    result = {
+        fmt::format(
+            "beta({}, {})", cache[node->a].string, cache[node->b].string),
+        Precedence::Term};
+  }
+  void visit(const DistributionBernoulliNode2* node) override {
+    result = {
+        fmt::format("bernoulli({})", cache[node->prob].string),
+        Precedence::Term};
+  }
+};
+
+PrintedForm print(Node2p node, PrintedFormVisitor& pfv) {
+  node.get()->accept(pfv);
+  return pfv.result;
+}
+
+} // namespace
+
+namespace beanmachine::minibmg {
+
+// Pretty-print a set of Nodes.  Returns a PrettyResult.
+const Pretty2Result pretty_print(std::vector<Node2p> roots) {
+  std::map<Node2p, unsigned> counts =
+      count_predecessors<Node2p>({roots.begin(), roots.end()}, in_nodes);
+  // count the roots as uses too, so that they get put into a variable if
+  // also used elsewhere.
+  for (auto n : roots) {
+    counts[n]++;
+  }
+
+  std::vector<Node2p> sorted;
+  if (!topological_sort<Node2p>(
+          {roots.begin(), roots.end()}, in_nodes, sorted)) {
+    throw std::logic_error("nodes have a cycle");
+  }
+  reverse(sorted.begin(), sorted.end());
+
+  std::map<Node2p, PrintedForm> cache;
+  PrintedFormVisitor pfv{cache};
+  std::vector<std::string> prelude;
+  unsigned next_temp = 1;
+  for (auto n : sorted) {
+    PrintedForm p = print(n, pfv);
+    // We do not dedup constants and variables in the printed form, as the
+    // printed form is simpler without doing do.
+    if (counts[n] > 1 && !dynamic_cast<const ScalarConstantNode2*>(n.get()) &&
+        !dynamic_cast<const ScalarVariableNode2*>(n.get())) {
+      std::string temp = fmt::format("temp_{}", next_temp++);
+      std::string assignment = fmt::format("auto {} = {};", temp, p.string);
+      prelude.push_back(assignment);
+      p = {temp, Precedence::Term};
+    }
+    cache[n] = p;
+  }
+
+  std::unordered_map<Node2p, std::string> code;
+  for (auto p : cache) {
+    code[p.first] = p.second.string;
+  }
+
+  return Pretty2Result{prelude, code};
+}
+
+// Pretty-print a graph into the code that would need to be written using the
+// fluid factory to reproduce it.  Assumes the graph has already been
+// deduplicated.
+std::string pretty_print(const Graph2& graph) {
+  std::vector<Node2p> roots;
+  for (auto p : graph.observations) {
+    roots.push_back(p.first);
+  }
+  for (auto n : graph.queries) {
+    roots.push_back(n);
+  }
+  auto pretty_result = pretty_print(roots);
+  std::stringstream code;
+  for (auto p : pretty_result.prelude) {
+    code << p << std::endl;
+  }
+  code << "Graph::FluentFactory fac;" << std::endl;
+  for (auto q : graph.queries) {
+    code << fmt::format("fac.query({});", pretty_result.code[q]) << std::endl;
+  }
+  for (auto o : graph.observations) {
+    code << fmt::format(
+                "fac.observe({}, {});", pretty_result.code[o.first], o.second)
+         << std::endl;
+  }
+
+  return code.str();
+}
+
+} // namespace beanmachine::minibmg

--- a/minibmg/pretty2.h
+++ b/minibmg/pretty2.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include "beanmachine/minibmg/graph2.h"
+#include "beanmachine/minibmg/node2.h"
+
+namespace beanmachine::minibmg {
+
+struct Pretty2Result {
+  // a set of variable assignments that are prelude to the expressions for the
+  // nodes.  These assignments are for shared intermediate results.
+  std::vector<std::string> prelude;
+
+  // For each remaining root, the expression for computing it, with identifiers
+  // referring to variables declared in the prelude for shared values.
+  std::unordered_map<Node2p, std::string> code;
+};
+
+// Pretty-print a set of Nodes.  Returns a PrettyResult.
+const Pretty2Result pretty_print(std::vector<Node2p> roots);
+
+// Pretty-print a graph into the code that would need to be written using the
+// fluid factory to reproduce it.
+std::string pretty_print(const Graph2& graph);
+
+} // namespace beanmachine::minibmg

--- a/minibmg/tests/json_test.cpp
+++ b/minibmg/tests/json_test.cpp
@@ -7,7 +7,7 @@
 
 #include <gtest/gtest.h>
 
-#include "beanmachine/minibmg/minibmg.h"
+#include "beanmachine/minibmg/graph2.h"
 
 using namespace ::testing;
 using namespace ::beanmachine::minibmg;
@@ -104,14 +104,6 @@ std::string raw_json = R"({
   ]
 })";
 
-TEST(json_test, test_from_string) {
-  folly::dynamic parsed = folly::parseJson(raw_json);
-  auto graph = beanmachine::minibmg::json_to_graph(parsed);
-  std::string s =
-      folly::toPrettyJson(beanmachine::minibmg::graph_to_json(graph));
-  ASSERT_EQ(raw_json, s);
-}
-
 std::string raw_json_without_types = R"({
   "comment": "created by graph_to_json",
   "nodes": [
@@ -194,11 +186,19 @@ std::string raw_json_without_types = R"({
   ]
 })";
 
+TEST(json_test, test_from_string) {
+  folly::dynamic parsed = folly::parseJson(raw_json);
+  auto graph = beanmachine::minibmg::json_to_graph2(parsed);
+  std::string s =
+      folly::toPrettyJson(beanmachine::minibmg::graph_to_json(graph));
+  ASSERT_EQ(raw_json_without_types, s);
+}
+
 TEST(json_test, test_from_string_without_types) {
   folly::dynamic parsed = folly::parseJson(raw_json_without_types);
-  auto graph = json_to_graph(parsed);
+  auto graph = json_to_graph2(parsed);
   std::string s = folly::toPrettyJson(graph_to_json(graph));
-  ASSERT_EQ(raw_json, s);
+  ASSERT_EQ(raw_json_without_types, s);
 }
 
 } // namespace json_test


### PR DESCRIPTION
Summary:
This is step 3c (below) in a series of refactoring steps that will replace minibmg nodes with a distinct node type for each operations and a visitor mechanism.  The idea is that we will write replacements for all of the parts of minibmg using the new paradigm, and then switch over the tests to the new code.

1. Introduce Node2 and Node2Visitor (without tests yet)
2. Introduce Graph2 using Node2 with json I/O (ditto)
3. Introduce Tracing2 using Node2 (ditto)
3a. Introduce pretty-printing for Node2 (ditto)
3b. Minor fixup to the json implementation
3c. Implement Graph2::Factory
4. Introduce Eval2 (ditto)
5. Migrate tests to Node2.
6. Migrate any remaining pieces to Node2.
7. Delete Node.h and Node.cpp and other things that have been replaced.
8. Rename Node2 to Node and similarly for other types and files.

Differential Revision: D40436160

