### PR TITLE
Refactoring and minor bug fixing in requirements fixer

### DIFF
--- a/src/beanmachine/ppl/compiler/lattice_typer.py
+++ b/src/beanmachine/ppl/compiler/lattice_typer.py
@@ -238,6 +238,11 @@ class LatticeTyper(TyperBase[bt.BMGLatticeType]):
     def _type_binary_elementwise_op(
         self, node: bn.BinaryOperatorNode
     ) -> bt.BMGLatticeType:
+        # Elementwise multiplication and addition require that the operands be
+        # of the same type and size, and that's the resulting type.  Rather than
+        # enforcing that here, find the supremum of the element types and a size
+        # where both operands can be broadcast to that size. We'll then add the
+        # appropriate broadcast nodes in the requirements fixer.
         left_type = self[node.left]
         right_type = self[node.right]
         assert isinstance(left_type, bt.BMGMatrixType)

--- a/tests/ppl/compiler/broadcast_test.py
+++ b/tests/ppl/compiler/broadcast_test.py
@@ -32,6 +32,7 @@ def broadcast_add():
 
 
 class BroadcastTest(unittest.TestCase):
+    # TODO: Test broadcast multiplication as well.
     def test_broadcast_add(self) -> None:
         self.maxDiff = None
         observations = {}

--- a/tests/ppl/compiler/fix_vectorized_models_test.py
+++ b/tests/ppl/compiler/fix_vectorized_models_test.py
@@ -878,7 +878,7 @@ digraph "graph" {
   N07[label=2];
   N08[label=1];
   N09[label=ToMatrix];
-  N10[label=ToRealMatrix];
+  N10[label=ToPosRealMatrix];
   N11[label="[5.0,6.0]"];
   N12[label=ElementwiseMult];
   N13[label=Query];


### PR DESCRIPTION
Summary:
The requirements-fixing code is not easy to understand, and some small errors and inefficiencies have crept in. I'm going to fix them in this diff to make it then easier to add a broadcasting fixer in an upcoming diff.

In this diff:

* elementwise multiplication now correctly creates the requirement that the input types be identical with the output type.  (As noted, in an upcoming diff we'll take care of the situation where inputs of dissimilar shape can be fixed by broadcasting.)

* Fixed a typo with a misspelling of "requirements"

* Methods `_meet_real_matrix_requirement_type`, and `_meet_real_matrix_requirement` were misordered and redundant to other logic in the operator requirements fixer. By more carefully ordering the cases in the operator requirements fixer, we can simply delete these redundant methods.

* As noted, `_meet_operator_requirement` was too long and confusing. I've broken it up into many smaller cases each with its own logic for applying a simple fix.

* Making these changes had the beneficial side effect of fixing a very small bug in a test case. In test_fix_vectorized_models_8 we have a multiplication of a matrix of probabilities and a constant matrix with all positive real values. The previous code converted both operands to a real matrix, but we can legally convert them to positive real matrix, a more specific type.  We now do so.

Reviewed By: AishwaryaSivaraman

Differential Revision: D40459965

