### PR TITLE
remove explict functorch dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ INSTALL_REQUIRES = [
     "botorch>=0.5.1",
     "gpytorch>=1.3.0, <1.9.0",
     "graphviz>=0.17",
-    "functorch>=0.2.0",
     "netCDF4<=1.5.8; python_version<'3.8'",
     "numpy>=1.18.1",
     "pandas>=0.24.2",


### PR DESCRIPTION
Summary: Remove explicit functorch dependency after new Pytorch release

Differential Revision: D40872661

