### PR TITLE
Support for non-constant LKJ Cholesky parent

### DIFF
--- a/src/beanmachine/graph/distribution/lkj_cholesky.h
+++ b/src/beanmachine/graph/distribution/lkj_cholesky.h
@@ -41,12 +41,12 @@ class LKJCholesky : public Distribution {
   static void
   _grad2_log_prob_value(double& grad2, double val, double m, double s_sq);
 
+  Eigen::VectorXd beta_conc0() const;
   Eigen::VectorXd beta_conc1;
-  Eigen::VectorXd beta_conc0;
   uint d;
 
  private:
-  Eigen::ArrayXd order;
+  Eigen::ArrayXd order() const;
 };
 
 } // namespace distribution


### PR DESCRIPTION
Summary: LKJ Cholesky should get the in-node values every time it computes log prob or gradients, since the parent value may change during inference runs.

Differential Revision: D40461168

