### PR TITLE
Fix bug in Marginal 1D tool & serialization

### DIFF
--- a/src/beanmachine/ppl/diagnostics/tools/js/src/marginal1d/callbacks.ts
+++ b/src/beanmachine/ppl/diagnostics/tools/js/src/marginal1d/callbacks.ts
@@ -72,7 +72,7 @@ export const computeStats = (
 
   // Compute the point statistics for the KDE, and create labels to display them in the
   // figures.
-  const mean = computeMean(marginalX);
+  const mean = computeMean(rawData);
   const hdiBounds = hdiInterval(rawData, hdiProbability);
   const x = [hdiBounds.lowerBound, mean, hdiBounds.upperBound];
   const y = interpolatePoints({x: marginalX, y: marginalY, points: x});

--- a/src/beanmachine/ppl/diagnostics/tools/marginal1d/tool.py
+++ b/src/beanmachine/ppl/diagnostics/tools/marginal1d/tool.py
@@ -143,7 +143,6 @@ class Marginal1d(DiagnosticToolBaseClass):
 
         # Each widget requires slightly different JS, except for the sliders.
         rv_select_js = f"""
-            console.log(toolView);
             const bwFactor = 1.0;
             const hdiProbability = 0.89;
             widgets.bw_factor_slider.value = bwFactor;

--- a/src/beanmachine/ppl/diagnostics/tools/utils/model_serializers.py
+++ b/src/beanmachine/ppl/diagnostics/tools/utils/model_serializers.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """Collection of serializers for the diagnostics tool use."""
+
 from typing import Dict, List
 
 from beanmachine.ppl.inference.monte_carlo_samples import MonteCarloSamples
@@ -12,40 +13,18 @@ from beanmachine.ppl.inference.monte_carlo_samples import MonteCarloSamples
 def serialize_bm(samples: MonteCarloSamples) -> Dict[str, List[List[float]]]:
     """
     Convert Bean Machine models to a JSON serializable object.
+
     Args:
         samples (MonteCarloSamples): Output of a model from Bean Machine.
+
     Returns
         Dict[str, List[List[float]]]: The JSON serializable object for use in the
             diagnostics tools.
     """
-    rv_identifiers = list(samples.keys())
-    reshaped_data = {}
-    for rv_identifier in rv_identifiers:
-        rv_data = samples[rv_identifier]
-        rv_shape = rv_data.shape
-        num_rv_chains = rv_shape[0]
-        reshaped_data[f"{str(rv_identifier)}"] = []
-        for rv_chain in range(num_rv_chains):
-            chain_data = rv_data[rv_chain, :]
-            chain_shape = chain_data.shape
-            if len(chain_shape) > 3 and 1 not in list(chain_shape):
-                msg = (
-                    "Unable to handle data with dimensionality larger than " "mxnxkx1."
-                )
-                raise ValueError(msg)
-            elif len(chain_shape) == 3 and 1 in list(chain_shape):
-                if chain_shape[1] == 1 in list(chain_shape):
-                    reshape_dimensions = chain_shape[2]
-                else:
-                    reshape_dimensions = chain_shape[1]
-                for i, reshape_dimension in enumerate(range(reshape_dimensions)):
-                    data = rv_data[rv_chain, :, reshape_dimension].reshape(-1)
-                    if f"{str(rv_identifier)}[{i}]" not in reshaped_data:
-                        reshaped_data[f"{str(rv_identifier)}[{i}]"] = []
-                    reshaped_data[f"{str(rv_identifier)}[{i}]"].append(data.tolist())
-            elif len(chain_shape) == 1:
-                reshaped_data[f"{str(rv_identifier)}"].append(
-                    rv_data[rv_chain, :].tolist(),
-                )
-    model = dict(sorted(reshaped_data.items(), key=lambda item: item[0]))
+    model = dict(
+        sorted(
+            {str(key): value.tolist() for key, value in samples.items()}.items(),
+            key=lambda item: item[0],
+        ),
+    )
     return model

--- a/src/beanmachine/ppl/diagnostics/tools/utils/model_serializers.py
+++ b/src/beanmachine/ppl/diagnostics/tools/utils/model_serializers.py
@@ -4,7 +4,6 @@
 # LICENSE file in the root directory of this source tree.
 
 """Collection of serializers for the diagnostics tool use."""
-
 from typing import Dict, List
 
 from beanmachine.ppl.inference.monte_carlo_samples import MonteCarloSamples
@@ -13,10 +12,8 @@ from beanmachine.ppl.inference.monte_carlo_samples import MonteCarloSamples
 def serialize_bm(samples: MonteCarloSamples) -> Dict[str, List[List[float]]]:
     """
     Convert Bean Machine models to a JSON serializable object.
-
     Args:
         samples (MonteCarloSamples): Output of a model from Bean Machine.
-
     Returns
         Dict[str, List[List[float]]]: The JSON serializable object for use in the
             diagnostics tools.
@@ -27,6 +24,7 @@ def serialize_bm(samples: MonteCarloSamples) -> Dict[str, List[List[float]]]:
         rv_data = samples[rv_identifier]
         rv_shape = rv_data.shape
         num_rv_chains = rv_shape[0]
+        reshaped_data[f"{str(rv_identifier)}"] = []
         for rv_chain in range(num_rv_chains):
             chain_data = rv_data[rv_chain, :]
             chain_shape = chain_data.shape
@@ -42,8 +40,12 @@ def serialize_bm(samples: MonteCarloSamples) -> Dict[str, List[List[float]]]:
                     reshape_dimensions = chain_shape[1]
                 for i, reshape_dimension in enumerate(range(reshape_dimensions)):
                     data = rv_data[rv_chain, :, reshape_dimension].reshape(-1)
-                    reshaped_data[f"{str(rv_identifier)}[{i}]"] = data.tolist()
+                    if f"{str(rv_identifier)}[{i}]" not in reshaped_data:
+                        reshaped_data[f"{str(rv_identifier)}[{i}]"] = []
+                    reshaped_data[f"{str(rv_identifier)}[{i}]"].append(data.tolist())
             elif len(chain_shape) == 1:
-                reshaped_data[f"{str(rv_identifier)}"] = rv_data[rv_chain, :].tolist()
+                reshaped_data[f"{str(rv_identifier)}"].append(
+                    rv_data[rv_chain, :].tolist(),
+                )
     model = dict(sorted(reshaped_data.items(), key=lambda item: item[0]))
     return model

--- a/src/beanmachine/ppl/diagnostics/tools/utils/model_serializers.py
+++ b/src/beanmachine/ppl/diagnostics/tools/utils/model_serializers.py
@@ -21,10 +21,29 @@ def serialize_bm(samples: MonteCarloSamples) -> Dict[str, List[List[float]]]:
         Dict[str, List[List[float]]]: The JSON serializable object for use in the
             diagnostics tools.
     """
-    model = dict(
-        sorted(
-            {str(key): value.tolist() for key, value in samples.items()}.items(),
-            key=lambda item: item[0],
-        ),
-    )
+    rv_identifiers = list(samples.keys())
+    reshaped_data = {}
+    for rv_identifier in rv_identifiers:
+        rv_data = samples[rv_identifier]
+        rv_shape = rv_data.shape
+        num_rv_chains = rv_shape[0]
+        for rv_chain in range(num_rv_chains):
+            chain_data = rv_data[rv_chain, :]
+            chain_shape = chain_data.shape
+            if len(chain_shape) > 3 and 1 not in list(chain_shape):
+                msg = (
+                    "Unable to handle data with dimensionality larger than " "mxnxkx1."
+                )
+                raise ValueError(msg)
+            elif len(chain_shape) == 3 and 1 in list(chain_shape):
+                if chain_shape[1] == 1 in list(chain_shape):
+                    reshape_dimensions = chain_shape[2]
+                else:
+                    reshape_dimensions = chain_shape[1]
+                for i, reshape_dimension in enumerate(range(reshape_dimensions)):
+                    data = rv_data[rv_chain, :, reshape_dimension].reshape(-1)
+                    reshaped_data[f"{str(rv_identifier)}[{i}]"] = data.tolist()
+            elif len(chain_shape) == 1:
+                reshaped_data[f"{str(rv_identifier)}"] = rv_data[rv_chain, :].tolist()
+    model = dict(sorted(reshaped_data.items(), key=lambda item: item[0]))
     return model


### PR DESCRIPTION
### Motivation

- Fixes incorrect mean value calculation in the tool.
- Updates how serialization is performed to catch indexed random variables.

### Changes proposed

- Removes console logging from the Marginal1d tool, as it is not necessary.
- Updates how a Bean Machine model is serialized. Previously, we were not capturing higher dimensions of random variables, which can happen when a random variable has a dummy index.
- Fixes a bug where we calculated the mean of the given 1D KDE estimate of a random variable, instead of calculating the mean of the actual raw data.

### Test Plan

More tutorials were used to visually inspect the output of the tool.

- Coin flipping.
- Robust linear regression.
- Logistic regression.
- Sparse logistic regression.

### Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](https://github.com/facebookresearch/beanmachine/blob/main/CONTRIBUTING.md)** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] The title of my pull request is a short description of the requested changes.