### PR TITLE
minibmg: fix some small issues detected during review

### DIFF
--- a/minibmg/graph_factory.cpp
+++ b/minibmg/graph_factory.cpp
@@ -150,7 +150,7 @@ void Graph::Factory::check_not_built() {
   }
 }
 
-void Graph::Factory::observe(ScalarNodeId sample, double value) {
+void Graph::Factory::observe(ScalarSampleNodeId sample, double value) {
   check_not_built();
   observations.push_back({map[sample], value});
 }

--- a/minibmg/graph_factory.h
+++ b/minibmg/graph_factory.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <fmt/format.h>
 #include <list>
 #include <memory>
 #include <unordered_map>
@@ -56,6 +57,14 @@ struct std::hash<beanmachine::minibmg::NodeId> {
     return (std::size_t)n->_value();
   }
 };
+template <>
+struct std::equal_to<beanmachine::minibmg::NodeId> {
+  bool operator()(
+      const beanmachine::minibmg::NodeId& lhs,
+      const beanmachine::minibmg::NodeId& rhs) const {
+    return lhs->_value() == rhs->_value();
+  }
+};
 
 // Make NodeId values printable using format.
 template <>
@@ -97,7 +106,7 @@ class Graph::Factory {
   DistributionNodeId bernoulli(ScalarNodeId prob);
   DistributionNodeId exponential(ScalarNodeId rate);
 
-  void observe(ScalarNodeId sample, double value);
+  void observe(ScalarSampleNodeId sample, double value);
   unsigned query(ScalarNodeId value);
 
   Nodep operator[](const NodeId& node_id) const;

--- a/minibmg/tests/minibmg_test.cpp
+++ b/minibmg/tests/minibmg_test.cpp
@@ -6,7 +6,9 @@
  */
 
 #include <gtest/gtest.h>
+#include <memory>
 #include <stdexcept>
+#include <unordered_map>
 
 #include "beanmachine/minibmg/dedup.h"
 #include "beanmachine/minibmg/graph.h"
@@ -79,4 +81,15 @@ TEST(test_minibmg, dedupable_concept) {
   ASSERT_TRUE(Rewritable<std::list<std::list<Nodep>>>);
   ASSERT_FALSE(Rewritable<std::list<int>>);
   ASSERT_FALSE(Rewritable<std::list<std::list<int>>>);
+}
+
+TEST(test_minibmg, graph_factory_nodeid_equality) {
+  NodeId a = std::make_shared<NodeIdentifier>(2);
+  NodeId b = std::make_shared<NodeIdentifier>(2);
+  std::unordered_set<NodeId> set{};
+  ASSERT_FALSE(set.contains(a));
+  ASSERT_FALSE(set.contains(b));
+  set.insert(a);
+  ASSERT_TRUE(set.contains(a));
+  ASSERT_TRUE(set.contains(b));
 }


### PR DESCRIPTION
Summary:
Fix two small issues noted during (live, recorded) review of the code:
- `NodeId` should have both hash code and equality defined.  Currently only hash code.
- `Graph::Factory::observe(...)` should take S`calarSampleNodeID`, not just any `ScalarNodeID`.

Differential Revision: D40783447

