### PR TITLE
minibmg: (work in progress) precompute expression trees for NUTS performance

### DIFF
--- a/minibmg/ad/reverse.h
+++ b/minibmg/ad/reverse.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <vector>
 #include "beanmachine/minibmg/ad/num2.h"
 #include "beanmachine/minibmg/ad/number.h"
 #include "beanmachine/minibmg/topological.h"

--- a/minibmg/ad/reverse.h
+++ b/minibmg/ad/reverse.h
@@ -49,12 +49,14 @@ requires Number<Underlying>
 class ReverseBody {
  public:
   Underlying primal;
-  std::list<Reverse<Underlying>> inputs;
+  std::vector<Reverse<Underlying>> inputs;
   Underlying adjoint = 0;
 
   /* implicit */ ReverseBody(double primal);
   /* implicit */ ReverseBody(Underlying primal);
-  ReverseBody(Underlying primal, const std::list<Reverse<Underlying>>& inputs);
+  ReverseBody(
+      Underlying primal,
+      const std::vector<Reverse<Underlying>>& inputs);
   ReverseBody(const ReverseBody<Underlying>& other);
   ReverseBody<Underlying>& operator=(const ReverseBody<Underlying>& other);
   virtual ~ReverseBody() {}
@@ -95,17 +97,17 @@ requires Number<Underlying> Reverse<Underlying>
 template <class Underlying>
 class PrecomputedGradients : public ReverseBody<Underlying> {
  public:
-  const std::list<Underlying> computed_partial_derivatives;
+  const std::vector<Underlying> computed_partial_derivatives;
   PrecomputedGradients(
       Underlying primal,
-      const std::list<Reverse<Underlying>>& inputs,
-      const std::list<Underlying>& computed_partial_derivatives)
+      const std::vector<Reverse<Underlying>>& inputs,
+      const std::vector<Underlying>& computed_partial_derivatives)
       : ReverseBody<Underlying>{primal, inputs},
         computed_partial_derivatives{computed_partial_derivatives} {}
   void backprop() override {
-    auto& /*std::list<Reverse<Underlying>>*/ t = this->inputs;
-    typename std::list<Reverse<Underlying>>::iterator it1 = t.begin();
-    typename std::list<Underlying>::const_iterator it2 =
+    auto& /*std::vector<Reverse<Underlying>>*/ t = this->inputs;
+    typename std::vector<Reverse<Underlying>>::iterator it1 = t.begin();
+    typename std::vector<Underlying>::const_iterator it2 =
         computed_partial_derivatives.begin();
     for (; it1 != t.end() && it2 != computed_partial_derivatives.end();
          ++it1, ++it2) {
@@ -132,7 +134,7 @@ requires Number<Underlying>
 void Reverse<Underlying>::reverse(double initial_adjoint) {
   // topologically sort the set of ReverseBody pointers reachable - these are
   // the nodes to which we need to backprop.
-  std::list<Bodyp> roots = {ptr};
+  std::vector<Bodyp> roots = {ptr};
   std::function<std::vector<Bodyp>(const Bodyp&)> predecessors =
       [&](const Bodyp& ptr) -> std::vector<Bodyp> {
     std::vector<Bodyp> result;
@@ -172,7 +174,7 @@ requires Number<Underlying> ReverseBody<Underlying>::ReverseBody(
 template <class Underlying>
 requires Number<Underlying> ReverseBody<Underlying>::ReverseBody(
     Underlying primal,
-    const std::list<Reverse<Underlying>>& inputs)
+    const std::vector<Reverse<Underlying>>& inputs)
     : primal{primal}, inputs{inputs} {}
 
 template <class Underlying>
@@ -185,8 +187,8 @@ operator+(const Reverse<Underlying>& left, const Reverse<Underlying>& right) {
   Underlying new_primal = left.ptr->primal + right.ptr->primal;
   return Reverse<Underlying>{std::make_shared<PrecomputedGradients<Underlying>>(
       new_primal,
-      std::list<Reverse<Underlying>>{left, right},
-      std::list<Underlying>{1, 1})};
+      std::vector<Reverse<Underlying>>{left, right},
+      std::vector<Underlying>{1, 1})};
 }
 
 template <class Underlying>
@@ -194,8 +196,8 @@ requires Number<Underlying> Reverse<Underlying>
 operator-(const Reverse<Underlying>& left, const Reverse<Underlying>& right) {
   return Reverse<Underlying>{std::make_shared<PrecomputedGradients<Underlying>>(
       left.ptr->primal - right.ptr->primal,
-      std::list<Reverse<Underlying>>{left, right},
-      std::list<Underlying>{1, -1})};
+      std::vector<Reverse<Underlying>>{left, right},
+      std::vector<Underlying>{1, -1})};
 }
 
 template <class Underlying>
@@ -203,8 +205,8 @@ requires Number<Underlying> Reverse<Underlying>
 operator-(const Reverse<Underlying>& x) {
   return Reverse<Underlying>{std::make_shared<PrecomputedGradients<Underlying>>(
       -x.ptr->primal,
-      std::list<Reverse<Underlying>>{x},
-      std::list<Underlying>{-1})};
+      std::vector<Reverse<Underlying>>{x},
+      std::vector<Underlying>{-1})};
 }
 
 template <class Underlying>
@@ -212,8 +214,8 @@ requires Number<Underlying> Reverse<Underlying>
 operator*(const Reverse<Underlying>& left, const Reverse<Underlying>& right) {
   return Reverse<Underlying>{std::make_shared<PrecomputedGradients<Underlying>>(
       left.ptr->primal * right.ptr->primal,
-      std::list<Reverse<Underlying>>{left, right},
-      std::list<Underlying>{right.ptr->primal, left.ptr->primal})};
+      std::vector<Reverse<Underlying>>{left, right},
+      std::vector<Underlying>{right.ptr->primal, left.ptr->primal})};
 }
 
 template <class Underlying>
@@ -224,8 +226,8 @@ operator/(const Reverse<Underlying>& left, const Reverse<Underlying>& right) {
 
   return Reverse<Underlying>{std::make_shared<PrecomputedGradients<Underlying>>(
       new_primal,
-      std::list<Reverse<Underlying>>{left, right},
-      std::list<Underlying>{
+      std::vector<Reverse<Underlying>>{left, right},
+      std::vector<Underlying>{
           1 / right.ptr->primal, -new_primal / right.ptr->primal})};
 }
 
@@ -255,8 +257,8 @@ requires Number<Underlying> Reverse<Underlying> pow(
                          .derivative1;
   return Reverse<Underlying>{std::make_shared<PrecomputedGradients<Underlying>>(
       new_primal,
-      std::list<Reverse<Underlying>>{base, exponent},
-      std::list<Underlying>{grad1, grad2})};
+      std::vector<Reverse<Underlying>>{base, exponent},
+      std::vector<Underlying>{grad1, grad2})};
 }
 
 template <class Underlying>
@@ -265,8 +267,8 @@ requires Number<Underlying> Reverse<Underlying> exp(
   Underlying new_primal = exp(x.ptr->primal);
   return Reverse<Underlying>{std::make_shared<PrecomputedGradients<Underlying>>(
       new_primal,
-      std::list<Reverse<Underlying>>{x},
-      std::list<Underlying>{new_primal})};
+      std::vector<Reverse<Underlying>>{x},
+      std::vector<Underlying>{new_primal})};
 }
 
 template <class Underlying>
@@ -275,8 +277,8 @@ requires Number<Underlying> Reverse<Underlying> log(
   Underlying new_primal = log(x.ptr->primal);
   return Reverse<Underlying>{std::make_shared<PrecomputedGradients<Underlying>>(
       new_primal,
-      std::list<Reverse<Underlying>>{x},
-      std::list<Underlying>{1 / x.ptr->primal})};
+      std::vector<Reverse<Underlying>>{x},
+      std::vector<Underlying>{1 / x.ptr->primal})};
 }
 
 template <class Underlying>
@@ -286,8 +288,8 @@ requires Number<Underlying> Reverse<Underlying> atan(
   Underlying new_derivative1 = 1 / (x.ptr->primal * x.ptr->primal + 1.0f);
   return Reverse<Underlying>{std::make_shared<PrecomputedGradients<Underlying>>(
       new_primal,
-      std::list<Reverse<Underlying>>{x},
-      std::list<Underlying>{new_derivative1})};
+      std::vector<Reverse<Underlying>>{x},
+      std::vector<Underlying>{new_derivative1})};
 }
 
 template <class Underlying>
@@ -297,8 +299,8 @@ requires Number<Underlying> Reverse<Underlying> lgamma(
   Underlying new_derivative1 = polygamma(0, x.ptr->primal);
   return Reverse<Underlying>{std::make_shared<PrecomputedGradients<Underlying>>(
       new_primal,
-      std::list<Reverse<Underlying>>{x},
-      std::list<Underlying>{new_derivative1})};
+      std::vector<Reverse<Underlying>>{x},
+      std::vector<Underlying>{new_derivative1})};
 }
 
 template <class Underlying>
@@ -309,8 +311,8 @@ requires Number<Underlying> Reverse<Underlying> polygamma(
   Underlying new_derivative1 = polygamma(n + 1, x.ptr->primal);
   return Reverse<Underlying>{std::make_shared<PrecomputedGradients<Underlying>>(
       new_primal,
-      std::list<Reverse<Underlying>>{x},
-      std::list<Underlying>{new_derivative1})};
+      std::vector<Reverse<Underlying>>{x},
+      std::vector<Underlying>{new_derivative1})};
 }
 
 template <class Underlying>
@@ -321,8 +323,8 @@ requires Number<Underlying> Reverse<Underlying> log1p(
   Underlying new_derivative1 = 1.0 / (x_value + 1);
   return Reverse<Underlying>{std::make_shared<PrecomputedGradients<Underlying>>(
       new_primal,
-      std::list<Reverse<Underlying>>{x},
-      std::list<Underlying>{new_derivative1})};
+      std::vector<Reverse<Underlying>>{x},
+      std::vector<Underlying>{new_derivative1})};
 }
 
 template <class Underlying>
@@ -340,8 +342,8 @@ requires Number<Underlying> Reverse<Underlying> if_equal(
       when_not_equal.ptr->primal);
   return Reverse<Underlying>{std::make_shared<PrecomputedGradients<Underlying>>(
       new_primal,
-      std::list<Reverse<Underlying>>{when_equal, when_not_equal},
-      std::list<Underlying>{
+      std::vector<Reverse<Underlying>>{when_equal, when_not_equal},
+      std::vector<Underlying>{
           if_equal(value.ptr->primal, comparand.ptr->primal, 1, 0),
           if_equal(value.ptr->primal, comparand.ptr->primal, 0, 1)})};
 }
