### PR TITLE
Support for non-constant multivariate normal parent

### DIFF
--- a/src/beanmachine/graph/distribution/multivariate_normal.h
+++ b/src/beanmachine/graph/distribution/multivariate_normal.h
@@ -37,8 +37,9 @@ class MultivariateNormal : public Distribution {
       const override;
 
  private:
+  Eigen::LLT<Eigen::MatrixXd> llt() const;
   Eigen::LLT<Eigen::MatrixXd>
-      llt; // cholesky decomposition of the covariance matrix
+      _llt; // cholesky decomposition of the covariance matrix if constant
 };
 } // namespace distribution
 } // namespace beanmachine


### PR DESCRIPTION
Summary: MV normal should get the in-node values every time it computes log prob or gradients, since the parent value may change during inference runs.

Differential Revision: D40461493

