### PR TITLE
Add extra directory to look for vcpkg in GitHub Actions runner.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -152,9 +152,10 @@ elif sys.platform.startswith("darwin"):
 elif platform.system() == "Windows":
     RANGE_V3_INCLUDE_DIR_CANDIDATES.extend(
         [
-            # GitHub Actions runner
+            "./vcpkg/packages/range-v3_x86-windows/include",
+            # The following two options were observed being used on GitHub Actions runner:
             "C:/vcpkg/packages/range-v3_x86-windows/include",
-            ".vcpkg/packages/range-v3_x86-windows/include",
+            "D:/a/beanmachine/beanmachine/vcpkg/packages/range-v3_x86-windows/include",
         ]
     )
 print(


### PR DESCRIPTION
Summary:
Adding extra directory to look for vcpkg in GitHub Actions runner.
In initial tests the `C:/vcpkg` has been used but recently a CI test failed because `D:/a/beanmachine/beanmachine/vcpkg` was used instead, so we are adding it to the search options.
Also fixing local directory search option.

Differential Revision: D40646091

