### PR TITLE
Rename `convert_parents_ids` to `convert_node_ids` and remove `from_id_to_ptr`

### DIFF
--- a/src/beanmachine/graph/distribution/tests/lkj_cholesky_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/lkj_cholesky_test.cpp
@@ -86,7 +86,7 @@ TEST(testdistrib, lkj_cholesky_betas) {
   Graph g;
   const double ETA = 3.0;
   auto pos1 = g.add_constant_pos_real(ETA);
-  auto parents = g.convert_parent_ids(std::vector<uint>{pos1});
+  auto parents = g.convert_node_ids(std::vector<uint>{pos1});
 
   auto lkj_chol_dist = std::make_unique<beanmachine::distribution::LKJCholesky>(
       ValueType(VariableType::BROADCAST_MATRIX, AtomicType::REAL, 5, 5),
@@ -108,7 +108,7 @@ TEST(testdistrib, lkj_cholesky_sample) {
   std::mt19937 mt1(0);
   const double ETA = 3.0;
   auto pos1 = g.add_constant_pos_real(ETA);
-  auto parents = g.convert_parent_ids(std::vector<uint>{pos1});
+  auto parents = g.convert_node_ids(std::vector<uint>{pos1});
 
   auto lkj_chol_dist = std::make_unique<beanmachine::distribution::LKJCholesky>(
       ValueType(VariableType::BROADCAST_MATRIX, AtomicType::REAL, 5, 5),

--- a/src/beanmachine/graph/graph.cpp
+++ b/src/beanmachine/graph/graph.cpp
@@ -1343,7 +1343,7 @@ void Graph::_clear_evaluation_and_inference_readiness_data() {
   _unobserved_mutable_support.clear();
   _unobserved_sto_mutable_support.clear();
   _sto_affected_nodes.clear();
-  _det_affected_operator_nodes.clear();
+  _det_affected_mutable_nodes.clear();
   unobserved_mutable_support_index_by_node_id.clear();
   unobserved_sto_mutable_support_index_by_node_id.clear();
 }
@@ -1403,7 +1403,7 @@ void Graph::_collect_affected_operator_nodes() {
     for (NodeID id : sto_node_ids) {
       sto_nodes.push_back(_node_ptrs[id]);
     }
-    _det_affected_operator_nodes.push_back(det_nodes);
+    _det_affected_mutable_nodes.push_back(det_nodes);
     _sto_affected_nodes.push_back(sto_nodes);
     if (_collect_performance_data) {
       profiler_data.det_supp_count[node->index] =
@@ -1412,8 +1412,8 @@ void Graph::_collect_affected_operator_nodes() {
   }
 }
 
-const vector<Node*>& Graph::get_det_affected_operator_nodes(NodeID node_id) {
-  return det_affected_operator_nodes()
+const vector<Node*>& Graph::get_det_affected_mutable_nodes(NodeID node_id) {
+  return det_affected_mutable_nodes()
       [unobserved_sto_mutable_support_index_by_node_id[node_id]];
 }
 
@@ -1424,16 +1424,16 @@ const vector<Node*>& Graph::get_sto_affected_nodes(NodeID node_id) {
 
 void Graph::revertibly_set_and_propagate(Node* node, const NodeValue& value) {
   save_old_value(node);
-  save_old_values(get_det_affected_operator_nodes(node));
+  save_old_values(get_det_affected_mutable_nodes(node));
   _old_sto_affected_nodes_log_prob =
       compute_log_prob_of(get_sto_affected_nodes(node));
   node->value = value;
-  eval(get_det_affected_operator_nodes(node));
+  eval(get_det_affected_mutable_nodes(node));
 }
 
 void Graph::revert_set_and_propagate(Node* node) {
   restore_old_value(node);
-  restore_old_values(get_det_affected_operator_nodes(node));
+  restore_old_values(get_det_affected_mutable_nodes(node));
 }
 
 void Graph::save_old_value(const Node* node) {
@@ -1520,7 +1520,7 @@ void Graph::clear_gradients(const vector<Node*>& nodes) {
 
 void Graph::clear_gradients_of_node_and_its_affected_nodes(Node* node) {
   clear_gradients(node);
-  clear_gradients(get_det_affected_operator_nodes(node));
+  clear_gradients(get_det_affected_mutable_nodes(node));
   clear_gradients(get_sto_affected_nodes(node));
 }
 

--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -978,9 +978,9 @@ class Graph {
   std::function<NodeID(NodeID)> remove_node(NodeID node_id);
   std::function<NodeID(NodeID)> remove_node(std::unique_ptr<Node>& node);
 
-  std::vector<Node*> convert_parent_ids(
-      const std::vector<NodeID>& parents) const;
-  std::vector<NodeID> get_parent_ids(
+  std::vector<Node*> convert_node_ids(
+      const std::vector<NodeID>& node_ids) const;
+  std::vector<NodeID> get_node_ids(
       const std::vector<Node*>& parent_nodes) const;
   void _infer(
       uint num_samples,
@@ -1357,10 +1357,9 @@ void duplicate_subgraph(
     Graph& graph,
     const std::vector<Node*>& subgraph_ordered_nodes);
 
-/* Returns a vector of Node * from a vector of node ids for given graph. */
-std::vector<Node*> from_id_to_ptr(
-    const Graph& graph,
-    const std::vector<NodeID>& node_ids);
+inline NodeID get_index(const Node* node) {
+  return node->index;
+}
 
 } // namespace graph
 } // namespace beanmachine

--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -1128,7 +1128,7 @@ class Graph {
  private:
   CACHED_PRIVATE_PROPERTY(
       std::vector<std::vector<Node*>>,
-      det_affected_operator_nodes)
+      det_affected_mutable_nodes)
   CACHED_PRIVATE_PROPERTY(std::vector<std::vector<Node*>>, sto_affected_nodes)
 
 #undef CACHED_PROPERTY
@@ -1190,11 +1190,11 @@ class Graph {
   void collect_sample(InferConfig infer_config);
 
  public:
-  const std::vector<Node*>& get_det_affected_operator_nodes(NodeID node_id);
+  const std::vector<Node*>& get_det_affected_mutable_nodes(NodeID node_id);
   const std::vector<Node*>& get_sto_affected_nodes(NodeID node_id);
 
-  inline const std::vector<Node*>& get_det_affected_operator_nodes(Node* node) {
-    return get_det_affected_operator_nodes(node->index);
+  inline const std::vector<Node*>& get_det_affected_mutable_nodes(Node* node) {
+    return get_det_affected_mutable_nodes(node->index);
   }
 
   inline const std::vector<Node*>& get_sto_affected_nodes(Node* node) {

--- a/src/beanmachine/graph/stepper/single_site/nmc_dirichlet_beta_single_site_stepping_method.cpp
+++ b/src/beanmachine/graph/stepper/single_site/nmc_dirichlet_beta_single_site_stepping_method.cpp
@@ -63,7 +63,7 @@ NMCDirichletBetaSingleSiteSteppingMethod::get_proposal_distribution(
   Grad1 << 1, -1;
   sto_tgt_node->Grad1 = Grad1;
   sto_tgt_node->Grad2 = Eigen::MatrixXd::Zero(2, 1);
-  graph->compute_gradients(graph->get_det_affected_operator_nodes(tgt_node));
+  graph->compute_gradients(graph->get_det_affected_mutable_nodes(tgt_node));
 
   // Use gradients to obtain NMC proposal
   // @lint-ignore CLANGTIDY

--- a/src/beanmachine/graph/stepper/single_site/nmc_dirichlet_gamma_single_site_stepping_method.cpp
+++ b/src/beanmachine/graph/stepper/single_site/nmc_dirichlet_gamma_single_site_stepping_method.cpp
@@ -43,8 +43,8 @@ void NMCDirichletGammaSingleSiteSteppingMethod::step(Node* tgt_node) {
 
   graph->pd_begin(ProfilerEvent::NMC_STEP_DIRICHLET);
 
-  const std::vector<Node*>& det_affected_operator_nodes =
-      graph->get_det_affected_operator_nodes(tgt_node);
+  const std::vector<Node*>& det_affected_mutable_nodes =
+      graph->get_det_affected_mutable_nodes(tgt_node);
 
   // Cast needed to access fields such as unconstrained_value:
   auto sto_tgt_node = static_cast<oper::StochasticOperator*>(tgt_node);
@@ -58,7 +58,7 @@ void NMCDirichletGammaSingleSiteSteppingMethod::step(Node* tgt_node) {
     double x_sum = sto_tgt_node->unconstrained_value._matrix.sum();
 
     // save old values
-    graph->save_old_values(det_affected_operator_nodes);
+    graph->save_old_values(det_affected_mutable_nodes);
     double old_x_k = sto_tgt_node->unconstrained_value._matrix.coeff(k);
     NodeValue old_x_k_value(AtomicType::POS_REAL, old_x_k);
     double old_sto_affected_nodes_log_prob =
@@ -79,7 +79,7 @@ void NMCDirichletGammaSingleSiteSteppingMethod::step(Node* tgt_node) {
         sto_tgt_node->unconstrained_value._matrix.array() / x_sum;
 
     // propagate new value
-    graph->eval(det_affected_operator_nodes);
+    graph->eval(det_affected_mutable_nodes);
     double new_sto_affected_nodes_log_prob =
         compute_sto_affected_nodes_log_prob(tgt_node, param_a_k, new_x_k_value);
 
@@ -97,7 +97,7 @@ void NMCDirichletGammaSingleSiteSteppingMethod::step(Node* tgt_node) {
     bool accepted = util::flip_coin_with_log_prob(mh->gen, logacc);
     if (!accepted) {
       // revert
-      graph->restore_old_values(det_affected_operator_nodes);
+      graph->restore_old_values(det_affected_mutable_nodes);
       *(sto_tgt_node->unconstrained_value._matrix.data() + k) = old_x_k;
       x_sum = sto_tgt_node->unconstrained_value._matrix.sum();
       sto_tgt_node->value._matrix =
@@ -111,7 +111,7 @@ void NMCDirichletGammaSingleSiteSteppingMethod::step(Node* tgt_node) {
     // TODO: identify code that depends on this, let it zero gradients
     // itself, and remove it from here since that's a long-distance,
     // implicit dependence that is hard to watch for.
-    graph->clear_gradients(det_affected_operator_nodes);
+    graph->clear_gradients(det_affected_mutable_nodes);
   } // k
   graph->pd_finish(ProfilerEvent::NMC_STEP_DIRICHLET);
 }
@@ -165,7 +165,7 @@ NMCDirichletGammaSingleSiteSteppingMethod::create_proposal_dirichlet_gamma(
   sto_tgt_node->Grad2 = sto_tgt_node->Grad1 * (-2.0) / x_sum;
 
   // Propagate gradients
-  graph->compute_gradients(graph->get_det_affected_operator_nodes(tgt_node));
+  graph->compute_gradients(graph->get_det_affected_mutable_nodes(tgt_node));
 
   // We want to compute the gradient of log prob with respect to x_k.
   // The probability is the product of the probabilities of x_k

--- a/src/beanmachine/graph/stepper/single_site/nmc_scalar_single_site_stepping_method.cpp
+++ b/src/beanmachine/graph/stepper/single_site/nmc_scalar_single_site_stepping_method.cpp
@@ -45,7 +45,7 @@ NMCScalarSingleSiteSteppingMethod::get_proposal_distribution(Node* tgt_node) {
 
   tgt_node->grad1 = 1;
   tgt_node->grad2 = 0;
-  graph->compute_gradients(graph->get_det_affected_operator_nodes(tgt_node));
+  graph->compute_gradients(graph->get_det_affected_mutable_nodes(tgt_node));
 
   double grad1 = 0;
   double grad2 = 0;

--- a/src/beanmachine/graph/tests/graph_test.cpp
+++ b/src/beanmachine/graph/tests/graph_test.cpp
@@ -1024,7 +1024,7 @@ void test_duplicate_subgraph(
     Graph& g,
     const vector<NodeID>& subgraph_node_ids,
     const string& expected_g_printout) {
-  auto subgraph_nodes = from_id_to_ptr(g, subgraph_node_ids);
+  auto subgraph_nodes = g.convert_node_ids(subgraph_node_ids);
   duplicate_subgraph(g, subgraph_nodes);
   EXPECT_EQ(g.to_string(), expected_g_printout);
 }

--- a/src/beanmachine/graph/util.h
+++ b/src/beanmachine/graph/util.h
@@ -218,6 +218,13 @@ auto map(const Container& c, Function f) {
       boost::make_transform_iterator(c.end(), f));
 }
 
+template <typename Container, typename R, typename... Args>
+auto map2vec(const Container& c, const std::function<R(Args...)>& f) {
+  return std::vector<R>(
+      boost::make_transform_iterator(c.begin(), f),
+      boost::make_transform_iterator(c.end(), f));
+}
+
 template <typename Iterator>
 auto sum(const std::pair<Iterator, Iterator>& range) {
   return std::accumulate(range.first, range.second, 0.0);


### PR DESCRIPTION
Summary:
* Renamed `convert_parents_ids` to `convert_node_ids` since it applies to any nodes.
* Renamed `get_parents_ids` to `get_nodes_ids` since it applies to any nodes.
* Replaced `from_id_to_ptr` by `convert_nodes_ids` since it was a duplicate, and deleted its definition.
* Implemented utilities `map2vec` and `get_index` and used them to simplify `get_nodes_ids`.

Reviewed By: AishwaryaSivaraman

Differential Revision: D40290343