@@ -361,8 +363,8 @@ requires Number<Underlying> Reverse<Underlying> if_less(
       when_not_less.ptr->primal);
   return Reverse<Underlying>{std::make_shared<PrecomputedGradients<Underlying>>(
       new_primal,
-      std::list<Reverse<Underlying>>{when_less, when_not_less},
-      std::list<Underlying>{
+      std::vector<Reverse<Underlying>>{when_less, when_not_less},
+      std::vector<Underlying>{
           if_less(value.ptr->primal, comparand.ptr->primal, 1, 0),
           if_less(value.ptr->primal, comparand.ptr->primal, 0, 1)})};
 }

--- a/minibmg/ad/traced.h
+++ b/minibmg/ad/traced.h
@@ -34,7 +34,7 @@ class Traced {
   /* implicit */ inline Traced(Real value)
       : node{std::make_shared<ScalarConstantNode>(value.as_double())} {}
 
-  static Traced variable(const std::string& name, const unsigned identifier) {
+  static Traced variable(const std::string& name, const int identifier) {
     return Traced{std::make_shared<ScalarVariableNode>(name, identifier)};
   }
 

--- a/minibmg/dedag.h
+++ b/minibmg/dedag.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <concepts>
+#include <memory>
+#include <stdexcept>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+#include "beanmachine/minibmg/node.h"
+#include "beanmachine/minibmg/rewrite_adapter.h"
+#include "node.h"
+
+namespace beanmachine::minibmg {
+
+// A prelude to a computation, which consists of a sequence of expressions, each
+// of which is computed and assigned to a variable.  This permits us to keep
+// every expression as a tree (rather than a directed acyclic graph).
+using Prelude =
+    std::vector<std::pair<std::shared_ptr<const ScalarVariableNode>, Nodep>>;
+
+// The result of "dedagging" a data structure containing nodes.  This rewrites
+// the dag so that there are no shared nodes - the result is that every node is
+// the root of a tree.  Sharing takes place by computations (subtrees) being
+// stored into temporary variables.  Those assignments are indicated by the
+// `prelude` part of the result, each entry of which indicates the index of a
+// temporary variable, and the expression tree that should be computed into it.
+// Previous temporaries are referenced using "Variable" nodes with an index
+// corresponding to the int assosicated with the prelude entry.
+template <class T>
+struct Dedagged {
+  Prelude prelude;
+  T result;
+};
+
+// implemented in dedup.cpp.
+std::unordered_map<Nodep, Nodep>
+dedag_map(const std::vector<Nodep>& roots, Prelude& prelude, int max_depth);
+
+// Rewrite a data structure by "dedagging" nodes reachable from it, and
+// returning a new data structure along with a "prelude" of assignments to
+// temporaries that are used to compute intermediate expressions (see
+// `Dedagged`).  Performs common subexpression elimination as a side-effect (see
+// `dedup`).  Also limits the nesting depth of subtrees to `max_depth`,
+// introducing temporaries as needed to enforce that limit.
+template <class T, class RewriteAdapter = NodeRewriteAdapter<T>>
+requires Rewritable<T, RewriteAdapter>
+const Dedagged<T> dedag(const T& data, int max_depth = 15) {
+  if (max_depth < 2) {
+    throw std::invalid_argument("max_depth must be >= 2");
+  }
+  RewriteAdapter adapter = RewriteAdapter{};
+  std::vector<Nodep> roots = adapter.find_roots(data);
+  Prelude prelude{};
+  auto map = dedag_map(roots, prelude, max_depth);
+  auto result = adapter.rewrite(data, map);
+  return Dedagged<T>{std::move(prelude), result};
+}
+
+} // namespace beanmachine::minibmg

--- a/minibmg/dedup.cpp
+++ b/minibmg/dedup.cpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <stdexcept>
 #include <unordered_map>
+#include "beanmachine/minibmg/dedag.h"
 #include "beanmachine/minibmg/node.h"
 #include "beanmachine/minibmg/topological.h"
 
@@ -232,7 +233,7 @@ namespace beanmachine::minibmg {
 // Take a set of root nodes as input, and return a map of deduplicated nodes,
 // which maps from a node in the transitive closure of the input to a
 // corresponding node in the transitive closure of the deduplicated graph.
-std::unordered_map<Nodep, Nodep> dedup_map(std::vector<Nodep> roots) {
+std::unordered_map<Nodep, Nodep> dedup_map(const std::vector<Nodep>& roots) {
   // a value-based, map, which treats semantically identical nodes as the same.
   NodeNodeValueMap map;
 
@@ -261,6 +262,69 @@ std::unordered_map<Nodep, Nodep> dedup_map(std::vector<Nodep> roots) {
     } else {
       auto rewritten = node_rewriter.rewrite(node);
       map.insert(node, rewritten);
+      identity_map.insert({node, rewritten});
+    }
+  }
+
+  return identity_map;
+}
+
+std::unordered_map<Nodep, Nodep> dedag_map(
+    const std::vector<Nodep>& roots,
+    std::vector<std::pair<std::shared_ptr<const ScalarVariableNode>, Nodep>>&
+        prelude,
+    int max_depth) {
+  // a value-based, map, which treats semantically identical nodes as the same.
+  int next_variable = 0;
+  NodeNodeValueMap map;
+
+  // We also build a map that uses object (pointer) identity to find elements,
+  // so that operations in clients are not using recursive equality operations.
+  std::unordered_map<Nodep, Nodep> identity_map;
+
+  std::vector<Nodep> sorted;
+  if (!topological_sort<Nodep>(
+          {roots.begin(), roots.end()}, in_nodes, sorted)) {
+    throw std::invalid_argument("graph has a cycle");
+  }
+  std::reverse(sorted.begin(), sorted.end());
+
+  NodeReplacementVisitor node_rewriter{map};
+  std::unordered_map<Nodep, int> depth_map{};
+
+  std::vector<Nodep> unused;
+  std::map<Nodep, unsigned> predecessor_count =
+      count_predecessors_internal<Nodep>(
+          roots, in_nodes, unused, /* include_roots = */ true);
+
+  // Compute a replacement for each node.
+  for (auto& node : sorted) {
+    auto found = map.find(node);
+    if (found != map.end()) {
+      auto mapping = found->second;
+      identity_map.insert({node, mapping});
+    } else {
+      auto rewritten = node_rewriter.rewrite(node);
+      int depth = 1;
+      for (auto in_node : in_nodes(rewritten)) {
+        depth = std::max(depth, 1 + depth_map.at(in_node));
+      }
+      if (depth >= max_depth || (depth > 1 && predecessor_count.at(node) > 1)) {
+        depth_map.insert({rewritten, depth});
+
+        // TODO: we should also do this for nodes that are shared values.
+        int this_variable = next_variable++;
+        auto variable_name = fmt::format("_temp{}", this_variable);
+        // temp indices are negative
+        auto variable_index = ~this_variable;
+        auto variable =
+            std::make_shared<ScalarVariableNode>(variable_name, variable_index);
+        prelude.push_back(std::pair(variable, rewritten));
+        rewritten = variable;
+        depth = 1;
+      }
+      map.insert(node, rewritten);
+      depth_map.insert({rewritten, depth});
       identity_map.insert({node, rewritten});
     }
   }

--- a/minibmg/dedup.h
+++ b/minibmg/dedup.h
@@ -26,7 +26,7 @@ namespace beanmachine::minibmg {
 // resulting data structure are semantically different). This is used in the
 // implementation of dedup(), but might occasionally be useful to clients in
 // this form.
-std::unordered_map<Nodep, Nodep> dedup_map(std::vector<Nodep> roots);
+std::unordered_map<Nodep, Nodep> dedup_map(const std::vector<Nodep>& roots);
 
 // Rewrite a data structure by "deduplicating" nodes reachable from it, and
 // returning a new data structure.  This is also known as common subexpression
@@ -44,7 +44,7 @@ dedup(const T& data, std::unordered_map<Nodep, Nodep>* ddmap = nullptr) {
   auto roots = adapter.find_roots(data);
   auto map = dedup_map(roots);
   if (ddmap != nullptr) {
-    ddmap->insert(map.begin(), map.end());
+    (*ddmap) = map;
   }
   return adapter.rewrite(data, map);
 }

--- a/minibmg/dedup.h
+++ b/minibmg/dedup.h
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <concepts>
-#include <list>
 #include <memory>
 #include <type_traits>
 #include <unordered_map>

--- a/minibmg/eval.cpp
+++ b/minibmg/eval.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "beanmachine/minibmg/eval.h"
+#include <stdexcept>
+
+namespace beanmachine::minibmg {
+
+RecursiveNodeEvaluatorVisitor::RecursiveNodeEvaluatorVisitor(
+    std::function<double(const std::string& name, const int identifier)>
+        read_variable)
+    : read_variable{read_variable} {}
+
+void RecursiveNodeEvaluatorVisitor::visit(const ScalarVariableNode* node) {
+  result = read_variable(node->name, node->identifier);
+}
+
+void RecursiveNodeEvaluatorVisitor::visit(const ScalarSampleNode* node) {
+  throw std::logic_error("recursive evaluator may not sample");
+}
+
+Real RecursiveNodeEvaluatorVisitor::evaluate_input(const ScalarNodep& node) {
+  return evaluate_scalar(node);
+}
+
+std::shared_ptr<const Distribution<Real>>
+RecursiveNodeEvaluatorVisitor::evaluate_input_distribution(
+    const DistributionNodep& node) {
+  throw std::logic_error(
+      "recursive evaluator may not traffic in distributions");
+}
+
+double eval_node(
+    RecursiveNodeEvaluatorVisitor& evaluator,
+    const ScalarNodep& node) {
+  return evaluator.evaluate_scalar(node).value;
+}
+
+} // namespace beanmachine::minibmg

--- a/minibmg/eval.h
+++ b/minibmg/eval.h
@@ -36,12 +36,6 @@ struct SampledValue {
   N log_prob;
 };
 
-} // namespace beanmachine::minibmg
-
-namespace {
-
-using namespace beanmachine::minibmg;
-
 // A visitor that evaluates a single node.  This method does not implement a
 // particular policy for providing values for the inputs to the node being
 // evaluated; the programmer must inherit from this class and implement several
@@ -79,7 +73,7 @@ class NodeEvaluatorVisitor : public NodeVisitor {
       const DistributionNodep& node) = 0;
 
   N result;
-  N evaluate_scalar(ScalarNodep& node) {
+  N evaluate_scalar(const ScalarNodep& node) {
     node->accept(*this);
     return result;
   }
@@ -171,8 +165,7 @@ class NodeEvaluatorVisitor : public NodeVisitor {
 template <class N>
 requires Number<N>
 class OneNodeAtATimeEvaluatorVisitor : public NodeEvaluatorVisitor<N> {
-  std::function<N(const std::string& name, const unsigned identifier)>
-      read_variable;
+  std::function<N(const std::string& name, const int identifier)> read_variable;
   std::unordered_map<const Node*, double> observations;
   N& log_prob;
   std::unordered_map<Nodep, N>& data;
@@ -196,7 +189,7 @@ class OneNodeAtATimeEvaluatorVisitor : public NodeEvaluatorVisitor<N> {
  public:
   OneNodeAtATimeEvaluatorVisitor(
       const Graph& graph,
-      std::function<N(const std::string& name, const unsigned identifier)>
+      std::function<N(const std::string& name, const int identifier)>
           read_variable,
       std::unordered_map<Nodep, N>& data,
       std::unordered_map<Nodep, std::shared_ptr<const Distribution<N>>>&
@@ -245,10 +238,6 @@ class OneNodeAtATimeEvaluatorVisitor : public NodeEvaluatorVisitor<N> {
   }
 };
 
-} // namespace
-
-namespace beanmachine::minibmg {
-
 template <class N>
 requires Number<N>
 struct EvalResult {
@@ -256,7 +245,7 @@ struct EvalResult {
   N log_prob;
 
   // The value of the queries.
-  std::vector<double> queries;
+  std::vector<N> queries;
 };
 
 template <class N>
@@ -290,7 +279,7 @@ template <class N>
 requires Number<N> EvalResult<N> eval_graph(
     const Graph& graph,
     std::mt19937& gen,
-    std::function<N(const std::string& name, const unsigned identifier)>
+    std::function<N(const std::string& name, const int identifier)>
         read_variable,
     std::unordered_map<Nodep, N>& data,
     bool run_queries = false,
@@ -330,11 +319,11 @@ requires Number<N> EvalResult<N> eval_graph(
     }
   }
 
-  std::vector<double> queries;
+  std::vector<N> queries;
   if (run_queries) {
     for (const auto& q : graph.queries) {
       auto d = data.find(q);
-      double value = (d == data.end()) ? 0 : d->second.as_double();
+      N value = (d == data.end()) ? 0 : d->second;
       queries.push_back(value);
     }
   }
@@ -357,5 +346,41 @@ class NodeRewriteAdapter<EvalResult<Underlying>> {
     return {new_log_prob, e.queries};
   }
 };
+
+class RecursiveNodeEvaluatorVisitor : public NodeEvaluatorVisitor<Real> {
+ private:
+  std::function<double(const std::string& name, const int identifier)>
+      read_variable;
+
+ public:
+  RecursiveNodeEvaluatorVisitor(
+      std::function<double(const std::string& name, const int identifier)>
+          read_variable);
+
+ private:
+  void visit(const ScalarVariableNode* node) override;
+
+  // The caller must provide a mechanism for proposing values for a sample node,
+  // e.g. by sampling from the distribution.
+  void visit(const ScalarSampleNode* node) override;
+
+  // The caller must provide a mechanism for evaluating the inputs to a node.
+  // For example, if the graph is a tree it might be done recursively.  Or it
+  // might keep values in a map from node to value.
+  Real evaluate_input(const ScalarNodep& node) override;
+
+  // Similarly, the caller must provide a mechanism to evaluate inputs that are
+  // distributions.
+  std::shared_ptr<const Distribution<Real>> evaluate_input_distribution(
+      const DistributionNodep& node) override;
+};
+
+// Evaluate a single node by recursive descent.  This works best if the node is
+// a tree, rather than a directed acyclic graph with shared values.  This
+// cannot sample from a distribution or compute log_prob values unless that
+// computation is already inlined into the node's tree.
+double eval_node(
+    RecursiveNodeEvaluatorVisitor& evaluator,
+    const ScalarNodep& node);
 
 } // namespace beanmachine::minibmg

--- a/minibmg/fluid_factory.h
+++ b/minibmg/fluid_factory.h
@@ -39,7 +39,7 @@ class Graph::FluidFactory {
 
  private:
   std::vector<Nodep> queries;
-  std::list<std::pair<Nodep, double>> observations;
+  std::vector<std::pair<Nodep, double>> observations;
 };
 
 } // namespace beanmachine::minibmg

--- a/minibmg/graph.cpp
+++ b/minibmg/graph.cpp
@@ -6,7 +6,6 @@
  */
 
 #include "beanmachine/minibmg/graph.h"
-#include <list>
 #include <memory>
 #include <stdexcept>
 #include <vector>
@@ -19,8 +18,8 @@ using namespace beanmachine::minibmg;
 
 const std::vector<Nodep> roots(
     const std::vector<Nodep>& queries,
-    const std::list<std::pair<Nodep, double>>& observations) {
-  std::list<Nodep> roots;
+    const std::vector<std::pair<Nodep, double>>& observations) {
+  std::vector<Nodep> roots;
   for (auto& n : queries) {
     roots.push_back(n);
   }
@@ -28,7 +27,7 @@ const std::vector<Nodep> roots(
     if (!std::dynamic_pointer_cast<const ScalarSampleNode>(p.first)) {
       throw std::invalid_argument(fmt::format("can only observe a sample"));
     }
-    roots.push_front(p.first);
+    roots.push_back(p.first);
   }
   std::vector<Nodep> all_nodes;
   if (!topological_sort<Nodep>(roots, &in_nodes, all_nodes)) {
@@ -40,7 +39,7 @@ const std::vector<Nodep> roots(
 
 struct QueriesAndObservations {
   std::vector<Nodep> queries;
-  std::list<std::pair<Nodep, double>> observations;
+  std::vector<std::pair<Nodep, double>> observations;
   ~QueriesAndObservations() {}
 };
 
@@ -65,7 +64,7 @@ class NodeRewriteAdapter<QueriesAndObservations> {
       const QueriesAndObservations& qo,
       const std::unordered_map<Nodep, Nodep>& map) const {
     NodeRewriteAdapter<std::vector<Nodep>> h1{};
-    NodeRewriteAdapter<std::list<std::pair<Nodep, double>>> h2{};
+    NodeRewriteAdapter<std::vector<std::pair<Nodep, double>>> h2{};
     return QueriesAndObservations{
         h1.rewrite(qo.queries, map), h2.rewrite(qo.observations, map)};
   }
@@ -75,7 +74,7 @@ using dynamic = folly::dynamic;
 
 Graph Graph::create(
     const std::vector<Nodep>& queries,
-    const std::list<std::pair<Nodep, double>>& observations,
+    const std::vector<std::pair<Nodep, double>>& observations,
     std::unordered_map<Nodep, Nodep>* built_map) {
   for (auto& p : observations) {
     if (!std::dynamic_pointer_cast<const ScalarSampleNode>(p.first)) {
@@ -95,7 +94,7 @@ Graph::~Graph() {}
 Graph::Graph(
     const std::vector<Nodep>& nodes,
     const std::vector<Nodep>& queries,
-    const std::list<std::pair<Nodep, double>>& observations)
+    const std::vector<std::pair<Nodep, double>>& observations)
     : nodes{nodes}, queries{queries}, observations{observations} {}
 
 } // namespace beanmachine::minibmg

--- a/minibmg/graph.h
+++ b/minibmg/graph.h
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <folly/json.h>
-#include <list>
+#include <vector>
 #include "beanmachine/minibmg/dedup.h"
 #include "beanmachine/minibmg/graph_properties/container.h"
 #include "beanmachine/minibmg/node.h"
@@ -27,7 +27,7 @@ class Graph : public Container {
 
   static Graph create(
       const std::vector<Nodep>& queries,
-      const std::list<std::pair<Nodep, double>>& observations,
+      const std::vector<std::pair<Nodep, double>>& observations,
       std::unordered_map<Nodep, Nodep>* built_map = nullptr);
   ~Graph();
 
@@ -55,7 +55,7 @@ class Graph : public Container {
 
   // Observations of the model.  These are SAMPLE nodes in the model whose
   // values are known.
-  const std::list<std::pair<Nodep, double>> observations;
+  const std::vector<std::pair<Nodep, double>> observations;
 
  private:
   // A private constructor that forms a graph without validation.
@@ -63,7 +63,7 @@ class Graph : public Container {
   Graph(
       const std::vector<Nodep>& nodes,
       const std::vector<Nodep>& queries,
-      const std::list<std::pair<Nodep, double>>& observations);
+      const std::vector<std::pair<Nodep, double>>& observations);
 
  public:
   // A factory for making graphs, like the bmg API used by Beanstalk
@@ -99,7 +99,7 @@ class NodeRewriteAdapter<Graph> {
   Graph rewrite(const Graph& qo, const std::unordered_map<Nodep, Nodep>& map)
       const {
     NodeRewriteAdapter<std::vector<Nodep>> h1{};
-    NodeRewriteAdapter<std::list<std::pair<Nodep, double>>> h2{};
+    NodeRewriteAdapter<std::vector<std::pair<Nodep, double>>> h2{};
     return Graph::create(
         h1.rewrite(qo.queries, map), h2.rewrite(qo.observations, map));
   }

--- a/minibmg/graph_factory.cpp
+++ b/minibmg/graph_factory.cpp
@@ -10,7 +10,6 @@
 #include <stdexcept>
 #include <unordered_map>
 #include "beanmachine/minibmg/node.h"
-#include "node.h"
 
 namespace beanmachine::minibmg {
 

--- a/minibmg/graph_factory.cpp
+++ b/minibmg/graph_factory.cpp
@@ -34,7 +34,7 @@ ScalarNodeId Graph::Factory::constant(double value) {
 }
 ScalarNodeId Graph::Factory::variable(
     const std::string& name,
-    const unsigned identifier) {
+    const int identifier) {
   ScalarNodep result = std::make_shared<ScalarVariableNode>(name, identifier);
   return add_node(result);
 }

--- a/minibmg/graph_factory.h
+++ b/minibmg/graph_factory.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <list>
 #include <memory>
 #include <unordered_map>
 #include <vector>
@@ -114,7 +113,7 @@ class Graph::Factory {
   std::unordered_map<NodeId, Nodep> identifer_to_node;
   std::unordered_map<Nodep, NodeId> node_to_identifier;
   std::vector<Nodep> queries;
-  std::list<std::pair<Nodep, double>> observations;
+  std::vector<std::pair<Nodep, double>> observations;
   unsigned long next_identifier = 0;
 
   ScalarNodeId add_node(ScalarNodep node);

--- a/minibmg/graph_factory.h
+++ b/minibmg/graph_factory.h
@@ -70,7 +70,7 @@ namespace beanmachine::minibmg {
 class Graph::Factory {
  public:
   ScalarNodeId constant(double value);
-  ScalarNodeId variable(const std::string& name, const unsigned identifier);
+  ScalarNodeId variable(const std::string& name, const int identifier);
   ScalarSampleNodeId sample(
       DistributionNodeId distribution,
       const std::string& rvid = make_fresh_rvid());

--- a/minibmg/graph_properties/observations_by_node.h
+++ b/minibmg/graph_properties/observations_by_node.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <list>
 #include <unordered_set>
 #include "beanmachine/minibmg/graph.h"
 #include "beanmachine/minibmg/node.h"

--- a/minibmg/graph_properties/out_nodes.cpp
+++ b/minibmg/graph_properties/out_nodes.cpp
@@ -7,7 +7,6 @@
 
 #include "beanmachine/minibmg/graph_properties/out_nodes.h"
 #include <exception>
-#include <list>
 #include <map>
 
 namespace {
@@ -17,13 +16,13 @@ using namespace beanmachine::minibmg;
 class OutNodesProperty : public Property<
                              OutNodesProperty,
                              Graph,
-                             std::map<Nodep, std::list<Nodep>>> {
+                             std::map<Nodep, std::vector<Nodep>>> {
  public:
-  std::map<Nodep, std::list<Nodep>>* create(const Graph& g) const override {
-    std::map<Nodep, std::list<Nodep>>* data =
-        new std::map<Nodep, std::list<Nodep>>{};
+  std::map<Nodep, std::vector<Nodep>>* create(const Graph& g) const override {
+    std::map<Nodep, std::vector<Nodep>>* data =
+        new std::map<Nodep, std::vector<Nodep>>{};
     for (auto node : g) {
-      (*data)[node] = std::list<Nodep>{};
+      (*data)[node] = std::vector<Nodep>{};
       for (auto in_node : in_nodes(node)) {
         auto& predecessor_out_set = (*data)[in_node];
         predecessor_out_set.push_back(node);
@@ -38,8 +37,8 @@ class OutNodesProperty : public Property<
 
 namespace beanmachine::minibmg {
 
-const std::list<Nodep>& out_nodes(const Graph& graph, Nodep node) {
-  std::map<Nodep, std::list<Nodep>>& node_map = *OutNodesProperty::get(graph);
+const std::vector<Nodep>& out_nodes(const Graph& graph, Nodep node) {
+  std::map<Nodep, std::vector<Nodep>>& node_map = *OutNodesProperty::get(graph);
   auto found = node_map.find(node);
   if (found == node_map.end()) {
     throw std::invalid_argument("node not in graph");

--- a/minibmg/graph_properties/out_nodes.h
+++ b/minibmg/graph_properties/out_nodes.h
@@ -7,8 +7,8 @@
 
 #pragma once
 
-#include <list>
 #include <unordered_set>
+#include <vector>
 #include "beanmachine/minibmg/graph.h"
 #include "beanmachine/minibmg/node.h"
 
@@ -16,6 +16,6 @@ namespace beanmachine::minibmg {
 
 // return the set of nodes that have the given node as an input in the given
 // graph.
-const std::list<Nodep>& out_nodes(const Graph& graph, Nodep node);
+const std::vector<Nodep>& out_nodes(const Graph& graph, Nodep node);
 
 } // namespace beanmachine::minibmg

--- a/minibmg/graph_properties/unobserved_samples.cpp
+++ b/minibmg/graph_properties/unobserved_samples.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "beanmachine/minibmg/graph_properties/unobserved_samples.h"
+#include <exception>
+#include <list>
+#include <map>
+#include <memory>
+#include <unordered_set>
+
+namespace {
+
+using namespace beanmachine::minibmg;
+
+class unobserved_samples_property
+    : public Property<unobserved_samples_property, Graph, std::vector<Nodep>> {
+ public:
+  std::vector<Nodep>* create(const Graph& g) const override {
+    auto result = new std::vector<Nodep>{};
+    std::unordered_set<Nodep> observed_samples;
+    for (auto& p : g.observations) {
+      observed_samples.insert(p.first);
+    }
+    for (auto& node : g) {
+      if (std::dynamic_pointer_cast<const ScalarSampleNode>(node) &&
+          !observed_samples.contains(node)) {
+        result->push_back(node);
+      }
+    }
+    return result;
+  }
+};
+
+} // namespace
+
+namespace beanmachine::minibmg {
+
+const std::vector<Nodep>& unobserved_samples(const Graph& graph) {
+  return *unobserved_samples_property::get(graph);
+}
+
+} // namespace beanmachine::minibmg

--- a/minibmg/graph_properties/unobserved_samples.h
+++ b/minibmg/graph_properties/unobserved_samples.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <list>
+#include <unordered_set>
+#include "beanmachine/minibmg/graph.h"
+#include "beanmachine/minibmg/node.h"
+
+namespace beanmachine::minibmg {
+
+const std::vector<Nodep>& unobserved_samples(const Graph& graph);
+
+} // namespace beanmachine::minibmg

--- a/minibmg/inference/global_state.cpp
+++ b/minibmg/inference/global_state.cpp
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "beanmachine/minibmg/inference/global_state.h"
+#include <math.h>
+#include <memory>
+#include "beanmachine/graph/global/global_state.h"
+#include "beanmachine/minibmg/eval.h"
+#include "beanmachine/minibmg/graph_properties/unobserved_samples.h"
+
+namespace beanmachine::minibmg {
+
+MinibmgGlobalState::MinibmgGlobalState(beanmachine::minibmg::Graph& graph)
+    : graph{graph}, world{hmc_world_0(graph)} {
+  samples.clear();
+  // Since we only support scalars, we count the unobserved samples by ones.
+  int num_unobserved_samples = -graph.observations.size();
+  for (auto& node : graph) {
+    if (std::dynamic_pointer_cast<const ScalarSampleNode>(node)) {
+      num_unobserved_samples++;
+    }
+  }
+  flat_size = num_unobserved_samples;
+}
+
+void MinibmgGlobalState::initialize_values(
+    beanmachine::graph::InitType init_type,
+    uint seed) {
+  std::mt19937 gen(31 * seed + 17);
+  std::vector<double>& samples = unconstrained_values;
+  switch (init_type) {
+    case graph::InitType::PRIOR: {
+      // Evaluate the graph, saving samples.
+      auto read_variable = [](const std::string&, const unsigned) -> Real {
+        // there are no variables, so we don't have to read them.
+        throw std::logic_error("models do not contain variables");
+      };
+      auto my_sampler = [&samples](
+                            const Distribution<Real>& distribution,
+                            std::mt19937& gen) -> SampledValue<Real> {
+        auto result = sample_from_distribution(distribution, gen);
+        // save the proposed value
+        samples.push_back(result.unconstrained.as_double());
+        return result;
+      };
+      auto eval_result = eval_graph<Real>(
+          graph,
+          gen,
+          /* read_variable= */ read_variable,
+          real_eval_data,
+          /* run_queries= */ false,
+          /* eval_log_prob= */ true,
+          /* sampler = */ my_sampler);
+    } break;
+    case graph::InitType::RANDOM: {
+      std::uniform_real_distribution<> uniform_real_distribution(-2, 2);
+      for (int i = 0; i < flat_size; i++) {
+        samples.push_back(uniform_real_distribution(gen));
+      }
+    } break;
+    default: {
+      for (int i = 0; i < flat_size; i++) {
+        samples.push_back(0);
+      }
+    } break;
+  }
+
+  // update and backup values, gradients, and log_prob
+  update_log_prob();
+  update_backgrad();
+  backup_unconstrained_values();
+  backup_unconstrained_grads();
+}
+
+void MinibmgGlobalState::backup_unconstrained_values() {
+  saved_unconstrained_values = unconstrained_values;
+}
+
+void MinibmgGlobalState::backup_unconstrained_grads() {
+  saved_unconstrained_grads = unconstrained_grads;
+}
+
+void MinibmgGlobalState::revert_unconstrained_values() {
+  unconstrained_values = saved_unconstrained_values;
+}
+
+void MinibmgGlobalState::revert_unconstrained_grads() {
+  unconstrained_grads = saved_unconstrained_grads;
+}
+
+void MinibmgGlobalState::add_to_stochastic_unconstrained_nodes(
+    Eigen::VectorXd& increment) {
+  if (increment.size() != flat_size) {
+    throw std::invalid_argument(
+        "The size of increment is inconsistent with the values in the graph");
+  }
+  for (int i = 0; i < flat_size; i++) {
+    unconstrained_values[i] += increment[i];
+  }
+}
+
+void MinibmgGlobalState::get_flattened_unconstrained_values(
+    Eigen::VectorXd& flattened_values) {
+  flattened_values.resize(flat_size);
+  for (int i = 0; i < flat_size; i++) {
+    flattened_values[i] = unconstrained_values[i];
+  }
+}
+
+void MinibmgGlobalState::set_flattened_unconstrained_values(
+    Eigen::VectorXd& flattened_values) {
+  if (flattened_values.size() != flat_size) {
+    throw std::invalid_argument(
+        "The size of flattened_values is inconsistent with the values in the graph");
+  }
+  for (int i = 0; i < flat_size; i++) {
+    unconstrained_values[i] = flattened_values[i];
+  }
+}
+
+void MinibmgGlobalState::get_flattened_unconstrained_grads(
+    Eigen::VectorXd& flattened_grad) {
+  flattened_grad.resize(flat_size);
+  for (int i = 0; i < flat_size; i++) {
+    flattened_grad[i] = unconstrained_grads[i];
+  }
+}
+
+double MinibmgGlobalState::get_log_prob() {
+  return log_prob;
+}
+
+void MinibmgGlobalState::update_log_prob() {
+  log_prob = world->log_prob(this->unconstrained_values);
+}
+
+void MinibmgGlobalState::update_backgrad() {
+  unconstrained_grads = world->gradients(this->unconstrained_values);
+}
+
+void MinibmgGlobalState::collect_sample() {
+  auto queries = world->queries(this->unconstrained_values);
+  std::vector<beanmachine::graph::NodeValue> compat_query;
+  for (auto v : queries) {
+    compat_query.emplace_back(v);
+  }
+  this->samples.emplace_back(compat_query);
+}
+
+std::vector<std::vector<beanmachine::graph::NodeValue>>&
+MinibmgGlobalState::get_samples() {
+  return samples;
+}
+
+void MinibmgGlobalState::set_default_transforms() {
+  // minibmg always uses the default transforms
+}
+
+void MinibmgGlobalState::set_agg_type(
+    beanmachine::graph::AggregationType agg_type) {
+  if (agg_type != beanmachine::graph::AggregationType::NONE) {
+    throw std::logic_error("unimplemented AggregationType");
+  }
+}
+
+void MinibmgGlobalState::clear_samples() {
+  samples.clear();
+}
+
+} // namespace beanmachine::minibmg

--- a/minibmg/inference/global_state.h
+++ b/minibmg/inference/global_state.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "beanmachine/graph/global/global_state.h"
+#include "beanmachine/graph/graph.h"
+#include "beanmachine/minibmg/ad/real.h"
+#include "beanmachine/minibmg/ad/reverse.h"
+#include "beanmachine/minibmg/graph.h"
+#include "hmc_world.h"
+
+namespace beanmachine::minibmg {
+
+// using namespace beanmachine::graph;
+
+// Global state, an implementation of beanmachine::graph::GlobalState which is
+// needed to use the NUTS api from bmg.
+class MinibmgGlobalState : public beanmachine::graph::GlobalState {
+ public:
+  explicit MinibmgGlobalState(beanmachine::minibmg::Graph& graph);
+  void initialize_values(beanmachine::graph::InitType init_type, uint seed)
+      override;
+  void backup_unconstrained_values() override;
+  void backup_unconstrained_grads() override;
+  void revert_unconstrained_values() override;
+  void revert_unconstrained_grads() override;
+  void add_to_stochastic_unconstrained_nodes(
+      Eigen::VectorXd& increment) override;
+  void get_flattened_unconstrained_values(
+      Eigen::VectorXd& flattened_values) override;
+  void set_flattened_unconstrained_values(
+      Eigen::VectorXd& flattened_values) override;
+  void get_flattened_unconstrained_grads(
+      Eigen::VectorXd& flattened_grad) override;
+  double get_log_prob() override;
+  void update_log_prob() override;
+  void update_backgrad() override;
+  void collect_sample() override;
+  std::vector<std::vector<beanmachine::graph::NodeValue>>& get_samples()
+      override;
+  void set_default_transforms() override;
+  void set_agg_type(beanmachine::graph::AggregationType) override;
+  void clear_samples() override;
+
+ private:
+  const beanmachine::minibmg::Graph& graph;
+  const std::unique_ptr<const HMCWorld> world;
+  std::vector<std::vector<beanmachine::graph::NodeValue>> samples;
+  int flat_size;
+  double log_prob;
+  std::vector<double> unconstrained_values;
+  std::vector<double> unconstrained_grads;
+  std::vector<double> saved_unconstrained_values;
+  std::vector<double> saved_unconstrained_grads;
+
+  // scratchpads for evaluation
+  std::unordered_map<Nodep, Reverse<Real>> reverse_eval_data;
+  std::unordered_map<Nodep, Real> real_eval_data;
+};
+
+} // namespace beanmachine::minibmg

--- a/minibmg/inference/hmc_world.cpp
+++ b/minibmg/inference/hmc_world.cpp
@@ -8,9 +8,13 @@
 #include "beanmachine/minibmg/inference/hmc_world.h"
 #include <memory>
 #include <random>
+#include <stdexcept>
 #include <unordered_set>
+#include <vector>
 #include "beanmachine/minibmg/ad/real.h"
 #include "beanmachine/minibmg/ad/reverse.h"
+#include "beanmachine/minibmg/ad/traced.h"
+#include "beanmachine/minibmg/dedag.h"
 #include "beanmachine/minibmg/distribution/bernoulli.h"
 #include "beanmachine/minibmg/eval.h"
 #include "beanmachine/minibmg/graph.h"
@@ -22,42 +26,10 @@ namespace {
 
 using namespace beanmachine::minibmg;
 
-class HMCWorld0 : public HMCWorld {
- private:
-  const Graph& graph;
-  std::unordered_set<Nodep> unobserved_sample_set;
-  std::unordered_map<Nodep, double> observations;
-
- public:
-  explicit HMCWorld0(const Graph& graph);
-
-  unsigned num_unobserved_samples() const override;
-
-  double log_prob(
-      const std::vector<double>& proposed_unconstrained_values) const override;
-
-  std::vector<double> gradients(
-      const std::vector<double>& proposed_unconstrained_values) const override;
-
-  std::vector<double> queries(
-      const std::vector<double>& proposed_unconstrained_values) const override;
-};
-
-HMCWorld0::HMCWorld0(const Graph& graph)
-    : graph{graph},
-      unobserved_sample_set{
-          unobserved_samples(graph).begin(),
-          unobserved_samples(graph).end()},
-      observations{observations_by_node(graph)} {}
-
-unsigned HMCWorld0::num_unobserved_samples() const {
-  return unobserved_sample_set.size();
-}
-
-template <class T>
+template <class T, class U = double>
 requires Number<T> EvalResult<T> evaluate_internal(
     const Graph& graph,
-    const std::vector<double>& proposed_unconstrained_values,
+    const std::vector<U>& proposed_unconstrained_values,
     std::unordered_map<Nodep, T>& data,
     std::mt19937& gen,
     bool run_queries,
@@ -111,6 +83,42 @@ requires Number<T> EvalResult<T> evaluate_internal(
       sample_from_distribution);
 }
 
+// "In a world in which" we evaluate things by computing them the hard way,
+// using automatic differentiation if necessary.
+class HMCWorld0 : public HMCWorld {
+ private:
+  const Graph& graph;
+  std::unordered_set<Nodep> unobserved_sample_set;
+  std::unordered_map<Nodep, double> observations;
+
+ public:
+  explicit HMCWorld0(const Graph& graph);
+
+  unsigned num_unobserved_samples() const override;
+
+  double log_prob(
+      const std::vector<double>& proposed_unconstrained_values) const override;
+
+  void gradients(
+      const std::vector<double>& proposed_unconstrained_values,
+      std::vector<double>& result) const override;
+
+  void queries(
+      const std::vector<double>& proposed_unconstrained_values,
+      std::vector<double>& result) const override;
+};
+
+HMCWorld0::HMCWorld0(const Graph& graph)
+    : graph{graph},
+      unobserved_sample_set{
+          unobserved_samples(graph).begin(),
+          unobserved_samples(graph).end()},
+      observations{observations_by_node(graph)} {}
+
+unsigned HMCWorld0::num_unobserved_samples() const {
+  return unobserved_sample_set.size();
+}
+
 double HMCWorld0::log_prob(
     const std::vector<double>& proposed_unconstrained_values) const {
   using T = Real;
@@ -129,8 +137,9 @@ double HMCWorld0::log_prob(
   return eval_result.log_prob.as_double();
 }
 
-std::vector<double> HMCWorld0::gradients(
-    const std::vector<double>& proposed_unconstrained_values) const {
+void HMCWorld0::gradients(
+    const std::vector<double>& proposed_unconstrained_values,
+    std::vector<double>& result) const {
   using T = Reverse<Real>;
   std::unordered_map<Nodep, T> data;
   std::mt19937 gen;
@@ -148,6 +157,8 @@ std::vector<double> HMCWorld0::gradients(
   eval_result.log_prob.reverse(1);
   std::vector<double> gradients;
   auto& obs = observations_by_node(graph);
+  result.resize(num_unobserved_samples());
+  int i = 0;
   for (const auto& node : graph) {
     if (dynamic_cast<const ScalarSampleNode*>(node.get()) &&
         !obs.contains(node)) {
@@ -158,15 +169,14 @@ std::vector<double> HMCWorld0::gradients(
       // the gradient is zero.
       auto grad =
           (found == data.end()) ? 0 : found->second.adjoint().as_double();
-      gradients.push_back(grad);
+      result[i++] = grad;
     }
   }
-
-  return gradients;
 }
 
-std::vector<double> HMCWorld0::queries(
-    const std::vector<double>& proposed_unconstrained_values) const {
+void HMCWorld0::queries(
+    const std::vector<double>& proposed_unconstrained_values,
+    std::vector<double>& result) const {
   // In order to evaluate the queries, we evaluate the graph without computing
   // gradients.
   using T = Real;
@@ -183,7 +193,174 @@ std::vector<double> HMCWorld0::queries(
       /* run_queries = */ true,
       /* eval_log_prob = */ false);
 
-  return eval_result.queries;
+  int n = eval_result.queries.size();
+  result.resize(n);
+  for (int i = 0; i < n; i++) {
+    result[i] = eval_result.queries[i].as_double();
+  }
+}
+
+// "In a world in which" we evaluate things by computing them the hard way once,
+// symbolically, and then optimize and save the symbolic form for (hopefully)
+// fast recursive evaluation later.  This recuces the memory allocation
+// overhead, because we do not need to allocate nodes for reverse AD.
+class HMCWorld1 : public HMCWorld {
+ private:
+  const Graph& graph;
+  std::unordered_set<Nodep> unobserved_sample_set;
+  std::unordered_map<Nodep, double> observations;
+
+  Dedagged<std::vector<ScalarNodep>> log_prob_graph;
+  Dedagged<std::vector<ScalarNodep>> gradients_graph;
+  Dedagged<std::vector<ScalarNodep>> queries_graph;
+
+ public:
+  explicit HMCWorld1(const Graph& graph);
+
+  unsigned num_unobserved_samples() const override;
+
+  double log_prob(
+      const std::vector<double>& proposed_unconstrained_values) const override;
+
+  void gradients(
+      const std::vector<double>& proposed_unconstrained_values,
+      std::vector<double>& result) const override;
+
+  void queries(
+      const std::vector<double>& proposed_unconstrained_values,
+      std::vector<double>& result) const override;
+};
+
+HMCWorld1::HMCWorld1(const Graph& graph)
+    : graph{graph},
+      unobserved_sample_set{
+          unobserved_samples(graph).begin(),
+          unobserved_samples(graph).end()},
+      observations{observations_by_node(graph)} {
+  // We evaluate the graph in reverse mode, computing symbolic forms for the
+  // queries, log_prob, and gradients.  We save those symbolic forms for fast
+  // recursive evaluation later.
+  using T = Reverse<Traced>;
+
+  unsigned next_sample = 0;
+  std::vector<T> samples{};
+
+  // Here is our function for producing an unobserved sample by drawing from
+  // `proposed_unconstrained_values`.  We produce a variable that will consume
+  // that data provided by the caller, transforming it if necessary.
+  std::function<SampledValue<T>(
+      const Distribution<T>& distribution, std::mt19937& gen)>
+      sample_from_distribution = [&](const Distribution<T>& distribution,
+                                     std::mt19937&) -> SampledValue<T> {
+    auto this_sample = next_sample++;
+    auto variable_name = fmt::format("proposals[{}]", this_sample);
+    auto variable_identifier = this_sample;
+    T unconstrained = T{Traced::variable(variable_name, variable_identifier)};
+    samples.push_back(unconstrained);
+    auto transform = distribution.transformation();
+    if (transform == nullptr) {
+      const T& constrained = unconstrained;
+      T logp = distribution.log_prob(constrained);
+      return {constrained, unconstrained, logp};
+    } else {
+      T constrained = transform->inverse(unconstrained);
+      T logp = distribution.log_prob(constrained);
+
+      // I am confused about how transforms are really supposed to work.  I am
+      // probably not understanding the math.  I need help understanding what to
+      // do here. For now we just avoid transforming the log_prob value.
+
+      // // logp = transform->transform_log_prob(constrained, logp);
+      return {constrained, unconstrained, logp};
+    }
+  };
+
+  // we don't need to read "variables" from a graph because there is no
+  // such concept as a variable in Bean Machine.
+  auto read_variable = [](const std::string&, const unsigned) -> T {
+    throw std::logic_error("Bean Machine models should not contain variables");
+  };
+
+  // evaluate the graph.
+  std::mt19937 gen;
+  std::unordered_map<Nodep, T> data{};
+  auto eval_result = eval_graph<T>(
+      graph,
+      gen,
+      read_variable,
+      data,
+      /* run_queries = */ true,
+      /* eval_log_prob  = */ true,
+      sample_from_distribution);
+  eval_result.log_prob.reverse(1);
+
+  std::vector<ScalarNodep> log_prob = {eval_result.log_prob.ptr->primal.node};
+  std::vector<ScalarNodep> queries{};
+  for (auto& q : eval_result.queries) {
+    queries.push_back(q.ptr->primal.node);
+  }
+  std::vector<ScalarNodep> gradients{};
+  for (auto& g : samples) {
+    gradients.push_back(g.ptr->adjoint.node);
+  }
+
+  this->log_prob_graph = dedag(opt(log_prob));
+  this->gradients_graph = dedag(opt(gradients));
+  this->queries_graph = dedag(opt(queries));
+}
+
+unsigned HMCWorld1::num_unobserved_samples() const {
+  return unobserved_sample_set.size();
+}
+
+void eval_graph(
+    const std::vector<double>& proposed_unconstrained_values,
+    Dedagged<std::vector<ScalarNodep>> dedagged,
+    std::vector<double>& result) {
+  // TODO: can we share this temp vector among all invocations of this method
+  // for the life of this World object?
+  std::vector<double> temps;
+  temps.resize(dedagged.prelude.size());
+  std::function<double(const std::string& name, const int identifier)>
+      read_variable =
+          [&](const std::string& name, const int identifier) -> double {
+    if (identifier >= 0)
+      return proposed_unconstrained_values[identifier];
+    else
+      return temps[~identifier];
+  };
+  RecursiveNodeEvaluatorVisitor evaluator{read_variable};
+  for (int i = 0, n = dedagged.prelude.size(); i < n; i++) {
+    assert(dedagged.prelude[i].first->identifier == ~i);
+    temps[i] = eval_node(
+        evaluator,
+        std::dynamic_pointer_cast<const ScalarNode>(
+            dedagged.prelude[i].second));
+  }
+  result.resize(dedagged.result.size());
+  for (int i = 0, n = dedagged.result.size(); i < n; i++) {
+    result[i] = eval_node(evaluator, dedagged.result[i]);
+  }
+}
+
+double HMCWorld1::log_prob(
+    const std::vector<double>& proposed_unconstrained_values) const {
+  // TODO: share the same result vector from call to call.
+  std::vector<double> result;
+  eval_graph(proposed_unconstrained_values, log_prob_graph, result);
+  return result[0];
+}
+
+void HMCWorld1::gradients(
+    const std::vector<double>& proposed_unconstrained_values,
+    std::vector<double>& result) const {
+  eval_graph(proposed_unconstrained_values, gradients_graph, result);
+}
+
+void HMCWorld1::queries(
+    const std::vector<double>& proposed_unconstrained_values,
+    std::vector<double>& result) const {
+  eval_graph(proposed_unconstrained_values, queries_graph, result);
 }
 
 } // namespace
@@ -192,6 +369,14 @@ namespace beanmachine::minibmg {
 
 std::unique_ptr<const HMCWorld> hmc_world_0(const Graph& graph) {
   return std::make_unique<HMCWorld0>(graph);
+}
+
+std::unique_ptr<const HMCWorld> hmc_world_1(const Graph& graph) {
+  return std::make_unique<HMCWorld1>(graph);
+}
+
+std::unique_ptr<const HMCWorld> hmc_world_2(const Graph& graph) {
+  throw std::logic_error("hmc_world_2 not implemented");
 }
 
 } // namespace beanmachine::minibmg

--- a/minibmg/inference/hmc_world.h
+++ b/minibmg/inference/hmc_world.h
@@ -34,11 +34,19 @@ class HMCWorld {
   // model (transformed, if necessary, so that they are unconstrained -
   // supported over the real numbers), given in the same order as the
   // observation nodes appear in the graph, compute the log probability of the
-  // model with that assignment, as well as the the first derivative of the log
-  // probability with respect to each of the proposed values.  The input vector
-  // is required to be of a size that is equal to the return value of
+  // model with that assignment.  The input vector is required to be of a size
+  // that is equal to the return value of num_unobserved_samples.
+  virtual double log_prob(
+      const std::vector<double>& proposed_unconstrained_values) const = 0;
+
+  // Given proposed assigned values for all of the onobserved samples in the
+  // model (transformed, if necessary, so that they are unconstrained -
+  // supported over the real numbers), given in the same order as the
+  // observation nodes appear in the graph, compute the first derivative of the
+  // log probability with respect to each of the proposed values.  The input
+  // vector is required to be of a size that is equal to the return value of
   // num_unobserved_samples.
-  virtual HMCWorldEvalResult evaluate(
+  virtual std::vector<double> gradients(
       const std::vector<double>& proposed_unconstrained_values) const = 0;
 
   // Given proposed assigned values for all of the onobserved samples in the
@@ -50,16 +58,6 @@ class HMCWorld {
       const std::vector<double>& proposed_unconstrained_values) const = 0;
 
   virtual ~HMCWorld() {}
-};
-
-struct HMCWorldEvalResult {
-  // The computed log probability of a given assignment to the samples in a
-  // model.
-  double log_prob;
-
-  // The derivative of the log probability with respect to each of the
-  // unobserved samples in a model.
-  std::vector<double> gradients;
 };
 
 // produce an abstraction of the graph for use by inference.  This

--- a/minibmg/inference/hmc_world.h
+++ b/minibmg/inference/hmc_world.h
@@ -46,16 +46,18 @@ class HMCWorld {
   // log probability with respect to each of the proposed values.  The input
   // vector is required to be of a size that is equal to the return value of
   // num_unobserved_samples.
-  virtual std::vector<double> gradients(
-      const std::vector<double>& proposed_unconstrained_values) const = 0;
+  virtual void gradients(
+      const std::vector<double>& proposed_unconstrained_values,
+      std::vector<double>& result) const = 0;
 
   // Given proposed assigned values for all of the onobserved samples in the
   // model (as in evaluate), compute the value of queried nodes in the model.
   // Queried values are returned in the untransformed space.  The input
   // vector is required to be of a size that is equal to the return value of
   // num_unobserved_samples.
-  virtual std::vector<double> queries(
-      const std::vector<double>& proposed_unconstrained_values) const = 0;
+  virtual void queries(
+      const std::vector<double>& proposed_unconstrained_values,
+      std::vector<double>& result) const = 0;
 
   virtual ~HMCWorld() {}
 };

--- a/minibmg/inference/mle_inference.cpp
+++ b/minibmg/inference/mle_inference.cpp
@@ -26,12 +26,15 @@ std::vector<double> mle_inference_0(
   proposals.resize(num_samples);
 
   for (int round = 0; round < num_rounds; round++) {
-    auto grads = abstraction->gradients(proposals);
+    std::vector<double> grads;
+    abstraction->gradients(proposals, grads);
     if (print_progress) {
+      std::vector<double> queries;
+      abstraction->queries(proposals, queries);
       std::cout << fmt::format(
           "log_prob: {} inferred: {}\n",
           abstraction->log_prob(proposals),
-          abstraction->queries(proposals)[0]);
+          queries[0]);
     }
     assert(!proposals.empty());
     for (int samp = 0; samp < num_samples; samp++) {
@@ -42,7 +45,9 @@ std::vector<double> mle_inference_0(
     }
   }
 
-  return abstraction->queries(proposals);
+  std::vector<double> queries;
+  abstraction->queries(proposals, queries);
+  return queries;
 }
 
 } // namespace beanmachine::minibmg

--- a/minibmg/inference/mle_inference.cpp
+++ b/minibmg/inference/mle_inference.cpp
@@ -26,11 +26,11 @@ std::vector<double> mle_inference_0(
   proposals.resize(num_samples);
 
   for (int round = 0; round < num_rounds; round++) {
-    auto result = abstraction->evaluate(proposals);
+    auto grads = abstraction->gradients(proposals);
     if (print_progress) {
       std::cout << fmt::format(
           "log_prob: {} inferred: {}\n",
-          result.log_prob,
+          abstraction->log_prob(proposals),
           abstraction->queries(proposals)[0]);
     }
     assert(!proposals.empty());
@@ -38,7 +38,7 @@ std::vector<double> mle_inference_0(
       // We use + rather than - here because we want to maximize (not minimize)
       // the log_prob; we move in the direction of the gradient rather than
       // opposite to it as we would in gradient descent.
-      proposals[samp] += result.gradients[samp] * learning_rate;
+      proposals[samp] += grads[samp] * learning_rate;
     }
   }
 

--- a/minibmg/json.cpp
+++ b/minibmg/json.cpp
@@ -431,7 +431,7 @@ Graph json_to_graph2(folly::dynamic d) {
     }
   }
 
-  std::list<std::pair<Nodep, double>> observations;
+  std::vector<std::pair<Nodep, double>> observations;
   auto observation_nodes = d["observations"];
   if (observation_nodes.isArray()) {
     for (auto& obs : observation_nodes) {

--- a/minibmg/node.cpp
+++ b/minibmg/node.cpp
@@ -272,7 +272,7 @@ void ScalarConstantNode::accept(NodeVisitor& visitor) const {
 
 ScalarVariableNode::ScalarVariableNode(
     const std::string& name,
-    const unsigned identifier)
+    const int identifier)
     : ScalarNode{hash_combine(
           std::hash<std::string>{}("ScalarVariableNode"),
           std::hash<std::string>{}(name),

--- a/minibmg/node.h
+++ b/minibmg/node.h
@@ -56,9 +56,9 @@ class ScalarConstantNode : public ScalarNode {
 
 class ScalarVariableNode : public ScalarNode {
  public:
-  ScalarVariableNode(const std::string& name, const unsigned identifier);
+  ScalarVariableNode(const std::string& name, const int identifier);
   std::string name;
-  unsigned identifier;
+  int identifier;
   void accept(NodeVisitor& visitor) const override;
 };
 

--- a/minibmg/rewrite_adapter.h
+++ b/minibmg/rewrite_adapter.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <list>
 #include <utility>
 #include <vector>
 #include "beanmachine/minibmg/ad/real.h"
@@ -107,33 +106,6 @@ class NodeRewriteAdapter<std::vector<T>> {
   }
 };
 static_assert(Rewritable<std::vector<Nodep>>);
-
-// A list can be deduplicated
-template <class T>
-requires Rewritable<T>
-class NodeRewriteAdapter<std::list<T>> {
-  NodeRewriteAdapter<T> t_helper{};
-
- public:
-  std::vector<Nodep> find_roots(const std::list<T>& roots) const {
-    std::vector<Nodep> result;
-    for (const auto& root : roots) {
-      auto more_roots = t_helper.find_roots(root);
-      result.push_back(more_roots.begin(), more_roots.end());
-    }
-    return result;
-  }
-  std::list<T> rewrite(
-      const std::list<T>& roots,
-      const std::unordered_map<Nodep, Nodep>& map) const {
-    std::list<T> result;
-    for (const auto& root : roots) {
-      result.push_back(t_helper.rewrite(root, map));
-    }
-    return result;
-  }
-};
-static_assert(Rewritable<std::list<Nodep>>);
 
 // A pair can be deduplicated
 template <class T, class U>

--- a/minibmg/tests/ad/num3_test.cpp
+++ b/minibmg/tests/ad/num3_test.cpp
@@ -9,7 +9,6 @@
 #include <cassert>
 #include <cmath>
 #include <cstdlib>
-#include <list>
 #include <random>
 
 #include "beanmachine/minibmg/ad/num2.h"

--- a/minibmg/tests/dedag_test.cpp
+++ b/minibmg/tests/dedag_test.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <stdexcept>
+#include "beanmachine/minibmg/ad/traced.h"
+#include "beanmachine/minibmg/dedag.h"
+
+using namespace ::testing;
+using namespace beanmachine::minibmg;
+
+TEST(dedag_test, depth) {
+  auto x = Traced::variable("x", 1);
+  auto deep = x + x + x + x + x + x + x + x + x + x;
+  ASSERT_THROW(dedag(deep, 1);, std::invalid_argument);
+  auto dedagged = dedag(deep, /* max_depth = */ 2);
+  ASSERT_EQ(dedagged.prelude.size(), 9);
+}
+
+TEST(dedag_test, simple) {
+  auto x = Traced::variable("x", 1);
+  auto d1 = x + x;
+  auto d2 = d1 + d1;
+  auto d3 = d2 + d2;
+  auto final = d3 + d3;
+  auto dedagged = dedag(final, /* max_depth = */ 20);
+  ASSERT_EQ(dedagged.prelude.size(), 3);
+}

--- a/minibmg/tests/eval_test.cpp
+++ b/minibmg/tests/eval_test.cpp
@@ -36,7 +36,7 @@ TEST(eval_test, simple1) {
   unordered_map<Nodep, Real> data;
   auto eval_result = eval_graph<Real>(
       graph, gen, read_variable, data, /* run_queries= */ true);
-  EXPECT_CLOSE(1.995, eval_result.queries[0]);
+  EXPECT_CLOSE(1.995, eval_result.queries[0].value);
 }
 
 TEST(eval_test, sample1) {
@@ -63,7 +63,7 @@ TEST(eval_test, sample1) {
   for (int i = 0; i < n; i++) {
     auto eval_result =
         eval_graph<Real>(graph, gen, nullptr, data, /* run_queries= */ true);
-    auto sample = eval_result.queries[0];
+    auto sample = eval_result.queries[0].value;
     sum += sample;
     sum_squared += sample * sample;
   }
@@ -171,7 +171,7 @@ TEST(eval_test, log1p) {
   std::unordered_map<Nodep, Real> data;
   auto eval_result = eval_graph<Real>(
       graph, gen, read_variable, data, /* run_queries = */ true);
-  EXPECT_CLOSE(eval_result.queries[qi], std::log1p(k));
+  EXPECT_CLOSE(eval_result.queries[qi].value, std::log1p(k));
 }
 
 TEST(eval_test, sample_exponential) {
@@ -197,7 +197,7 @@ TEST(eval_test, sample_exponential) {
   for (int i = 0; i < n; i++) {
     auto eval_result =
         eval_graph<Real>(graph, gen, nullptr, data, /* run_queries= */ true);
-    auto sample = eval_result.queries[0];
+    auto sample = eval_result.queries[0].value;
     sum += sample;
     sum_squared += sample * sample;
   }

--- a/minibmg/tests/fluid_factory_test.cpp
+++ b/minibmg/tests/fluid_factory_test.cpp
@@ -14,7 +14,7 @@
 using namespace ::testing;
 using namespace beanmachine::minibmg;
 
-namespace fluent_factory_test {
+namespace fluid_factory_test {
 
 std::string raw_json = R"({
   "comment": "created by graph_to_json",
@@ -109,7 +109,7 @@ std::string raw_json = R"({
   ]
 })";
 
-TEST(fluent_factory_test, simple_test) {
+TEST(fluid_factory_test, simple_test) {
   Graph::FluidFactory fac;
   auto b = beta(2, 2);
   auto s = sample(b);
@@ -127,7 +127,7 @@ TEST(fluent_factory_test, simple_test) {
   ASSERT_EQ(raw_json, json);
 }
 
-TEST(fluent_factory_test, deduplication_01) {
+TEST(fluid_factory_test, deduplication_01) {
   Graph::FluidFactory fac;
   auto b = beta(2, 2);
   auto s = sample(b, "S0");
@@ -168,7 +168,7 @@ fac.observe(sample(temp_2, "S10"), 0);
   ASSERT_EQ(expected, pretty);
 }
 
-TEST(fluent_factory_test, deduplication_02) {
+TEST(fluid_factory_test, deduplication_02) {
   Value final = 0;
   for (int i = 0; i < 2; i++) {
     auto t1 = beta(2, 2);
@@ -229,7 +229,7 @@ fac.query(0 + temp_20 + temp_20);
 }
 
 // test constant folding of log1p
-TEST(fluent_factory_test, log1p_kfold) {
+TEST(fluid_factory_test, log1p_kfold) {
   Value k = 1.1;
   Value l = log1p(k);
   Graph::FluidFactory fac;
@@ -242,4 +242,4 @@ TEST(fluent_factory_test, log1p_kfold) {
   ASSERT_TRUE(NodepValueEquals{}(expected.node, folded.node));
 }
 
-} // namespace fluent_factory_test
+} // namespace fluid_factory_test

--- a/minibmg/tests/graph_properties/out_nodes_test.cpp
+++ b/minibmg/tests/graph_properties/out_nodes_test.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <list>
+#include <vector>
 #include "beanmachine/minibmg/graph.h"
 #include "beanmachine/minibmg/graph_factory.h"
 #include "beanmachine/minibmg/graph_properties/out_nodes.h"
@@ -33,15 +33,15 @@ TEST(out_nodes_test, simple) {
   Nodep betan = gf[beta];
   Nodep samplen = gf[sample];
 
-  ASSERT_EQ(out_nodes(g, k12n), std::list{plusn});
-  ASSERT_EQ(out_nodes(g, k34n), (std::list{plusn}));
-  ASSERT_EQ(out_nodes(g, plusn), std::list<Nodep>{betan});
-  ASSERT_EQ(out_nodes(g, k56n), std::list{betan});
-  ASSERT_EQ(out_nodes(g, betan), (std::list{samplen}));
-  ASSERT_EQ(out_nodes(g, samplen), std::list<Nodep>{});
+  ASSERT_EQ(out_nodes(g, k12n), std::vector{plusn});
+  ASSERT_EQ(out_nodes(g, k34n), (std::vector{plusn}));
+  ASSERT_EQ(out_nodes(g, plusn), std::vector<Nodep>{betan});
+  ASSERT_EQ(out_nodes(g, k56n), std::vector{betan});
+  ASSERT_EQ(out_nodes(g, betan), (std::vector{samplen}));
+  ASSERT_EQ(out_nodes(g, samplen), std::vector<Nodep>{});
 
   ASSERT_EQ(g.queries, std::vector{samplen});
-  std::list<std::pair<Nodep, double>> expected_observations;
+  std::vector<std::pair<Nodep, double>> expected_observations;
   expected_observations.push_back(std::pair{samplen, 7.8});
   ASSERT_EQ(g.observations, expected_observations);
 }

--- a/minibmg/tests/inference/nuts_test.cpp
+++ b/minibmg/tests/inference/nuts_test.cpp
@@ -55,7 +55,7 @@ TEST(nuts_test, coin_flipping) {
   f.query(s);
   auto graph = f.build();
 
-  auto state = std::make_unique<MinibmgGlobalState>(graph);
+  auto state = MinibmgGlobalState::create1(graph);
   auto nuts = NUTS(std::move(state));
 
   auto start = std::chrono::high_resolution_clock::now();

--- a/minibmg/tests/inference/nuts_test.cpp
+++ b/minibmg/tests/inference/nuts_test.cpp
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <chrono>
+#include <memory>
+#include "beanmachine/graph/global/global_mh.h"
+#include "beanmachine/graph/global/nuts.h"
+#include "beanmachine/minibmg/fluid_factory.h"
+#include "beanmachine/minibmg/graph.h"
+#include "beanmachine/minibmg/inference/global_state.h"
+
+using namespace ::testing;
+using namespace beanmachine::minibmg;
+using beanmachine::graph::GlobalState;
+using beanmachine::graph::NodeValue;
+using beanmachine::graph::NUTS;
+
+template <typename T>
+requires Number<T> T expit(const T& x) {
+  return 1 / (1 + exp(-x));
+}
+
+const int num_heads = 15;
+const int num_tails = 1;
+const int num_samples = 1000;
+const int skip_samples = std::min(num_samples / 2, 500);
+const int seed = 12345;
+
+// Take a familiar-looking model and runs NUTS.
+TEST(nuts_test, coin_flipping) {
+  Graph::FluidFactory f;
+
+  // We would like to use
+  //
+  //     auto d = beta(1, 1);
+  //     auto s = sample(d);
+  //
+  // but we don't have transformations working quite right yet, which we would
+  // need to use beta.  So we use a distribution that doesn't require it.
+
+  auto s = expit(sample(normal(0, 100)));
+
+  auto bn = bernoulli(s);
+  for (int i = 0; i < num_heads; i++) {
+    f.observe(sample(bn), 1);
+  }
+  for (int i = 0; i < num_tails; i++) {
+    f.observe(sample(bn), 0);
+  }
+  f.query(s);
+  auto graph = f.build();
+
+  auto state = std::make_unique<MinibmgGlobalState>(graph);
+  auto nuts = NUTS(std::move(state));
+
+  auto start = std::chrono::high_resolution_clock::now();
+  std::vector<std::vector<NodeValue>> infer_results =
+      nuts.infer(/* num_samples = */ num_samples, /* seed = */ seed);
+  auto finish = std::chrono::high_resolution_clock::now();
+  auto time_in_microseconds =
+      std::chrono::duration_cast<std::chrono::microseconds>(finish - start)
+          .count();
+  std::cout << fmt::format(
+                   "minibmg NUTS: ran in {} s", time_in_microseconds / 1E6)
+            << std::endl;
+
+  // check that the results are as expected
+  ASSERT_EQ(infer_results.size(), num_samples);
+  double sum = 0;
+  int count = 0;
+  for (int i = skip_samples; i < num_samples; i++) {
+    auto estimate = infer_results[i][0]._double;
+    sum += estimate;
+    count++;
+  }
+
+  double average = sum / num_samples;
+  // the following is the actual computed value using bmg
+  double expected =
+      0.46432190477921237; // num_heads / (num_heads + num_tails + 0.0);
+  ASSERT_NEAR(average, expected, 0.001);
+}
+
+// Take a familiar-looking model and runs NUTS using bmg.
+TEST(nuts_test, coin_flipping_bmg) {
+  using namespace beanmachine::graph;
+  using Graph = beanmachine::graph::Graph;
+
+  Graph g;
+
+  //   auto s = expit(sample(normal(0, 100)));
+  auto k0 = g.add_constant(0.0);
+  auto k100 = g.add_constant_pos_real(100.0);
+  auto normal = g.add_distribution(
+      DistributionType::NORMAL, AtomicType::REAL, {k0, k100});
+  auto sample_normal = g.add_operator(OperatorType::SAMPLE, {normal});
+  // s = (expit =) 1 / (1 + exp(-sample_normal))
+  auto neg_sample = g.add_operator(OperatorType::NEGATE, {sample_normal});
+  auto exp = g.add_operator(OperatorType::EXP, {neg_sample});
+  auto k1 = g.add_constant_pos_real(1.0);
+  auto denom = g.add_operator(OperatorType::ADD, {k1, exp});
+  // At this point we would like to compute
+  //    s = 1 / denom
+  // but BMG has no divide or reciprocal operation.  So instead we compute
+  //    s = exp(-log(denom))
+  auto log_denom = g.add_operator(OperatorType::LOG, {denom});
+  auto nld = g.add_operator(OperatorType::NEGATE, {log_denom});
+  auto s0 = g.add_operator(OperatorType::EXP, {nld});
+  auto s = g.add_operator(OperatorType::TO_PROBABILITY, {s0});
+
+  auto bn =
+      g.add_distribution(DistributionType::BERNOULLI, AtomicType::BOOLEAN, {s});
+
+  for (int i = 0; i < num_heads; i++) {
+    auto sample = g.add_operator(OperatorType::SAMPLE, {bn});
+    g.observe(sample, true);
+  }
+  for (int i = 0; i < num_tails; i++) {
+    auto sample = g.add_operator(OperatorType::SAMPLE, {bn});
+    g.observe(sample, false);
+  }
+
+  g.query(s);
+  auto nuts = NUTS(g);
+
+  auto start = std::chrono::high_resolution_clock::now();
+  std::vector<std::vector<NodeValue>> infer_results =
+      nuts.infer(/* num_samples = */ num_samples, /* seed = */ seed);
+  auto finish = std::chrono::high_resolution_clock::now();
+  auto time_in_microseconds =
+      std::chrono::duration_cast<std::chrono::microseconds>(finish - start)
+          .count();
+  std::cout << fmt::format(
+                   "    bmg NUTS: ran in {} s", time_in_microseconds / 1E6)
+            << std::endl;
+
+  // check that the results are as expected
+  ASSERT_EQ(infer_results.size(), num_samples);
+  double sum = 0;
+  int count = 0;
+  for (int i = skip_samples; i < num_samples; i++) {
+    auto estimate = infer_results[i][0]._double;
+    sum += estimate;
+    count++;
+  }
+
+  double average = sum / num_samples;
+  // the following is the actual computed value using bmg
+  double expected =
+      0.46432190477921237; // num_heads / (num_heads + num_tails + 0.0);
+  ASSERT_NEAR(average, expected, 0.001);
+}

--- a/minibmg/tests/localopt_test.cpp
+++ b/minibmg/tests/localopt_test.cpp
@@ -41,8 +41,8 @@ TEST(localopt_test, symbolic_derivatives) {
   // evaluate the graph's log prob, and its first and second derivatives.
   using T = Num3<Traced>;
   std::mt19937 gen;
-  std::function<T(const std::string&, const unsigned int)> read_variable =
-      [](const std::string& name, const unsigned int id) -> T {
+  std::function<T(const std::string&, const int)> read_variable =
+      [](const std::string& name, const int id) -> T {
     return Traced::variable(name, id);
   };
   std::unordered_map<Nodep, T> data;

--- a/minibmg/tests/localopt_test.cpp
+++ b/minibmg/tests/localopt_test.cpp
@@ -83,16 +83,16 @@ TEST(localopt_test, symbolic_derivatives) {
   printed << "d2 = ";
   printed << print_result.code[d2] << std::endl;
 
-  auto expected = R"(auto temp_1 = -pow(rvid.constrained, -2);
+  auto expected = R"(auto temp_1 = log(rvid.constrained);
 auto temp_2 = 1 - rvid.constrained;
-auto temp_3 = -pow(temp_2, -2);
+auto temp_3 = log(temp_2);
 auto temp_4 = 1 / rvid.constrained;
 auto temp_5 = -1 / temp_2;
-auto temp_6 = log(rvid.constrained);
-auto temp_7 = log(temp_2);
-log_prob = temp_6 + temp_7 + 1.791759469228055 + temp_6 + temp_6 + temp_7
+auto temp_6 = -pow(rvid.constrained, -2);
+auto temp_7 = -pow(temp_2, -2);
+log_prob = temp_1 + temp_3 + 1.791759469228055 + temp_1 + temp_1 + temp_3
 d1 = temp_4 + temp_5 + temp_4 + temp_4 + temp_5
-d2 = temp_1 + temp_3 + temp_1 + temp_1 + temp_3
+d2 = temp_6 + temp_7 + temp_6 + temp_6 + temp_7
 )";
   ASSERT_EQ(expected, printed.str());
 }

--- a/minibmg/tests/minibmg_test.cpp
+++ b/minibmg/tests/minibmg_test.cpp
@@ -75,8 +75,8 @@ TEST(test_minibmg, dedupable_concept) {
   ASSERT_FALSE(Rewritable<std::vector<std::vector<int>>>);
   ASSERT_TRUE((Rewritable<std::pair<Nodep, double>>));
   ASSERT_FALSE((Rewritable<std::pair<int, double>>));
-  ASSERT_TRUE(Rewritable<std::list<Nodep>>);
-  ASSERT_TRUE(Rewritable<std::list<std::list<Nodep>>>);
-  ASSERT_FALSE(Rewritable<std::list<int>>);
-  ASSERT_FALSE(Rewritable<std::list<std::list<int>>>);
+  ASSERT_TRUE(Rewritable<std::vector<Nodep>>);
+  ASSERT_TRUE(Rewritable<std::vector<std::vector<Nodep>>>);
+  ASSERT_FALSE(Rewritable<std::vector<int>>);
+  ASSERT_FALSE(Rewritable<std::vector<std::vector<int>>>);
 }

--- a/minibmg/tests/topological_test.cpp
+++ b/minibmg/tests/topological_test.cpp
@@ -80,7 +80,7 @@ TEST(topological_test, ensure_sorted) {
     // topologically sort them.
     std::vector<Node*> result;
     auto sorted = topological_sort<Node*>(
-        std::list<Node*>{nodes.begin(), nodes.end()},
+        nodes,
         [](Node* node) {
           return std::vector<Node*>{
               node->successors.begin(), node->successors.end()};
@@ -105,7 +105,7 @@ TEST(topological_test, ensure_sorted) {
     // topologically sort them.  if there was a cycle, this should return false.
     result.clear();
     sorted = topological_sort<Node*>(
-        std::list<Node*>{nodes.begin(), nodes.end()},
+        nodes,
         [](Node* const& node) {
           return std::vector<Node*>{
               node->successors.begin(), node->successors.end()};

--- a/minibmg/topological.h
+++ b/minibmg/topological.h
@@ -12,7 +12,7 @@
 #include <set>
 #include <vector>
 
-namespace {
+namespace beanmachine::minibmg {
 
 // Compute the predecessor count for all nodes reachable from the set of roots
 // given.
@@ -104,10 +104,6 @@ bool topological_sort_internal(
   // cycle.  We return true when we succeed (no cycle).
   return predecessor_counts.size() == result.size();
 }
-
-} // namespace
-
-namespace beanmachine::minibmg {
 
 // Compute the predecessor count for all nodes reachable from the set of roots
 // given.

--- a/minibmg/topological.h
+++ b/minibmg/topological.h
@@ -8,9 +8,9 @@
 #pragma once
 
 #include <functional>
-#include <list>
 #include <map>
 #include <set>
+#include <vector>
 
 namespace {
 
@@ -18,15 +18,24 @@ namespace {
 // given.
 template <class T>
 std::map<T, unsigned> count_predecessors_internal(
-    const std::list<T>& root_nodes,
+    const std::vector<T>& root_nodes,
     std::function<std::vector<T>(const T&)> successors,
-    std::list<T>& nodes) {
+    std::vector<T>& nodes,
+    bool include_roots = false) {
   std::map<T, unsigned> predecessor_counts;
-  std::list<T> to_count;
+  std::vector<T> to_count;
   std::set<T> counted;
   for (const auto& node : root_nodes) {
     to_count.push_back(node);
+    if (include_roots) {
+      if (!predecessor_counts.contains(node)) {
+        predecessor_counts[node] = 1;
+      } else {
+        predecessor_counts[node] = predecessor_counts[node] + 1;
+      }
+    }
   }
+  std::reverse(to_count.begin(), to_count.end());
 
   while (!to_count.empty()) {
     auto node = to_count.back();
@@ -64,10 +73,10 @@ template <class T>
 bool topological_sort_internal(
     std::map<T, unsigned>& predecessor_counts,
     std::function<std::vector<T>(const T&)> successors,
-    std::list<T>& nodes,
+    std::vector<T>& nodes,
     std::vector<T>& result) {
   // initialize the ready set with those nodes that have no predecessors
-  std::list<T> ready;
+  std::vector<T> ready;
   for (auto node : nodes) {
     if (predecessor_counts[node] == 0) {
       ready.push_back(node);
@@ -104,9 +113,9 @@ namespace beanmachine::minibmg {
 // given.
 template <class T>
 std::map<T, unsigned> count_predecessors(
-    const std::list<T>& root_nodes,
+    const std::vector<T>& root_nodes,
     std::function<std::vector<T>(const T&)> successors) {
-  std::list<T> ready;
+  std::vector<T> ready;
   return count_predecessors_internal<T>(root_nodes, successors, ready);
 }
 
@@ -116,10 +125,10 @@ std::map<T, unsigned> count_predecessors(
 // sorted result in the `result` parameter.
 template <class T>
 bool topological_sort(
-    const std::list<T>& root_nodes,
+    const std::vector<T>& root_nodes,
     std::function<std::vector<T>(const T&)> successors,
     std::vector<T>& result) {
-  std::list<T> ready;
+  std::vector<T> ready;
   // count the predecessors of each node.
   std::map<T, unsigned> predecessor_counts =
       count_predecessors_internal<T>(root_nodes, successors, ready);


### PR DESCRIPTION
Summary:
Precompute the expression trees needed to evaluate the graph for NUTS.  Avoids all use of AD.

This brings our performance to within a factor of two of bmg.

Differential Revision: D40813973

