### PR TITLE
Fixing Pyre Errors

### DIFF
--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -7,7 +7,8 @@
     "src/beanmachine/ppl/inference/bmg_inference.py",
     "src/beanmachine/ppl/testlib/abstract_conjugate.py",
     "src/beanmachine/ppl/testlib/hypothesis_testing.py",
-    "src/beanmachine/ppl/experimental/torch_jit_backend.py"
+    "src/beanmachine/ppl/experimental/torch_jit_backend.py",
+    "src/beanmachine/ppl/diagnostics/tools/utils/diagnostic_tool_base.py"
   ],
   "site_package_search_strategy": "all",
   "source_directories": [


### PR DESCRIPTION
Summary: src/beanmachine/ppl/diagnostics/tools/utils/diagnostic_tool_base.py:92:8 Unused ignore [0]: The `pyre-ignore[21]` or `pyre-fixme[21]` comment is not suppressing type errors, please remove it.

Differential Revision: D40773191

