### PR TITLE
Ignore TorchScript warning introduced in PyTorch 1.13 when using NNC

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,8 @@ filterwarnings = [
     # NNC/TorchInductor warning
     "ignore:The support of TorchInductor is experimental*:UserWarning",
     "ignore:The support of NNC compiler is experimental*:UserWarning",
+    # NNC warning introduced in PyTorch 1.13
+    "ignore:The TorchScript type system doesn't support*:UserWarning",
 ]
 
 [tool.usort]


### PR DESCRIPTION
Summary:
In PyTorch (and functorch) 1.13, `nnc_jit` raises the following warning that breaks our CI:
```
import torch
from functorch.compile import nnc_jit
nnc_jit
def f(x):
    return x ** 2
x0 = torch.tensor(2.0)
print(f(x0))
```
outputs:
```
.../lib/python3.8/site-packages/torch/jit/_check.py:181: UserWarning: The TorchScript type system doesn't support instance-level annotations on empty non-base types in `__init__`. Instead, either 1) use a type annotation in the class body, or 2) wrap the type in `torch.jit.Attribute`.
  warnings.warn("The TorchScript type system doesn't support "
tensor(4.)
```

As a temporary workaround, let's add this warning to our filter warning list to keep our test signal green.

Differential Revision: D40821675

