### PR TITLE
Fix assertion in BMG's log1mexp

### DIFF
--- a/src/beanmachine/graph/util.cpp
+++ b/src/beanmachine/graph/util.cpp
@@ -135,6 +135,9 @@ Eigen::MatrixXd log1pexp(const Eigen::MatrixXd& x) {
 }
 
 double log1mexp(double x) {
+  if (std::isnan(x)) {
+    return x;
+  }
   assert(x <= 0);
   if (x < -0.693) {
     return std::log1p(-std::exp(x));


### PR DESCRIPTION
Summary:
In any code path where we end up with a log1mexp of NaN, we were asserting. Remember, NaN <= anything is *always* false, including NaN <= NaN. All comparisons on NaN are false.

In the particular tests which are re-enabled, the NaN arises from an unfortunately multiplication of 0 by -infinity which is NaN in the IEEE double system, but this problem is more general than just the model under test; lots of things can result in NaN.

We now explicitly check for NaN and return NaN before doing the assertion.

There still might be a code path on which a truly negative number can be passed to this function, but I will attempt to produce that scenario and address it in a later diff.

Differential Revision: D40808256

