### PR TITLE
Fix gradient bugs in transpose and LKJ

### DIFF
--- a/src/beanmachine/graph/distribution/lkj_cholesky.cpp
+++ b/src/beanmachine/graph/distribution/lkj_cholesky.cpp
@@ -192,9 +192,9 @@ void LKJCholesky::backward_value(
   auto grad_diagonal = adjunct * o / diag_elems;
 
   for (uint i = 1; i < d; i++) {
-    back_grad(i, i) = grad_diagonal(i - 1);
+    back_grad(i, i) += grad_diagonal(i - 1);
   }
-};
+}
 
 void LKJCholesky::backward_param(const graph::NodeValue& value, double adjunct)
     const {

--- a/src/beanmachine/graph/distribution/multivariate_normal.cpp
+++ b/src/beanmachine/graph/distribution/multivariate_normal.cpp
@@ -52,15 +52,32 @@ MultivariateNormal::MultivariateNormal(
   }
   if (sample_type.rows != rows or sample_type.cols != 1) {
     throw std::invalid_argument(
-        "Multivariate Normal's second parent must be a real-valued square matrix with the same number of rows as the first parent");
+        "Multivariate Normal's sample type should match the shape of the first parent");
   }
   // We also require that the covariance matrix be positive definite. We check
   // this using Cholesky decomposition and store the lower triangular matrix for
   // use in sampling later.
-  llt = in_nodes[1]->value._matrix.llt();
-  if (llt.info() == Eigen::NumericalIssue) {
-    throw std::invalid_argument(
-        "Multivariate Normal's covariance matrix must be positive definite");
+  if (in_nodes[1]->node_type == graph::NodeType::CONSTANT) {
+    // LLT is the Eigen operation for Cholesky decomposition. We store this value
+    // for constant covariance to avoid recomputation.
+    _llt = in_nodes[1]->value._matrix.llt();
+    if (_llt.info() == Eigen::NumericalIssue) {
+      throw std::invalid_argument(
+          "Multivariate Normal's covariance matrix must be positive definite");
+    }
+  }
+}
+
+Eigen::LLT<Eigen::MatrixXd> MultivariateNormal::llt() const {
+  if (in_nodes[1]->node_type == graph::NodeType::CONSTANT) {
+    return _llt;
+  } else {
+    auto result = in_nodes[1]->value._matrix.llt();
+    if (result.info() == Eigen::NumericalIssue) {
+      throw std::invalid_argument(
+          "Multivariate Normal's covariance matrix must be positive definite");
+    }
+    return result;
   }
 }
 
@@ -78,7 +95,7 @@ Eigen::MatrixXd MultivariateNormal::_matrix_sampler(std::mt19937& gen) const {
   }
 
   Eigen::MatrixXd mean = in_nodes[0]->value._matrix;
-  return llt.matrixL() * sample + mean;
+  return llt().matrixL() * sample + mean;
 }
 
 double MultivariateNormal::log_prob(const graph::NodeValue& value) const {
@@ -89,10 +106,11 @@ double MultivariateNormal::log_prob(const graph::NodeValue& value) const {
   Eigen::MatrixXd mean = in_nodes[0]->value._matrix;
   int dims = static_cast<int>(in_nodes[0]->value._matrix.rows());
 
-  double mdist = llt.matrixL().solve(x - mean).squaredNorm();
+  auto computed_llt = llt();
+  double mdist = computed_llt.matrixL().solve(x - mean).squaredNorm();
   const double log2pi = std::log(2 * M_PI);
   double log_det =
-      2 * std::log(llt.matrixL().nestedExpression().diagonal().prod());
+      2 * std::log(computed_llt.matrixL().nestedExpression().diagonal().prod());
 
   return -0.5 * (dims * log2pi + log_det + mdist);
 }

--- a/src/beanmachine/graph/distribution/multivariate_normal.h
+++ b/src/beanmachine/graph/distribution/multivariate_normal.h
@@ -37,8 +37,9 @@ class MultivariateNormal : public Distribution {
       const override;
 
  private:
+  Eigen::LLT<Eigen::MatrixXd> llt() const;
   Eigen::LLT<Eigen::MatrixXd>
-      llt; // cholesky decomposition of the covariance matrix
+      _llt; // cholesky decomposition of the covariance matrix if constant
 };
 } // namespace distribution
 } // namespace beanmachine

