### PR TITLE
Update range-v3 search path to fix deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,7 @@ jobs:
     if: github.repository == 'facebookresearch/beanmachine'
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [windows-latest]
         python-version: ['3.7', '3.8', '3.9', '3.10']
@@ -55,6 +56,16 @@ jobs:
         bootstrap-vcpkg.bat
         vcpkg integrate install
         vcpkg install range-v3
+
+    - name: Install Unix range-v3 dependency
+      if: matrix.os != 'windows-latest'
+      run: |
+        git clone https://github.com/Microsoft/vcpkg.git
+        cd vcpkg
+        ./bootstrap-vcpkg.sh
+        ./vcpkg integrate install
+        ./vcpkg install range-v3
+        sudo mv ./packages/range-v3_x64-linux/include /usr/include/range-v3
 
     - name: Install other dependencies
       run: |
@@ -114,12 +125,12 @@ jobs:
         CIBW_ARCHS_MACOS: x86_64 universal2 arm64
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
         CIBW_BEFORE_ALL_LINUX: >  # Manually install range-v3 with vcpkg and Eigen3.4 since yum is not up to date
+          yum install -y curl zip unzip tar wget boost169-devel &&
           git clone https://github.com/Microsoft/vcpkg.git &&
           cd vcpkg &&
           ./bootstrap-vcpkg.sh &&
           ./vcpkg integrate install &&
-          ./vcpkg install range-v3
-          yum install -y wget boost169-devel &&
+          ./vcpkg install range-v3 &&
           wget https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz &&
           tar -xvf eigen-3.4.0.tar.gz &&
           mv eigen-3.4.0 /usr/include/eigen3

--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,6 @@ website/static/js/*
 !website/static/js/code_block_buttons.js
 website/static/_sphinx-sources/
 docs/api/
+
+## ignore user's local installation of vcpkg
+vcpkg

--- a/setup.py
+++ b/setup.py
@@ -132,30 +132,23 @@ RANGE_V3_INCLUDE_DIR_CANDIDATES = [
 if sys.platform.startswith("linux"):
     RANGE_V3_INCLUDE_DIR_CANDIDATES.extend(
         [
-            # first one is GitHub Actions runner
-            "/home/runner/work/beanmachine/beanmachine/vcpkg/packages/range-v3_x64-linux/include",
-            "./vcpkg/packages/range-v3_x64-linux/include",
-            "/usr/include",
+            os.path.join(current_dir, "vcpkg/packages/range-v3_x64-linux/include"),
             "/usr/include/range-v3",
-            "/usr/include/x86_64-linux-gnu",
         ]
     )
 elif sys.platform.startswith("darwin"):
     RANGE_V3_INCLUDE_DIR_CANDIDATES.extend(
         [
-            # first one is GitHub Actions runner
-            "/Users/runner/work/beanmachine/beanmachine/vcpkg/packages/range-v3_x64-osx/include",
-            "./vcpkg/packages/range-v3_x64-osx/include",
-            *glob("/usr/local/Cellar/range-v3/*/include/range-v3"),
+            os.path.join(current_dir, "vcpkg/packages/range-v3_x64-osx/include"),
+            *glob("/usr/local/Cellar/range-v3/*/include"),  # Homebrew
         ]
     )
 elif platform.system() == "Windows":
     RANGE_V3_INCLUDE_DIR_CANDIDATES.extend(
         [
-            "./vcpkg/packages/range-v3_x86-windows/include",
-            # The following two options were observed being used on GitHub Actions runner:
+            os.path.join(current_dir, "vcpkg/packages/range-v3_x86-windows/include"),
+            # The following option was observed being used on GitHub Actions runner:
             "C:/vcpkg/packages/range-v3_x86-windows/include",
-            "D:/a/beanmachine/beanmachine/vcpkg/packages/range-v3_x86-windows/include",
         ]
     )
 print(


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookresearch/beanmachine/pull/1780

Making the changes here because the range-v3 dependency isn't correctly set up for the deployment workflow yet ([e.g. see this failing workflow](https://github.com/facebookresearch/beanmachine/actions/runs/3316902968)), which means that if we don't fix them now, we will run into issue in our next release :).

Here's the summary of the changes:
- added range-v3 installation for ubuntu workflow in `deploy.yml` (which is used to build the source distribution of BM)
- added `vcpkg` to `.gitignore`, so that if user follow our README to install range-v3 through vcpkg, they won't end up with this additional `vcpkg` directory in their git status
- remove the hard-coded path for GitHub Action runners
    - because we configured GitHub Actions to download and install `vcpkg` under `./vcpkg`, the hard coded paths are redundant

Differential Revision: D40662880