### PR TITLE
minibmg: port minibmg_test to the new factory.

### DIFF
--- a/minibmg/ad/num2.h
+++ b/minibmg/ad/num2.h
@@ -16,6 +16,7 @@
 #include "beanmachine/minibmg/ad/number.h"
 #include "beanmachine/minibmg/ad/real.h"
 #include "beanmachine/minibmg/dedup.h"
+#include "beanmachine/minibmg/dedup2.h"
 
 namespace beanmachine::minibmg {
 
@@ -259,6 +260,28 @@ class DedupHelper<Num2<Underlying>> {
   Num2<Underlying> rewrite(
       const Num2<Underlying>& num2,
       const std::unordered_map<Nodep, Nodep>& map) const {
+    auto new_primal = helper.rewrite(num2.primal, map);
+    auto new_derivative1 = helper.rewrite(num2.derivative1, map);
+    return {new_primal, new_derivative1};
+  }
+};
+
+template <class Underlying>
+requires Number<Underlying>
+class DedupAdapter<Num2<Underlying>> {
+  DedupHelper<Underlying> helper{};
+
+ public:
+  std::vector<Node2p> find_roots(const Num2<Underlying>& num2) const {
+    std::vector<Node2p> result = helper.find_roots(num2.primal);
+    for (auto& n : helper.find_roots(num2.derivative1)) {
+      result.push_back(n);
+    }
+    return result;
+  }
+  Num2<Underlying> rewrite(
+      const Num2<Underlying>& num2,
+      const std::unordered_map<Node2p, Node2p>& map) const {
     auto new_primal = helper.rewrite(num2.primal, map);
     auto new_derivative1 = helper.rewrite(num2.derivative1, map);
     return {new_primal, new_derivative1};

--- a/minibmg/ad/num3.h
+++ b/minibmg/ad/num3.h
@@ -15,6 +15,7 @@
 #include "beanmachine/minibmg/ad/number.h"
 #include "beanmachine/minibmg/ad/real.h"
 #include "beanmachine/minibmg/dedup.h"
+#include "beanmachine/minibmg/dedup2.h"
 #include "beanmachine/minibmg/node.h"
 
 namespace beanmachine::minibmg {
@@ -373,6 +374,32 @@ class DedupHelper<Num3<Underlying>> {
   Num3<Underlying> rewrite(
       const Num3<Underlying>& num3,
       const std::unordered_map<Nodep, Nodep>& map) const {
+    auto new_primal = helper.rewrite(num3.primal, map);
+    auto new_derivative1 = helper.rewrite(num3.derivative1, map);
+    auto new_derivative2 = helper.rewrite(num3.derivative2, map);
+    return {new_primal, new_derivative1, new_derivative2};
+  }
+};
+
+template <class Underlying>
+requires Number<Underlying>
+class DedupAdapter<Num3<Underlying>> {
+  DedupAdapter<Underlying> helper{};
+
+ public:
+  std::vector<Node2p> find_roots(const Num3<Underlying>& num3) const {
+    std::vector<Node2p> result = helper.find_roots(num3.primal);
+    for (auto& n : helper.find_roots(num3.derivative1)) {
+      result.push_back(n);
+    }
+    for (auto& n : helper.find_roots(num3.derivative2)) {
+      result.push_back(n);
+    }
+    return result;
+  }
+  Num3<Underlying> rewrite(
+      const Num3<Underlying>& num3,
+      const std::unordered_map<Node2p, Node2p>& map) const {
     auto new_primal = helper.rewrite(num3.primal, map);
     auto new_derivative1 = helper.rewrite(num3.derivative1, map);
     auto new_derivative2 = helper.rewrite(num3.derivative2, map);

--- a/minibmg/ad/traced2.cpp
+++ b/minibmg/ad/traced2.cpp
@@ -121,9 +121,8 @@ bool is_constant(const Traced2& x, const double& value) {
   return is_constant(x, v) && v == value;
 }
 
-std::string to_string(const Traced2&) {
-  return fmt::format(
-      "{}:{}: to_string(Traced2) not implemented", __FILE__, __LINE__);
+std::string to_string(const Traced2& traced) {
+  return to_string(traced.node);
 }
 
 } // namespace beanmachine::minibmg

--- a/minibmg/ad/traced2.cpp
+++ b/minibmg/ad/traced2.cpp
@@ -122,7 +122,8 @@ bool is_constant(const Traced2& x, const double& value) {
 }
 
 std::string to_string(const Traced2& traced) {
-  return to_string(traced.node);
+  Node2p node = traced.node;
+  return to_string(node);
 }
 
 } // namespace beanmachine::minibmg

--- a/minibmg/ad/traced2.cpp
+++ b/minibmg/ad/traced2.cpp
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "beanmachine/minibmg/ad/traced2.h"
+#include <functional>
+#include <memory>
+#include <set>
+#include <vector>
+#include "beanmachine/minibmg/ad/real.h"
+#include "beanmachine/minibmg/eval_error.h"
+#include "beanmachine/minibmg/node2.h"
+
+namespace beanmachine::minibmg {
+
+double Traced2::as_double() const {
+  double value;
+  if (is_constant(node, value)) {
+    return value;
+  }
+
+  throw EvalError("constant value expected but found " + to_string(*this));
+}
+
+// We perform some optimizations during construction.
+// It might be better to do no optimizations at this point and have a tree
+// rewriter that can be reused, but for now this is a simpler approach.
+Traced2 operator+(const Traced2& left, const Traced2& right) {
+  ScalarNode2p result = std::make_shared<ScalarAddNode2>(left.node, right.node);
+  return result;
+}
+
+Traced2 operator-(const Traced2& left, const Traced2& right) {
+  ScalarNode2p result =
+      std::make_shared<ScalarSubtractNode2>(left.node, right.node);
+  return result;
+}
+
+Traced2 operator-(const Traced2& x) {
+  ScalarNode2p result = std::make_shared<ScalarNegateNode2>(x.node);
+  return result;
+}
+
+Traced2 operator*(const Traced2& left, const Traced2& right) {
+  ScalarNode2p result =
+      std::make_shared<ScalarMultiplyNode2>(left.node, right.node);
+  return result;
+}
+
+Traced2 operator/(const Traced2& left, const Traced2& right) {
+  ScalarNode2p result =
+      std::make_shared<ScalarDivideNode2>(left.node, right.node);
+  return result;
+}
+
+Traced2 pow(const Traced2& base, const Traced2& exponent) {
+  ScalarNode2p result =
+      std::make_shared<ScalarPowNode2>(base.node, exponent.node);
+  return result;
+}
+
+Traced2 exp(const Traced2& x) {
+  ScalarNode2p result = std::make_shared<ScalarExpNode2>(x.node);
+  return result;
+}
+
+Traced2 log(const Traced2& x) {
+  ScalarNode2p result = std::make_shared<ScalarLogNode2>(x.node);
+  return result;
+}
+
+Traced2 atan(const Traced2& x) {
+  ScalarNode2p result = std::make_shared<ScalarAtanNode2>(x.node);
+  return result;
+}
+
+Traced2 lgamma(const Traced2& x) {
+  ScalarNode2p result = std::make_shared<ScalarLgammaNode2>(x.node);
+  return result;
+}
+
+Traced2 polygamma(const int n, const Traced2& x) {
+  ScalarNode2p nn = std::make_shared<ScalarConstantNode2>(n);
+  ScalarNode2p result = std::make_shared<ScalarPolygammaNode2>(nn, x.node);
+  return result;
+}
+
+Traced2 if_equal(
+    const Traced2& value,
+    const Traced2& comparand,
+    const Traced2& when_equal,
+    const Traced2& when_not_equal) {
+  ScalarNode2p result = std::make_shared<ScalarIfEqualNode2>(
+      value.node, comparand.node, when_equal.node, when_not_equal.node);
+  return result;
+}
+
+Traced2 if_less(
+    const Traced2& value,
+    const Traced2& comparand,
+    const Traced2& when_less,
+    const Traced2& when_not_less) {
+  ScalarNode2p result = std::make_shared<ScalarIfLessNode2>(
+      value.node, comparand.node, when_less.node, when_not_less.node);
+  return result;
+}
+
+bool is_constant(const Traced2& x, double& value) {
+  if (auto xnode = dynamic_cast<const ScalarConstantNode2*>(x.node.get())) {
+    value = xnode->constant_value;
+    return true;
+  }
+  return false;
+}
+
+bool is_constant(const Traced2& x, const double& value) {
+  double v;
+  return is_constant(x, v) && v == value;
+}
+
+std::string to_string(const Traced2&) {
+  return fmt::format(
+      "{}:{}: to_string(Traced2) not implemented", __FILE__, __LINE__);
+}
+
+} // namespace beanmachine::minibmg

--- a/minibmg/ad/traced2.h
+++ b/minibmg/ad/traced2.h
@@ -14,6 +14,7 @@
 #include "beanmachine/minibmg/ad/number.h"
 #include "beanmachine/minibmg/ad/real.h"
 #include "beanmachine/minibmg/dedup2.h"
+#include "beanmachine/minibmg/localopt.h"
 #include "beanmachine/minibmg/node2.h"
 
 namespace beanmachine::minibmg {

--- a/minibmg/ad/traced2.h
+++ b/minibmg/ad/traced2.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <memory>
+#include <stdexcept>
+#include <unordered_map>
+#include <vector>
+#include "beanmachine/minibmg/ad/number.h"
+#include "beanmachine/minibmg/ad/real.h"
+#include "beanmachine/minibmg/dedup2.h"
+#include "beanmachine/minibmg/node2.h"
+
+namespace beanmachine::minibmg {
+
+/*
+An implementation of the Number concept that simply builds an expression tree
+(actually, a DAG: directed acyclic graph) representing the computation
+performed.  This is also used for the fluent factory.
+ */
+class Traced2 {
+ public:
+  ScalarNode2p node;
+
+  /* implicit */ inline Traced2(ScalarNode2p node) : node{node} {}
+  /* implicit */ inline Traced2(double value)
+      : node{std::make_shared<ScalarConstantNode2>(value)} {}
+  /* implicit */ inline Traced2(Real value)
+      : node{std::make_shared<ScalarConstantNode2>(value.as_double())} {}
+
+  static Traced2 variable(const std::string& name, const unsigned identifier) {
+    return Traced2{std::make_shared<ScalarVariableNode2>(name, identifier)};
+  }
+
+  double as_double() const;
+};
+
+Traced2 operator+(const Traced2& left, const Traced2& right);
+Traced2 operator-(const Traced2& left, const Traced2& right);
+Traced2 operator-(const Traced2& x);
+Traced2 operator*(const Traced2& left, const Traced2& right);
+Traced2 operator/(const Traced2& left, const Traced2& right);
+Traced2 pow(const Traced2& base, const Traced2& exponent);
+Traced2 exp(const Traced2& x);
+Traced2 log(const Traced2& x);
+Traced2 atan(const Traced2& x);
+Traced2 lgamma(const Traced2& x);
+Traced2 polygamma(int n, const Traced2& other);
+Traced2 if_equal(
+    const Traced2& value,
+    const Traced2& comparand,
+    const Traced2& when_equal,
+    const Traced2& when_not_equal);
+Traced2 if_less(
+    const Traced2& value,
+    const Traced2& comparand,
+    const Traced2& when_less,
+    const Traced2& when_not_less);
+bool is_constant(const Traced2& x, double& value);
+bool is_constant(const Traced2& x, const double& value);
+std::string to_string(const Traced2& x);
+
+static_assert(Number<Traced2>);
+
+template <>
+class DedupAdapter<Traced2> {
+ public:
+  std::vector<Node2p> find_roots(const Traced2& t) const {
+    return {t.node};
+  }
+  Traced2 rewrite(
+      const Traced2& t,
+      const std::unordered_map<Node2p, Node2p>& map) const {
+    const auto& f = map.find(t.node);
+    return (f == map.end())
+        ? t
+        : Traced2(std::dynamic_pointer_cast<const ScalarNode2>(f->second));
+  }
+};
+
+} // namespace beanmachine::minibmg
+
+// We want to use Traced2 values in (unordered) maps and sets, so we need a good
+// comparison function.  We delegate to the underlying node pointer for
+// that comparison.
+template <>
+struct ::std::less<beanmachine::minibmg::Traced2> {
+  bool operator()(
+      const beanmachine::minibmg::Traced2& lhs,
+      const beanmachine::minibmg::Traced2& rhs) const {
+    static const auto x = ::std::less<beanmachine::minibmg::ScalarNode2p>{};
+    return x(lhs.node, rhs.node);
+  }
+};

--- a/minibmg/dedup2.cpp
+++ b/minibmg/dedup2.cpp
@@ -1,0 +1,255 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "beanmachine/minibmg/dedup2.h"
+#include <map>
+#include <memory>
+#include <stdexcept>
+#include <unordered_map>
+#include "beanmachine/minibmg/node2.h"
+#include "beanmachine/minibmg/topological.h"
+
+namespace {
+
+using namespace beanmachine::minibmg;
+
+// A visitor whose job is to perform one step in deduplication, by deduplicating
+// a single given node assuming all nodes reachable from its inputs have been
+// deduplicated, and those deduplications recorded in the given map.
+//
+// Deduplication is not done recursively as we want to bound the depth of
+// recursive execution at runtime.
+class NodeReplacementVisitor : Node2Visitor {
+ private:
+  Node2Node2ValueMap& map;
+  Node2p original;
+  Node2p result;
+
+ public:
+  explicit NodeReplacementVisitor(Node2Node2ValueMap& map) : map{map} {}
+
+  Node2p rewrite(Node2p node) {
+    // We save the original so that, in case no rewriting is needed, we can
+    // return it as the new `result`.  We cannot return "node" in the visit
+    // method in that case, as we are trying to return smart pointers rather
+    // than raw pointers.
+    original = node;
+    node->accept(*this);
+    return result;
+  }
+
+ private:
+  void visit(const ScalarConstantNode2*) override {
+    result = original;
+  }
+  void visit(const ScalarVariableNode2*) override {
+    result = original;
+  }
+  void visit(const ScalarSampleNode2* node) override {
+    const DistributionNode2p dist = map.at(node->distribution);
+    if (dist == node->distribution) {
+      result = original;
+    } else {
+      result = std::make_shared<ScalarSampleNode2>(dist);
+    }
+  }
+  void visit(const ScalarAddNode2* node) override {
+    const ScalarNode2p left = map.at(node->left);
+    const ScalarNode2p right = map.at(node->right);
+    if (left == node->left && right == node->right) {
+      result = original;
+    } else {
+      result = std::make_shared<ScalarAddNode2>(left, right);
+    }
+  }
+  void visit(const ScalarSubtractNode2* node) override {
+    const ScalarNode2p left = map.at(node->left);
+    const ScalarNode2p right = map.at(node->right);
+    if (left == node->left && right == node->right) {
+      result = original;
+    } else {
+      result = std::make_shared<ScalarSubtractNode2>(left, right);
+    }
+  }
+  void visit(const ScalarNegateNode2* node) override {
+    const ScalarNode2p x = map.at(node->x);
+    if (x == node->x) {
+      result = original;
+    } else {
+      result = std::make_shared<ScalarNegateNode2>(x);
+    }
+  }
+  void visit(const ScalarMultiplyNode2* node) override {
+    const ScalarNode2p left = map.at(node->left);
+    const ScalarNode2p right = map.at(node->right);
+    if (left == node->left && right == node->right) {
+      result = original;
+    } else {
+      result = std::make_shared<ScalarMultiplyNode2>(left, right);
+    }
+  }
+  void visit(const ScalarDivideNode2* node) override {
+    const ScalarNode2p left = map.at(node->left);
+    const ScalarNode2p right = map.at(node->right);
+    if (left == node->left && right == node->right) {
+      result = original;
+    } else {
+      result = std::make_shared<ScalarDivideNode2>(left, right);
+    }
+  }
+  void visit(const ScalarPowNode2* node) override {
+    const ScalarNode2p left = map.at(node->left);
+    const ScalarNode2p right = map.at(node->right);
+    if (left == node->left && right == node->right) {
+      result = original;
+    } else {
+      result = std::make_shared<ScalarPowNode2>(left, right);
+    }
+  }
+  void visit(const ScalarExpNode2* node) override {
+    const ScalarNode2p x = map.at(node->x);
+    if (x == node->x) {
+      result = original;
+    } else {
+      result = std::make_shared<ScalarExpNode2>(x);
+    }
+  }
+  void visit(const ScalarLogNode2* node) override {
+    const ScalarNode2p x = map.at(node->x);
+    if (x == node->x) {
+      result = original;
+    } else {
+      result = std::make_shared<ScalarLogNode2>(x);
+    }
+  }
+  void visit(const ScalarAtanNode2* node) override {
+    const ScalarNode2p x = map.at(node->x);
+    if (x == node->x) {
+      result = original;
+    } else {
+      result = std::make_shared<ScalarAtanNode2>(x);
+    }
+  }
+  void visit(const ScalarLgammaNode2* node) override {
+    const ScalarNode2p x = map.at(node->x);
+    if (x == node->x) {
+      result = original;
+    } else {
+      result = std::make_shared<ScalarLgammaNode2>(x);
+    }
+  }
+  void visit(const ScalarPolygammaNode2* node) override {
+    const ScalarNode2p n = map.at(node->n);
+    const ScalarNode2p x = map.at(node->x);
+    if (n == node->n && x == node->x) {
+      result = original;
+    } else {
+      result = std::make_shared<ScalarPolygammaNode2>(n, x);
+    }
+  }
+  void visit(const ScalarIfEqualNode2* node) override {
+    const ScalarNode2p a = map.at(node->a);
+    const ScalarNode2p b = map.at(node->b);
+    const ScalarNode2p c = map.at(node->c);
+    const ScalarNode2p d = map.at(node->d);
+    if (a == node->a && b == node->b && c == node->c && d == node->d) {
+      result = original;
+    } else {
+      result = std::make_shared<ScalarIfEqualNode2>(a, b, c, d);
+    }
+  }
+  void visit(const ScalarIfLessNode2* node) override {
+    const ScalarNode2p a = map.at(node->a);
+    const ScalarNode2p b = map.at(node->b);
+    const ScalarNode2p c = map.at(node->c);
+    const ScalarNode2p d = map.at(node->d);
+    if (a == node->a && b == node->b && c == node->c && d == node->d) {
+      result = original;
+    } else {
+      result = std::make_shared<ScalarIfLessNode2>(a, b, c, d);
+    }
+  }
+  void visit(const DistributionNormalNode2* node) override {
+    const ScalarNode2p mean = map.at(node->mean);
+    const ScalarNode2p stddev = map.at(node->stddev);
+    if (mean == node->mean && stddev == node->stddev) {
+      result = original;
+    } else {
+      result = std::make_shared<DistributionNormalNode2>(mean, stddev);
+    }
+  }
+  void visit(const DistributionHalfNormalNode2* node) override {
+    const ScalarNode2p stddev = map.at(node->stddev);
+    if (stddev == node->stddev) {
+      result = original;
+    } else {
+      result = std::make_shared<DistributionHalfNormalNode2>(stddev);
+    }
+  }
+  void visit(const DistributionBetaNode2* node) override {
+    const ScalarNode2p a = map.at(node->a);
+    const ScalarNode2p b = map.at(node->b);
+    if (a == node->a && b == node->b) {
+      result = original;
+    } else {
+      result = std::make_shared<DistributionBetaNode2>(a, b);
+    }
+  }
+  void visit(const DistributionBernoulliNode2* node) override {
+    const ScalarNode2p prob = map.at(node->prob);
+    if (prob == node->prob) {
+      result = original;
+    } else {
+      result = std::make_shared<DistributionBernoulliNode2>(prob);
+    }
+  }
+};
+
+} // namespace
+
+namespace beanmachine::minibmg {
+
+// Take a set of root nodes as input, and return a map of deduplicated nodes,
+// which maps from a node in the transitive closure of the input to a
+// corresponding node in the transitive closure of the deduplicated graph.
+std::unordered_map<Node2p, Node2p> dedup_map(std::vector<Node2p> roots) {
+  // a value-based, map, which treats semantically identical nodes as the same.
+  Node2Node2ValueMap map;
+
+  // We also build a map that uses object (pointer) identity to find elements,
+  // so that operations in clients are not using recursive equality operations.
+  std::unordered_map<Node2p, Node2p> identity_map;
+
+  std::vector<Node2p> sorted;
+  if (!topological_sort<Node2p>(
+          {roots.begin(), roots.end()}, in_nodes, sorted)) {
+    throw std::invalid_argument("graph has a cycle");
+  }
+  std::reverse(sorted.begin(), sorted.end());
+
+  // A node replacement rewriter that offers a replacement for a node by
+  // rewriting its immediate inputs if necessary.  Note that it keep a reference
+  // to the map.
+  NodeReplacementVisitor node_rewriter{map};
+
+  // Compute a replacement for each node.
+  for (auto& node : sorted) {
+    auto found = map.find(node);
+    if (found != map.end()) {
+      auto mapping = found->second;
+      identity_map.insert({node, mapping});
+    } else {
+      auto rewritten = node_rewriter.rewrite(node);
+      map.insert(node, rewritten);
+      identity_map.insert({node, rewritten});
+    }
+  }
+
+  return identity_map;
+}
+
+} // namespace beanmachine::minibmg

--- a/minibmg/dedup2.cpp
+++ b/minibmg/dedup2.cpp
@@ -54,7 +54,7 @@ class NodeReplacementVisitor : Node2Visitor {
     if (dist == node->distribution) {
       result = original;
     } else {
-      result = std::make_shared<ScalarSampleNode2>(dist);
+      result = std::make_shared<ScalarSampleNode2>(dist, node->rvid);
     }
   }
   void visit(const ScalarAddNode2* node) override {

--- a/minibmg/dedup2.h
+++ b/minibmg/dedup2.h
@@ -78,10 +78,14 @@ std::unordered_map<Node2p, Node2p> dedup_map(std::vector<Node2p> roots);
 // a DAG (directed acyclic graph) of nodes that is no longer a tree due to
 // shared (semantically equivalent) subexpressions.
 template <class T, class DDAdapter = DedupAdapter<T>>
-requires Dedupable<T, DDAdapter> T dedup2(const T& data) {
+requires Dedupable<T, DDAdapter> T
+dedup2(const T& data, std::unordered_map<Node2p, Node2p>* ddmap = nullptr) {
   DDAdapter adapter = DDAdapter{};
   auto roots = adapter.find_roots(data);
   auto map = dedup_map(roots);
+  if (ddmap != nullptr) {
+    ddmap->insert(map.begin(), map.end());
+  }
   return adapter.rewrite(data, map);
 }
 

--- a/minibmg/dedup2.h
+++ b/minibmg/dedup2.h
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <concepts>
+#include <list>
+#include <memory>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+#include "beanmachine/minibmg/ad/real.h"
+#include "beanmachine/minibmg/node2.h"
+
+namespace beanmachine::minibmg {
+
+template <class T>
+class DedupAdapter;
+
+// A concept asserting that the type T is a valid argument to dedup2 using the
+// adapter DDAdapter.
+template <class T, class DDAdapter>
+concept Dedupable = requires(
+    const T& t,
+    const DDAdapter& a,
+    const std::unordered_map<Node2p, Node2p>& map) {
+  { a.find_roots(t) } -> std::convertible_to<std::vector<Node2p>>;
+  { a.rewrite(t, map) } -> std::same_as<T>;
+  {
+    new DDAdapter {}
+    } -> std::same_as<DDAdapter*>;
+};
+
+// In order to deduplicate data in a given data structure, the programmer must
+// specialize this template class to (1) locate the roots contained in
+// that data structure, and (2) write a replacement data structure in which
+// nodes (values of type Node2p) have been deduplicated.  We provide a number of
+// specializations for data structures likely to be needed.  `T` here is the
+// type of the data structure for which nodes contained in it are to be
+// deduplicated.
+//
+// The idea of organizing the code this way, with a type that the caller may
+// specialize, is something I learned from the C++ standard template library.
+// See std::hash<Key> and std::equal_to<Key> and their use in
+// std::unordered_map.
+template <class T>
+class DedupAdapter {
+ public:
+  DedupAdapter() = delete;
+  // locate all of the roots.
+  std::vector<Node2p> find_roots(const T&) const;
+  // rewrite the T, given a mapping from each node to its replacement.
+  T rewrite(const T&, const std::unordered_map<Node2p, Node2p>&) const;
+};
+
+// Take a set of root nodes as input, and return a map of deduplicated nodes,
+// which maps from a node in the transitive closure of the roots to a
+// corresponding node in the transitive closure of the deduplicated graph.
+// A deduplicated graph is one in which there is only one (shared) copy of
+// equivalent expressions (that is, every pair of distinct nodes in the
+// resulting data structure are semantically different). This is used in the
+// implementation of dedup(), but might occasionally be useful to clients in
+// this form.
+std::unordered_map<Node2p, Node2p> dedup_map(std::vector<Node2p> roots);
+
+// Rewrite a data structure by "deduplicating" nodes reachable from it, and
+// returning a new data structure.  This is also known as common subexpression
+// elimination.  The nodes in the resulting data structure will have only one
+// (shared) copy of equivalent expressions (that is, every pair of distinct
+// nodes in the resulting data structure are semantically different). The
+// programmer must either specialize DedupAdapter<T> or provide a type to be
+// used in its place.  If the input has a tree of nodes, the result may contain
+// a DAG (directed acyclic graph) of nodes that is no longer a tree due to
+// shared (semantically equivalent) subexpressions.
+template <class T, class DDAdapter = DedupAdapter<T>>
+requires Dedupable<T, DDAdapter> T dedup2(const T& data) {
+  DDAdapter adapter = DDAdapter{};
+  auto roots = adapter.find_roots(data);
+  auto map = dedup_map(roots);
+  return adapter.rewrite(data, map);
+}
+
+// A single node can be deduplicated
+template <>
+class DedupAdapter<Node2p> {
+ public:
+  std::vector<Node2p> find_roots(const Node2p& n) const {
+    return {n};
+  }
+  Node2p rewrite(
+      const Node2p& node,
+      const std::unordered_map<Node2p, Node2p>& map) const {
+    auto f = map.find(node);
+    return f == map.end() ? node : f->second;
+  }
+};
+
+// A vector can be deduplicated.
+template <class T>
+class DedupAdapter<std::vector<T>> {
+  DedupAdapter<T> t_helper{};
+
+ public:
+  std::vector<Node2p> find_roots(const std::vector<T>& roots) const {
+    std::vector<Node2p> result;
+    for (const auto& root : roots) {
+      auto more_roots = t_helper.find_roots(root);
+      result.push_back(more_roots.begin(), more_roots.end());
+    }
+    return result;
+  }
+  std::vector<T> rewrite(
+      const std::vector<T>& roots,
+      const std::unordered_map<Node2p, Node2p>& map) const {
+    std::vector<T> result;
+    for (const auto& root : roots) {
+      result.push_back(t_helper.rewrite(root, map));
+    }
+    return result;
+  }
+};
+
+// A list can be deduplicated
+template <class T>
+class DedupAdapter<std::list<T>> {
+  DedupAdapter<T> t_helper{};
+
+ public:
+  std::vector<Node2p> find_roots(const std::list<T>& roots) const {
+    std::vector<Node2p> result;
+    for (const auto& root : roots) {
+      auto more_roots = t_helper.find_roots(root);
+      result.push_back(more_roots.begin(), more_roots.end());
+    }
+    return result;
+  }
+  std::list<T> rewrite(
+      const std::list<T>& roots,
+      const std::unordered_map<Node2p, Node2p>& map) const {
+    std::list<T> result;
+    for (const auto& root : roots) {
+      result.push_back(t_helper.rewrite(root, map));
+    }
+    return result;
+  }
+};
+
+// A pair can be deduplicated
+template <class T, class U>
+class DedupAdapter<std::pair<T, U>> {
+  DedupAdapter<T> t_helper{};
+  DedupAdapter<U> u_helper{};
+
+ public:
+  std::vector<Node2p> find_roots(const std::pair<T, U>& root) const {
+    std::vector<Node2p> result = t_helper(root.first);
+    for (auto& r : u_helper.find_roots(root.second)) {
+      result.push_back(r);
+    }
+    return result;
+  }
+  std::pair<T, U> rewrite(
+      const std::pair<T, U>& root,
+      const std::unordered_map<Node2p, Node2p>& map) const {
+    return {
+        t_helper.rewrite(root.first, map), u_helper.rewrite(root.second, map)};
+  }
+};
+
+// A double can be deduplicated (no action)
+template <>
+class DedupAdapter<double> {
+ public:
+  std::vector<Node2p> find_roots(const double&) const {
+    return {};
+  }
+  double rewrite(const double& root, std::unordered_map<Node2p, Node2p>) const {
+    return root;
+  }
+};
+
+// A Real (wrapper around a double) can be deduplicated (no action)
+template <>
+class DedupAdapter<Real> {
+ public:
+  std::vector<Node2p> find_roots(const Real&) const {
+    return {};
+  }
+  // rewrite the T, given a mapping from each node to its replacement.
+  Real rewrite(const Real& t, const std::unordered_map<Node2p, Node2p>&) const {
+    return t;
+  }
+};
+
+} // namespace beanmachine::minibmg

--- a/minibmg/eval2.h
+++ b/minibmg/eval2.h
@@ -1,0 +1,324 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <fmt/format.h>
+#include <functional>
+#include <memory>
+#include <random>
+#include <stdexcept>
+#include <variant>
+#include "beanmachine/minibmg/ad/number.h"
+#include "beanmachine/minibmg/dedup2.h"
+#include "beanmachine/minibmg/distribution/distribution.h"
+#include "beanmachine/minibmg/distribution/make_distribution.h"
+#include "beanmachine/minibmg/eval_error.h"
+#include "beanmachine/minibmg/graph2.h"
+#include "beanmachine/minibmg/graph_properties/observations_by_node2.h"
+#include "beanmachine/minibmg/node2.h"
+
+namespace beanmachine::minibmg {
+
+template <class N>
+requires Number<N>
+struct SampledValue {
+  N constrained;
+  N unconstrained;
+  N log_prob;
+};
+
+} // namespace beanmachine::minibmg
+
+namespace {
+
+using namespace beanmachine::minibmg;
+
+template <class N>
+requires Number<N>
+class NodeEvaluatorVisitor : public Node2Visitor {
+ public:
+  // We intentionally leave the following methods abstract for the caller to
+  // fill in
+  void visit(const ScalarVariableNode2* node) override = 0;
+  void visit(const ScalarSampleNode2* node) override = 0;
+  virtual N evaluate_input(const ScalarNode2p& node) = 0;
+  virtual std::shared_ptr<const Distribution<N>> evaluate_input_distribution(
+      const DistributionNode2p& node) = 0;
+
+  N result;
+  N evaluate_scalar(ScalarNode2p& node) {
+    node->accept(*this);
+    return result;
+  }
+
+  std::shared_ptr<Distribution<N>> dist_result;
+  std::shared_ptr<Distribution<N>> evaluate_distribution(
+      DistributionNode2p& node) {
+    node->accept(*this);
+    return dist_result;
+  }
+
+  void visit(const ScalarConstantNode2* node) override {
+    result = node->constant_value;
+  }
+
+  void visit(const ScalarAddNode2* node) override {
+    result = evaluate_input(node->left) + evaluate_input(node->right);
+  }
+  void visit(const ScalarSubtractNode2* node) override {
+    result = evaluate_input(node->left) - evaluate_input(node->right);
+  }
+  void visit(const ScalarNegateNode2* node) override {
+    result = -evaluate_input(node->x);
+  }
+  void visit(const ScalarMultiplyNode2* node) override {
+    result = evaluate_input(node->left) * evaluate_input(node->right);
+  }
+  void visit(const ScalarDivideNode2* node) override {
+    result = evaluate_input(node->left) / evaluate_input(node->right);
+  }
+  void visit(const ScalarPowNode2* node) override {
+    result = pow(evaluate_input(node->left), evaluate_input(node->right));
+  }
+  void visit(const ScalarExpNode2* node) override {
+    result = exp(evaluate_input(node->x));
+  }
+  void visit(const ScalarLogNode2* node) override {
+    result = log(evaluate_input(node->x));
+  }
+  void visit(const ScalarAtanNode2* node) override {
+    result = atan(evaluate_input(node->x));
+  }
+  void visit(const ScalarLgammaNode2* node) override {
+    result = lgamma(evaluate_input(node->x));
+  }
+  void visit(const ScalarPolygammaNode2* node) override {
+    int nv = (int)evaluate_input(node->n).as_double();
+    result = polygamma(nv, evaluate_input(node->x));
+  }
+  void visit(const ScalarIfEqualNode2* node) override {
+    result = if_equal(
+        evaluate_input(node->a),
+        evaluate_input(node->b),
+        evaluate_input(node->c),
+        evaluate_input(node->d));
+  }
+  void visit(const ScalarIfLessNode2* node) override {
+    result = if_less(
+        evaluate_input(node->a),
+        evaluate_input(node->b),
+        evaluate_input(node->c),
+        evaluate_input(node->d));
+  }
+  void visit(const DistributionNormalNode2* node) override {
+    dist_result = std::make_shared<Normal<N>>(
+        evaluate_input(node->mean), evaluate_input(node->stddev));
+  }
+  void visit(const DistributionHalfNormalNode2* node) override {
+    dist_result = std::make_shared<HalfNormal<N>>(evaluate_input(node->stddev));
+  }
+  void visit(const DistributionBetaNode2* node) override {
+    dist_result = std::make_shared<Beta<N>>(
+        evaluate_input(node->a), evaluate_input(node->b));
+  }
+  void visit(const DistributionBernoulliNode2* node) override {
+    dist_result = std::make_shared<Bernoulli<N>>(evaluate_input(node->prob));
+  }
+};
+
+template <class N>
+requires Number<N>
+class OneNodeAtATimeEvaluatorVisitor : public NodeEvaluatorVisitor<N> {
+  std::function<N(const std::string& name, const unsigned identifier)>
+      read_variable;
+  std::unordered_map<const Node2*, double> observations;
+  N& log_prob;
+  std::unordered_map<Node2p, N>& data;
+  std::unordered_map<Node2p, std::shared_ptr<const Distribution<N>>>&
+      distributions;
+  bool eval_log_prob;
+  std::mt19937& gen;
+  const std::function<SampledValue<N>(
+      const Distribution<N>& distribution,
+      std::mt19937& gen)>& sampler;
+
+  static std::unordered_map<const Node2*, double> make_observations_by_node(
+      const Graph2& graph) {
+    std::unordered_map<const Node2*, double> result;
+    for (auto& p : observations_by_node(graph)) {
+      result[p.first.get()] = p.second;
+    }
+    return result;
+  }
+
+ public:
+  OneNodeAtATimeEvaluatorVisitor(
+      const Graph2& graph,
+      std::function<N(const std::string& name, const unsigned identifier)>
+          read_variable,
+      std::unordered_map<Node2p, N>& data,
+      std::unordered_map<Node2p, std::shared_ptr<const Distribution<N>>>&
+          distributions,
+      N& log_prob,
+      bool eval_log_prob,
+      std::mt19937& gen,
+      const std::function<SampledValue<
+          N>(const Distribution<N>& distribution, std::mt19937& gen)>& sampler)
+      : read_variable{read_variable},
+        observations{make_observations_by_node(graph)},
+        log_prob{log_prob},
+        data{data},
+        distributions{distributions},
+        eval_log_prob{eval_log_prob},
+        gen{gen},
+        sampler{sampler} {}
+
+  void visit(const ScalarVariableNode2* node) override {
+    this->result = read_variable(node->name, node->identifier);
+  }
+  void visit(const ScalarSampleNode2* node) override {
+    auto obsp = observations.find(node);
+    auto dist_node = node->distribution;
+    auto dist = distributions.at(dist_node);
+    if (obsp != observations.end()) {
+      auto value = this->result = obsp->second;
+      if (eval_log_prob) {
+        N logp = dist->log_prob(value);
+        log_prob = log_prob + logp;
+      }
+    } else {
+      auto sampled_value = sampler(*dist, gen);
+      this->result = sampled_value.constrained;
+      if (eval_log_prob) {
+        log_prob = log_prob + sampled_value.log_prob;
+      }
+    }
+  }
+  N evaluate_input(const ScalarNode2p& node) override {
+    return data.at(node);
+  }
+  std::shared_ptr<const Distribution<N>> evaluate_input_distribution(
+      const DistributionNode2p& node) override {
+    return distributions.at(node);
+  }
+};
+
+} // namespace
+
+namespace beanmachine::minibmg {
+
+template <class N>
+requires Number<N>
+struct EvalResult {
+  // The log probability of the overall computation.
+  N log_prob;
+
+  // The value of the queries.
+  std::vector<double> queries;
+};
+
+template <class N>
+requires Number<N> SampledValue<N> sample_from_distribution(
+    const Distribution<N>& distribution,
+    std::mt19937& gen) {
+  auto transformation = distribution.transformation();
+  if (transformation == nullptr) {
+    N constrained = distribution.sample(gen);
+    N unconstrained = constrained;
+    N log_prob = distribution.log_prob(constrained);
+    return {constrained, unconstrained, log_prob};
+  } else {
+    N constrained = distribution.sample(gen);
+    N unconstrained = transformation->call(constrained);
+    N log_prob = distribution.log_prob(constrained);
+    // Transforming the log_prob is on hold until I understand the math.
+    // log_prob = transformation->transform_log_prob(constrained, log_prob);
+    return {constrained, unconstrained, log_prob};
+  }
+}
+
+// Evaluating an entire graph, producing into `data` a map of doubles that
+// contains, for each scalar-valued node at graph index i, the evaluated value
+// of that node at the corresponding index in the returned value.  Also returns
+// the log probability of the samples.  The sampler function, if passed, is used
+// to sample from the distribution.  It should return the sample in both
+// constrained and unconstrained spaces, and a log_prob value with respect to
+// its distribution transformed to the unconstrained space.
+template <class N>
+requires Number<N> EvalResult<N> eval_graph(
+    const Graph2& graph,
+    std::mt19937& gen,
+    std::function<N(const std::string& name, const unsigned identifier)>
+        read_variable,
+    std::unordered_map<Node2p, N>& data,
+    bool run_queries = false,
+    bool eval_log_prob = false,
+    std::function<
+        SampledValue<N>(const Distribution<N>& distribution, std::mt19937& gen)>
+        sampler = sample_from_distribution<N>) {
+  std::unordered_map<Node2p, std::shared_ptr<const Distribution<N>>>
+      distributions;
+  N log_prob = 0;
+
+  std::function<SampledValue<N>(
+      const Distribution<N>& distribution, std::mt19937& gen)>& sampler2 =
+      sampler;
+  OneNodeAtATimeEvaluatorVisitor<N> evaluator{
+      graph,
+      read_variable,
+      data,
+      distributions,
+      log_prob,
+      eval_log_prob,
+      gen,
+      sampler2};
+
+  for (const auto& node : graph) {
+    if (auto dist_node =
+            std::dynamic_pointer_cast<const DistributionNode2>(node)) {
+      std::shared_ptr<const Distribution<N>> dist =
+          evaluator.evaluate_distribution(dist_node);
+      distributions[node] = dist;
+    } else if (
+        auto expr_node = std::dynamic_pointer_cast<const ScalarNode2>(node)) {
+      N expr = evaluator.evaluate_scalar(expr_node);
+      data[node] = expr;
+    } else {
+      throw std::logic_error("unexpected node");
+    }
+  }
+
+  std::vector<double> queries;
+  if (run_queries) {
+    for (const auto& q : graph.queries) {
+      auto d = data.find(q);
+      double value = (d == data.end()) ? 0 : d->second.as_double();
+      queries.push_back(value);
+    }
+  }
+  return {log_prob, queries};
+}
+
+template <class Underlying>
+requires Number<Underlying>
+class DedupAdapter<EvalResult<Underlying>> {
+  DedupAdapter<Underlying> helper{};
+
+ public:
+  std::vector<Node2p> find_roots(const EvalResult<Underlying>& e) const {
+    return helper.find_roots(e.log_prob);
+  }
+  EvalResult<Underlying> rewrite(
+      const EvalResult<Underlying>& e,
+      const std::unordered_map<Node2p, Node2p>& map) const {
+    auto new_log_prob = helper.rewrite(e.log_prob, map);
+    return {new_log_prob, e.queries};
+  }
+};
+
+} // namespace beanmachine::minibmg

--- a/minibmg/fluid_factory.cpp
+++ b/minibmg/fluid_factory.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "beanmachine/minibmg/fluid_factory.h"
+#include <memory>
+#include <stdexcept>
+#include "beanmachine/minibmg/distribution/normal.h"
+
+namespace beanmachine::minibmg {
+
+FluidDistribution::FluidDistribution(DistributionNode2p node) : node{node} {}
+
+const FluidDistribution half_normal(Value2 stddev) {
+  DistributionNode2p node =
+      std::make_shared<const DistributionHalfNormalNode2>(stddev.node);
+  return node;
+}
+
+const FluidDistribution normal(Value2 mean, Value2 stddev) {
+  DistributionNode2p node =
+      std::make_shared<const DistributionNormalNode2>(mean.node, stddev.node);
+  return node;
+}
+
+const FluidDistribution beta(Value2 a, Value2 b) {
+  DistributionNode2p node =
+      std::make_shared<const DistributionBetaNode2>(a.node, b.node);
+  return node;
+}
+
+const FluidDistribution bernoulli(Value2 p) {
+  DistributionNode2p node =
+      std::make_shared<const DistributionBernoulliNode2>(p.node);
+  return node;
+}
+
+Value2 sample(const FluidDistribution& d, std::string rvid) {
+  ScalarNode2p node = std::make_shared<const ScalarSampleNode2>(d.node, rvid);
+  return node;
+}
+
+void Graph2::FluidFactory::observe(const Value2& sample, double value) {
+  auto node = sample.node;
+  if (!dynamic_cast<const ScalarSampleNode2*>(node.get())) {
+    throw std::invalid_argument("can only observe a sample");
+  }
+  for (const auto& n : observations) {
+    if (n.first == node) {
+      throw std::invalid_argument("sample already observed");
+    }
+  }
+  observations.push_back({node, value});
+}
+
+unsigned Graph2::FluidFactory::query(const Value2& value) {
+  auto result = queries.size();
+  queries.push_back(value.node);
+  return result;
+}
+
+Graph2 Graph2::FluidFactory::build() {
+  return Graph2::create(queries, observations);
+}
+
+} // namespace beanmachine::minibmg

--- a/minibmg/fluid_factory.h
+++ b/minibmg/fluid_factory.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "beanmachine/minibmg/ad/traced2.h"
+#include "beanmachine/minibmg/graph2.h"
+#include "beanmachine/minibmg/node2.h"
+
+namespace beanmachine::minibmg {
+
+// For values
+using Value2 = Traced2;
+
+// For distributions
+class FluidDistribution {
+ public:
+  DistributionNode2p node;
+  /* implicit */ FluidDistribution(DistributionNode2p node);
+};
+
+const FluidDistribution half_normal(Value2 stddev);
+const FluidDistribution normal(Value2 mean, Value2 stddev);
+const FluidDistribution beta(Value2 a, Value2 b);
+const FluidDistribution bernoulli(Value2 p);
+
+Value2 sample(const FluidDistribution& d, std::string rvid = make_fresh_rvid());
+
+class Graph2::FluidFactory {
+ public:
+  void observe(const Traced2& sample, double value);
+  unsigned query(const Traced2& value);
+  Graph2 build();
+
+ private:
+  std::vector<Node2p> queries;
+  std::list<std::pair<Node2p, double>> observations;
+};
+
+} // namespace beanmachine::minibmg

--- a/minibmg/graph.cpp
+++ b/minibmg/graph.cpp
@@ -245,6 +245,8 @@ folly::dynamic graph_to_json(const Graph& g) {
   return result;
 }
 
+JsonError::JsonError(const std::string& message) : message(message) {}
+
 Graph json_to_graph(folly::dynamic d) {
   // Nodes are identified by a "sequence" number appearing in json.
   // They are arbitrary numbers.  The only requirement is that they

--- a/minibmg/graph.cpp
+++ b/minibmg/graph.cpp
@@ -245,10 +245,7 @@ folly::dynamic graph_to_json(const Graph& g) {
   return result;
 }
 
-JsonError::JsonError(const std::string& message) : message(message) {}
-
 Graph json_to_graph(folly::dynamic d) {
-  Graph::Factory gf;
   // Nodes are identified by a "sequence" number appearing in json.
   // They are arbitrary numbers.  The only requirement is that they
   // are distinct.  They are used to identify nodes in the json.

--- a/minibmg/graph2.cpp
+++ b/minibmg/graph2.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "beanmachine/minibmg/graph2.h"
+#include <list>
+#include <stdexcept>
+#include <vector>
+#include "beanmachine/minibmg/dedup2.h"
+#include "beanmachine/minibmg/topological.h"
+
+namespace {
+
+using namespace beanmachine::minibmg;
+
+const std::vector<Node2p> roots(
+    const std::vector<Node2p>& queries,
+    const std::list<std::pair<Node2p, double>>& observations) {
+  std::list<Node2p> roots;
+  for (auto& n : queries) {
+    roots.push_back(n);
+  }
+  for (auto& p : observations) {
+    if (typeid(p.first.get()) != typeid(ScalarSampleNode2*)) {
+      throw std::invalid_argument(fmt::format("can only observe a sample"));
+    }
+    roots.push_front(p.first);
+  }
+  std::vector<Node2p> all_nodes;
+  if (!topological_sort<Node2p>(roots, &in_nodes, all_nodes)) {
+    throw std::invalid_argument("graph has a cycle");
+  }
+  std::reverse(all_nodes.begin(), all_nodes.end());
+  return all_nodes;
+}
+
+struct QueriesAndObservations {
+  std::vector<Node2p> queries;
+  std::list<std::pair<Node2p, double>> observations;
+  ~QueriesAndObservations() {}
+};
+
+} // namespace
+
+namespace beanmachine::minibmg {
+
+template <>
+class DedupAdapter<QueriesAndObservations> {
+ public:
+  std::vector<Node2p> find_roots(const QueriesAndObservations& qo) const {
+    std::vector<Node2p> roots;
+    for (auto& q : qo.observations) {
+      roots.push_back(q.first);
+    }
+    for (auto& n : qo.queries) {
+      roots.push_back(n);
+    }
+    return roots;
+  }
+  QueriesAndObservations rewrite(
+      const QueriesAndObservations& qo,
+      const std::unordered_map<Node2p, Node2p>& map) const {
+    DedupAdapter<std::vector<Node2p>> h1{};
+    DedupAdapter<std::list<std::pair<Node2p, double>>> h2{};
+    return QueriesAndObservations{
+        h1.rewrite(qo.queries, map), h2.rewrite(qo.observations, map)};
+  }
+};
+
+using dynamic = folly::dynamic;
+
+Graph2 Graph2::create(
+    const std::vector<Node2p>& queries,
+    const std::list<std::pair<Node2p, double>>& observations) {
+  for (auto& p : observations) {
+    if (typeid(p.first.get()) != typeid(ScalarSampleNode2*)) {
+      throw std::invalid_argument(fmt::format("can only observe a sample"));
+    }
+  }
+
+  auto qo0 = QueriesAndObservations{queries, observations};
+  auto qo1 = dedup2(qo0);
+
+  std::vector<Node2p> all_nodes = roots(qo1.queries, qo1.observations);
+  return Graph2{all_nodes, qo1.queries, qo1.observations};
+}
+
+Graph2::~Graph2() {}
+
+Graph2::Graph2(
+    const std::vector<Node2p>& nodes,
+    const std::vector<Node2p>& queries,
+    const std::list<std::pair<Node2p, double>>& observations)
+    : nodes{nodes}, queries{queries}, observations{observations} {}
+
+} // namespace beanmachine::minibmg

--- a/minibmg/graph2.cpp
+++ b/minibmg/graph2.cpp
@@ -75,7 +75,8 @@ using dynamic = folly::dynamic;
 
 Graph2 Graph2::create(
     const std::vector<Node2p>& queries,
-    const std::list<std::pair<Node2p, double>>& observations) {
+    const std::list<std::pair<Node2p, double>>& observations,
+    std::unordered_map<Node2p, Node2p>* built_map) {
   for (auto& p : observations) {
     if (!std::dynamic_pointer_cast<const ScalarSampleNode2>(p.first)) {
       throw std::invalid_argument(fmt::format("can only observe a sample"));
@@ -83,7 +84,7 @@ Graph2 Graph2::create(
   }
 
   auto qo0 = QueriesAndObservations{queries, observations};
-  auto qo1 = dedup2(qo0);
+  auto qo1 = dedup2(qo0, built_map);
 
   std::vector<Node2p> all_nodes = roots(qo1.queries, qo1.observations);
   return Graph2{all_nodes, qo1.queries, qo1.observations};

--- a/minibmg/graph2.cpp
+++ b/minibmg/graph2.cpp
@@ -7,6 +7,7 @@
 
 #include "beanmachine/minibmg/graph2.h"
 #include <list>
+#include <memory>
 #include <stdexcept>
 #include <vector>
 #include "beanmachine/minibmg/dedup2.h"
@@ -24,7 +25,7 @@ const std::vector<Node2p> roots(
     roots.push_back(n);
   }
   for (auto& p : observations) {
-    if (typeid(p.first.get()) != typeid(ScalarSampleNode2*)) {
+    if (!std::dynamic_pointer_cast<const ScalarSampleNode2>(p.first)) {
       throw std::invalid_argument(fmt::format("can only observe a sample"));
     }
     roots.push_front(p.first);
@@ -76,7 +77,7 @@ Graph2 Graph2::create(
     const std::vector<Node2p>& queries,
     const std::list<std::pair<Node2p, double>>& observations) {
   for (auto& p : observations) {
-    if (typeid(p.first.get()) != typeid(ScalarSampleNode2*)) {
+    if (!std::dynamic_pointer_cast<const ScalarSampleNode2>(p.first)) {
       throw std::invalid_argument(fmt::format("can only observe a sample"));
     }
   }

--- a/minibmg/graph2.h
+++ b/minibmg/graph2.h
@@ -69,9 +69,9 @@ class Graph2 : public Container {
 };
 
 // Exception to throw when json_to_graph fails.
-class JsonError : public std::exception {
+class JsonError2 : public std::exception {
  public:
-  explicit JsonError(const std::string& message);
+  explicit JsonError2(const std::string& message);
   const std::string message;
 };
 

--- a/minibmg/graph2.h
+++ b/minibmg/graph2.h
@@ -23,7 +23,8 @@ class Graph2 : public Container {
   // graph.
   static Graph2 create(
       const std::vector<Node2p>& queries,
-      const std::list<std::pair<Node2p, double>>& observations);
+      const std::list<std::pair<Node2p, double>>& observations,
+      std::unordered_map<Node2p, Node2p>* built_map = nullptr);
   ~Graph2();
 
   // Implement the iterator pattern so clients can iterate over the nodes.

--- a/minibmg/graph2.h
+++ b/minibmg/graph2.h
@@ -75,7 +75,7 @@ class JsonError2 : public std::exception {
   const std::string message;
 };
 
-folly::dynamic graph_to_json2(const Graph2& g);
-Graph2 json2_to_graph(folly::dynamic d); // throw (JsonError)
+folly::dynamic graph_to_json(const Graph2& g);
+Graph2 json_to_graph2(folly::dynamic d); // throw (JsonError)
 
 } // namespace beanmachine::minibmg

--- a/minibmg/graph2.h
+++ b/minibmg/graph2.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/json.h>
+#include <list>
+#include "beanmachine/minibmg/graph_properties/container.h"
+#include "beanmachine/minibmg/node2.h"
+
+namespace beanmachine::minibmg {
+
+class Graph2 : public Container {
+ public:
+  // produces a graph by computing the transitive closure of the input queries
+  // and observations and topologically sorting the set of nodes so reached.
+  // valudates that the list of nodes so reached forms a valid graph, and
+  // returns that graph.  Throws an exception if the nodes do not form a valid
+  // graph.
+  static Graph2 create(
+      const std::vector<Node2p>& queries,
+      const std::list<std::pair<Node2p, double>>& observations);
+  ~Graph2();
+
+  // Implement the iterator pattern so clients can iterate over the nodes.
+  inline auto begin() const {
+    return nodes.begin();
+  }
+  inline auto end() const {
+    return nodes.end();
+  }
+  inline Node2p operator[](int index) const {
+    return nodes[index];
+  }
+  inline int size() const {
+    return nodes.size();
+  }
+
+  // All of the nodes, in a topologically sorted order such that a node can only
+  // be used as an input in subsequent (and not previous) nodes.
+  const std::vector<Node2p> nodes;
+
+  // Queries of the model.  These are nodes whose values are sampled by
+  // inference.
+  const std::vector<Node2p> queries;
+
+  // Observations of the model.  These are SAMPLE nodes in the model whose
+  // values are known.
+  const std::list<std::pair<Node2p, double>> observations;
+
+ private:
+  // A private constructor that forms a graph without validation.
+  // Used internally.  All exposed graphs should be validated.
+  Graph2(
+      const std::vector<Node2p>& nodes,
+      const std::vector<Node2p>& queries,
+      const std::list<std::pair<Node2p, double>>& observations);
+
+ public:
+  // A factory for making graphs, like the bmg API used by Beanstalk
+  class Factory;
+
+  // A more natural factory for making graphs, using operator overloading.
+  class FluidFactory;
+};
+
+// Exception to throw when json_to_graph fails.
+class JsonError : public std::exception {
+ public:
+  explicit JsonError(const std::string& message);
+  const std::string message;
+};
+
+folly::dynamic graph_to_json2(const Graph2& g);
+Graph2 json2_to_graph(folly::dynamic d); // throw (JsonError)
+
+} // namespace beanmachine::minibmg

--- a/minibmg/graph2_factory.cpp
+++ b/minibmg/graph2_factory.cpp
@@ -138,16 +138,25 @@ DistributionNode2Id Graph2::Factory::bernoulli(ScalarNode2Id prob) {
 }
 
 void Graph2::Factory::observe(ScalarNode2Id sample, double value) {
+  if (built) {
+    throw std::invalid_argument("Graph has already been built");
+  }
   observations.push_back({map[sample], value});
 }
 
 ScalarNode2Id Graph2::Factory::add_node(ScalarNode2p node) {
+  if (built) {
+    throw std::invalid_argument("Graph has already been built");
+  }
   auto id = std::make_shared<ScalarNode2Identifier>(next_identifier++);
   identifer_to_node[id] = node;
   node_to_identifier[node] = id;
   return id;
 }
 DistributionNode2Id Graph2::Factory::add_node(DistributionNode2p node) {
+  if (built) {
+    throw std::invalid_argument("Graph has already been built");
+  }
   auto id = std::make_shared<DistributionNode2Identifier>(next_identifier++);
   identifer_to_node[id] = node;
   node_to_identifier[node] = id;
@@ -155,6 +164,9 @@ DistributionNode2Id Graph2::Factory::add_node(DistributionNode2p node) {
 }
 ScalarSampleNode2Id Graph2::Factory::add_node(
     std::shared_ptr<ScalarSampleNode2> node) {
+  if (built) {
+    throw std::invalid_argument("Graph has already been built");
+  }
   auto id = std::make_shared<ScalarSampleNode2Identifier>(next_identifier++);
   identifer_to_node[id] = node;
   node_to_identifier[node] = id;
@@ -162,6 +174,9 @@ ScalarSampleNode2Id Graph2::Factory::add_node(
 }
 
 unsigned Graph2::Factory::query(ScalarNode2Id value) {
+  if (built) {
+    throw std::invalid_argument("Graph has already been built");
+  }
   unsigned result = queries.size();
   queries.push_back(map[value]);
   return result;

--- a/minibmg/graph2_factory.cpp
+++ b/minibmg/graph2_factory.cpp
@@ -179,6 +179,11 @@ DistributionNode2p Graph2::Factory::operator[](
   return std::dynamic_pointer_cast<const DistributionNode2>(
       identifer_to_node.at(node_id));
 }
+ScalarSampleNode2p Graph2::Factory::operator[](
+    const ScalarSampleNode2Id& node_id) const {
+  return std::dynamic_pointer_cast<const ScalarSampleNode2>(
+      identifer_to_node.at(node_id));
+}
 
 Graph2 Graph2::Factory::build() {
   if (built) {

--- a/minibmg/graph2_factory.cpp
+++ b/minibmg/graph2_factory.cpp
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "beanmachine/minibmg/graph2_factory.h"
+#include <memory>
+#include <stdexcept>
+#include "beanmachine/minibmg/node2.h"
+
+namespace beanmachine::minibmg {
+
+Node2Identifier::Node2Identifier(unsigned long value) : value{value} {}
+
+unsigned long Node2Identifier::_value() const {
+  return value;
+}
+
+ScalarNode2Identifier::ScalarNode2Identifier(unsigned long value)
+    : Node2Identifier{value} {}
+
+ScalarSampleNode2Identifier::ScalarSampleNode2Identifier(unsigned long value)
+    : ScalarNode2Identifier{value} {}
+
+DistributionNode2Identifier::DistributionNode2Identifier(unsigned long value)
+    : Node2Identifier{value} {}
+
+ScalarNode2Id Graph2::Factory::constant(double value) {
+  ScalarNode2p result = std::make_shared<ScalarConstantNode2>(value);
+  return add_node(result);
+}
+ScalarNode2Id Graph2::Factory::variable(
+    const std::string& name,
+    const unsigned identifier) {
+  ScalarNode2p result = std::make_shared<ScalarVariableNode2>(name, identifier);
+  return add_node(result);
+}
+ScalarSampleNode2Id Graph2::Factory::sample(
+    DistributionNode2Id distribution,
+    const std::string& rvid) {
+  auto result = std::make_shared<ScalarSampleNode2>(map[distribution], rvid);
+  return add_node(result);
+}
+ScalarNode2Id Graph2::Factory::add(ScalarNode2Id left, ScalarNode2Id right) {
+  ScalarNode2p result = std::make_shared<ScalarAddNode2>(map[left], map[right]);
+  return add_node(result);
+}
+ScalarNode2Id Graph2::Factory::subtract(
+    ScalarNode2Id left,
+    ScalarNode2Id right) {
+  ScalarNode2p result =
+      std::make_shared<ScalarSubtractNode2>(map[left], map[right]);
+  return add_node(result);
+}
+ScalarNode2Id Graph2::Factory::negate(ScalarNode2Id x) {
+  ScalarNode2p result = std::make_shared<ScalarNegateNode2>(map[x]);
+  return add_node(result);
+}
+ScalarNode2Id Graph2::Factory::multiply(
+    ScalarNode2Id left,
+    ScalarNode2Id right) {
+  ScalarNode2p result =
+      std::make_shared<ScalarMultiplyNode2>(map[left], map[right]);
+  return add_node(result);
+}
+ScalarNode2Id Graph2::Factory::divide(ScalarNode2Id left, ScalarNode2Id right) {
+  ScalarNode2p result =
+      std::make_shared<ScalarDivideNode2>(map[left], map[right]);
+  return add_node(result);
+}
+ScalarNode2Id Graph2::Factory::pow(ScalarNode2Id left, ScalarNode2Id right) {
+  ScalarNode2p result = std::make_shared<ScalarPowNode2>(map[left], map[right]);
+  return add_node(result);
+}
+ScalarNode2Id Graph2::Factory::exp(ScalarNode2Id x) {
+  ScalarNode2p result = std::make_shared<ScalarExpNode2>(map[x]);
+  return add_node(result);
+}
+ScalarNode2Id Graph2::Factory::log(ScalarNode2Id x) {
+  ScalarNode2p result = std::make_shared<ScalarLogNode2>(map[x]);
+  return add_node(result);
+}
+ScalarNode2Id Graph2::Factory::atan(ScalarNode2Id x) {
+  ScalarNode2p result = std::make_shared<ScalarAtanNode2>(map[x]);
+  return add_node(result);
+}
+ScalarNode2Id Graph2::Factory::lgamma(ScalarNode2Id x) {
+  ScalarNode2p result = std::make_shared<ScalarLgammaNode2>(map[x]);
+  return add_node(result);
+}
+ScalarNode2Id Graph2::Factory::polygamma(int n, ScalarNode2Id x) {
+  ScalarNode2p k = std::make_shared<ScalarConstantNode2>(n);
+  ScalarNode2p result = std::make_shared<ScalarPolygammaNode2>(k, map[x]);
+  return add_node(result);
+}
+ScalarNode2Id Graph2::Factory::if_equal(
+    ScalarNode2Id a,
+    ScalarNode2Id b,
+    ScalarNode2Id c,
+    ScalarNode2Id d) {
+  ScalarNode2p result =
+      std::make_shared<ScalarIfEqualNode2>(map[a], map[b], map[c], map[d]);
+  return add_node(result);
+}
+ScalarNode2Id Graph2::Factory::if_less(
+    ScalarNode2Id a,
+    ScalarNode2Id b,
+    ScalarNode2Id c,
+    ScalarNode2Id d) {
+  ScalarNode2p result =
+      std::make_shared<ScalarIfLessNode2>(map[a], map[b], map[c], map[d]);
+  return add_node(result);
+}
+DistributionNode2Id Graph2::Factory::normal(
+    ScalarNode2Id mean,
+    ScalarNode2Id stddev) {
+  DistributionNode2p result =
+      std::make_shared<DistributionNormalNode2>(map[mean], map[stddev]);
+  return add_node(result);
+}
+DistributionNode2Id Graph2::Factory::half_normal(ScalarNode2Id stddev) {
+  DistributionNode2p result =
+      std::make_shared<DistributionHalfNormalNode2>(map[stddev]);
+  return add_node(result);
+}
+DistributionNode2Id Graph2::Factory::beta(ScalarNode2Id a, ScalarNode2Id b) {
+  DistributionNode2p result =
+      std::make_shared<DistributionBetaNode2>(map[a], map[b]);
+  return add_node(result);
+}
+DistributionNode2Id Graph2::Factory::bernoulli(ScalarNode2Id prob) {
+  DistributionNode2p result =
+      std::make_shared<DistributionBernoulliNode2>(map[prob]);
+  return add_node(result);
+}
+
+void Graph2::Factory::observe(ScalarNode2Id sample, double value) {
+  observations.push_back({map[sample], value});
+}
+
+ScalarNode2Id Graph2::Factory::add_node(ScalarNode2p node) {
+  auto id = std::make_shared<ScalarNode2Identifier>(next_identifier++);
+  identifer_to_node[id] = node;
+  node_to_identifier[node] = id;
+  return id;
+}
+DistributionNode2Id Graph2::Factory::add_node(DistributionNode2p node) {
+  auto id = std::make_shared<DistributionNode2Identifier>(next_identifier++);
+  identifer_to_node[id] = node;
+  node_to_identifier[node] = id;
+  return id;
+}
+ScalarSampleNode2Id Graph2::Factory::add_node(
+    std::shared_ptr<ScalarSampleNode2> node) {
+  auto id = std::make_shared<ScalarSampleNode2Identifier>(next_identifier++);
+  identifer_to_node[id] = node;
+  node_to_identifier[node] = id;
+  return id;
+}
+
+unsigned Graph2::Factory::query(ScalarNode2Id value) {
+  unsigned result = queries.size();
+  queries.push_back(map[value]);
+  return result;
+}
+
+Node2p Graph2::Factory::operator[](const Node2Id& node_id) const {
+  return identifer_to_node.at(node_id);
+}
+ScalarNode2p Graph2::Factory::operator[](const ScalarNode2Id& node_id) const {
+  return std::dynamic_pointer_cast<const ScalarNode2>(
+      identifer_to_node.at(node_id));
+}
+DistributionNode2p Graph2::Factory::operator[](
+    const DistributionNode2Id& node_id) const {
+  return std::dynamic_pointer_cast<const DistributionNode2>(
+      identifer_to_node.at(node_id));
+}
+
+Graph2 Graph2::Factory::build() {
+  if (built) {
+    throw std::invalid_argument("Graph has already been built");
+  }
+  built = true;
+  auto result = Graph2::create(queries, observations);
+
+  // TODO: Update the identifier_to_node map to reflect the set of dedulplicated
+  // nodes in the graph.  This permits the caller to continue using this
+  // factory to map node identifiers to nodes in the now deduplicated graph.
+  identifer_to_node.clear();
+  node_to_identifier.clear();
+
+  return result;
+}
+
+} // namespace beanmachine::minibmg

--- a/minibmg/graph2_factory.h
+++ b/minibmg/graph2_factory.h
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <list>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+#include "beanmachine/minibmg/graph2.h"
+
+namespace beanmachine::minibmg {
+
+class Node2;
+
+// An opaque identifier for a node.
+class Node2Identifier {
+ public:
+  Node2Identifier() = delete;
+  explicit Node2Identifier(unsigned long value);
+  unsigned long _value() const;
+
+ private:
+  unsigned long value;
+};
+using Node2Id = std::shared_ptr<Node2Identifier>;
+
+class ScalarNode2Identifier : public Node2Identifier {
+ public:
+  explicit ScalarNode2Identifier(unsigned long value);
+};
+using ScalarNode2Id = std::shared_ptr<ScalarNode2Identifier>;
+
+class ScalarSampleNode2Identifier : public ScalarNode2Identifier {
+ public:
+  explicit ScalarSampleNode2Identifier(unsigned long value);
+};
+using ScalarSampleNode2Id = std::shared_ptr<ScalarSampleNode2Identifier>;
+
+class DistributionNode2Identifier : public Node2Identifier {
+ public:
+  explicit DistributionNode2Identifier(unsigned long value);
+};
+using DistributionNode2Id = std::shared_ptr<DistributionNode2Identifier>;
+
+} // namespace beanmachine::minibmg
+
+// Make Node2Id values usable as a key in a hash table.
+template <>
+struct std::hash<beanmachine::minibmg::Node2Id> {
+  std::size_t operator()(
+      const beanmachine::minibmg::Node2Id& n) const noexcept {
+    return (std::size_t)n->_value();
+  }
+};
+
+// Make Node2Id values printable using format.
+template <>
+struct fmt::formatter<beanmachine::minibmg::Node2Id>
+    : fmt::formatter<std::string> {
+  auto format(const beanmachine::minibmg::Node2Id& n, format_context& ctx) {
+    return formatter<std::string>::format(fmt::format("{}", n->_value()), ctx);
+  }
+};
+
+namespace beanmachine::minibmg {
+
+class Graph2::Factory {
+ public:
+  ScalarNode2Id constant(double value);
+  ScalarNode2Id variable(const std::string& name, const unsigned identifier);
+  ScalarSampleNode2Id sample(
+      DistributionNode2Id distribution,
+      const std::string& rvid = make_fresh_rvid());
+  ScalarNode2Id add(ScalarNode2Id left, ScalarNode2Id right);
+  ScalarNode2Id subtract(ScalarNode2Id left, ScalarNode2Id right);
+  ScalarNode2Id negate(ScalarNode2Id x);
+  ScalarNode2Id multiply(ScalarNode2Id left, ScalarNode2Id right);
+  ScalarNode2Id divide(ScalarNode2Id left, ScalarNode2Id right);
+  ScalarNode2Id pow(ScalarNode2Id left, ScalarNode2Id right);
+  ScalarNode2Id exp(ScalarNode2Id x);
+  ScalarNode2Id log(ScalarNode2Id x);
+  ScalarNode2Id atan(ScalarNode2Id x);
+  ScalarNode2Id lgamma(ScalarNode2Id x);
+  ScalarNode2Id polygamma(int n, ScalarNode2Id x);
+  ScalarNode2Id
+  if_equal(ScalarNode2Id a, ScalarNode2Id b, ScalarNode2Id c, ScalarNode2Id d);
+  ScalarNode2Id
+  if_less(ScalarNode2Id a, ScalarNode2Id b, ScalarNode2Id c, ScalarNode2Id d);
+  DistributionNode2Id normal(ScalarNode2Id mean, ScalarNode2Id stddev);
+  DistributionNode2Id half_normal(ScalarNode2Id stddev);
+  DistributionNode2Id beta(ScalarNode2Id a, ScalarNode2Id b);
+  DistributionNode2Id bernoulli(ScalarNode2Id prob);
+
+  void observe(ScalarNode2Id sample, double value);
+  unsigned query(ScalarNode2Id value);
+
+  Node2p operator[](const Node2Id& node_id) const;
+  ScalarNode2p operator[](const ScalarNode2Id& node_id) const;
+  DistributionNode2p operator[](const DistributionNode2Id& node_id) const;
+
+  Graph2 build();
+  ~Factory();
+
+ private:
+  Graph2::Factory& map = *this;
+  bool built = false;
+  std::unordered_map<Node2Id, Node2p> identifer_to_node;
+  std::unordered_map<Node2p, Node2Id> node_to_identifier;
+  std::vector<Node2p> queries;
+  std::list<std::pair<Node2p, double>> observations;
+  unsigned long next_identifier = 0;
+
+  ScalarNode2Id add_node(ScalarNode2p node);
+  DistributionNode2Id add_node(DistributionNode2p node);
+  ScalarSampleNode2Id add_node(std::shared_ptr<ScalarSampleNode2> node);
+};
+
+} // namespace beanmachine::minibmg

--- a/minibmg/graph2_factory.h
+++ b/minibmg/graph2_factory.h
@@ -107,7 +107,7 @@ class Graph2::Factory {
   ~Factory();
 
  private:
-  Graph2::Factory& map = *this;
+  Graph2::Factory& map = *this; // for convenience
   bool built = false;
   std::unordered_map<Node2Id, Node2p> identifer_to_node;
   std::unordered_map<Node2p, Node2Id> node_to_identifier;

--- a/minibmg/graph2_factory.h
+++ b/minibmg/graph2_factory.h
@@ -102,6 +102,7 @@ class Graph2::Factory {
   Node2p operator[](const Node2Id& node_id) const;
   ScalarNode2p operator[](const ScalarNode2Id& node_id) const;
   DistributionNode2p operator[](const DistributionNode2Id& node_id) const;
+  ScalarSampleNode2p operator[](const ScalarSampleNode2Id& node_id) const;
 
   Graph2 build();
   ~Factory();

--- a/minibmg/graph_properties/observations_by_node2.cpp
+++ b/minibmg/graph_properties/observations_by_node2.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "beanmachine/minibmg/graph_properties/observations_by_node2.h"
+
+namespace {
+
+using namespace beanmachine::minibmg;
+
+class ObservationByNodeProperty
+    : public Property<
+          ObservationByNodeProperty,
+          Graph2,
+          const std::unordered_map<Node2p, double>> {
+ public:
+  const std::unordered_map<Node2p, double>* create(
+      const Graph2& g) const override {
+    return new std::unordered_map<Node2p, double>{
+        g.observations.begin(), g.observations.end()};
+  }
+  ~ObservationByNodeProperty() {}
+};
+
+} // namespace
+
+namespace beanmachine::minibmg {
+
+const std::unordered_map<Node2p, double>& observations_by_node(
+    const Graph2& graph) {
+  return *ObservationByNodeProperty::get(graph);
+}
+
+} // namespace beanmachine::minibmg

--- a/minibmg/graph_properties/observations_by_node2.h
+++ b/minibmg/graph_properties/observations_by_node2.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <list>
+#include <unordered_set>
+#include "beanmachine/minibmg/graph2.h"
+#include "beanmachine/minibmg/node2.h"
+
+namespace beanmachine::minibmg {
+
+// A map from an observation node to its observed value.
+const std::unordered_map<Node2p, double>& observations_by_node(
+    const Graph2& graph);
+
+} // namespace beanmachine::minibmg

--- a/minibmg/graph_properties/out_nodes2.cpp
+++ b/minibmg/graph_properties/out_nodes2.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "beanmachine/minibmg/graph_properties/out_nodes2.h"
+#include <exception>
+#include <list>
+#include <map>
+
+namespace {
+
+using namespace beanmachine::minibmg;
+
+class Out_Nodes_Data {
+ public:
+  std::map<Node2p, std::list<Node2p>> node_map{};
+  std::list<Node2p>& for_node(Node2p node) {
+    auto found = node_map.find(node);
+    if (found == node_map.end()) {
+      throw std::invalid_argument("node not in graph");
+    }
+    return found->second;
+  }
+};
+
+class Out_Nodes_Property
+    : public Property<Out_Nodes_Property, Graph2, Out_Nodes_Data> {
+ public:
+  Out_Nodes_Data* create(const Graph2& g) const override {
+    Out_Nodes_Data* data = new Out_Nodes_Data{};
+    for (auto node : g) {
+      data->node_map[node] = std::list<Node2p>{};
+      for (auto in_node : in_nodes(node)) {
+        auto& predecessor_out_set = data->for_node(in_node);
+        predecessor_out_set.push_back(node);
+      }
+    }
+
+    return data;
+  }
+};
+
+} // namespace
+
+namespace beanmachine::minibmg {
+
+const std::list<Node2p>& out_nodes(const Graph2& graph, Node2p node) {
+  Out_Nodes_Data* data = Out_Nodes_Property::get(graph);
+  std::list<Node2p>& result = data->for_node(node);
+  return result;
+}
+
+} // namespace beanmachine::minibmg

--- a/minibmg/graph_properties/out_nodes2.h
+++ b/minibmg/graph_properties/out_nodes2.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <list>
+#include <unordered_set>
+#include "beanmachine/minibmg/graph2.h"
+#include "beanmachine/minibmg/node2.h"
+
+namespace beanmachine::minibmg {
+
+// return the set of nodes that have the given node as an input in the given
+// graph.
+const std::list<Node2p>& out_nodes(const Graph2& graph, Node2p node);
+
+} // namespace beanmachine::minibmg

--- a/minibmg/json2.cpp
+++ b/minibmg/json2.cpp
@@ -105,7 +105,7 @@ class JsonNodeWriterVisitor : public Node2Visitor {
 
 namespace beanmachine::minibmg {
 
-JsonError::JsonError(const std::string& message) : message(message) {}
+JsonError2::JsonError2(const std::string& message) : message(message) {}
 
 folly::dynamic graph2_to_json(const Graph2& g) {
   std::unordered_map<Node2p, unsigned long> node_to_identifier;
@@ -169,13 +169,13 @@ json_to_node( // NOLINT: large cyclomatic complexity doe not imply code
     int& identifier) {
   auto identifierv = json_node["sequence"];
   if (!identifierv.isInt()) {
-    throw JsonError("missing sequence number.");
+    throw JsonError2("missing sequence number.");
   }
   identifier = identifierv.asInt();
 
   auto opv = json_node["operator"];
   if (!opv.isString()) {
-    throw JsonError("missing operator.");
+    throw JsonError2("missing operator.");
   }
 
   std::vector<Node2p> in_nodes{};
@@ -187,15 +187,15 @@ json_to_node( // NOLINT: large cyclomatic complexity doe not imply code
     default:
       auto in_nodesv = json_node["in_nodes"];
       if (!in_nodesv.isArray()) {
-        throw JsonError("missing in_nodes.");
+        throw JsonError2("missing in_nodes.");
       }
       for (auto& in_nodev : in_nodesv) {
         if (!in_nodev.isInt()) {
-          throw JsonError("missing in_node for operator.");
+          throw JsonError2("missing in_node for operator.");
         }
         auto in_node_i = in_nodev.asInt();
         if (!identifier_to_node.contains(in_node_i)) {
-          throw JsonError("bad in_node for operator.");
+          throw JsonError2("bad in_node for operator.");
         }
         auto in_node = identifier_to_node[in_node_i];
         in_nodes.push_back(in_node);
@@ -212,7 +212,7 @@ json_to_node( // NOLINT: large cyclomatic complexity doe not imply code
       } else if (valuev.isDouble()) {
         value = valuev.asDouble();
       } else {
-        throw JsonError("bad value for constant.");
+        throw JsonError2("bad value for constant.");
       }
       return std::make_shared<const ScalarConstantNode2>(value);
     }
@@ -222,18 +222,18 @@ json_to_node( // NOLINT: large cyclomatic complexity doe not imply code
       if (namev.isString()) {
         name = namev.asString();
       } else {
-        throw JsonError("bad name for variable.");
+        throw JsonError2("bad name for variable.");
       }
       auto variable_indexv = json_node["variable_index"];
       if (!variable_indexv.isInt()) {
-        throw JsonError("bad variable_index for variable.");
+        throw JsonError2("bad variable_index for variable.");
       }
       auto variable_index = (unsigned)variable_indexv.asInt();
       return std::make_shared<const ScalarVariableNode2>(name, variable_index);
     }
     case "ADD"_sh: {
       if (in_nodes.size() != 2) {
-        throw JsonError("bad in_node for operator.");
+        throw JsonError2("bad in_node for operator.");
       }
       return std::make_shared<ScalarAddNode2>(
           std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
@@ -241,7 +241,7 @@ json_to_node( // NOLINT: large cyclomatic complexity doe not imply code
     }
     case "SUBTRACT"_sh: {
       if (in_nodes.size() != 2) {
-        throw JsonError("bad in_node for operator.");
+        throw JsonError2("bad in_node for operator.");
       }
       return std::make_shared<ScalarSubtractNode2>(
           std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
@@ -249,14 +249,14 @@ json_to_node( // NOLINT: large cyclomatic complexity doe not imply code
     }
     case "NEGATE"_sh: {
       if (in_nodes.size() != 1) {
-        throw JsonError("bad in_node for operator.");
+        throw JsonError2("bad in_node for operator.");
       }
       return std::make_shared<ScalarNegateNode2>(
           std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]));
     }
     case "MULTIPLY"_sh: {
       if (in_nodes.size() != 2) {
-        throw JsonError("bad in_node for operator.");
+        throw JsonError2("bad in_node for operator.");
       }
       return std::make_shared<ScalarMultiplyNode2>(
           std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
@@ -264,7 +264,7 @@ json_to_node( // NOLINT: large cyclomatic complexity doe not imply code
     }
     case "DIVIDE"_sh: {
       if (in_nodes.size() != 2) {
-        throw JsonError("bad in_node for operator.");
+        throw JsonError2("bad in_node for operator.");
       }
       return std::make_shared<ScalarDivideNode2>(
           std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
@@ -272,7 +272,7 @@ json_to_node( // NOLINT: large cyclomatic complexity doe not imply code
     }
     case "POW"_sh: {
       if (in_nodes.size() != 2) {
-        throw JsonError("bad in_node for operator.");
+        throw JsonError2("bad in_node for operator.");
       }
       return std::make_shared<ScalarPowNode2>(
           std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
@@ -280,35 +280,35 @@ json_to_node( // NOLINT: large cyclomatic complexity doe not imply code
     }
     case "EXP"_sh: {
       if (in_nodes.size() != 1) {
-        throw JsonError("bad in_node for operator.");
+        throw JsonError2("bad in_node for operator.");
       }
       return std::make_shared<ScalarExpNode2>(
           std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]));
     }
     case "LOG"_sh: {
       if (in_nodes.size() != 1) {
-        throw JsonError("bad in_node for operator.");
+        throw JsonError2("bad in_node for operator.");
       }
       return std::make_shared<ScalarLogNode2>(
           std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]));
     }
     case "ATAN"_sh: {
       if (in_nodes.size() != 1) {
-        throw JsonError("bad in_node for operator.");
+        throw JsonError2("bad in_node for operator.");
       }
       return std::make_shared<ScalarAtanNode2>(
           std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]));
     }
     case "LGAMMA"_sh: {
       if (in_nodes.size() != 1) {
-        throw JsonError("bad in_node for operator.");
+        throw JsonError2("bad in_node for operator.");
       }
       return std::make_shared<ScalarLgammaNode2>(
           std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]));
     }
     case "POLYGAMMA"_sh: {
       if (in_nodes.size() != 2) {
-        throw JsonError("bad in_node for operator.");
+        throw JsonError2("bad in_node for operator.");
       }
       return std::make_shared<ScalarPolygammaNode2>(
           std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
@@ -316,7 +316,7 @@ json_to_node( // NOLINT: large cyclomatic complexity doe not imply code
     }
     case "IF_EQUAL"_sh: {
       if (in_nodes.size() != 4) {
-        throw JsonError("bad in_node for operator.");
+        throw JsonError2("bad in_node for operator.");
       }
       return std::make_shared<ScalarIfEqualNode2>(
           std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
@@ -326,7 +326,7 @@ json_to_node( // NOLINT: large cyclomatic complexity doe not imply code
     }
     case "IF_LESS"_sh: {
       if (in_nodes.size() != 4) {
-        throw JsonError("bad in_node for operator.");
+        throw JsonError2("bad in_node for operator.");
       }
       return std::make_shared<ScalarIfLessNode2>(
           std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
@@ -336,7 +336,7 @@ json_to_node( // NOLINT: large cyclomatic complexity doe not imply code
     }
     case "DISTRIBUTION_NORMAL"_sh: {
       if (in_nodes.size() != 2) {
-        throw JsonError("bad in_node for operator.");
+        throw JsonError2("bad in_node for operator.");
       }
       return std::make_shared<DistributionNormalNode2>(
           std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
@@ -344,7 +344,7 @@ json_to_node( // NOLINT: large cyclomatic complexity doe not imply code
     }
     case "DISTRIBUTION_HALF_NORMAL"_sh: {
       if (in_nodes.size() != 1) {
-        throw JsonError("bad in_node for operator.");
+        throw JsonError2("bad in_node for operator.");
       }
       return std::make_shared<DistributionHalfNormalNode2>(
           std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]));
@@ -352,7 +352,7 @@ json_to_node( // NOLINT: large cyclomatic complexity doe not imply code
     }
     case "DISTRIBUTION_BETA"_sh: {
       if (in_nodes.size() != 2) {
-        throw JsonError("bad in_node for operator.");
+        throw JsonError2("bad in_node for operator.");
       }
       return std::make_shared<DistributionBetaNode2>(
           std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
@@ -360,20 +360,20 @@ json_to_node( // NOLINT: large cyclomatic complexity doe not imply code
     }
     case "DISTRIBUTION_BERNOULLI"_sh: {
       if (in_nodes.size() != 1) {
-        throw JsonError("bad in_node for operator.");
+        throw JsonError2("bad in_node for operator.");
       }
       return std::make_shared<DistributionBernoulliNode2>(
           std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]));
     }
     case "SAMPLE"_sh: {
       if (in_nodes.size() != 1) {
-        throw JsonError("bad in_node for operator.");
+        throw JsonError2("bad in_node for operator.");
       }
       return std::make_shared<ScalarSampleNode2>(
           std::dynamic_pointer_cast<const DistributionNode2>(in_nodes[0]));
     }
     default:
-      throw JsonError("operator unknown: " + opv.asString());
+      throw JsonError2("operator unknown: " + opv.asString());
   }
 }
 
@@ -391,14 +391,14 @@ Graph2 json_to_graph2(folly::dynamic d) {
 
   auto json_nodes = d["nodes"];
   if (!json_nodes.isArray()) {
-    throw JsonError("missing \"nodes\" property");
+    throw JsonError2("missing \"nodes\" property");
   }
 
   for (auto json_node : json_nodes) {
     int identifier;
     auto node = json_to_node(json_node, identifier_to_node, identifier);
     if (identifier_to_node.contains(identifier)) {
-      throw JsonError(fmt::format("duplicate node ID {}.", identifier));
+      throw JsonError2(fmt::format("duplicate node ID {}.", identifier));
     }
     identifier_to_node[identifier] = node;
   }
@@ -408,11 +408,11 @@ Graph2 json_to_graph2(folly::dynamic d) {
   if (query_nodes.isArray()) {
     for (auto& query : query_nodes) {
       if (!query.isInt()) {
-        throw JsonError("bad query value.");
+        throw JsonError2("bad query value.");
       }
       auto query_i = query.asInt();
       if (!identifier_to_node.contains(query_i)) {
-        throw JsonError(fmt::format("bad in_node {} for query.", query_i));
+        throw JsonError2(fmt::format("bad in_node {} for query.", query_i));
       }
       auto query_node = identifier_to_node[query_i];
       queries.push_back(query_node);
@@ -425,16 +425,17 @@ Graph2 json_to_graph2(folly::dynamic d) {
     for (auto& obs : observation_nodes) {
       auto node = obs["node"];
       if (!node.isInt()) {
-        throw JsonError("bad observation node.");
+        throw JsonError2("bad observation node.");
       }
       auto node_i = node.asInt();
       if (!identifier_to_node.contains(node_i)) {
-        throw JsonError(fmt::format("bad in_node {} for observation.", node_i));
+        throw JsonError2(
+            fmt::format("bad in_node {} for observation.", node_i));
       }
       auto& obs_node = identifier_to_node[node_i];
       auto& value = obs["value"];
       if (!node.isDouble() && !node.isInt()) {
-        throw JsonError("bad value for observation.");
+        throw JsonError2("bad value for observation.");
       }
       auto value_d = value.asDouble();
       observations.push_back(std::pair{obs_node, value_d});

--- a/minibmg/json2.cpp
+++ b/minibmg/json2.cpp
@@ -107,7 +107,7 @@ namespace beanmachine::minibmg {
 
 JsonError2::JsonError2(const std::string& message) : message(message) {}
 
-folly::dynamic graph2_to_json(const Graph2& g) {
+folly::dynamic graph_to_json(const Graph2& g) {
   std::unordered_map<Node2p, unsigned long> node_to_identifier;
   dynamic result = dynamic::object;
   result["comment"] = "created by graph_to_json";

--- a/minibmg/json2.cpp
+++ b/minibmg/json2.cpp
@@ -1,0 +1,447 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <folly/json.h>
+#include <memory>
+#include <string>
+#include <string_view>
+#include "beanmachine/minibmg/graph2.h"
+
+namespace {
+
+using namespace beanmachine::minibmg;
+using dynamic = folly::dynamic;
+
+inline constexpr auto hash_djb2a(const std::string_view sv) {
+  unsigned long hash{5381};
+  for (unsigned char c : sv) {
+    hash = ((hash << 5) + hash) ^ c;
+  }
+  return hash;
+}
+
+inline constexpr auto // NOLINT: this is used to effectively switch on a string
+                      // below. If we replace that implementation by one that
+                      // indexes a table of functions on a string, this would
+                      // not be necessary.
+operator"" _sh(const char* str, size_t len) {
+  return hash_djb2a(std::string_view{str, len});
+}
+
+class JsonNodeWriterVisitor : public Node2Visitor {
+ public:
+  explicit JsonNodeWriterVisitor(dynamic& dyn_node) : dyn_node{dyn_node} {}
+  dynamic& dyn_node;
+  void visit(const ScalarConstantNode2* node) override {
+    dyn_node["operator"] = "CONSTANT";
+    dyn_node["value"] = node->constant_value;
+  }
+  void visit(const ScalarVariableNode2* node) override {
+    dyn_node["operator"] = "VARIABLE";
+    dyn_node["name"] = node->name;
+    dyn_node["identifier"] = node->identifier;
+  }
+  void visit(const ScalarSampleNode2*) override {
+    dyn_node["operator"] = "SAMPLE";
+  }
+  void visit(const ScalarAddNode2*) override {
+    dyn_node["operator"] = "ADD";
+  }
+  void visit(const ScalarSubtractNode2*) override {
+    dyn_node["operator"] = "SUBTRACT";
+  }
+  void visit(const ScalarNegateNode2*) override {
+    dyn_node["operator"] = "NEGATE";
+  }
+  void visit(const ScalarMultiplyNode2*) override {
+    dyn_node["operator"] = "MULTIPLY";
+  }
+  void visit(const ScalarDivideNode2*) override {
+    dyn_node["operator"] = "DIVIDE";
+  }
+  void visit(const ScalarPowNode2*) override {
+    dyn_node["operator"] = "POW";
+  }
+  void visit(const ScalarExpNode2*) override {
+    dyn_node["operator"] = "EXP";
+  }
+  void visit(const ScalarLogNode2*) override {
+    dyn_node["operator"] = "LOG";
+  }
+  void visit(const ScalarAtanNode2*) override {
+    dyn_node["operator"] = "ATAN";
+  }
+  void visit(const ScalarLgammaNode2*) override {
+    dyn_node["operator"] = "LGAMMA";
+  }
+  void visit(const ScalarPolygammaNode2*) override {
+    dyn_node["operator"] = "POLYGAMMA";
+  }
+  void visit(const ScalarIfEqualNode2*) override {
+    dyn_node["operator"] = "IF_EQUAL";
+  }
+  void visit(const ScalarIfLessNode2*) override {
+    dyn_node["operator"] = "IF_LESS";
+  }
+  void visit(const DistributionNormalNode2*) override {
+    dyn_node["operator"] = "DISTRIBUTION_NORMAL";
+  }
+  void visit(const DistributionHalfNormalNode2*) override {
+    dyn_node["operator"] = "DISTRIBUTION_HALF_NORMAL";
+  }
+  void visit(const DistributionBetaNode2*) override {
+    dyn_node["operator"] = "DISTRIBUTION_BETA";
+  }
+  void visit(const DistributionBernoulliNode2*) override {
+    dyn_node["operator"] = "DISTRIBUTION_BERNOULLI";
+  }
+};
+
+} // namespace
+
+namespace beanmachine::minibmg {
+
+JsonError::JsonError(const std::string& message) : message(message) {}
+
+folly::dynamic graph2_to_json(const Graph2& g) {
+  std::unordered_map<Node2p, unsigned long> node_to_identifier;
+  dynamic result = dynamic::object;
+  result["comment"] = "created by graph_to_json";
+  dynamic a = dynamic::array;
+
+  unsigned long next_identifier = 0;
+  for (auto& node : g) {
+    // assign node identifiers sequentially.  They are called "sequence" in the
+    // generated json.
+    auto identifier = next_identifier++;
+    node_to_identifier[node] = identifier;
+    dynamic dyn_node = dynamic::object;
+    dyn_node["sequence"] = identifier;
+    JsonNodeWriterVisitor v{dyn_node};
+    node->accept(v);
+    auto in = in_nodes(node);
+    if (in.size() > 0) {
+      dynamic in_nodes = dynamic::array;
+      for (auto& n : in) {
+        in_nodes.push_back(node_to_identifier[n]);
+      }
+      dyn_node["in_nodes"] = in_nodes;
+    }
+
+    a.push_back(dyn_node);
+  }
+  result["nodes"] = a;
+
+  dynamic observations = dynamic::array;
+  for (auto& q : g.observations) {
+    dynamic d = dynamic::object;
+    auto id = node_to_identifier[q.first];
+    d["node"] = id;
+    d["value"] = q.second;
+    observations.push_back(d);
+  }
+  result["observations"] = observations;
+
+  dynamic queries = dynamic::array;
+  for (auto& q : g.queries) {
+    queries.push_back(node_to_identifier[q]);
+  }
+  result["queries"] = queries;
+
+  return result;
+}
+
+} // namespace beanmachine::minibmg
+
+namespace {
+
+Node2p
+json_to_node( // NOLINT: large cyclomatic complexity doe not imply code
+              // that is difficult to maintain.  In this case we might be able
+              // to replace the code with a table of functions indexed by
+              // string, but I'm not sure that would be better.
+    folly::dynamic json_node,
+    std::unordered_map<int, Node2p>& identifier_to_node,
+    int& identifier) {
+  auto identifierv = json_node["sequence"];
+  if (!identifierv.isInt()) {
+    throw JsonError("missing sequence number.");
+  }
+  identifier = identifierv.asInt();
+
+  auto opv = json_node["operator"];
+  if (!opv.isString()) {
+    throw JsonError("missing operator.");
+  }
+
+  std::vector<Node2p> in_nodes{};
+  switch (hash_djb2a(opv.asString())) {
+    case "CONSTANT"_sh:
+    case "VARIABLE"_sh:
+      // in_nodes ignored
+      break;
+    default:
+      auto in_nodesv = json_node["in_nodes"];
+      if (!in_nodesv.isArray()) {
+        throw JsonError("missing in_nodes.");
+      }
+      for (auto& in_nodev : in_nodesv) {
+        if (!in_nodev.isInt()) {
+          throw JsonError("missing in_node for operator.");
+        }
+        auto in_node_i = in_nodev.asInt();
+        if (!identifier_to_node.contains(in_node_i)) {
+          throw JsonError("bad in_node for operator.");
+        }
+        auto in_node = identifier_to_node[in_node_i];
+        in_nodes.push_back(in_node);
+      }
+      break;
+  }
+
+  switch (hash_djb2a(opv.asString())) {
+    case "CONSTANT"_sh: {
+      auto valuev = json_node["value"];
+      double value;
+      if (valuev.isInt()) {
+        value = valuev.asInt();
+      } else if (valuev.isDouble()) {
+        value = valuev.asDouble();
+      } else {
+        throw JsonError("bad value for constant.");
+      }
+      return std::make_shared<const ScalarConstantNode2>(value);
+    }
+    case "VARIABLE"_sh: {
+      auto namev = json_node["name"];
+      std::string name = "";
+      if (namev.isString()) {
+        name = namev.asString();
+      } else {
+        throw JsonError("bad name for variable.");
+      }
+      auto variable_indexv = json_node["variable_index"];
+      if (!variable_indexv.isInt()) {
+        throw JsonError("bad variable_index for variable.");
+      }
+      auto variable_index = (unsigned)variable_indexv.asInt();
+      return std::make_shared<const ScalarVariableNode2>(name, variable_index);
+    }
+    case "ADD"_sh: {
+      if (in_nodes.size() != 2) {
+        throw JsonError("bad in_node for operator.");
+      }
+      return std::make_shared<ScalarAddNode2>(
+          std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
+          std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[1]));
+    }
+    case "SUBTRACT"_sh: {
+      if (in_nodes.size() != 2) {
+        throw JsonError("bad in_node for operator.");
+      }
+      return std::make_shared<ScalarSubtractNode2>(
+          std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
+          std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[1]));
+    }
+    case "NEGATE"_sh: {
+      if (in_nodes.size() != 1) {
+        throw JsonError("bad in_node for operator.");
+      }
+      return std::make_shared<ScalarNegateNode2>(
+          std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]));
+    }
+    case "MULTIPLY"_sh: {
+      if (in_nodes.size() != 2) {
+        throw JsonError("bad in_node for operator.");
+      }
+      return std::make_shared<ScalarMultiplyNode2>(
+          std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
+          std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[1]));
+    }
+    case "DIVIDE"_sh: {
+      if (in_nodes.size() != 2) {
+        throw JsonError("bad in_node for operator.");
+      }
+      return std::make_shared<ScalarDivideNode2>(
+          std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
+          std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[1]));
+    }
+    case "POW"_sh: {
+      if (in_nodes.size() != 2) {
+        throw JsonError("bad in_node for operator.");
+      }
+      return std::make_shared<ScalarPowNode2>(
+          std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
+          std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[1]));
+    }
+    case "EXP"_sh: {
+      if (in_nodes.size() != 1) {
+        throw JsonError("bad in_node for operator.");
+      }
+      return std::make_shared<ScalarExpNode2>(
+          std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]));
+    }
+    case "LOG"_sh: {
+      if (in_nodes.size() != 1) {
+        throw JsonError("bad in_node for operator.");
+      }
+      return std::make_shared<ScalarLogNode2>(
+          std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]));
+    }
+    case "ATAN"_sh: {
+      if (in_nodes.size() != 1) {
+        throw JsonError("bad in_node for operator.");
+      }
+      return std::make_shared<ScalarAtanNode2>(
+          std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]));
+    }
+    case "LGAMMA"_sh: {
+      if (in_nodes.size() != 1) {
+        throw JsonError("bad in_node for operator.");
+      }
+      return std::make_shared<ScalarLgammaNode2>(
+          std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]));
+    }
+    case "POLYGAMMA"_sh: {
+      if (in_nodes.size() != 2) {
+        throw JsonError("bad in_node for operator.");
+      }
+      return std::make_shared<ScalarPolygammaNode2>(
+          std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
+          std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[1]));
+    }
+    case "IF_EQUAL"_sh: {
+      if (in_nodes.size() != 4) {
+        throw JsonError("bad in_node for operator.");
+      }
+      return std::make_shared<ScalarIfEqualNode2>(
+          std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
+          std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[1]),
+          std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[2]),
+          std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[3]));
+    }
+    case "IF_LESS"_sh: {
+      if (in_nodes.size() != 4) {
+        throw JsonError("bad in_node for operator.");
+      }
+      return std::make_shared<ScalarIfLessNode2>(
+          std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
+          std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[1]),
+          std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[2]),
+          std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[3]));
+    }
+    case "DISTRIBUTION_NORMAL"_sh: {
+      if (in_nodes.size() != 2) {
+        throw JsonError("bad in_node for operator.");
+      }
+      return std::make_shared<DistributionNormalNode2>(
+          std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
+          std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[1]));
+    }
+    case "DISTRIBUTION_HALF_NORMAL"_sh: {
+      if (in_nodes.size() != 1) {
+        throw JsonError("bad in_node for operator.");
+      }
+      return std::make_shared<DistributionHalfNormalNode2>(
+          std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]));
+      break;
+    }
+    case "DISTRIBUTION_BETA"_sh: {
+      if (in_nodes.size() != 2) {
+        throw JsonError("bad in_node for operator.");
+      }
+      return std::make_shared<DistributionBetaNode2>(
+          std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]),
+          std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[1]));
+    }
+    case "DISTRIBUTION_BERNOULLI"_sh: {
+      if (in_nodes.size() != 1) {
+        throw JsonError("bad in_node for operator.");
+      }
+      return std::make_shared<DistributionBernoulliNode2>(
+          std::dynamic_pointer_cast<const ScalarNode2>(in_nodes[0]));
+    }
+    case "SAMPLE"_sh: {
+      if (in_nodes.size() != 1) {
+        throw JsonError("bad in_node for operator.");
+      }
+      return std::make_shared<ScalarSampleNode2>(
+          std::dynamic_pointer_cast<const DistributionNode2>(in_nodes[0]));
+    }
+    default:
+      throw JsonError("operator unknown: " + opv.asString());
+  }
+}
+
+} // namespace
+
+namespace beanmachine::minibmg {
+
+Graph2 json_to_graph2(folly::dynamic d) {
+  // Nodes are identified by a "sequence" number appearing in json.
+  // They are arbitrary numbers.  The only requirement is that they
+  // are distinct.  They are used to identify nodes in the json.
+  // This map is used to identify the specific node when it is
+  // referenced in the json.
+  std::unordered_map<int, Node2p> identifier_to_node;
+
+  auto json_nodes = d["nodes"];
+  if (!json_nodes.isArray()) {
+    throw JsonError("missing \"nodes\" property");
+  }
+
+  for (auto json_node : json_nodes) {
+    int identifier;
+    auto node = json_to_node(json_node, identifier_to_node, identifier);
+    if (identifier_to_node.contains(identifier)) {
+      throw JsonError(fmt::format("duplicate node ID {}.", identifier));
+    }
+    identifier_to_node[identifier] = node;
+  }
+
+  std::vector<Node2p> queries;
+  auto query_nodes = d["queries"];
+  if (query_nodes.isArray()) {
+    for (auto& query : query_nodes) {
+      if (!query.isInt()) {
+        throw JsonError("bad query value.");
+      }
+      auto query_i = query.asInt();
+      if (!identifier_to_node.contains(query_i)) {
+        throw JsonError(fmt::format("bad in_node {} for query.", query_i));
+      }
+      auto query_node = identifier_to_node[query_i];
+      queries.push_back(query_node);
+    }
+  }
+
+  std::list<std::pair<Node2p, double>> observations;
+  auto observation_nodes = d["observations"];
+  if (observation_nodes.isArray()) {
+    for (auto& obs : observation_nodes) {
+      auto node = obs["node"];
+      if (!node.isInt()) {
+        throw JsonError("bad observation node.");
+      }
+      auto node_i = node.asInt();
+      if (!identifier_to_node.contains(node_i)) {
+        throw JsonError(fmt::format("bad in_node {} for observation.", node_i));
+      }
+      auto& obs_node = identifier_to_node[node_i];
+      auto& value = obs["value"];
+      if (!node.isDouble() && !node.isInt()) {
+        throw JsonError("bad value for observation.");
+      }
+      auto value_d = value.asDouble();
+      observations.push_back(std::pair{obs_node, value_d});
+    }
+  }
+
+  return Graph2::create(queries, observations);
+}
+
+} // namespace beanmachine::minibmg

--- a/minibmg/localopt.cpp
+++ b/minibmg/localopt.cpp
@@ -7,29 +7,16 @@
 
 #include "beanmachine/minibmg/localopt.h"
 #include <memory>
+#include <stdexcept>
 #include <unordered_map>
-#include "beanmachine/minibmg/node.h"
-#include "beanmachine/minibmg/operator.h"
+#include "beanmachine/minibmg/node2.h"
 #include "beanmachine/minibmg/topological.h"
 
 namespace {
 
 using namespace beanmachine::minibmg;
-double k(Nodep node) {
-  return std::dynamic_pointer_cast<const ConstantNode>(node)->value;
-}
 
-NodepIdentityEquals same{};
-
-Nodep make_operator(Operator op, std::vector<Nodep> in_nodes) {
-  return std::make_shared<OperatorNode>(in_nodes, op, Type::REAL);
-}
-
-} // namespace
-
-namespace beanmachine::minibmg {
-
-Nodep rewrite_node(const Nodep& node, NodeValueMap<Nodep>& map);
+Node2pIdentityEquals same{};
 
 // This is a temporary hack to perform some local optimizations on the a graph
 // node. Ultimately, these should be organized into a rewriter based on tree
@@ -37,317 +24,562 @@ Nodep rewrite_node(const Nodep& node, NodeValueMap<Nodep>& map);
 // faster.  For now we hand-implement a few rules by brute force.  The one-line
 // comment before each transformation shows what the rule would look like in a
 // hypothetical rewriting system.
-Nodep rewrite_one(const Nodep& node, NodeValueMap<Nodep>& map) {
-  // A semantically equivalent node was already rewritten.
-  if (auto found = map.find(node); found != map.end()) {
-    return found->second;
-  }
-  switch (node->op) {
-    case Operator::ADD: {
-      auto op = std::dynamic_pointer_cast<const OperatorNode>(node);
-      // {k1 + k2, k3}, // constant fold
-      auto left = map.at(op->in_nodes[0]);
-      auto right = map.at(op->in_nodes[1]);
-      if (left->op == Operator::CONSTANT && right->op == Operator::CONSTANT) {
-        return std::make_shared<ConstantNode>(k(left) + k(right));
-      }
-      // {0 + x, x},
-      if (left->op == Operator::CONSTANT && k(left) == 0) {
-        return right;
-      }
-      // {x + 0, x},
-      if (right->op == Operator::CONSTANT && k(right) == 0) {
-        return left;
-      }
-      // {x + x, 2 * x},
-      if (same(left, right)) {
-        auto two = rewrite_node(std::make_shared<ConstantNode>(2), map);
-        return make_operator(Operator::MULTIPLY, {two, left});
-      }
-      if (left == op->in_nodes[0] && right == op->in_nodes[1]) {
-        return node;
-      }
-      return make_operator(Operator::ADD, {left, right});
+class RewriteOneVisitor : Node2Visitor {
+ private:
+  Node2Node2ValueMap& map;
+  Node2p original;
+  Node2p rewritten;
+
+ public:
+  explicit RewriteOneVisitor(Node2Node2ValueMap& map) : map{map} {}
+  Node2p rewrite_one(const Node2p& node) {
+    if (auto found = map.find(node); found != map.end()) {
+      // A semantically equivalent node was already rewritten.
+      return found->second;
     }
 
-    case Operator::SUBTRACT: {
-      auto op = std::dynamic_pointer_cast<const OperatorNode>(node);
-      auto left = map.at(op->in_nodes[0]);
-      auto right = map.at(op->in_nodes[1]);
-      // {k1 - k2, k3}, // constant fold
-      if (left->op == Operator::CONSTANT && right->op == Operator::CONSTANT) {
-        return std::make_shared<ConstantNode>(k(left) - k(right));
-      }
-      // {0 - x, -x},
-      if (left->op == Operator::CONSTANT && k(left) == 0) {
-        return make_operator(Operator::NEGATE, {right});
-      }
-      // {x - 0, x},
-      if (right->op == Operator::CONSTANT && k(right) == 0) {
-        return left;
-      }
-      // {x - x, 0},
-      if (same(left, right)) {
-        return std::make_shared<ConstantNode>(0);
-      }
-      if (left == op->in_nodes[0] && right == op->in_nodes[1]) {
-        return node;
-      }
-      return make_operator(Operator::SUBTRACT, {left, right});
+    rewritten = nullptr;
+    original = node;
+    node->accept(*this);
+    if (rewritten == nullptr) {
+      throw std::logic_error("missing node rewrite case");
     }
 
-    case Operator::NEGATE: {
-      auto op = std::dynamic_pointer_cast<const OperatorNode>(node);
-      auto x = map.at(op->in_nodes[0]);
-      // {-k, k3}, // constant fold
-      if (x->op == Operator::CONSTANT) {
-        return std::make_shared<ConstantNode>(-k(x));
-      }
-      // {--x, x},
-      if (x->op == Operator::NEGATE) {
-        return std::dynamic_pointer_cast<const OperatorNode>(x)->in_nodes[0];
-      }
-      if (x == op->in_nodes[0]) {
-        return node;
-      }
-      return make_operator(Operator::NEGATE, {x});
-    }
-
-    case Operator::MULTIPLY: {
-      auto op = std::dynamic_pointer_cast<const OperatorNode>(node);
-      auto left = map.at(op->in_nodes[0]);
-      auto right = map.at(op->in_nodes[1]);
-      // {k1 * k2, k3}, // constant fold
-      if (left->op == Operator::CONSTANT && right->op == Operator::CONSTANT) {
-        return std::make_shared<ConstantNode>(k(left) * k(right));
-      }
-      // {0 * x, 0},
-      if (left->op == Operator::CONSTANT && k(left) == 0) {
-        return left;
-      }
-      // {-1 * x, -x},
-      if (left->op == Operator::CONSTANT && k(left) == -1) {
-        return make_operator(Operator::NEGATE, {right});
-      }
-      // {1 * x, x},
-      if (left->op == Operator::CONSTANT && k(left) == 1) {
-        return right;
-      }
-      // {x * 0, 0},
-      if (right->op == Operator::CONSTANT && k(right) == 0) {
-        return right;
-      }
-      // {x * 1, x},
-      if (right->op == Operator::CONSTANT && k(right) == 1) {
-        return left;
-      }
-      // {k1 * (k2 * x), k3 * x },
-      if (left->op == Operator::CONSTANT && right->op == Operator::MULTIPLY) {
-        auto rop = std::dynamic_pointer_cast<const OperatorNode>(node);
-        if (rop->in_nodes[0]->op == Operator::CONSTANT) {
-          auto k3 = rewrite_node(
-              std::make_shared<ConstantNode>(k(left) * k(rop->in_nodes[0])),
-              map);
-          return make_operator(Operator::MULTIPLY, {k3, rop->in_nodes[1]});
-        }
-      }
-      if (left == op->in_nodes[0] && right == op->in_nodes[1]) {
-        return node;
-      }
-      return make_operator(Operator::MULTIPLY, {left, right});
-    }
-
-    case Operator::DIVIDE: {
-      auto op = std::dynamic_pointer_cast<const OperatorNode>(node);
-      auto left = map.at(op->in_nodes[0]);
-      auto right = map.at(op->in_nodes[1]);
-      // {k1 / k2, k3}, // constant fold
-      if (left->op == Operator::CONSTANT && right->op == Operator::CONSTANT) {
-        return std::make_shared<ConstantNode>(k(left) / k(right));
-      }
-      // {x / k, (1/k) * x},
-      if (right->op == Operator::CONSTANT) {
-        auto k3 =
-            rewrite_node(std::make_shared<ConstantNode>(1 / k(right)), map);
-        return make_operator(Operator::MULTIPLY, {k3, left});
-      }
-      if (left == op->in_nodes[0] && right == op->in_nodes[1]) {
-        return node;
-      }
-      return make_operator(Operator::DIVIDE, {left, right});
-    }
-
-    case Operator::POW: {
-      auto op = std::dynamic_pointer_cast<const OperatorNode>(node);
-      auto left = map.at(op->in_nodes[0]);
-      auto right = map.at(op->in_nodes[1]);
-      // {pow(k1, k2), k3}, // constant fold
-      if (left->op == Operator::CONSTANT && right->op == Operator::CONSTANT) {
-        auto k3 = std::pow(k(left), k(right));
-        return std::make_shared<ConstantNode>(k3);
-      }
-      // {pow(x, 1), x},
-      if (right->op == Operator::CONSTANT && k(right) == 1) {
-        return left;
-      }
-      if (left == op->in_nodes[0] && right == op->in_nodes[1]) {
-        return node;
-      }
-      return make_operator(Operator::POW, {left, right});
-    }
-
-    case Operator::EXP: {
-      auto op = std::dynamic_pointer_cast<const OperatorNode>(node);
-      auto x = map.at(op->in_nodes[0]);
-      // {exp(k), k3}, // constant fold
-      if (x->op == Operator::CONSTANT) {
-        return std::make_shared<ConstantNode>(std::exp(k(x)));
-      }
-      // {exp(log(x)), x},
-      if (x->op == Operator::LOG) {
-        return std::dynamic_pointer_cast<const OperatorNode>(x)->in_nodes[0];
-      }
-      if (x == op->in_nodes[0]) {
-        return node;
-      }
-      return make_operator(Operator::EXP, {x});
-    }
-
-    case Operator::LOG: {
-      auto op = std::dynamic_pointer_cast<const OperatorNode>(node);
-      auto x = map.at(op->in_nodes[0]);
-      // {log(k), k3}, // constant fold
-      if (x->op == Operator::CONSTANT) {
-        return std::make_shared<ConstantNode>(std::log(k(x)));
-      }
-      // {log(exp(x)), x},
-      if (x->op == Operator::EXP) {
-        return std::dynamic_pointer_cast<const OperatorNode>(x)->in_nodes[0];
-      }
-      if (x == op->in_nodes[0]) {
-        return node;
-      }
-      return make_operator(Operator::LOG, {x});
-    }
-
-    case Operator::ATAN: {
-      auto op = std::dynamic_pointer_cast<const OperatorNode>(node);
-      auto x = map.at(op->in_nodes[0]);
-      // {atan(k), k3}, // constant fold
-      if (x->op == Operator::CONSTANT) {
-        return std::make_shared<ConstantNode>(std::atan(k(x)));
-      }
-      if (x == op->in_nodes[0]) {
-        return node;
-      }
-      return make_operator(Operator::ATAN, {x});
-    }
-
-    case Operator::LGAMMA: {
-      auto op = std::dynamic_pointer_cast<const OperatorNode>(node);
-      auto x = map.at(op->in_nodes[0]);
-      // {lgamma(k), k3}, // constant fold
-      if (x->op == Operator::CONSTANT) {
-        return std::make_shared<ConstantNode>(std::lgamma(k(x)));
-      }
-      if (x == op->in_nodes[0]) {
-        return node;
-      }
-      return make_operator(Operator::LGAMMA, {x});
-    }
-
-    case Operator::POLYGAMMA: {
-      auto op = std::dynamic_pointer_cast<const OperatorNode>(node);
-      auto left = map.at(op->in_nodes[0]);
-      auto right = map.at(op->in_nodes[1]);
-      // {polygamma(k1, k2), k3}, // constant fold
-      if (left->op == Operator::CONSTANT && right->op == Operator::CONSTANT) {
-        auto value = boost::math::polygamma(k(left), k(right));
-        return std::make_shared<ConstantNode>(value);
-      }
-      if (left == op->in_nodes[0] && right == op->in_nodes[1]) {
-        return node;
-      }
-      return make_operator(Operator::POLYGAMMA, {left, right});
-    }
-
-    default:
-      break;
+    return rewritten;
   }
 
-  return node;
-}
+  ScalarNode2p rewrite_scalar_node(const ScalarNode2p& node) {
+    return std::dynamic_pointer_cast<const ScalarNode2>(rewrite_node(node));
+  }
 
-// The following method may be useful in debugging the problematic case
-// that the rewrite_one method returns nested nodes that it does not
-// place in the map. It is commented out in normal use, but when the
-// optimizer throws an exception because a node is not in the map, this
-// will likely be helpful in finding the problem.
-bool check_children(const Nodep& node, NodeValueMap<Nodep>& map) {
-  if (auto op = std::dynamic_pointer_cast<const OperatorNode>(node)) {
-    for (auto& in : op->in_nodes) {
+  // The following method may be useful in debugging the problematic case
+  // that the rewrite_one method returns nested nodes that it does not
+  // place in the map. It is commented out in normal use, but when the
+  // optimizer throws an exception because a node is not in the map, this
+  // will likely be helpful in finding the problem.
+  bool check_children(const Node2p& node) {
+    for (auto in : in_nodes(node)) {
       if (!map.contains(in) || map.at(in) == nullptr) {
         return false;
       }
     }
+    return true;
   }
-  return true;
-}
 
-// An intermediate method placed into the call-chain just to make debugging
-// easier.
-inline Nodep rewrite_one_internal(const Nodep& node, NodeValueMap<Nodep>& map) {
-  return rewrite_one(node, map);
-}
-
-// Call the rewriter repeatedly on a node until a fixed-point is reached, and
-// then place the result in the node-value-based map.
-Nodep rewrite_node(const Nodep& node, NodeValueMap<Nodep>& map) {
-  // check_children(node, map);
-  Nodep rewritten = node;
-  while (true) {
-    const Nodep n = rewrite_one_internal(rewritten, map);
-    if (same(n, rewritten)) {
+  // Call the rewriter repeatedly on a node until a fixed-point is reached, and
+  // then place the result in the node-value-based map.
+  Node2p rewrite_node(const Node2p& node) {
+    // check_children(node, map);
+    Node2p rewritten = node;
+    while (true) {
+      const Node2p n = rewrite_one(rewritten);
+      if (same(n, rewritten)) {
+        rewritten = n;
+        break;
+      }
+      if (n == nullptr) {
+        throw std::logic_error("rewriter should not return nullptr");
+      }
       rewritten = n;
-      break;
     }
-    if (n == nullptr) {
-      throw std::logic_error("rewriter should not return nullptr");
-    }
-    map[rewritten] = n;
-    rewritten = n;
-  }
-  if (auto found = map.find(node);
-      found == map.end() || !same(rewritten, found->second)) {
-    if (rewritten == nullptr) {
-      throw std::logic_error("rewriter should not return nullptr");
-    }
-    map[node] = rewritten;
-  }
-  map[rewritten] = rewritten;
-  return rewritten;
-}
 
-std::unordered_map<Nodep, Nodep> opt_map(std::vector<Nodep> roots) {
-  std::vector<Nodep> sorted;
-  if (!topological_sort<Nodep>(
+    if (auto found = map.find(node);
+        found == map.end() || !same(rewritten, found->second)) {
+      if (rewritten == nullptr) {
+        throw std::logic_error("rewriter should not return nullptr");
+      }
+      map.insert(node, rewritten);
+    }
+
+    map.insert(rewritten, rewritten);
+    return rewritten;
+  }
+
+ private:
+  void visit(const ScalarConstantNode2*) override {
+    rewritten = original;
+  }
+
+  void visit(const ScalarVariableNode2*) override {
+    rewritten = original;
+  }
+
+  void visit(const ScalarSampleNode2* node) override {
+    auto d = map.at(node->distribution);
+    if (node->distribution != d) {
+      rewritten = std::make_shared<ScalarSampleNode2>(d, node->rvid);
+    }
+
+    else {
+      rewritten = original;
+    }
+  }
+
+  void visit(const ScalarAddNode2* node) override {
+    auto left = map.at(node->left);
+    auto right = map.at(node->right);
+    auto left_constant =
+        std::dynamic_pointer_cast<const ScalarConstantNode2>(left);
+    auto right_constant =
+        std::dynamic_pointer_cast<const ScalarConstantNode2>(right);
+
+    // {k1 + k2, k3}, // constant fold
+    if (left_constant && right_constant) {
+      rewritten = std::make_shared<ScalarConstantNode2>(
+          left_constant->constant_value + right_constant->constant_value);
+    }
+
+    // {0 + x, x},
+    else if (left_constant && left_constant->constant_value == 0) {
+      rewritten = right;
+    }
+
+    // {x + 0, x},
+    else if (right_constant && right_constant->constant_value == 0) {
+      rewritten = left;
+    }
+
+    // {x + x, 2 * x},
+    else if (same(left, right)) {
+      ScalarNode2p two =
+          rewrite_scalar_node(std::make_shared<ScalarConstantNode2>(2));
+      rewritten = std::make_shared<ScalarMultiplyNode2>(two, left);
+    }
+
+    else if (left != node->left || right != node->right) {
+      rewritten = std::make_shared<ScalarAddNode2>(left, right);
+    }
+
+    else {
+      rewritten = original;
+    }
+  }
+
+  void visit(const ScalarSubtractNode2* node) override {
+    auto left = map.at(node->left);
+    auto right = map.at(node->right);
+    auto left_constant =
+        std::dynamic_pointer_cast<const ScalarConstantNode2>(left);
+    auto right_constant =
+        std::dynamic_pointer_cast<const ScalarConstantNode2>(right);
+
+    // {k1 - k2, k3}, // constant fold
+    if (left_constant && right_constant) {
+      rewritten = std::make_shared<ScalarConstantNode2>(
+          left_constant->constant_value - right_constant->constant_value);
+    }
+
+    // {0 - x, -x},
+    else if (left_constant && left_constant->constant_value == 0) {
+      rewritten = std::make_shared<ScalarNegateNode2>(right);
+    }
+
+    // {x - 0, x},
+    else if (right_constant && right_constant->constant_value == 0) {
+      rewritten = left;
+    }
+
+    // {x - x, 0},
+    else if (same(left, right)) {
+      rewritten = std::make_shared<ScalarConstantNode2>(0);
+    }
+
+    else if (left != node->left || right != node->right) {
+      rewritten = std::make_shared<ScalarSubtractNode2>(left, right);
+    }
+
+    else {
+      rewritten = original;
+    }
+  }
+
+  void visit(const ScalarNegateNode2* node) override {
+    auto x = map.at(node->x);
+    auto x_constant = std::dynamic_pointer_cast<const ScalarConstantNode2>(x);
+
+    // {-k, k3}, // constant fold
+    if (x_constant) {
+      rewritten =
+          std::make_shared<ScalarConstantNode2>(-x_constant->constant_value);
+    }
+
+    // {--x, x},
+    else if (
+        auto x_negate = std::dynamic_pointer_cast<const ScalarNegateNode2>(x)) {
+      rewritten = x_negate->x;
+    }
+
+    else if (x != node->x) {
+      rewritten = std::make_shared<ScalarNegateNode2>(x);
+    }
+
+    else {
+      rewritten = original;
+    }
+  }
+
+  void visit(const ScalarMultiplyNode2* node) override {
+    auto left = map.at(node->left);
+    auto right = map.at(node->right);
+    auto left_constant =
+        std::dynamic_pointer_cast<const ScalarConstantNode2>(left);
+    auto right_constant =
+        std::dynamic_pointer_cast<const ScalarConstantNode2>(right);
+
+    // {k1 * k2, k3}, // constant fold
+    if (left_constant && right_constant) {
+      rewritten = std::make_shared<ScalarConstantNode2>(
+          left_constant->constant_value * right_constant->constant_value);
+    }
+
+    // {0 * x, 0},
+    else if (left_constant && left_constant->constant_value == 0) {
+      rewritten = left;
+    }
+
+    // {-1 * x, -x},
+    else if (left_constant && left_constant->constant_value == -1) {
+      rewritten = std::make_shared<ScalarNegateNode2>(right);
+    }
+
+    // {1 * x, x},
+    else if (left_constant && left_constant->constant_value == 1) {
+      rewritten = right;
+    }
+
+    // {x * 0, 0},
+    else if (right_constant && right_constant->constant_value == 0) {
+      rewritten = right;
+    }
+
+    // {x * 1, x},
+    else if (right_constant && right_constant->constant_value == 1) {
+      rewritten = left;
+    }
+
+    // {k1 * (k2 * x), k3 * x },
+    else if (auto right_multiply =
+                 std::dynamic_pointer_cast<const ScalarMultiplyNode2>(right);
+             left_constant && right_multiply) {
+      if (auto right_left_constant =
+              std::dynamic_pointer_cast<const ScalarConstantNode2>(
+                  right_multiply->left);
+          right_left_constant) {
+        auto k3 = rewrite_scalar_node(std::make_shared<ScalarConstantNode2>(
+            left_constant->constant_value *
+            right_left_constant->constant_value));
+        rewritten =
+            std::make_shared<ScalarMultiplyNode2>(k3, right_multiply->right);
+      }
+    }
+
+    if (rewritten == nullptr) {
+      if (left != node->left || right != node->right) {
+        rewritten = std::make_shared<ScalarMultiplyNode2>(left, right);
+      }
+
+      else {
+        rewritten = original;
+      }
+    }
+  }
+
+  void visit(const ScalarDivideNode2* node) override {
+    auto left = map.at(node->left);
+    auto right = map.at(node->right);
+    auto left_constant =
+        std::dynamic_pointer_cast<const ScalarConstantNode2>(left);
+    auto right_constant =
+        std::dynamic_pointer_cast<const ScalarConstantNode2>(right);
+
+    // {k1 / k2, k3}, // constant fold
+    if (left_constant && right_constant) {
+      rewritten = std::make_shared<ScalarConstantNode2>(
+          left_constant->constant_value / right_constant->constant_value);
+    }
+
+    // {0 / x, 0},
+    else if (left_constant && left_constant->constant_value == 0) {
+      rewritten = left;
+    }
+
+    // {x / k, (1/k) * x},
+    else if (right_constant) {
+      auto k3 = rewrite_scalar_node(std::make_shared<ScalarConstantNode2>(
+          1 / right_constant->constant_value));
+      rewritten = std::make_shared<ScalarMultiplyNode2>(k3, left);
+    }
+
+    else if (left != node->left || right != node->right) {
+      rewritten = std::make_shared<ScalarDivideNode2>(left, right);
+    }
+
+    else {
+      rewritten = original;
+    }
+  }
+
+  void visit(const ScalarPowNode2* node) override {
+    auto left = map.at(node->left);
+    auto right = map.at(node->right);
+    auto left_constant =
+        std::dynamic_pointer_cast<const ScalarConstantNode2>(left);
+    auto right_constant =
+        std::dynamic_pointer_cast<const ScalarConstantNode2>(right);
+
+    // {pow(k1, k2), k3}, // constant fold
+    if (left_constant && right_constant) {
+      auto k3 = std::pow(
+          left_constant->constant_value, right_constant->constant_value);
+      rewritten = std::make_shared<ScalarConstantNode2>(k3);
+    }
+
+    // {pow(x, 1), x},
+    else if (right_constant && right_constant->constant_value == 1) {
+      rewritten = left;
+    }
+
+    else if (left == node->left && right == node->right) {
+      rewritten = original;
+    }
+
+    else {
+      rewritten = std::make_shared<ScalarPowNode2>(left, right);
+    }
+  }
+
+  void visit(const ScalarExpNode2* node) override {
+    auto x = map.at(node->x);
+    auto x_constant = std::dynamic_pointer_cast<const ScalarConstantNode2>(x);
+
+    // {exp(k), k3}, // constant fold
+    if (x_constant) {
+      rewritten = std::make_shared<ScalarConstantNode2>(
+          std::exp(x_constant->constant_value));
+    }
+
+    // {exp(log(x)), x},
+    else if (auto x_log = std::dynamic_pointer_cast<const ScalarLogNode2>(x)) {
+      rewritten = x_log->x;
+    }
+
+    else if (x == node->x) {
+      rewritten = original;
+    }
+
+    else {
+      rewritten = std::make_shared<ScalarExpNode2>(x);
+    }
+  }
+
+  void visit(const ScalarLogNode2* node) override {
+    auto x = map.at(node->x);
+    auto x_constant = std::dynamic_pointer_cast<const ScalarConstantNode2>(x);
+
+    // {log(k), k3}, // constant fold
+    if (x_constant) {
+      rewritten = std::make_shared<ScalarConstantNode2>(
+          std::log(x_constant->constant_value));
+    }
+
+    // {log(exp(x)), x},
+    else if (auto x_exp = std::dynamic_pointer_cast<const ScalarExpNode2>(x)) {
+      rewritten = x_exp->x;
+    }
+
+    else if (x == node->x) {
+      rewritten = original;
+    }
+
+    else {
+      rewritten = std::make_shared<ScalarLogNode2>(x);
+    }
+  }
+
+  void visit(const ScalarAtanNode2* node) override {
+    auto x = map.at(node->x);
+    auto x_constant = std::dynamic_pointer_cast<const ScalarConstantNode2>(x);
+
+    // {atan(k), k3}, // constant fold
+    if (x_constant) {
+      rewritten = std::make_shared<ScalarConstantNode2>(
+          std::atan(x_constant->constant_value));
+    }
+
+    else if (x == node->x) {
+      rewritten = original;
+    }
+
+    else {
+      rewritten = std::make_shared<ScalarAtanNode2>(x);
+    }
+  }
+
+  void visit(const ScalarLgammaNode2* node) override {
+    auto x = map.at(node->x);
+    auto x_constant = std::dynamic_pointer_cast<const ScalarConstantNode2>(x);
+
+    // {lgamma(k), k3}, // constant fold
+    if (x_constant) {
+      rewritten = std::make_shared<ScalarConstantNode2>(
+          std::lgamma(x_constant->constant_value));
+    }
+
+    else if (x == node->x) {
+      rewritten = original;
+    }
+
+    else {
+      rewritten = std::make_shared<ScalarLgammaNode2>(x);
+    }
+  }
+
+  void visit(const ScalarPolygammaNode2* node) override {
+    auto n = map.at(node->n);
+    auto x = map.at(node->x);
+    auto n_constant = std::dynamic_pointer_cast<const ScalarConstantNode2>(n);
+    auto x_constant = std::dynamic_pointer_cast<const ScalarConstantNode2>(x);
+
+    // {lgamma(k), k3}, // constant fold
+    if (n_constant && x_constant) {
+      auto value = boost::math::polygamma(
+          n_constant->constant_value, x_constant->constant_value);
+      rewritten = std::make_shared<ScalarConstantNode2>(value);
+    }
+
+    else if (n == node->n && x == node->x) {
+      rewritten = original;
+    }
+
+    else {
+      rewritten = std::make_shared<ScalarPolygammaNode2>(n, x);
+    }
+  }
+
+  void visit(const ScalarIfEqualNode2* node) override {
+    auto a = map.at(node->a);
+    auto b = map.at(node->b);
+    auto c = map.at(node->c);
+    auto d = map.at(node->d);
+    auto a_constant = std::dynamic_pointer_cast<const ScalarConstantNode2>(a);
+    auto b_constant = std::dynamic_pointer_cast<const ScalarConstantNode2>(b);
+
+    if (a_constant && b_constant) {
+      rewritten =
+          (a_constant->constant_value == b_constant->constant_value) ? c : d;
+    }
+
+    else if (a == node->a && b == node->b && c == node->c && d == node->d) {
+      rewritten = original;
+    }
+
+    else {
+      rewritten = std::make_shared<ScalarIfEqualNode2>(a, b, c, d);
+    }
+  }
+
+  void visit(const ScalarIfLessNode2* node) override {
+    auto a = map.at(node->a);
+    auto b = map.at(node->b);
+    auto c = map.at(node->c);
+    auto d = map.at(node->d);
+    auto a_constant = std::dynamic_pointer_cast<const ScalarConstantNode2>(a);
+    auto b_constant = std::dynamic_pointer_cast<const ScalarConstantNode2>(b);
+
+    if (a_constant && b_constant) {
+      rewritten =
+          (a_constant->constant_value < b_constant->constant_value) ? c : d;
+    }
+
+    else if (a == node->a && b == node->b && c == node->c && d == node->d) {
+      rewritten = original;
+    }
+
+    else {
+      rewritten = std::make_shared<ScalarIfLessNode2>(a, b, c, d);
+    }
+  }
+
+  void visit(const DistributionNormalNode2* node) override {
+    auto mean = map.at(node->mean);
+    auto stddev = map.at(node->stddev);
+
+    if (mean == node->mean && stddev == node->stddev) {
+      rewritten = original;
+    }
+
+    else {
+      rewritten = std::make_shared<DistributionNormalNode2>(mean, stddev);
+    }
+  }
+
+  void visit(const DistributionHalfNormalNode2* node) override {
+    auto stddev = map.at(node->stddev);
+
+    if (stddev == node->stddev) {
+      rewritten = original;
+    }
+
+    else {
+      rewritten = std::make_shared<DistributionHalfNormalNode2>(stddev);
+    }
+  }
+
+  void visit(const DistributionBetaNode2* node) override {
+    auto a = map.at(node->a);
+    auto b = map.at(node->b);
+
+    if (a == node->a && b == node->b) {
+      rewritten = original;
+    }
+
+    else {
+      rewritten = std::make_shared<DistributionBetaNode2>(a, b);
+    }
+  }
+
+  void visit(const DistributionBernoulliNode2* node) override {
+    auto prob = map.at(node->prob);
+
+    if (prob == node->prob) {
+      rewritten = original;
+    }
+
+    else {
+      rewritten = std::make_shared<DistributionBernoulliNode2>(prob);
+    }
+  }
+};
+
+} // namespace
+
+namespace beanmachine::minibmg {
+
+Node2p rewrite_node(const Node2p& node, Node2Node2ValueMap& map);
+
+std::unordered_map<Node2p, Node2p> opt_map(std::vector<Node2p> roots) {
+  std::vector<Node2p> sorted;
+  if (!topological_sort<Node2p>(
           {roots.begin(), roots.end()}, in_nodes, sorted)) {
     throw std::invalid_argument("graph has a cycle");
   }
   std::reverse(sorted.begin(), sorted.end());
 
   // a value-based, map, which treats semantically identical nodes as the same.
-  NodeValueMap<Nodep> map;
+  Node2Node2ValueMap map;
+  RewriteOneVisitor v{map};
+
   for (auto& node : sorted) {
-    rewrite_node(node, map);
+    v.rewrite_node(node);
   }
 
   // We also build a map that uses object (pointer) identity to find elements,
-  // so that operations in clients are not using recursive equality operations.
-  std::unordered_map<Nodep, Nodep> identity_map;
+  // so that clients are not using recursive node equality tests.
+  std::unordered_map<Node2p, Node2p> identity_map;
   for (auto& node : sorted) {
     identity_map.insert({node, map.at(node)});
   }
+
   return identity_map;
 }
 

--- a/minibmg/localopt.h
+++ b/minibmg/localopt.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include "beanmachine/minibmg/dedup.h"
+#include "beanmachine/minibmg/dedup2.h"
 
 namespace beanmachine::minibmg {
 
@@ -16,16 +16,12 @@ namespace beanmachine::minibmg {
 // corresponding node in the transitive closure of the optimized graph.
 // This is used in the implementation of opt(), but might occasionally be
 // useful in this form.
-std::unordered_map<Nodep, Nodep> opt_map(std::vector<Nodep> roots);
-
-// See dedup.h
-template <class T>
-class DedupHelper;
+std::unordered_map<Node2p, Node2p> opt_map(std::vector<Node2p> roots);
 
 // Rewrite a data structure by "optimizing" its nodes, applying local
 // transformations that are expected to improve runtime required to evaluate it.
 template <class T>
-T opt(const T& data, const DedupHelper<T>& helper = DedupHelper<T>{}) {
+T opt(const T& data, const DedupAdapter<T>& helper = DedupAdapter<T>{}) {
   auto roots = helper.find_roots(data);
   auto map = opt_map(roots);
   return helper.rewrite(data, map);

--- a/minibmg/node2.cpp
+++ b/minibmg/node2.cpp
@@ -10,6 +10,7 @@
 #include <fmt/format.h>
 #include <atomic>
 #include <typeinfo>
+#include "beanmachine/minibmg/pretty2.h"
 
 namespace {
 
@@ -46,6 +47,16 @@ Node2::Node2(std::size_t cached_hash_value)
     : cached_hash_value{cached_hash_value} {}
 
 Node2::~Node2() {}
+
+std::string to_string(const Node2p& node) {
+  auto pretty_result = pretty_print({node});
+  std::stringstream code;
+  for (auto p : pretty_result.prelude) {
+    code << p << std::endl;
+  }
+  code << pretty_result.code[node];
+  return code.str();
+}
 
 ScalarNode2::ScalarNode2(std::size_t cached_hash_value)
     : Node2{cached_hash_value} {}

--- a/minibmg/node2.h
+++ b/minibmg/node2.h
@@ -5,23 +5,25 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#pragma once
+
 #include <memory>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
-
-#pragma once
 
 namespace beanmachine::minibmg {
 
 class Node2;
 class ScalarNode2;
 class DistributionNode2;
+class ScalarSampleNode2;
 class Node2Visitor;
 
 using Node2p = std::shared_ptr<const Node2>;
 using ScalarNode2p = std::shared_ptr<const ScalarNode2>;
 using DistributionNode2p = std::shared_ptr<const DistributionNode2>;
+using ScalarSampleNode2p = std::shared_ptr<const ScalarSampleNode2>;
 
 class Node2 {
  public:

--- a/minibmg/node2.h
+++ b/minibmg/node2.h
@@ -65,7 +65,7 @@ class ScalarSampleNode2 : public ScalarNode2 {
   explicit ScalarSampleNode2(
       const DistributionNode2p& distribution,
       const std::string& rvid = make_fresh_rvid());
-  const DistributionNode2p& distribution;
+  const DistributionNode2p distribution;
   std::string rvid;
   void accept(Node2Visitor& visitor) const override;
 };

--- a/minibmg/node2.h
+++ b/minibmg/node2.h
@@ -226,13 +226,35 @@ struct Node2pIdentityEquals {
 
 // A value-based map from Node2s to T.  Used for deduplicating and
 // optimizing a graph.
-template <class T>
-using Node2ValueMap =
-    std::unordered_map<Node2p, T, Node2pIdentityHash, Node2pIdentityEquals>;
+class Node2Node2ValueMap {
+ private:
+  std::unordered_map<Node2p, Node2p, Node2pIdentityHash, Node2pIdentityEquals>
+      map;
 
-// A value-based set of Node2s.
-using Node2ValueSet =
-    std::unordered_set<Node2p, Node2pIdentityHash, Node2pIdentityEquals>;
+ public:
+  ~Node2Node2ValueMap() {}
+  ScalarNode2p at(const ScalarNode2p& p) const {
+    return std::dynamic_pointer_cast<const ScalarNode2>(map.at(p));
+  }
+  DistributionNode2p at(const DistributionNode2p& p) const {
+    return std::dynamic_pointer_cast<const DistributionNode2>(map.at(p));
+  }
+  Node2p at(const Node2p& p) const {
+    return map.at(p);
+  }
+  bool contains(const Node2p& p) const {
+    return map.contains(p);
+  }
+  void insert(const Node2p& key, const Node2p& value) {
+    map.insert({key, value});
+  }
+  auto find(const Node2p& key) {
+    return map.find(key);
+  }
+  auto end() {
+    return map.end();
+  }
+};
 
 // A visitor for nodes
 class Node2Visitor {

--- a/minibmg/node2.h
+++ b/minibmg/node2.h
@@ -209,6 +209,8 @@ class DistributionBernoulliNode2 : public DistributionNode2 {
 // shape).
 std::vector<Node2p> in_nodes(const Node2p& n);
 
+std::string to_string(const Node2p& node);
+
 // Provide a good hash function so ScalarNode2p values can be used in unordered
 // maps and sets.  This treats ScalarNode2p values as semantically value-based.
 struct Node2pIdentityHash {

--- a/minibmg/pretty2.cpp
+++ b/minibmg/pretty2.cpp
@@ -89,25 +89,25 @@ class PrintedFormVisitor : public Node2Visitor {
   }
   void visit(const ScalarMultiplyNode2* node) override {
     auto left = cache[node->left];
-    auto ls = (left.precedence > Precedence::Term)
+    auto ls = (left.precedence > Precedence::Product)
         ? fmt::format("({})", left.string)
         : left.string;
     auto right = cache[node->right];
-    const auto& rs = (right.precedence >= Precedence::Term)
+    const auto& rs = (right.precedence >= Precedence::Product)
         ? fmt::format("({})", right.string)
         : right.string;
-    result = {fmt::format("{} * {}", ls, rs), Precedence::Term};
+    result = {fmt::format("{} * {}", ls, rs), Precedence::Product};
   }
   void visit(const ScalarDivideNode2* node) override {
     auto left = cache[node->left];
-    auto ls = (left.precedence > Precedence::Term)
+    auto ls = (left.precedence > Precedence::Product)
         ? fmt::format("({})", left.string)
         : left.string;
     auto right = cache[node->right];
-    const auto& rs = (right.precedence >= Precedence::Term)
+    const auto& rs = (right.precedence >= Precedence::Product)
         ? fmt::format("({})", right.string)
         : right.string;
-    result = {fmt::format("{} / {}", ls, rs), Precedence::Term};
+    result = {fmt::format("{} / {}", ls, rs), Precedence::Product};
   }
   void visit(const ScalarPowNode2* node) override {
     result = {
@@ -248,7 +248,7 @@ std::string pretty_print(const Graph2& graph) {
   for (auto p : pretty_result.prelude) {
     code << p << std::endl;
   }
-  code << "Graph::FluentFactory fac;" << std::endl;
+  code << "Graph::FluidFactory fac;" << std::endl;
   for (auto q : graph.queries) {
     code << fmt::format("fac.query({});", pretty_result.code[q]) << std::endl;
   }

--- a/minibmg/pretty2.cpp
+++ b/minibmg/pretty2.cpp
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "beanmachine/minibmg/pretty2.h"
+#include <map>
+#include <sstream>
+#include <stdexcept>
+#include <unordered_map>
+#include "beanmachine/minibmg/node2.h"
+#include "beanmachine/minibmg/topological.h"
+
+// Private helper data structures and functions used in producing a string form
+// for a Traced.
+namespace {
+
+using namespace beanmachine::minibmg;
+
+enum class Precedence {
+  Term,
+  Product,
+  Sum,
+};
+
+struct PrintedForm {
+  std::string string;
+  Precedence precedence;
+
+  PrintedForm() : string{""}, precedence{Precedence::Term} {}
+  PrintedForm(std::string string, Precedence precedence)
+      : string{string}, precedence{precedence} {}
+  PrintedForm(const PrintedForm& other)
+      : string{other.string}, precedence{other.precedence} {}
+  PrintedForm& operator=(const PrintedForm& other) = default;
+  ~PrintedForm() {}
+};
+
+class PrintedFormVisitor : public Node2Visitor {
+ public:
+  std::map<Node2p, PrintedForm>& cache;
+  explicit PrintedFormVisitor(std::map<Node2p, PrintedForm>& cache)
+      : cache{cache} {}
+  PrintedForm result;
+  void visit(const ScalarConstantNode2* node) override {
+    result = {fmt::format("{}", node->constant_value), Precedence::Term};
+  }
+  void visit(const ScalarVariableNode2* node) override {
+    const auto& name = (node->name.length() == 0)
+        ? fmt::format("__{}", node->identifier)
+        : node->name;
+    result = {name, Precedence::Term};
+  }
+  void visit(const ScalarSampleNode2* node) override {
+    auto name = fmt::format(
+        "sample({}, \"{}\")", cache[node->distribution].string, node->rvid);
+    result = {name, Precedence::Term};
+  }
+  void visit(const ScalarAddNode2* node) override {
+    auto left = cache[node->left];
+    auto ls = (left.precedence > Precedence::Sum)
+        ? fmt::format("({})", left.string)
+        : left.string;
+    auto right = cache[node->right];
+    const auto& rs = (right.precedence >= Precedence::Sum)
+        ? fmt::format("({})", right.string)
+        : right.string;
+    result = {fmt::format("{} + {}", ls, rs), Precedence::Sum};
+  }
+  void visit(const ScalarSubtractNode2* node) override {
+    auto left = cache[node->left];
+    auto ls = (left.precedence > Precedence::Sum)
+        ? fmt::format("({})", left.string)
+        : left.string;
+    auto right = cache[node->right];
+    const auto& rs = (right.precedence >= Precedence::Sum)
+        ? fmt::format("({})", right.string)
+        : right.string;
+    result = {fmt::format("{} - {}", ls, rs), Precedence::Sum};
+  }
+  void visit(const ScalarNegateNode2* node) override {
+    auto right = cache[node->x];
+    auto rs = (right.precedence > Precedence::Term)
+        ? fmt::format("({})", right.string)
+        : right.string;
+    result = {fmt::format("-{}", rs), Precedence::Term};
+  }
+  void visit(const ScalarMultiplyNode2* node) override {
+    auto left = cache[node->left];
+    auto ls = (left.precedence > Precedence::Term)
+        ? fmt::format("({})", left.string)
+        : left.string;
+    auto right = cache[node->right];
+    const auto& rs = (right.precedence >= Precedence::Term)
+        ? fmt::format("({})", right.string)
+        : right.string;
+    result = {fmt::format("{} * {}", ls, rs), Precedence::Term};
+  }
+  void visit(const ScalarDivideNode2* node) override {
+    auto left = cache[node->left];
+    auto ls = (left.precedence > Precedence::Term)
+        ? fmt::format("({})", left.string)
+        : left.string;
+    auto right = cache[node->right];
+    const auto& rs = (right.precedence >= Precedence::Term)
+        ? fmt::format("({})", right.string)
+        : right.string;
+    result = {fmt::format("{} / {}", ls, rs), Precedence::Term};
+  }
+  void visit(const ScalarPowNode2* node) override {
+    result = {
+        fmt::format(
+            "pow({}, {})", cache[node->left].string, cache[node->right].string),
+        Precedence::Term};
+  }
+  void visit(const ScalarExpNode2* node) override {
+    result = {fmt::format("exp({})", cache[node->x].string), Precedence::Term};
+  }
+  void visit(const ScalarLogNode2* node) override {
+    result = {fmt::format("log({})", cache[node->x].string), Precedence::Term};
+  }
+  void visit(const ScalarAtanNode2* node) override {
+    result = {fmt::format("atan({})", cache[node->x].string), Precedence::Term};
+  }
+  void visit(const ScalarLgammaNode2* node) override {
+    result = {
+        fmt::format("lgamma({})", cache[node->x].string), Precedence::Term};
+  }
+  void visit(const ScalarPolygammaNode2* node) override {
+    result = {
+        fmt::format(
+            "polygamma({}, {})", cache[node->n].string, cache[node->x].string),
+        Precedence::Term};
+  }
+  void visit(const ScalarIfEqualNode2* node) override {
+    result = {
+        fmt::format(
+            "if_equal({}, {}, {}, {})",
+            cache[node->a].string,
+            cache[node->b].string,
+            cache[node->c].string,
+            cache[node->d].string),
+        Precedence::Term};
+  }
+  void visit(const ScalarIfLessNode2* node) override {
+    result = {
+        fmt::format(
+            "if_less({}, {}, {}, {})",
+            cache[node->a].string,
+            cache[node->b].string,
+            cache[node->c].string,
+            cache[node->d].string),
+        Precedence::Term};
+  }
+  void visit(const DistributionNormalNode2* node) override {
+    result = {
+        fmt::format(
+            "normal({}, {})",
+            cache[node->mean].string,
+            cache[node->stddev].string),
+        Precedence::Term};
+  }
+  void visit(const DistributionHalfNormalNode2* node) override {
+    result = {
+        fmt::format("half_normal({})", cache[node->stddev].string),
+        Precedence::Term};
+  }
+  void visit(const DistributionBetaNode2* node) override {
+    result = {
+        fmt::format(
+            "beta({}, {})", cache[node->a].string, cache[node->b].string),
+        Precedence::Term};
+  }
+  void visit(const DistributionBernoulliNode2* node) override {
+    result = {
+        fmt::format("bernoulli({})", cache[node->prob].string),
+        Precedence::Term};
+  }
+};
+
+PrintedForm print(Node2p node, PrintedFormVisitor& pfv) {
+  node.get()->accept(pfv);
+  return pfv.result;
+}
+
+} // namespace
+
+namespace beanmachine::minibmg {
+
+// Pretty-print a set of Nodes.  Returns a PrettyResult.
+const Pretty2Result pretty_print(std::vector<Node2p> roots) {
+  std::map<Node2p, unsigned> counts =
+      count_predecessors<Node2p>({roots.begin(), roots.end()}, in_nodes);
+  // count the roots as uses too, so that they get put into a variable if
+  // also used elsewhere.
+  for (auto n : roots) {
+    counts[n]++;
+  }
+
+  std::vector<Node2p> sorted;
+  if (!topological_sort<Node2p>(
+          {roots.begin(), roots.end()}, in_nodes, sorted)) {
+    throw std::logic_error("nodes have a cycle");
+  }
+  reverse(sorted.begin(), sorted.end());
+
+  std::map<Node2p, PrintedForm> cache;
+  PrintedFormVisitor pfv{cache};
+  std::vector<std::string> prelude;
+  unsigned next_temp = 1;
+  for (auto n : sorted) {
+    PrintedForm p = print(n, pfv);
+    // We do not dedup constants and variables in the printed form, as the
+    // printed form is simpler without doing do.
+    if (counts[n] > 1 && !dynamic_cast<const ScalarConstantNode2*>(n.get()) &&
+        !dynamic_cast<const ScalarVariableNode2*>(n.get())) {
+      std::string temp = fmt::format("temp_{}", next_temp++);
+      std::string assignment = fmt::format("auto {} = {};", temp, p.string);
+      prelude.push_back(assignment);
+      p = {temp, Precedence::Term};
+    }
+    cache[n] = p;
+  }
+
+  std::unordered_map<Node2p, std::string> code;
+  for (auto p : cache) {
+    code[p.first] = p.second.string;
+  }
+
+  return Pretty2Result{prelude, code};
+}
+
+// Pretty-print a graph into the code that would need to be written using the
+// fluid factory to reproduce it.  Assumes the graph has already been
+// deduplicated.
+std::string pretty_print(const Graph2& graph) {
+  std::vector<Node2p> roots;
+  for (auto p : graph.observations) {
+    roots.push_back(p.first);
+  }
+  for (auto n : graph.queries) {
+    roots.push_back(n);
+  }
+  auto pretty_result = pretty_print(roots);
+  std::stringstream code;
+  for (auto p : pretty_result.prelude) {
+    code << p << std::endl;
+  }
+  code << "Graph::FluentFactory fac;" << std::endl;
+  for (auto q : graph.queries) {
+    code << fmt::format("fac.query({});", pretty_result.code[q]) << std::endl;
+  }
+  for (auto o : graph.observations) {
+    code << fmt::format(
+                "fac.observe({}, {});", pretty_result.code[o.first], o.second)
+         << std::endl;
+  }
+
+  return code.str();
+}
+
+} // namespace beanmachine::minibmg

--- a/minibmg/pretty2.cpp
+++ b/minibmg/pretty2.cpp
@@ -261,4 +261,15 @@ std::string pretty_print(const Graph2& graph) {
   return code.str();
 }
 
+std::string pretty_print(Node2p node) {
+  std::vector<Node2p> roots{node};
+  auto pretty_result = pretty_print(roots);
+  std::stringstream code;
+  for (auto p : pretty_result.prelude) {
+    code << p << std::endl;
+  }
+  code << pretty_result.code[node];
+  return code.str();
+}
+
 } // namespace beanmachine::minibmg

--- a/minibmg/pretty2.h
+++ b/minibmg/pretty2.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include "beanmachine/minibmg/graph2.h"
+#include "beanmachine/minibmg/node2.h"
+
+namespace beanmachine::minibmg {
+
+struct Pretty2Result {
+  // a set of variable assignments that are prelude to the expressions for the
+  // nodes.  These assignments are for shared intermediate results.
+  std::vector<std::string> prelude;
+
+  // For each remaining root, the expression for computing it, with identifiers
+  // referring to variables declared in the prelude for shared values.
+  std::unordered_map<Node2p, std::string> code;
+};
+
+// Pretty-print a set of Nodes.  Returns a PrettyResult.
+const Pretty2Result pretty_print(std::vector<Node2p> roots);
+
+// Pretty-print a graph into the code that would need to be written using the
+// fluid factory to reproduce it.
+std::string pretty_print(const Graph2& graph);
+
+} // namespace beanmachine::minibmg

--- a/minibmg/tests/ad/traced_test.cpp
+++ b/minibmg/tests/ad/traced_test.cpp
@@ -7,63 +7,63 @@
 
 #include <gtest/gtest.h>
 #include "beanmachine/minibmg/ad/num2.h"
-#include "beanmachine/minibmg/ad/traced.h"
+#include "beanmachine/minibmg/ad/traced2.h"
 
 using namespace ::testing;
 using namespace ::beanmachine::minibmg;
 
 TEST(traced_test, simple0) {
-  Traced x = Traced::variable("x", 0);
-  Traced r = 100 + x;
+  Traced2 x = Traced2::variable("x", 0);
+  Traced2 r = 100 + x;
   ASSERT_EQ("100 + x", to_string(r));
 }
 
 TEST(traced_test, simple1) {
-  Traced x = Traced::variable("x", 0);
+  Traced2 x = Traced2::variable("x", 0);
   auto r = 100 * pow(x, 3) + 10 * pow(x, 2) + 1 * x - 5;
-  ASSERT_EQ("100 * pow(x, 3) + 10 * pow(x, 2) + x - 5", to_string(r));
+  ASSERT_EQ("100 * pow(x, 3) + 10 * pow(x, 2) + 1 * x - 5", to_string(r));
 }
 
 TEST(traced_test, simple2) {
-  Traced x = Traced::variable("x", 0);
+  Traced2 x = Traced2::variable("x", 0);
   auto r = pow(x, -x);
   ASSERT_EQ("pow(x, -x)", to_string(r));
 }
 
 TEST(traced_test, simple3) {
-  Traced x = Traced::variable("x", 0);
+  Traced2 x = Traced2::variable("x", 0);
   auto r = (x + 1) / (x + 2);
   ASSERT_EQ("(x + 1) / (x + 2)", to_string(r));
 }
 
 TEST(traced_test, simple4) {
-  Traced x = Traced::variable("x", 0);
+  Traced2 x = Traced2::variable("x", 0);
   auto r = exp(x) + log(x) + atan(x) + lgamma(x) + polygamma(5, x);
   ASSERT_EQ(
       "exp(x) + log(x) + atan(x) + lgamma(x) + polygamma(5, x)", to_string(r));
 }
 
 TEST(traced_test, simple5) {
-  Traced x = Traced::variable("x", 0);
-  Traced y = Traced::variable("y", 1);
-  Traced z = Traced::variable("z", 2);
-  Traced w = Traced::variable("w", 3);
+  Traced2 x = Traced2::variable("x", 0);
+  Traced2 y = Traced2::variable("y", 1);
+  Traced2 z = Traced2::variable("z", 2);
+  Traced2 w = Traced2::variable("w", 3);
   auto r = if_equal(x, y, z, w);
   ASSERT_EQ("if_equal(x, y, z, w)", to_string(r));
 }
 
 TEST(traced_test, simple6) {
-  Traced x = Traced::variable("x", 0);
-  Traced y = Traced::variable("y", 1);
-  Traced z = Traced::variable("z", 2);
-  Traced w = Traced::variable("w", 3);
+  Traced2 x = Traced2::variable("x", 0);
+  Traced2 y = Traced2::variable("y", 1);
+  Traced2 z = Traced2::variable("z", 2);
+  Traced2 w = Traced2::variable("w", 3);
   auto r = if_less(x, y, z, w);
   ASSERT_EQ("if_less(x, y, z, w)", to_string(r));
 }
 
 // Show what happens when the computation graph is a dag instead of a tree.
 TEST(traced_test, dag) {
-  Traced x = Traced::variable("x", 0);
+  Traced2 x = Traced2::variable("x", 0);
   auto t1 = x + x;
   auto t2 = t1 + t1;
   auto t3 = t2 + t2;
@@ -75,9 +75,10 @@ temp_2 + temp_2):";
 }
 
 TEST(traced_test, derivative1) {
-  Traced tx = Traced::variable("x", 0);
-  Num2<Traced> x{tx, 1};
+  Traced2 tx = Traced2::variable("x", 0);
+  Num2<Traced2> x{tx, 1};
   auto r = pow(x, 2) + 10 * x + 100;
   auto rp = r.derivative1;
-  ASSERT_EQ("2 * x + 10", to_string(rp));
+  auto rpopt = opt(rp);
+  ASSERT_EQ("2 * x + 10", to_string(rpopt));
 }

--- a/minibmg/tests/eval_test.cpp
+++ b/minibmg/tests/eval_test.cpp
@@ -5,14 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <beanmachine/minibmg/minibmg.h>
+#include <beanmachine/minibmg/graph2_factory.h>
 #include <beanmachine/minibmg/tests/test_utils.h>
 #include <gtest/gtest.h>
 #include <random>
 #include "beanmachine/minibmg/ad/num2.h"
 #include "beanmachine/minibmg/ad/num3.h"
 #include "beanmachine/minibmg/ad/real.h"
-#include "beanmachine/minibmg/eval.h"
+#include "beanmachine/minibmg/eval2.h"
 
 // using namespace ::testing;
 using namespace ::beanmachine::minibmg;
@@ -21,48 +21,50 @@ using namespace ::std;
 TEST(eval_test, simple1) {
   // a simple graph that evaluates a few operators is evaluated and the final
   // result is compared to its expected value.
-  Graph::Factory fac;
-  auto k0 = fac.add_constant(1.2); // 1.2
-  auto k1 = fac.add_constant(4.1); // 4.1
-  auto add0 = fac.add_operator(Operator::ADD, {k0, k1}); // 5.3
-  auto v1 = fac.add_variable("x", 0); // 1.15
-  auto mul1 = fac.add_operator(Operator::MULTIPLY, {add0, v1}); // 6.095
-  auto sub1 = fac.add_operator(Operator::SUBTRACT, {mul1, k1}); // 1.995
-  fac.add_query(sub1); // add a root to the graph.
+  Graph2::Factory fac;
+  auto k0 = fac.constant(1.2); // 1.2
+  auto k1 = fac.constant(4.1); // 4.1
+  auto add0 = fac.add(k0, k1); // 5.3
+  auto v1 = fac.variable("x", 0); // 1.15
+  auto mul1 = fac.multiply(add0, v1); // 6.095
+  auto sub1 = fac.subtract(mul1, k1); // 1.995
+  fac.query(sub1); // add a root to the Graph2.
   auto graph = fac.build();
-  std::mt19937 gen;
+  std::mt19937 gen{123456};
   auto read_variable = [](const std::string&, const unsigned) { return 1.15; };
   int graph_size = graph.size();
-  unordered_map<Nodep, Real> data;
-  eval_graph<Real>(graph, gen, read_variable, data);
-  EXPECT_CLOSE(1.995, data[fac[sub1]].as_double());
+  unordered_map<Node2p, Real> data;
+  auto eval_result = eval_graph<Real>(
+      graph, gen, read_variable, data, /* run_queries= */ true);
+  EXPECT_CLOSE(1.995, eval_result.queries[0]);
 }
 
 TEST(eval_test, sample1) {
   // a graph that produces normal samples is evaluated many times
   // and the statistics of the samples are compared to their expected values.
   std::exception x1;
-  Graph::Factory fac;
+  Graph2::Factory fac;
   double expected_mean = 12.34;
-  double expected_stdev = 41.78;
-  auto k0 = fac.add_constant(expected_mean);
-  auto k1 = fac.add_constant(expected_stdev);
-  auto normal0 = fac.add_operator(Operator::DISTRIBUTION_NORMAL, {k0, k1});
-  auto sample0 = fac.add_sample(normal0);
-  fac.add_query(sample0); // add a root to the graph.
+  double expected_stdev = 5.67;
+  auto k0 = fac.constant(expected_mean);
+  auto k1 = fac.constant(expected_stdev);
+  auto normal0 = fac.normal(k0, k1);
+  auto sample0 = fac.sample(normal0);
+  fac.query(sample0); // add a root to the graph.
   auto graph = fac.build();
-  // We create a new random number generator with its default (deterministic)
-  // seed so that this test will not be flaky.
-  std::mt19937 gen;
+  // We create a new random number generator with a specific seed so that this
+  // test will be deterministic and not be flaky.
+  std::mt19937 gen{123456};
   // Evaluate the graph many times and gather stats.
   int n = 10000;
   double sum = 0;
   double sum_squared = 0;
   int graph_size = graph.size();
-  std::unordered_map<Nodep, Real> data;
+  std::unordered_map<Node2p, Real> data;
   for (int i = 0; i < n; i++) {
-    eval_graph<Real>(graph, gen, nullptr, data);
-    auto sample = data[fac[sample0]].as_double();
+    auto eval_result =
+        eval_graph<Real>(graph, gen, nullptr, data, /* run_queries= */ true);
+    auto sample = eval_result.queries[0];
     sum += sample;
     sum_squared += sample * sample;
   }
@@ -97,31 +99,30 @@ using Dual = Num2<Real>;
 TEST(eval_test, derivative_dual) {
   // a graph that computes a function of a variable, so we can compute
   // the derivative with respect to that variable.
-  std::mt19937 gen;
-  Graph::Factory fac;
-  auto s = fac.add_operator(
-      Operator::MULTIPLY,
-      {fac.add_constant(1.1),
-       fac.add_operator(
-           Operator::POW, {fac.add_variable("x", 0), fac.add_constant(2)})});
-  fac.add_query(s); // add a root to the graph.
-  Graph graph = fac.build();
+  std::mt19937 gen{123456};
+  Graph2::Factory fac;
+  auto s = fac.multiply(
+      fac.constant(1.1), fac.pow(fac.variable("x", 0), fac.constant(2)));
+  fac.query(s); // add a root to the graph.
+  Graph2 graph = fac.build();
   int graph_size = graph.size();
 
   // We generate several doubles between -2.0 and 2.0 to test with.
   std::uniform_real_distribution<double> unif(-2.0, 2.0);
 
-  std::unordered_map<Nodep, Dual> data;
+  std::unordered_map<Node2p, Dual> data;
   for (int i = 0; i < 10; i++) {
     double input = unif(gen);
     auto read_variable = [=](const std::string&, const unsigned) {
       return Dual{input, 1};
     };
     data.clear();
-    eval_graph<Dual>(graph, gen, read_variable, data);
-    EXPECT_CLOSE(f<Real>(input).as_double(), data[fac[s]].primal.as_double());
+    auto eval_result = eval_graph<Dual>(
+        graph, gen, read_variable, data, /* run_queries = */ true);
+    Node2p s_node = fac[s];
+    EXPECT_CLOSE(f<Real>(input).as_double(), data[s_node].primal.as_double());
     EXPECT_CLOSE(
-        fp<Real>(input).as_double(), data[fac[s]].derivative1.as_double());
+        fp<Real>(input).as_double(), data[s_node].derivative1.as_double());
   }
 }
 
@@ -130,22 +131,19 @@ using Triune = Num3<Real>;
 TEST(eval_test, derivatives_triune) {
   // a graph that computes a function of a variable, so we can compute
   // the first and second derivatives with respect to that variable.
-  std::mt19937 gen;
-  Graph::Factory fac;
-  auto s = fac.add_operator(
-      Operator::MULTIPLY,
-      {fac.add_constant(1.1),
-       fac.add_operator(
-           Operator::POW, {fac.add_variable("x", 0), fac.add_constant(2)})});
-  fac.add_query(s); // add a root to the graph.
+  std::mt19937 gen{123456};
+  Graph2::Factory fac;
+  auto s = fac.multiply(
+      fac.constant(1.1), fac.pow(fac.variable("x", 0), fac.constant(2)));
+  fac.query(s); // add a root to the graph.
   auto sn = fac[s];
-  Graph graph = fac.build();
+  Graph2 graph = fac.build();
   int graph_size = graph.size();
 
   // We generate several doubles between -2.0 and 2.0 to test with.
   std::uniform_real_distribution<double> unif(-2.0, 2.0);
 
-  std::unordered_map<Nodep, Triune> data;
+  std::unordered_map<Node2p, Triune> data;
   for (int i = 0; i < 10; i++) {
     double input = unif(gen);
     auto read_variable = [=](const std::string&, const unsigned) {

--- a/minibmg/tests/graph_properties/observations_by_node_test.cpp
+++ b/minibmg/tests/graph_properties/observations_by_node_test.cpp
@@ -6,15 +6,15 @@
  */
 
 #include <gtest/gtest.h>
-#include "beanmachine/minibmg/fluent_factory.h"
-#include "beanmachine/minibmg/graph.h"
-#include "beanmachine/minibmg/graph_properties/observations_by_node.h"
+#include "beanmachine/minibmg/fluid_factory.h"
+#include "beanmachine/minibmg/graph2.h"
+#include "beanmachine/minibmg/graph_properties/observations_by_node2.h"
 
 using namespace ::testing;
 using namespace beanmachine::minibmg;
 
 TEST(observations_by_node_test, simple) {
-  Graph::FluentFactory f;
+  Graph2::FluidFactory f;
   auto b = beta(2, 2);
   auto s1 = sample(b);
   auto s2 = sample(b);

--- a/minibmg/tests/graph_properties/out_nodes_test.cpp
+++ b/minibmg/tests/graph_properties/out_nodes_test.cpp
@@ -7,47 +7,48 @@
 
 #include <gtest/gtest.h>
 #include <list>
-#include "beanmachine/minibmg/graph_properties/out_nodes.h"
-#include "beanmachine/minibmg/minibmg.h"
+#include "beanmachine/minibmg/graph2.h"
+#include "beanmachine/minibmg/graph2_factory.h"
+#include "beanmachine/minibmg/graph_properties/out_nodes2.h"
 
 using namespace ::testing;
 using namespace ::beanmachine::minibmg;
 
 TEST(out_nodes_test, simple) {
-  Graph::Factory gf;
-  auto k12 = gf.add_constant(1.2);
-  auto k34 = gf.add_constant(3.4);
-  auto plus = gf.add_operator(Operator::ADD, {k12, k34});
-  auto k56 = gf.add_constant(5.6);
-  auto beta = gf.add_operator(Operator::DISTRIBUTION_BETA, {plus, k56});
-  auto sample = gf.add_sample(beta);
-  gf.add_observation(sample, 7.8);
-  /* auto query_ = */ gf.add_query(sample);
-  Graph g = gf.build();
+  Graph2::Factory gf;
+  auto k12 = gf.constant(1.2);
+  auto k34 = gf.constant(3.4);
+  auto plus = gf.add(k12, k34);
+  auto k56 = gf.constant(5.6);
+  auto beta = gf.beta(plus, k56);
+  auto sample = gf.sample(beta);
+  gf.observe(sample, 7.8);
+  /* auto query_ = */ gf.query(sample);
+  Graph2 g = gf.build();
 
-  Nodep k12n = gf[k12];
-  Nodep k34n = gf[k34];
-  Nodep plusn = gf[plus];
-  Nodep k56n = gf[k56];
-  Nodep betan = gf[beta];
-  Nodep samplen = gf[sample];
+  Node2p k12n = gf[k12];
+  Node2p k34n = gf[k34];
+  Node2p plusn = gf[plus];
+  Node2p k56n = gf[k56];
+  Node2p betan = gf[beta];
+  Node2p samplen = gf[sample];
 
   ASSERT_EQ(out_nodes(g, k12n), std::list{plusn});
   ASSERT_EQ(out_nodes(g, k34n), (std::list{plusn}));
-  ASSERT_EQ(out_nodes(g, plusn), std::list<Nodep>{betan});
+  ASSERT_EQ(out_nodes(g, plusn), std::list<Node2p>{betan});
   ASSERT_EQ(out_nodes(g, k56n), std::list{betan});
   ASSERT_EQ(out_nodes(g, betan), (std::list{samplen}));
-  ASSERT_EQ(out_nodes(g, samplen), std::list<Nodep>{});
+  ASSERT_EQ(out_nodes(g, samplen), std::list<Node2p>{});
 
   ASSERT_EQ(g.queries, std::vector{samplen});
-  std::list<std::pair<Nodep, double>> expected_observations;
+  std::list<std::pair<Node2p, double>> expected_observations;
   expected_observations.push_back(std::pair{samplen, 7.8});
   ASSERT_EQ(g.observations, expected_observations);
 }
 
 TEST(out_nodes_test, not_found2) {
-  Graph::Factory gf;
-  Graph g = gf.build();
-  Nodep n = std::make_shared<const ConstantNode>(0);
+  Graph2::Factory gf;
+  Graph2 g = gf.build();
+  Node2p n = std::make_shared<ScalarConstantNode2>(0);
   ASSERT_THROW(out_nodes(g, n), std::invalid_argument);
 }

--- a/minibmg/tests/json_test.cpp
+++ b/minibmg/tests/json_test.cpp
@@ -7,7 +7,7 @@
 
 #include <gtest/gtest.h>
 
-#include "beanmachine/minibmg/minibmg.h"
+#include "beanmachine/minibmg/graph2.h"
 
 using namespace ::testing;
 using namespace ::beanmachine::minibmg;
@@ -104,14 +104,6 @@ std::string raw_json = R"({
   ]
 })";
 
-TEST(json_test, test_from_string) {
-  folly::dynamic parsed = folly::parseJson(raw_json);
-  auto graph = beanmachine::minibmg::json_to_graph(parsed);
-  std::string s =
-      folly::toPrettyJson(beanmachine::minibmg::graph_to_json(graph));
-  ASSERT_EQ(raw_json, s);
-}
-
 std::string raw_json_without_types = R"({
   "comment": "created by graph_to_json",
   "nodes": [
@@ -194,11 +186,19 @@ std::string raw_json_without_types = R"({
   ]
 })";
 
+TEST(json_test, test_from_string) {
+  folly::dynamic parsed = folly::parseJson(raw_json);
+  auto graph = beanmachine::minibmg::json_to_graph2(parsed);
+  std::string s =
+      folly::toPrettyJson(beanmachine::minibmg::graph_to_json(graph));
+  ASSERT_EQ(raw_json_without_types, s);
+}
+
 TEST(json_test, test_from_string_without_types) {
   folly::dynamic parsed = folly::parseJson(raw_json_without_types);
-  auto graph = json_to_graph(parsed);
+  auto graph = json_to_graph2(parsed);
   std::string s = folly::toPrettyJson(graph_to_json(graph));
-  ASSERT_EQ(raw_json, s);
+  ASSERT_EQ(raw_json_without_types, s);
 }
 
 } // namespace json_test

--- a/minibmg/tests/minibmg_test.cpp
+++ b/minibmg/tests/minibmg_test.cpp
@@ -8,105 +8,60 @@
 #include <gtest/gtest.h>
 #include <stdexcept>
 
-#include "beanmachine/minibmg/minibmg.h"
+#include "beanmachine/minibmg/graph2.h"
+#include "beanmachine/minibmg/graph2_factory.h"
+#include "beanmachine/minibmg/node2.h"
 
 using namespace ::testing;
 using namespace beanmachine::minibmg;
 
-#define ASSERT_ID(node, num) ASSERT_EQ(node, NodeId{(unsigned long)(num)})
+#define ASSERT_ID(node, num) ASSERT_EQ(node->_value(), num)
 
 TEST(test_minibmg, basic_building_1) {
-  Graph::Factory gf;
-  auto k12 = gf.add_constant(1.2);
+  Graph2::Factory gf;
+  auto k12 = gf.constant(1.2);
   ASSERT_ID(k12, 0);
-  auto k34 = gf.add_constant(3.4);
+  auto k34 = gf.constant(3.4);
   ASSERT_ID(k34, 1);
-  auto plus = gf.add_operator(Operator::ADD, {k12, k34});
+  auto plus = gf.add(k12, k34);
   ASSERT_ID(plus, 2);
-  auto k56 = gf.add_constant(5.6);
+  auto k56 = gf.constant(5.6);
   ASSERT_ID(k56, 3);
-  auto beta = gf.add_operator(Operator::DISTRIBUTION_BETA, {plus, k56});
+  auto beta = gf.beta(plus, k56);
   ASSERT_ID(beta, 4);
-  auto sample = gf.add_sample(beta);
+  auto sample = gf.sample(beta);
   ASSERT_ID(sample, 5);
-  gf.add_observation(sample, 7.8);
-  auto query = gf.add_query(sample);
+  gf.observe(sample, 7.8);
+  auto query = gf.query(sample);
   ASSERT_EQ(query, 0);
-  Graph g = gf.build();
+  Graph2 g = gf.build();
   ASSERT_EQ(g.size(), 6);
 }
 
 TEST(test_minibmg, dead_code_dropped) {
-  Graph::Factory gf;
-  auto k12 = gf.add_constant(1.2);
+  Graph2::Factory gf;
+  auto k12 = gf.constant(1.2);
   ASSERT_ID(k12, 0);
-  auto k34 = gf.add_constant(3.4);
+  auto k34 = gf.constant(3.4);
   ASSERT_ID(k34, 1);
-  auto plus = gf.add_operator(Operator::ADD, {k12, k34});
+  auto plus = gf.add(k12, k34);
   ASSERT_ID(plus, 2);
-  auto k56 = gf.add_constant(5.6);
+  auto k56 = gf.constant(5.6);
   ASSERT_ID(k56, 3);
-  auto beta = gf.add_operator(Operator::DISTRIBUTION_BETA, {k34, k56});
+  auto beta = gf.beta(k34, k56);
   ASSERT_ID(beta, 4);
-  auto sample = gf.add_sample(beta);
+  auto sample = gf.sample(beta);
   ASSERT_ID(sample, 5);
-  gf.add_observation(sample, 7.8);
-  auto query = gf.add_query(sample);
+  gf.observe(sample, 7.8);
+  auto query = gf.query(sample);
   ASSERT_EQ(query, 0);
-  Graph g = gf.build();
+  Graph2 g = gf.build();
   ASSERT_EQ(g.size(), 4); // k34 and plus are dead code.
 }
 
-TEST(test_minibmg, operator_from_name) {
-  ASSERT_EQ(operator_from_name("CONSTANT"), Operator::CONSTANT);
-  ASSERT_EQ(operator_from_name("ADD"), Operator::ADD);
-  ASSERT_EQ(operator_from_name("MULTIPLY"), Operator::MULTIPLY);
-  ASSERT_EQ(
-      operator_from_name("DISTRIBUTION_NORMAL"), Operator::DISTRIBUTION_NORMAL);
-  ASSERT_EQ(
-      operator_from_name("DISTRIBUTION_BETA"), Operator::DISTRIBUTION_BETA);
-  ASSERT_EQ(
-      operator_from_name("DISTRIBUTION_BERNOULLI"),
-      Operator::DISTRIBUTION_BERNOULLI);
-  ASSERT_EQ(operator_from_name("SAMPLE"), Operator::SAMPLE);
-
-  ASSERT_EQ(operator_from_name("GIBBERISH"), Operator::NO_OPERATOR);
-}
-
-TEST(test_minibmg, operator_to_string) {
-  ASSERT_EQ(to_string(Operator::CONSTANT), "CONSTANT");
-  ASSERT_EQ(to_string(Operator::ADD), "ADD");
-  ASSERT_EQ(to_string(Operator::MULTIPLY), "MULTIPLY");
-  ASSERT_EQ(to_string(Operator::DISTRIBUTION_NORMAL), "DISTRIBUTION_NORMAL");
-  ASSERT_EQ(to_string(Operator::DISTRIBUTION_BETA), "DISTRIBUTION_BETA");
-  ASSERT_EQ(
-      to_string(Operator::DISTRIBUTION_BERNOULLI), "DISTRIBUTION_BERNOULLI");
-  ASSERT_EQ(to_string(Operator::SAMPLE), "SAMPLE");
-
-  // with runtime checks enabled, the following would crash at the cast.
-  // ASSERT_EQ(to_string((Operator)10000), "NO_OPERATOR");
-}
-
-TEST(test_minibmg, type_from_name) {
-  ASSERT_EQ(type_from_name("NONE"), Type::NONE);
-  ASSERT_EQ(type_from_name("DISTRIBUTION"), Type::DISTRIBUTION);
-  ASSERT_EQ(type_from_name("REAL"), Type::REAL);
-
-  ASSERT_EQ(type_from_name("GIBBERISH"), Type::NONE);
-}
-
-TEST(test_minibmg, type_to_string) {
-  ASSERT_EQ(to_string(Type::NONE), "NONE");
-  ASSERT_EQ(to_string(Type::DISTRIBUTION), "DISTRIBUTION");
-  ASSERT_EQ(to_string(Type::REAL), "REAL");
-
-  // with runtime checks enabled, the following would crash at the cast.
-  // ASSERT_EQ(to_string((Type)10000), "NONE");
-}
-
 TEST(test_minibmg, duplicate_build) {
-  Graph::Factory gf;
-  Graph g = gf.build();
-  ASSERT_THROW(gf.add_constant(1.2);, std::invalid_argument);
+  Graph2::Factory gf;
+  Graph2 g = gf.build();
+  ASSERT_THROW(gf.constant(1.2);, std::invalid_argument);
   ASSERT_THROW(gf.build();, std::invalid_argument);
 }


### PR DESCRIPTION
Summary:
This is part of step 5 (below) in a series of refactoring steps that will replace minibmg nodes with a distinct node type for each operations and a visitor mechanism.  The idea is that we will write replacements for all of the parts of minibmg using the new paradigm, and then switch over the tests to the new code.  Here we continue porting tests.

1. Introduce Node2 and Node2Visitor (without tests yet)
2. Introduce Graph2 using Node2 with json I/O (ditto)
3. Introduce Tracing2 using Node2 (ditto)
3a. Introduce pretty-printing for Node2 (ditto)
3b. Minor fixup to the json implementation
3c. Implement Graph2::Factory
4. Introduce Eval2 and optimization with some tests
5. Migrate tests to Node2.
6. Migrate any remaining pieces to Node2.
7. Delete Node.h and Node.cpp and other things that have been replaced.
8. Rename Node2 to Node and similarly for other types and files.

Differential Revision: D40561455

