### PR TITLE
Fix MatrixLog second derivative computation in BMG

### DIFF
--- a/src/beanmachine/graph/operator/gradient.cpp
+++ b/src/beanmachine/graph/operator/gradient.cpp
@@ -568,13 +568,13 @@ void MatrixLog::compute_gradients() {
   assert(in_nodes.size() == 1);
   // f(x) = log(g(x))
   // f'(x) = g'(x) / g(x)
-  // f''(x) = (g''(x) * g(x) + g'(x) * g'(x)) / (g(x) * g(x))
-  //        = g''(x) / g(x) + f'(x) * f'(x)
+  // f''(x) = (g''(x) * g(x) - g'(x) * g'(x)) / (g(x) * g(x))
+  //        = g''(x) / g(x) - f'(x) * f'(x)
   auto g = in_nodes[0]->value._matrix;
   auto g1 = in_nodes[0]->Grad1;
   auto g2 = in_nodes[0]->Grad2;
   Grad1 = g1.cwiseQuotient(g);
-  Grad2 = g2.cwiseQuotient(g) + Grad1.cwiseProduct(Grad1);
+  Grad2 = g2.cwiseQuotient(g) - Grad1.cwiseProduct(Grad1);
 }
 
 void LogProb::compute_gradients() {

--- a/src/beanmachine/graph/operator/tests/gradient_test.cpp
+++ b/src/beanmachine/graph/operator/tests/gradient_test.cpp
@@ -1194,10 +1194,10 @@ TEST(testgradient, matrix_log_grad_forward) {
   auto cm = g.add_operator(OperatorType::MATRIX_SCALE, {c, cm1});
   auto mlog = g.add_operator(OperatorType::MATRIX_LOG, {cm});
   // f(x) = log(2 * g(x))
-  // g(x) = [2, 3]
-  // but we artificially set
-  // g'(x) = [1, 1]
-  // g''(x) = [0, 0]
+  // g(x) = x, x = [2, 3]
+  // hence we set
+  // g'(x) = 1
+  // g''(x) = 0
   // for testing.
 
   Node* cm1_node = g.get_node(cm1);
@@ -1218,9 +1218,9 @@ TEST(testgradient, matrix_log_grad_forward) {
   Eigen::MatrixXd second_grad = mlog_node->Grad2;
   Eigen::MatrixXd expected_second_grad(1, 2);
   // f''(x) = (g''(x) * g'(x) + g'(x) * g'(x)) / (g(x) * g(x))
-  // = ([0, 0] * [1, 1] + [1, 1] * [1, 1]) / ([2, 3] * [2, 3])
-  // = [0.25, 0.11]
-  expected_second_grad << 0.25, 1.0 / 9.0;
+  // = ([0, 0] * [1, 1] - [1, 1] * [1, 1]) / ([2, 3] * [2, 3])
+  // = [-0.25, -0.11]
+  expected_second_grad << -0.25, -1.0 / 9.0;
   EXPECT_NEAR_MATRIX(second_grad, expected_second_grad);
 }
 


### PR DESCRIPTION
Summary:
Second gradient of matrix log was computing `g''(x) / g(x) + f'(x) * f'(x)` instead of `g''(x) / g(x) - f'(x) * f'(x)` which was causing errors in Overall GEP model.

Updated the code and corresponding test case.

Differential Revision: D40942050