--- a/src/beanmachine/graph/distribution/tests/lkj_cholesky_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/lkj_cholesky_test.cpp
@@ -329,6 +329,60 @@ TEST(testdistrib, lkj_cholesky_log_prob_backward_value) {
   }
 }
 
+TEST(testdistrib, lkj_cholesky_log_prob_backward_value_2) {
+  Graph g;
+  const double ETA = 3.0;
+  Eigen::MatrixXd mu(3, 1);
+  mu << 3.0, 2.0, -1.5;
+  auto pos1 = g.add_constant_pos_real(ETA);
+  auto means = g.add_constant_real_matrix(mu);
+
+  /***
+   * For PyTorch verification:
+   *
+   * TODO: paste from notebook
+   ***/
+
+  auto lkj_chol_dist = g.add_distribution(
+      DistributionType::LKJ_CHOLESKY,
+      ValueType(VariableType::BROADCAST_MATRIX, AtomicType::REAL, 3, 3),
+      std::vector<uint>{pos1});
+
+  uint cov_llt = g.add_operator(OperatorType::SAMPLE, {lkj_chol_dist});
+  uint cov_llt_t = g.add_operator(OperatorType::TRANSPOSE, {cov_llt});
+  uint cov =
+      g.add_operator(OperatorType::MATRIX_MULTIPLY, {cov_llt, cov_llt_t});
+
+  auto mv_dist = g.add_distribution(
+      DistributionType::MULTIVARIATE_NORMAL,
+      ValueType(VariableType::BROADCAST_MATRIX, AtomicType::REAL, 3, 1),
+      std::vector<uint>{means, cov});
+
+  uint mv_sample = g.add_operator(OperatorType::SAMPLE, {mv_dist});
+
+  Eigen::MatrixXd obs(3, 1), obs2(3, 3), expected_grad(3, 3);
+  obs << 3.0, 3.0, -1.0;
+  obs2 << 1.0, 0.0, 0.0, 0.1206, 0.9927, 0.0, 0.1033, 0.4061, 0.9080;
+  expected_grad << -1.0000, -0.007852, 0.046564, 0.0000, 5.0062, 0.54763,
+      0.0000, 0.1110, 3.3151;
+
+  uint lkj_chol_sample = g.add_operator(OperatorType::SAMPLE, {lkj_chol_dist});
+  g.observe(cov_llt, obs2);
+  g.observe(mv_sample, obs);
+
+  std::vector<DoubleMatrix*> grad1;
+  g.eval_and_grad(grad1);
+  EXPECT_EQ(grad1.size(), 2);
+
+  auto grad = grad1[0]->as_matrix();
+
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      EXPECT_NEAR(grad(i, j), expected_grad(i, j), 0.001);
+    }
+  }
+}
+
 TEST(testdistrib, lkj_cholesky_log_prob_backward_param) {
   Graph g;
   auto scale = g.add_constant_pos_real(3.0);

--- a/src/beanmachine/graph/operator/backward.cpp
+++ b/src/beanmachine/graph/operator/backward.cpp
@@ -475,7 +475,7 @@ void MatrixComplement::backward() {
 void Transpose::backward() {
   assert(in_nodes.size() == 1);
   if (in_nodes[0]->needs_gradient()) {
-    in_nodes[0]->back_grad1 = back_grad1.as_matrix().transpose();
+    in_nodes[0]->back_grad1 += back_grad1.as_matrix().transpose();
   }
 }
 


### PR DESCRIPTION
Summary: I accidentally set the transpose and LKJ gradients to overwrite instead of accumulate. This fixes it and adds a test which (a) simulates intended usage of LKJ to some degree and (b) fails if gradient values are overwritten.

Differential Revision: D40687223

