### PR TITLE
Marginalization inference for multiple variables

### DIFF
--- a/src/beanmachine/graph/distribution/bimixture.h
+++ b/src/beanmachine/graph/distribution/bimixture.h
@@ -11,6 +11,15 @@
 namespace beanmachine {
 namespace distribution {
 
+/*
+  A distribution representing the mixture of two distributions D1 and D2
+  with probability P1 of sampling from D1 and 1 - P1 of sampling from D2.
+
+  It must have exactly three parents.
+  The first parent for bimixture distribution must be the probability P1.
+  The second and third parents must be distributions D1 and D2.
+  The sample type must be consistent with the distribution parents.
+*/
 class Bimixture : public Distribution {
  public:
   Bimixture(

--- a/src/beanmachine/graph/distribution/tests/lkj_cholesky_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/lkj_cholesky_test.cpp
@@ -86,7 +86,7 @@ TEST(testdistrib, lkj_cholesky_betas) {
   Graph g;
   const double ETA = 3.0;
   auto pos1 = g.add_constant_pos_real(ETA);
-  auto parents = g.convert_parent_ids(std::vector<uint>{pos1});
+  auto parents = g.convert_node_ids(std::vector<uint>{pos1});
 
   auto lkj_chol_dist = std::make_unique<beanmachine::distribution::LKJCholesky>(
       ValueType(VariableType::BROADCAST_MATRIX, AtomicType::REAL, 5, 5),
@@ -108,7 +108,7 @@ TEST(testdistrib, lkj_cholesky_sample) {
   std::mt19937 mt1(0);
   const double ETA = 3.0;
   auto pos1 = g.add_constant_pos_real(ETA);
-  auto parents = g.convert_parent_ids(std::vector<uint>{pos1});
+  auto parents = g.convert_node_ids(std::vector<uint>{pos1});
 
   auto lkj_chol_dist = std::make_unique<beanmachine::distribution::LKJCholesky>(
       ValueType(VariableType::BROADCAST_MATRIX, AtomicType::REAL, 5, 5),

--- a/src/beanmachine/graph/distribution/tests/product_test.cpp
+++ b/src/beanmachine/graph/distribution/tests/product_test.cpp
@@ -15,7 +15,7 @@
 #include "beanmachine/graph/global/global_state.h"
 #include "beanmachine/graph/global/nuts.h"
 #include "beanmachine/graph/graph.h"
-#include "beanmachine/graph/testing_util.h"
+#include "beanmachine/graph/tests/testing_util_test.h"
 #include "beanmachine/graph/third-party/nameof.h"
 #include "beanmachine/graph/util.h"
 
@@ -117,22 +117,17 @@ TEST(testdistrib, product_construction_and_log_prob) {
 }
 
 void run_nmc_against_nuts_test(Graph& g) {
-  auto max_abs_mean_diff = 0.1;
   // Increase number of rounds and observe
   // output to see the maximum absolute mean difference found
   // in case you need to adjust max_abs_mean_diff.
   auto num_rounds = 1;
   auto num_samples = 10000;
   auto warmup_samples = 1000;
-  auto seed_getter = [] { return time(nullptr); };
-  // Defining assert_near here because gtest macros
-  // are not available in util.cpp where test_nmc_against_nuts is.
-  auto assert_near = [&](double d1, double d2) {
-    ASSERT_NEAR(d1, d2, max_abs_mean_diff);
-  };
+  auto seed = time(nullptr);
+  auto max_abs_mean_diff = 0.1;
 
   test_nmc_against_nuts(
-      g, num_rounds, num_samples, warmup_samples, seed_getter, assert_near);
+      g, num_rounds, num_samples, warmup_samples, seed, max_abs_mean_diff);
 }
 
 TEST(testdistrib, product_inference_downstream) {

--- a/src/beanmachine/graph/global/tests/conjugate_util_test.cpp
+++ b/src/beanmachine/graph/global/tests/conjugate_util_test.cpp
@@ -5,10 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "beanmachine/graph/global/tests/conjugate_util_test.h"
 #include <gtest/gtest.h>
+
+#include "beanmachine/graph/global/tests/conjugate_util_test.h"
 #include "beanmachine/graph/graph.h"
-#include "beanmachine/graph/testing_util.h"
+#include "beanmachine/graph/tests/testing_util_test.h"
 #include "beanmachine/graph/util.h"
 
 namespace beanmachine {

--- a/src/beanmachine/graph/graph.cpp
+++ b/src/beanmachine/graph/graph.cpp
@@ -1343,7 +1343,7 @@ void Graph::_clear_evaluation_and_inference_readiness_data() {
   _unobserved_mutable_support.clear();
   _unobserved_sto_mutable_support.clear();
   _sto_affected_nodes.clear();
-  _det_affected_operator_nodes.clear();
+  _det_affected_mutable_nodes.clear();
   unobserved_mutable_support_index_by_node_id.clear();
   unobserved_sto_mutable_support_index_by_node_id.clear();
 }
@@ -1403,7 +1403,7 @@ void Graph::_collect_affected_operator_nodes() {
     for (NodeID id : sto_node_ids) {
       sto_nodes.push_back(_node_ptrs[id]);
     }
-    _det_affected_operator_nodes.push_back(det_nodes);
+    _det_affected_mutable_nodes.push_back(det_nodes);
     _sto_affected_nodes.push_back(sto_nodes);
     if (_collect_performance_data) {
       profiler_data.det_supp_count[node->index] =
@@ -1412,8 +1412,8 @@ void Graph::_collect_affected_operator_nodes() {
   }
 }
 
-const vector<Node*>& Graph::get_det_affected_operator_nodes(NodeID node_id) {
-  return det_affected_operator_nodes()
+const vector<Node*>& Graph::get_det_affected_mutable_nodes(NodeID node_id) {
+  return det_affected_mutable_nodes()
       [unobserved_sto_mutable_support_index_by_node_id[node_id]];
 }
 
@@ -1424,16 +1424,16 @@ const vector<Node*>& Graph::get_sto_affected_nodes(NodeID node_id) {
 
 void Graph::revertibly_set_and_propagate(Node* node, const NodeValue& value) {
   save_old_value(node);
-  save_old_values(get_det_affected_operator_nodes(node));
+  save_old_values(get_det_affected_mutable_nodes(node));
   _old_sto_affected_nodes_log_prob =
       compute_log_prob_of(get_sto_affected_nodes(node));
   node->value = value;
-  eval(get_det_affected_operator_nodes(node));
+  eval(get_det_affected_mutable_nodes(node));
 }
 
 void Graph::revert_set_and_propagate(Node* node) {
   restore_old_value(node);
-  restore_old_values(get_det_affected_operator_nodes(node));
+  restore_old_values(get_det_affected_mutable_nodes(node));
 }
 
 void Graph::save_old_value(const Node* node) {
@@ -1520,7 +1520,7 @@ void Graph::clear_gradients(const vector<Node*>& nodes) {
 
 void Graph::clear_gradients_of_node_and_its_affected_nodes(Node* node) {
   clear_gradients(node);
-  clear_gradients(get_det_affected_operator_nodes(node));
+  clear_gradients(get_det_affected_mutable_nodes(node));
   clear_gradients(get_sto_affected_nodes(node));
 }
 

--- a/src/beanmachine/graph/graph.cpp
+++ b/src/beanmachine/graph/graph.cpp
@@ -604,6 +604,7 @@ NodeID Graph::add_node(unique_ptr<Node> node) {
   if (node_is_observed) {
     observe(index, node_value);
   }
+  update_structure_based_properties();
   return index;
 }
 
@@ -614,6 +615,8 @@ void Graph::update_structure_based_properties() {
   ready_for_evaluation_and_inference = false;
   // Stored old values no longer valid
   _old_values_vector_has_the_right_size = false;
+  support_cache_is_valid = false;
+  mutable_support_cache_is_valid = false;
 }
 
 function<NodeID(NodeID)> Graph::remove_node(NodeID node_id) {
@@ -1063,6 +1066,9 @@ void Graph::add_observe(Node* node, NodeValue value) {
   node->value = value;
   node->is_observed = true;
   observed.insert(node->index);
+  ready_for_evaluation_and_inference = false;
+  support_cache_is_valid = false;
+  mutable_support_cache_is_valid = false;
 }
 
 void Graph::customize_transformation(
@@ -1141,6 +1147,9 @@ NodeID Graph::query(NodeID node_id) {
     return static_cast<NodeID>(it - queries.begin());
   }
   queries.push_back(node_id);
+  ready_for_evaluation_and_inference = false;
+  support_cache_is_valid = false;
+  mutable_support_cache_is_valid = false;
   return static_cast<NodeID>(queries.size() - 1); // the index is 0-based
 }
 

--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -978,9 +978,9 @@ class Graph {
   std::function<NodeID(NodeID)> remove_node(NodeID node_id);
   std::function<NodeID(NodeID)> remove_node(std::unique_ptr<Node>& node);
 
-  std::vector<Node*> convert_parent_ids(
-      const std::vector<NodeID>& parents) const;
-  std::vector<NodeID> get_parent_ids(
+  std::vector<Node*> convert_node_ids(
+      const std::vector<NodeID>& node_ids) const;
+  std::vector<NodeID> get_node_ids(
       const std::vector<Node*>& parent_nodes) const;
   void _infer(
       uint num_samples,
@@ -1357,10 +1357,9 @@ void duplicate_subgraph(
     Graph& graph,
     const std::vector<Node*>& subgraph_ordered_nodes);
 
-/* Returns a vector of Node * from a vector of node ids for given graph. */
-std::vector<Node*> from_id_to_ptr(
-    const Graph& graph,
-    const std::vector<NodeID>& node_ids);
+inline NodeID get_index(const Node* node) {
+  return node->index;
+}
 
 } // namespace graph
 } // namespace beanmachine

--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -1131,6 +1131,12 @@ class Graph {
   std::vector<NodeValue> _old_values;
   double _old_sto_affected_nodes_log_prob = 0;
 
+  bool support_cache_is_valid = false;
+  Support support_cache;
+
+  bool mutable_support_cache_is_valid = false;
+  Support mutable_support_cache;
+
   inline void _ensure_old_values_has_the_right_size() {
     if (not _old_values_vector_has_the_right_size) {
       _old_values = std::vector<NodeValue>(nodes.size());

--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -1128,7 +1128,7 @@ class Graph {
  private:
   CACHED_PRIVATE_PROPERTY(
       std::vector<std::vector<Node*>>,
-      det_affected_operator_nodes)
+      det_affected_mutable_nodes)
   CACHED_PRIVATE_PROPERTY(std::vector<std::vector<Node*>>, sto_affected_nodes)
 
 #undef CACHED_PROPERTY
@@ -1190,11 +1190,11 @@ class Graph {
   void collect_sample(InferConfig infer_config);
 
  public:
-  const std::vector<Node*>& get_det_affected_operator_nodes(NodeID node_id);
+  const std::vector<Node*>& get_det_affected_mutable_nodes(NodeID node_id);
   const std::vector<Node*>& get_sto_affected_nodes(NodeID node_id);
 
-  inline const std::vector<Node*>& get_det_affected_operator_nodes(Node* node) {
-    return get_det_affected_operator_nodes(node->index);
+  inline const std::vector<Node*>& get_det_affected_mutable_nodes(Node* node) {
+    return get_det_affected_mutable_nodes(node->index);
   }
 
   inline const std::vector<Node*>& get_sto_affected_nodes(Node* node) {

--- a/src/beanmachine/graph/marginalization/marginalization_extensional.cpp
+++ b/src/beanmachine/graph/marginalization/marginalization_extensional.cpp
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <stdexcept>
+
+#include <range/v3/algorithm/contains.hpp>
+#include <range/v3/core.hpp>
+#include <range/v3/view/filter.hpp>
+#include <range/v3/view/join.hpp>
+#include <range/v3/view/transform.hpp>
+#include "beanmachine/graph/distribution/bernoulli.h"
+#include "beanmachine/graph/distribution/distribution.h"
+#include "beanmachine/graph/marginalization/marginalization_extensional.h"
+#include "beanmachine/graph/operator/operator.h"
+#include "beanmachine/graph/third-party/nameof.h"
+#include "beanmachine/graph/util.h"
+
+namespace beanmachine::graph {
+
+using namespace ranges;
+using namespace std;
+using namespace util;
+using namespace distribution;
+using namespace oper;
+
+void check_discrete_is_a_sample_node(const Node* discrete) {
+  if (!is_sample_or_sample_iid(discrete)) {
+    throw marginalization_on_non_sample_node();
+  }
+}
+
+void check_discrete_is_not_observed(const Node* discrete, const Graph& graph) {
+  if (contains(graph.observed, discrete->index) or
+      contains(graph.queries, discrete->index)) {
+    throw marginalization_on_observed_or_queried_node();
+  }
+}
+
+void check_distribution_is_supported(const Node* discrete) {
+  assert(discrete->in_nodes.size() == 1);
+  auto parent = discrete->in_nodes[0];
+  Bernoulli* bernoulli = dynamic_cast<Bernoulli*>(parent);
+  if (bernoulli == nullptr) {
+    auto* distribution = dynamic_cast<Distribution*>(parent);
+    throw marginalization_not_supported_for_samples_of(distribution->dist_type);
+  }
+}
+
+// NOLINTNEXTLINE(clang-diagnostic-unused-parameter)
+vector<NodeValue> values_of(const Node* discrete) {
+  // Only distribution supported as of yet is Bernoulli:
+  return {NodeValue(false), NodeValue(true)};
+}
+
+const Distribution* distribution_of(const Node* node) {
+  assert(node->in_nodes.size() == 1);
+  return dynamic_cast<const Distribution*>(node->in_nodes[0]);
+}
+
+Node* child_of(const vector<Node*>& det_affected) {
+  // clang-format off
+  auto children = det_affected
+                | views::filter(is(NodeType::DISTRIBUTION))
+                | views::transform(get_out_nodes)
+                | views::join // flattens sets of out-nodes
+                | views::filter(is_sample_or_sample_iid)
+                | to<vector>();
+  // clang-format on
+
+  if (children.size() == 1) {
+    return children[0];
+  } else if (children.size() == 0) {
+    throw marginalization_no_children();
+  } else {
+    throw marginalization_multiple_children();
+  }
+}
+
+Node* add_mixture(
+    Graph& graph,
+    const vector<Node*>& weight_nodes,
+    const vector<Node*>& distributions) {
+  // weight w_i of the i-th is a log unnormalized probability
+  // (because Distributions are only required to provide
+  // log unnormalized probabilities).
+  // That is to say,
+  // w_i = log c p_i = log c + log p_i
+  // for some constant c.
+  // The Bimixture distribution requires the value p0 (probability
+  // of the first value).
+  // This means exp(w_i) is the unnormalized probability of i-th value.
+  // Therefore, p0 results from normalizing the set of exp(w_i):
+  // p0 = exp(w0) / sum_i exp(w_i).
+  // Because of numeric reasons, we do not want to compute sum_i exp(w_i)
+  // directly, but instead use the logsumexp(w) function
+  // which computes log(sum_i exp(w_i)).
+  // This can be done by computing instead log p0 and exponentiating it later:
+  // p0 = exp(log p0) = exp(log(exp(w0) / sum_i exp(w_i)))
+  // = exp( log(exp(w0)) - log(sum_i exp(w_i)) )
+  // = exp( w0 - logsumexp(w) )
+  // We assemble the nodes computing this expression:
+  auto weight_ids = graph.get_node_ids(weight_nodes);
+  assert(weight_ids.size() != 0);
+  auto logsumexp_w = graph.add_operator(OperatorType::LOGSUMEXP, weight_ids);
+  auto minus_one = graph.add_constant_real(-1);
+  auto minus_logsumexp_w =
+      graph.add_operator(OperatorType::MULTIPLY, {minus_one, logsumexp_w});
+  auto log_prob =
+      graph.add_operator(OperatorType::ADD, {weight_ids[0], minus_logsumexp_w});
+  auto prob_real = graph.add_operator(OperatorType::EXP, {log_prob});
+  auto prob = graph.add_operator(OperatorType::TO_PROBABILITY, {prob_real});
+  Distribution* distr0 = dynamic_cast<Distribution*>(distributions[0]);
+  auto mixture = graph.add_distribution(
+      DistributionType::BIMIXTURE,
+      distr0->sample_type,
+      {prob, distributions[0]->index, distributions[1]->index});
+  return graph.get_node(mixture);
+}
+
+void marginalize(const Node* discrete, Graph& graph) {
+  check_discrete_is_a_sample_node(discrete);
+  check_discrete_is_not_observed(discrete, graph);
+  check_distribution_is_supported(discrete);
+
+  // Capture neighborhood of 'discrete':
+  // The distribution of 'discrete':
+  auto prior_discrete = distribution_of(discrete);
+  // The deterministic nodes directly affected by 'discrete':
+  AffectedNodes affected_ids = graph.compute_affected_nodes_except_self(
+      discrete->index, graph.compute_support());
+  auto det_affected_ids = get<0>(affected_ids);
+  auto det_affected = graph.convert_node_ids(det_affected_ids);
+  // the (required to be the only one for now) sample node
+  // descending from 'discrete' through deterministic nodes only:
+  auto child = child_of(det_affected);
+
+  // As we duplicate det_affected, the child's distribution will always
+  // occupy the same position in the list of nodes.
+  // We determine this position's index here to find these distributions
+  // for each value later.
+  auto child_dist = child->in_nodes[0];
+  auto child_dist_index_in_det_affected = find_index(det_affected, child_dist);
+
+  // Function making a constant node for a given 'discrete' value:
+  auto make_constant_node = std::function([&](const NodeValue& v) {
+    auto id = graph.add_constant(v);
+    return graph.get_node(id);
+  });
+
+  // Function making a node for the weight of a given 'discrete' value,
+  // equal to its log prob according to 'discrete''s distribution:
+  auto make_weight_node = std::function([&](const Node* v) {
+    auto id = graph.add_operator(
+        OperatorType::LOG_PROB, {prior_discrete->index, v->index});
+    return graph.get_node(id);
+  });
+
+  // Function making copy of det_affected for a given 'discrete' value:
+  auto make_det_affected = std::function([&](Node* v) {
+    auto duplicate_nodes = duplicate_subgraph(graph, det_affected);
+    for (auto duplicate_node : duplicate_nodes) {
+      graph.replace_edges(duplicate_node, discrete, v);
+    }
+    return duplicate_nodes;
+  });
+
+  // Function getting the child's distribution for a given 'discrete' value:
+  auto get_child_dist =
+      std::function([&](const vector<Node*>& value_det_affected) {
+        return value_det_affected[child_dist_index_in_det_affected];
+      });
+
+  auto values = values_of(discrete);
+  auto value_constant_nodes = map2vec(values, make_constant_node);
+  auto value_weight_nodes = map2vec(value_constant_nodes, make_weight_node);
+  auto value_det_affecteds = map2vec(value_constant_nodes, make_det_affected);
+  auto value_child_distributions = map2vec(value_det_affecteds, get_child_dist);
+  auto mixture_ptr =
+      add_mixture(graph, value_weight_nodes, value_child_distributions);
+  graph.set_edge(child, /* in-node index=*/0, /* new_in-node=*/mixture_ptr);
+}
+
+} // namespace beanmachine::graph

--- a/src/beanmachine/graph/marginalization/marginalization_extensional.h
+++ b/src/beanmachine/graph/marginalization/marginalization_extensional.h
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <memory>
+#include <stdexcept>
+
+#include "beanmachine/graph/graph.h"
+
+namespace beanmachine::graph {
+
+// Marginalizes a discrete variable away from a given graph (in-place)
+// (see case limitations below).
+//
+// Let us define *child* of a node 'n' as a descendant of 'n'
+// that is a sample operator and whose path from 'n' includes
+// deterministic nodes only (including distribution nodes).
+//
+// Example: consider the graph for the following model:
+// n = sample(Normal(0,1))
+// twice = n*2
+// c1 = sample(Normal(n, 1.0))
+// c2 = sample(Normal(twice, 1.0))
+// c3 = sample(Normal(c2, 1.0))
+//
+// In such a graph, both c1 and c2 are
+// children of n but c3 is not, even though
+// it is a descendant of n (because the path
+// from n to n3 involves other sample nodes).
+//
+// Let the initial graph have a discrete sample node d with distribution P(d),
+// and set of values v1 and v2,
+// let 'child' be the *only* child of d as defined above,
+// let det_affected are the
+// intervening deterministic nodes between d and 'child'
+// (including 'child''s distribution),
+// as in the following diagram:
+//
+//    Ancestors of P(d)
+//           |
+//           v
+//          P(d) (discrete distribution over v1, v2)
+//           |
+//           v
+//           d   (discrete sample node)
+//           |
+//           |  Other inputs
+//           |       |
+//           |       |
+//           v       v
+//         det_affected (deterministic nodes,
+//           |          including distribution of 'child')
+//           |
+//           v
+//         child (sole sample descendant of d)
+//           |
+//           v
+//          ...
+//
+//  We wish the rewrite the graph to the following configuration,
+//  where P(d=vi) is the prob of P(d) for value vi,
+//  det_affected(d=vi) is a clone of set det_affected
+//  where any inputs from d are replaced by the constant vi,
+//  and the bimixture distribution selected among
+//  det_affected(d=vi) according to weight_nodes P(d=vi).
+//
+//   Ancestors of P(d)               Other inputs
+//         |                              |
+//     +---+---+               +----------+--------+
+//     |       |               |                   |
+//     v       v               v                   v
+//  P(d=v1) P(d=v2)    det_affected(d=v1)  det_affected(d=v2)
+//     |       |               |                   |
+//     v       v               v                   v
+//  +-------------------------------------------------------+
+//  |                 MIXTURE DISTRIBUTION                  |
+//  +-------------------------------------------------------+
+//                            |
+//                            v
+//                          child
+//                            |
+//                            v
+//                           ...
+//
+// It holds that the final graph defines a joint probability
+// distribution that is equal to the result of marginalizing d
+// from the original joint probability distribution.
+//
+// Sampling from the resulting graph should produce better samples
+// since each sample follows from information about both values of d.
+//
+// Current limitations: method only works for d a Bernoulli variable
+// with a single child.
+//
+void marginalize(const Node* discrete, Graph& graph);
+
+struct marginalization_on_non_sample_node : std::invalid_argument {
+  marginalization_on_non_sample_node()
+      : std::invalid_argument("Marginalization requested on non-sample node") {}
+};
+
+struct marginalization_on_observed_or_queried_node : std::invalid_argument {
+  explicit marginalization_on_observed_or_queried_node()
+      : std::invalid_argument(
+            "Marginalization requested on observed or queried node") {}
+};
+
+struct marginalization_not_supported_for_samples_of : std::invalid_argument {
+  explicit marginalization_not_supported_for_samples_of(
+      DistributionType dist_type)
+      : std::invalid_argument(
+            std::string("Marginalization not yet supported for samples of ") +
+            std::string(NAMEOF_ENUM(dist_type))) {}
+};
+
+struct marginalization_no_children : std::invalid_argument {
+  marginalization_no_children()
+      : std::invalid_argument(
+            "Marginalization requested on discrete variable with no stochastic children") {
+  }
+};
+
+struct marginalization_multiple_children : std::invalid_argument {
+  marginalization_multiple_children()
+      : std::invalid_argument(
+            "Marginalization requested on discrete variable with multiple children") {
+  }
+};
+
+} // namespace beanmachine::graph

--- a/src/beanmachine/graph/marginalization/marginalization_extensional.h
+++ b/src/beanmachine/graph/marginalization/marginalization_extensional.h
@@ -99,6 +99,13 @@ namespace beanmachine::graph {
 //
 void marginalize(const Node* discrete, Graph& graph);
 
+/* Indicates whether a node is marginalizable from the graph. */
+bool is_marginalizable(Graph& graph, const Node* node);
+
+void marginalize_all_marginalizable_variables(Graph& graph);
+
+/**** Exceptions ****/
+
 struct marginalization_on_non_sample_node : std::invalid_argument {
   marginalization_on_non_sample_node()
       : std::invalid_argument("Marginalization requested on non-sample node") {}

--- a/src/beanmachine/graph/marginalization/marginalization_extensional_test.cpp
+++ b/src/beanmachine/graph/marginalization/marginalization_extensional_test.cpp
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include <ctime>
+#include <iostream>
+#include <stdexcept>
+
+#include "beanmachine/graph/distribution/bernoulli.h"
+#include "beanmachine/graph/distribution/distribution.h"
+#include "beanmachine/graph/marginalization/marginalization_extensional.h"
+#include "beanmachine/graph/operator/operator.h"
+#include "beanmachine/graph/util.h"
+
+using namespace ::testing;
+
+using namespace beanmachine;
+using namespace graph;
+using namespace std;
+using namespace util;
+
+std::tuple<NodeID, NodeID> make_childless_base_graph(Graph& graph) {
+  // discrete = sample(Bernoulli(0.4))
+  // real_discrete = to_real(discrete)
+  // Normal(real_discrete, 0.5))
+  auto point_four = graph.add_constant_probability(0.4);
+  auto stddev = graph.add_constant_pos_real(1.0);
+  auto bernoulli = graph.add_distribution(
+      DistributionType::BERNOULLI, AtomicType::BOOLEAN, {point_four});
+  auto discrete =
+      graph.add_operator(OperatorType::SAMPLE, {bernoulli}); // node_id = 3
+  auto real_discrete = graph.add_operator(OperatorType::TO_REAL, {discrete});
+  auto normal = graph.add_distribution( // node_id = 5
+      DistributionType::NORMAL,
+      AtomicType::REAL,
+      {real_discrete, stddev});
+
+  return {discrete, normal};
+}
+
+std::tuple<NodeID, NodeID, NodeID> make_base_graph(Graph& graph) {
+  // discrete = sample(Bernoulli(0.4))
+  // real_discrete = to_real(discrete)
+  // x = sample(Normal(real_discrete, 0.5))
+  // // include descendants to make sure they are processed correctly
+  // y = sample(Normal(x, stddev))
+  // z = x + real_discrete
+  // query(x)
+  // observe(y, 3.1)
+  //
+  // Expected resulting graph:
+  //
+  // x = sample(bimixture(0.4, Normal(to_real(true), 1.0),
+  //                           Normal(to_real(false), 1.0)))
+  // y = sample(Normal(x, stddev))
+  // z = x + real_discrete
+  // query(x)
+  // observe(y, 3.1)
+  auto point_four = graph.add_constant_probability(0.4);
+  auto stddev = graph.add_constant_pos_real(1.0);
+  auto bernoulli = graph.add_distribution(
+      DistributionType::BERNOULLI, AtomicType::BOOLEAN, {point_four});
+  auto discrete =
+      graph.add_operator(OperatorType::SAMPLE, {bernoulli}); // node_id = 3
+  auto real_discrete = graph.add_operator(OperatorType::TO_REAL, {discrete});
+  auto normal = graph.add_distribution( // node_id = 5
+      DistributionType::NORMAL,
+      AtomicType::REAL,
+      {real_discrete, stddev});
+  auto x = graph.add_operator(OperatorType::SAMPLE, {normal});
+  auto normal2 = graph.add_distribution(
+      DistributionType::NORMAL, AtomicType::REAL, {x, stddev});
+  auto y = graph.add_operator(OperatorType::SAMPLE, {normal2});
+  auto z = graph.add_operator(OperatorType::ADD, {y, real_discrete});
+  graph.query(x);
+  graph.observe(y, 3.1);
+
+  return {discrete, normal, y};
+}
+
+TEST(marginalization_extensional_test, marginalization) {
+  Graph graph;
+  NodeID discrete, normal, y;
+  std::tie(discrete, normal, y) = make_base_graph(graph);
+
+  cout << "Original:\n" << graph.to_string() << endl;
+
+  auto expected = R"(0: CONSTANT(probability 0.4) (out nodes: 2)
+1: CONSTANT(positive real 1) (out nodes: 5, 22, 11, 13)
+2: BERNOULLI(0) (out nodes: 3, 8, 9)
+3: SAMPLE(2) (out nodes: 4)
+4: TO_REAL(3) (out nodes: 5, 24)
+5: NORMAL(4, 1) (out nodes: )
+6: CONSTANT(boolean 0) (out nodes: 8, 10)
+7: CONSTANT(boolean 1) (out nodes: 9, 12)
+8: LOG_PROB(2, 6) (out nodes: 14, 17)
+9: LOG_PROB(2, 7) (out nodes: 14)
+10: TO_REAL(6) (out nodes: 11)
+11: NORMAL(10, 1) (out nodes: 20)
+12: TO_REAL(7) (out nodes: 13)
+13: NORMAL(12, 1) (out nodes: 20)
+14: LOGSUMEXP(8, 9) (out nodes: 16)
+15: CONSTANT(real -1) (out nodes: 16)
+16: MULTIPLY(15, 14) (out nodes: 17)
+17: ADD(8, 16) (out nodes: 18)
+18: EXP(17) (out nodes: 19)
+19: TO_PROBABILITY(18) (out nodes: 20)
+20: BIMIXTURE(19, 11, 13) (out nodes: 21)
+21: SAMPLE(20) (out nodes: 22) queried
+22: NORMAL(21, 1) (out nodes: 23)
+23: SAMPLE(22) (out nodes: 24) observed to be real 3.1
+24: ADD(23, 4) (out nodes: )
+)";
+
+  marginalize(graph.get_node(discrete), graph);
+
+  cout << "Result:\n" << graph.to_string() << endl;
+
+  ASSERT_EQ(expected, graph.to_string());
+}
+
+TEST(marginalization_extensional_test, marginalization_on_non_sample_node) {
+  Graph graph;
+  NodeID discrete, normal, y;
+  std::tie(discrete, normal, y) = make_base_graph(graph);
+
+  EXPECT_THROW(
+      marginalize(graph.get_node(normal), graph),
+      marginalization_on_non_sample_node);
+}
+
+TEST(
+    marginalization_extensional_test,
+    marginalization_on_observed_or_queried_node) {
+  Graph graph;
+  NodeID discrete, normal, y;
+  std::tie(discrete, normal, y) = make_base_graph(graph);
+  graph.observe(discrete, true);
+
+  EXPECT_THROW(
+      marginalize(graph.get_node(discrete), graph),
+      marginalization_on_observed_or_queried_node);
+}
+
+TEST(
+    marginalization_extensional_test,
+    marginalization_not_supported_for_samples_of) {
+  Graph graph;
+  auto point_four = graph.add_constant_pos_real(0.4);
+  auto poisson = graph.add_distribution(
+      DistributionType::POISSON, AtomicType::NATURAL, {point_four});
+  auto x = graph.add_operator(OperatorType::SAMPLE, {poisson});
+
+  EXPECT_THROW(
+      marginalize(graph.get_node(x), graph),
+      marginalization_not_supported_for_samples_of);
+}
+
+TEST(marginalization_extensional_test, marginalization_multiple_children) {
+  Graph graph;
+  NodeID discrete, normal, y;
+  std::tie(discrete, normal, y) = make_base_graph(graph);
+
+  // Algorithm does not currently support multiple children
+  auto x2 = graph.add_operator(OperatorType::SAMPLE, {normal});
+
+  EXPECT_THROW(
+      marginalize(graph.get_node(discrete), graph),
+      marginalization_multiple_children);
+}
+
+TEST(marginalization_extensional_test, marginalization_no_children) {
+  Graph graph;
+  NodeID discrete, normal;
+  std::tie(discrete, normal) = make_childless_base_graph(graph);
+
+  EXPECT_THROW(
+      marginalize(graph.get_node(discrete), graph),
+      marginalization_no_children);
+}
+
+TEST(marginalization_extensional_test, marginalization_inference) {
+  Graph graph;
+  NodeID discrete, normal, y;
+  std::tie(discrete, normal, y) = make_base_graph(graph);
+
+  auto num_samples = 50000;
+  auto seed = std::time(nullptr);
+  auto original_mean = graph.infer_mean(num_samples, InferenceType::NMC, seed);
+  cout << "Mean from original graph: " << util::join(original_mean) << endl;
+
+  marginalize(graph.get_node(discrete), graph);
+  auto marginalized_mean =
+      graph.infer_mean(num_samples, InferenceType::NMC, seed);
+  cout << "Mean from marginalized graph: " << util::join(marginalized_mean)
+       << endl;
+
+  ASSERT_NEAR(original_mean[0], marginalized_mean[0], 1e-2);
+}

--- a/src/beanmachine/graph/operator/operator.cpp
+++ b/src/beanmachine/graph/operator/operator.cpp
@@ -17,7 +17,12 @@ namespace oper {
 using namespace std;
 
 unique_ptr<graph::Node> Operator::clone() {
-  return OperatorFactory::create_op(op_type, in_nodes);
+  auto result = OperatorFactory::create_op(op_type, in_nodes);
+  result->is_observed = this->is_observed;
+  if (result->is_observed) {
+    result->value = this->value;
+  }
+  return result;
 }
 
 double Operator::log_prob() const {

--- a/src/beanmachine/graph/operator/operator.h
+++ b/src/beanmachine/graph/operator/operator.h
@@ -78,5 +78,12 @@ class OperatorFactory {
   static bool factories_are_registered;
 };
 
+inline bool is_sample_or_sample_iid(const graph::Node* node) {
+  auto* op = dynamic_cast<const Operator*>(node);
+  return op != nullptr and
+      (op->op_type == graph::OperatorType::SAMPLE or
+       op->op_type == graph::OperatorType::IID_SAMPLE);
+}
+
 } // namespace oper
 } // namespace beanmachine

--- a/src/beanmachine/graph/out_nodes_reflexive_transitive_closure.cpp
+++ b/src/beanmachine/graph/out_nodes_reflexive_transitive_closure.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <utility>
+
+#include "beanmachine/graph/out_nodes_reflexive_transitive_closure.h"
+#include "beanmachine/graph/util.h"
+
+namespace beanmachine::graph {
+
+using namespace std;
+using namespace util;
+
+OutNodesReflexiveTransitiveClosure::OutNodesReflexiveTransitiveClosure(
+    Node* node,
+    std::function<pair<bool, bool>(Node*)> prune,
+    std::function<pair<bool, bool>(Node*)> abort) {
+  // clang-format off
+  _success = bfs<Node*, vector<Node*>>(
+      node,
+      get_out_nodes,
+      prune,
+      abort,
+      push_back_to(_result));
+  // clang-format on
+}
+
+} // namespace beanmachine::graph

--- a/src/beanmachine/graph/out_nodes_reflexive_transitive_closure.h
+++ b/src/beanmachine/graph/out_nodes_reflexive_transitive_closure.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <functional>
+#include <unordered_set>
+#include <vector>
+
+#include "beanmachine/graph/graph.h"
+
+namespace beanmachine::graph {
+
+/*
+A class representing the out-nodes reflexive transitive closure of a node in a
+graph, that is, the set of itself and its descendants.
+
+The class receives two optional functions for controlling the search:
+
+- the 'abort' function returns a pair of booleans. The first boolean indicates
+whether the search is to be aborted, whereas the second indicates whether the
+node causing the abort should be excluded from the result.
+
+- the 'prune' function returns a pair of booleans. The first boolean indicates
+whether the search is to be pruned, whether the second indicates whether the
+node causing the pruning should be excluded from the result.
+*/
+class OutNodesReflexiveTransitiveClosure {
+ public:
+  explicit OutNodesReflexiveTransitiveClosure(
+      Node* node,
+      std::function<std::pair<bool, bool>(Node*)> prune =
+          [](Node*) {
+            return std::pair<bool, bool>{false, false};
+          },
+      std::function<std::pair<bool, bool>(Node*)> abort =
+          [](Node*) { return std::pair<bool, bool>(false, false); });
+
+  const std::vector<Node*> get_result() const {
+    return _result;
+  }
+
+  bool aborted() const {
+    return not _success;
+  }
+
+  bool success() const {
+    return _success;
+  }
+
+ private:
+  bool _success;
+  std::vector<Node*> _result;
+};
+
+} // namespace beanmachine::graph

--- a/src/beanmachine/graph/pybindings.cpp
+++ b/src/beanmachine/graph/pybindings.cpp
@@ -157,7 +157,11 @@ PYBIND11_MODULE(graph, module) {
   // add_constant(tensor(2.5)) has the effect of calling add_constant(True).
   py::class_<Graph>(module, "Graph")
       .def(py::init())
-      .def("to_string", &Graph::to_string, "string representation of the graph")
+      .def(
+          "to_string",
+          &Graph::to_string,
+          "string representation of the graph",
+          py::arg("show_pointers") = false)
       .def("to_dot", &Graph::to_dot, "DOT representation of the graph")
       .def(
           "add_constant_bool",

--- a/src/beanmachine/graph/stepper/single_site/nmc_dirichlet_beta_single_site_stepping_method.cpp
+++ b/src/beanmachine/graph/stepper/single_site/nmc_dirichlet_beta_single_site_stepping_method.cpp
@@ -63,7 +63,7 @@ NMCDirichletBetaSingleSiteSteppingMethod::get_proposal_distribution(
   Grad1 << 1, -1;
   sto_tgt_node->Grad1 = Grad1;
   sto_tgt_node->Grad2 = Eigen::MatrixXd::Zero(2, 1);
-  graph->compute_gradients(graph->get_det_affected_operator_nodes(tgt_node));
+  graph->compute_gradients(graph->get_det_affected_mutable_nodes(tgt_node));
 
   // Use gradients to obtain NMC proposal
   // @lint-ignore CLANGTIDY

--- a/src/beanmachine/graph/stepper/single_site/nmc_dirichlet_gamma_single_site_stepping_method.cpp
+++ b/src/beanmachine/graph/stepper/single_site/nmc_dirichlet_gamma_single_site_stepping_method.cpp
@@ -43,8 +43,8 @@ void NMCDirichletGammaSingleSiteSteppingMethod::step(Node* tgt_node) {
 
   graph->pd_begin(ProfilerEvent::NMC_STEP_DIRICHLET);
 
-  const std::vector<Node*>& det_affected_operator_nodes =
-      graph->get_det_affected_operator_nodes(tgt_node);
+  const std::vector<Node*>& det_affected_mutable_nodes =
+      graph->get_det_affected_mutable_nodes(tgt_node);
 
   // Cast needed to access fields such as unconstrained_value:
   auto sto_tgt_node = static_cast<oper::StochasticOperator*>(tgt_node);
@@ -58,7 +58,7 @@ void NMCDirichletGammaSingleSiteSteppingMethod::step(Node* tgt_node) {
     double x_sum = sto_tgt_node->unconstrained_value._matrix.sum();
 
     // save old values
-    graph->save_old_values(det_affected_operator_nodes);
+    graph->save_old_values(det_affected_mutable_nodes);
     double old_x_k = sto_tgt_node->unconstrained_value._matrix.coeff(k);
     NodeValue old_x_k_value(AtomicType::POS_REAL, old_x_k);
     double old_sto_affected_nodes_log_prob =
@@ -79,7 +79,7 @@ void NMCDirichletGammaSingleSiteSteppingMethod::step(Node* tgt_node) {
         sto_tgt_node->unconstrained_value._matrix.array() / x_sum;
 
     // propagate new value
-    graph->eval(det_affected_operator_nodes);
+    graph->eval(det_affected_mutable_nodes);
     double new_sto_affected_nodes_log_prob =
         compute_sto_affected_nodes_log_prob(tgt_node, param_a_k, new_x_k_value);
 
@@ -97,7 +97,7 @@ void NMCDirichletGammaSingleSiteSteppingMethod::step(Node* tgt_node) {
     bool accepted = util::flip_coin_with_log_prob(mh->gen, logacc);
     if (!accepted) {
       // revert
-      graph->restore_old_values(det_affected_operator_nodes);
+      graph->restore_old_values(det_affected_mutable_nodes);
       *(sto_tgt_node->unconstrained_value._matrix.data() + k) = old_x_k;
       x_sum = sto_tgt_node->unconstrained_value._matrix.sum();
       sto_tgt_node->value._matrix =
@@ -111,7 +111,7 @@ void NMCDirichletGammaSingleSiteSteppingMethod::step(Node* tgt_node) {
     // TODO: identify code that depends on this, let it zero gradients
     // itself, and remove it from here since that's a long-distance,
     // implicit dependence that is hard to watch for.
-    graph->clear_gradients(det_affected_operator_nodes);
+    graph->clear_gradients(det_affected_mutable_nodes);
   } // k
   graph->pd_finish(ProfilerEvent::NMC_STEP_DIRICHLET);
 }
@@ -165,7 +165,7 @@ NMCDirichletGammaSingleSiteSteppingMethod::create_proposal_dirichlet_gamma(
   sto_tgt_node->Grad2 = sto_tgt_node->Grad1 * (-2.0) / x_sum;
 
   // Propagate gradients
-  graph->compute_gradients(graph->get_det_affected_operator_nodes(tgt_node));
+  graph->compute_gradients(graph->get_det_affected_mutable_nodes(tgt_node));
 
   // We want to compute the gradient of log prob with respect to x_k.
   // The probability is the product of the probabilities of x_k

--- a/src/beanmachine/graph/stepper/single_site/nmc_scalar_single_site_stepping_method.cpp
+++ b/src/beanmachine/graph/stepper/single_site/nmc_scalar_single_site_stepping_method.cpp
@@ -45,7 +45,7 @@ NMCScalarSingleSiteSteppingMethod::get_proposal_distribution(Node* tgt_node) {
 
   tgt_node->grad1 = 1;
   tgt_node->grad2 = 0;
-  graph->compute_gradients(graph->get_det_affected_operator_nodes(tgt_node));
+  graph->compute_gradients(graph->get_det_affected_mutable_nodes(tgt_node));
 
   double grad1 = 0;
   double grad2 = 0;

--- a/src/beanmachine/graph/support.cpp
+++ b/src/beanmachine/graph/support.cpp
@@ -17,11 +17,19 @@ namespace graph {
 using namespace std;
 
 Support Graph::compute_support() {
-  return _compute_support_given_mutable_choice(false);
+  if (not support_cache_is_valid) {
+    support_cache = _compute_support_given_mutable_choice(false);
+    support_cache_is_valid = true;
+  }
+  return support_cache;
 }
 
 MutableSupport Graph::compute_mutable_support() {
-  return _compute_support_given_mutable_choice(true);
+  if (not mutable_support_cache_is_valid) {
+    mutable_support_cache = _compute_support_given_mutable_choice(true);
+    mutable_support_cache_is_valid = true;
+  }
+  return mutable_support_cache;
 }
 
 Support Graph::_compute_support_given_mutable_choice(bool mutable_only) {

--- a/src/beanmachine/graph/tests/graph_test.cpp
+++ b/src/beanmachine/graph/tests/graph_test.cpp
@@ -1024,7 +1024,7 @@ void test_duplicate_subgraph(
     Graph& g,
     const vector<NodeID>& subgraph_node_ids,
     const string& expected_g_printout) {
-  auto subgraph_nodes = from_id_to_ptr(g, subgraph_node_ids);
+  auto subgraph_nodes = g.convert_node_ids(subgraph_node_ids);
   duplicate_subgraph(g, subgraph_nodes);
   EXPECT_EQ(g.to_string(), expected_g_printout);
 }

--- a/src/beanmachine/graph/tests/graph_test.cpp
+++ b/src/beanmachine/graph/tests/graph_test.cpp
@@ -1040,15 +1040,15 @@ TEST(testgraph, duplicate_subgraph_basic1) {
   auto subgraph_node_ids = vector<NodeID>({c1, c2, exp, times});
 
   auto expected_g_printout =
-      R"(Node 0 type 1 parents [ ] children [ 2 4 ] real 10
-Node 1 type 1 parents [ ] children [ 2 ] real 20
-Node 2 type 3 parents [ 0 1 ] children [ 3 4 7 8 ] real 0
-Node 3 type 3 parents [ 2 ] children [ ] positive real 1e-10
-Node 4 type 3 parents [ 2 0 ] children [ ] real 0
-Node 5 type 1 parents [ ] children [ 8 ] real 10
-Node 6 type 1 parents [ ] children [ ] real 20
-Node 7 type 3 parents [ 2 ] children [ ] positive real 1e-10
-Node 8 type 3 parents [ 2 5 ] children [ ] real 0
+      R"(0: CONSTANT(real 10) (out nodes: 2, 4)
+1: CONSTANT(real 20) (out nodes: 2)
+2: ADD(0, 1) (out nodes: 3, 4, 7, 8)
+3: EXP(2) (out nodes: )
+4: MULTIPLY(2, 0) (out nodes: )
+5: CONSTANT(real 10) (out nodes: 8)
+6: CONSTANT(real 20) (out nodes: )
+7: EXP(2) (out nodes: )
+8: MULTIPLY(2, 5) (out nodes: )
 )";
 
   test_duplicate_subgraph(g, subgraph_node_ids, expected_g_printout);
@@ -1065,13 +1065,13 @@ TEST(testgraph, duplicate_subgraph_basic2) {
   auto subgraph_node_ids = vector<NodeID>({plus, times});
 
   auto expected_g_printout =
-      R"(Node 0 type 1 parents [ ] children [ 2 4 5 6 ] real 10
-Node 1 type 1 parents [ ] children [ 2 5 ] real 20
-Node 2 type 3 parents [ 0 1 ] children [ 3 4 ] real 0
-Node 3 type 3 parents [ 2 ] children [ ] positive real 1e-10
-Node 4 type 3 parents [ 2 0 ] children [ ] real 0
-Node 5 type 3 parents [ 0 1 ] children [ 6 ] real 0
-Node 6 type 3 parents [ 5 0 ] children [ ] real 0
+      R"(0: CONSTANT(real 10) (out nodes: 2, 4, 5, 6)
+1: CONSTANT(real 20) (out nodes: 2, 5)
+2: ADD(0, 1) (out nodes: 3, 4)
+3: EXP(2) (out nodes: )
+4: MULTIPLY(2, 0) (out nodes: )
+5: ADD(0, 1) (out nodes: 6)
+6: MULTIPLY(5, 0) (out nodes: )
 )";
 
   test_duplicate_subgraph(g, subgraph_node_ids, expected_g_printout);
@@ -1103,16 +1103,16 @@ TEST(testgraph, duplicate_full_graph) {
   auto subgraph_node_ids = vector<NodeID>({c1, c2, plus, exp, times});
 
   auto expected_g_printout =
-      R"(Node 0 type 1 parents [ ] children [ 2 4 ] real 10
-Node 1 type 1 parents [ ] children [ 2 ] real 20
-Node 2 type 3 parents [ 0 1 ] children [ 3 4 ] real 0
-Node 3 type 3 parents [ 2 ] children [ ] positive real 1e-10
-Node 4 type 3 parents [ 2 0 ] children [ ] real 0
-Node 5 type 1 parents [ ] children [ 7 9 ] real 10
-Node 6 type 1 parents [ ] children [ 7 ] real 20
-Node 7 type 3 parents [ 5 6 ] children [ 8 9 ] real 0
-Node 8 type 3 parents [ 7 ] children [ ] positive real 1e-10
-Node 9 type 3 parents [ 7 5 ] children [ ] real 0
+      R"(0: CONSTANT(real 10) (out nodes: 2, 4)
+1: CONSTANT(real 20) (out nodes: 2)
+2: ADD(0, 1) (out nodes: 3, 4)
+3: EXP(2) (out nodes: )
+4: MULTIPLY(2, 0) (out nodes: )
+5: CONSTANT(real 10) (out nodes: 7, 9)
+6: CONSTANT(real 20) (out nodes: 7)
+7: ADD(5, 6) (out nodes: 8, 9)
+8: EXP(7) (out nodes: )
+9: MULTIPLY(7, 5) (out nodes: )
 )";
 
   test_duplicate_subgraph(g, subgraph_node_ids, expected_g_printout);

--- a/src/beanmachine/graph/tests/out_nodes_reflexive_transitive_closure_test.cpp
+++ b/src/beanmachine/graph/tests/out_nodes_reflexive_transitive_closure_test.cpp
@@ -1,0 +1,299 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include <iostream>
+
+#include "beanmachine/graph/graph.h"
+#include "beanmachine/graph/out_nodes_reflexive_transitive_closure.h"
+
+using namespace ::testing;
+
+using namespace beanmachine;
+using namespace std;
+using namespace graph;
+using namespace util;
+
+void run_ortc_test(
+    const char* name,
+    const Graph& graph,
+    NodeID node_id,
+    std::function<pair<bool, bool>(Node*)> prune,
+    std::function<pair<bool, bool>(Node*)> abort,
+    bool success,
+    vector<NodeID> expected_ids) {
+  cout << "Testing " << name << endl;
+  auto ortc =
+      OutNodesReflexiveTransitiveClosure(graph.get_node(node_id), prune, abort);
+  ASSERT_EQ(ortc.success(), success);
+  auto actual_ids = graph.get_node_ids(ortc.get_result());
+  ASSERT_EQ(actual_ids, expected_ids);
+}
+
+TEST(out_nodes_reflexive_transitive_closure_test, basic_ortc) {
+  /*
+                         0.1    0.2
+                          | \   /
+                          |   +
+                          |  /
+                          | /
+                          *
+  */
+  Graph g;
+  auto point_one = g.add_constant_real(0.1);
+  auto point_two = g.add_constant_real(0.2);
+  auto sum = g.add_operator(OperatorType::ADD, {point_one, point_two});
+  auto product = g.add_operator(OperatorType::MULTIPLY, {sum, point_one});
+
+  auto prune = std::function([&](Node*) { return make_pair(false, false); });
+  auto abort = std::function([&](Node*) { return make_pair(false, false); });
+
+  auto name = "point_one"; // for error messages
+  NodeID node = point_one;
+  auto success = true;
+  vector<NodeID> expected{point_one, sum, product};
+  run_ortc_test(name, g, node, prune, abort, success, expected);
+
+  name = "point_two";
+  node = point_two;
+  success = true;
+  expected = {point_two, sum, product};
+  run_ortc_test(name, g, node, prune, abort, success, expected);
+
+  name = "sum";
+  node = sum;
+  success = true;
+  expected = {sum, product};
+  run_ortc_test(name, g, node, prune, abort, success, expected);
+
+  name = "product";
+  node = product;
+  success = true;
+  expected = {product};
+  run_ortc_test(name, g, node, prune, abort, success, expected);
+}
+
+TEST(out_nodes_reflexive_transitive_closure_test, ortc_with_abort) {
+  /*
+                         n0
+                      /  |  \
+                    n1   n2  n3
+                     \  / \
+                      n4   n5
+                        \  /
+                         n6
+  */
+  Graph g;
+  auto n0 = g.add_constant_real(0.1);
+  auto n1 = g.add_operator(OperatorType::EXP, {n0});
+  auto n2 = g.add_operator(OperatorType::EXP, {n0});
+  auto n3 = g.add_operator(OperatorType::EXP, {n0});
+  auto n4 = g.add_operator(OperatorType::ADD, {n1, n2});
+  auto n5 = g.add_operator(OperatorType::EXP, {n2});
+  auto n6 = g.add_operator(OperatorType::ADD, {n4, n5});
+
+  auto prune = std::function([&](Node*) { return make_pair(false, false); });
+
+  // Abort if hitting n5
+  auto abort = std::function([&](Node* node) {
+    auto abort_even_for_self = true;
+    return make_pair(node->index == n5, abort_even_for_self);
+  });
+
+  auto name = "n0"; // for error messages
+  NodeID node = n0;
+  auto success = false;
+  vector<NodeID> expected{n0, n1, n2, n3, n4};
+  run_ortc_test(name, g, node, prune, abort, success, expected);
+
+  name = "n1";
+  node = n1;
+  success = true;
+  expected = {n1, n4, n6};
+  run_ortc_test(name, g, node, prune, abort, success, expected);
+
+  name = "n2";
+  node = n2;
+  success = false;
+  expected = {n2, n4};
+  run_ortc_test(name, g, node, prune, abort, success, expected);
+
+  name = "n3";
+  node = n3;
+  success = true;
+  expected = {n3};
+  run_ortc_test(name, g, node, prune, abort, success, expected);
+
+  name = "n4";
+  node = n4;
+  success = true;
+  expected = {n4, n6};
+  run_ortc_test(name, g, node, prune, abort, success, expected);
+
+  name = "n5";
+  node = n5;
+  success = false;
+  expected = {};
+  run_ortc_test(name, g, node, prune, abort, success, expected);
+
+  name = "n6";
+  node = n6;
+  success = true;
+  expected = {n6};
+  run_ortc_test(name, g, node, prune, abort, success, expected);
+}
+
+TEST(out_nodes_reflexive_transitive_closure_test, ortc_with_prune_and_abort) {
+  /*
+                         n0
+                      /  |  \
+                    n1   n2  n3
+                     \  / \
+                      n4   n5
+                        \  /
+                         n6
+  */
+  Graph g;
+  auto n0 = g.add_constant_real(0.1);
+  auto n1 = g.add_operator(OperatorType::EXP, {n0});
+  auto n2 = g.add_operator(OperatorType::EXP, {n0});
+  auto n3 = g.add_operator(OperatorType::EXP, {n0});
+  auto n4 = g.add_operator(OperatorType::ADD, {n1, n2});
+  auto n5 = g.add_operator(OperatorType::EXP, {n2});
+  auto n6 = g.add_operator(OperatorType::ADD, {n4, n5});
+
+  // Prune n2, including itself
+  auto prune = std::function([&](Node* node) {
+    auto prune_even_for_self = true;
+    return make_pair(node->index == n2, prune_even_for_self);
+  });
+
+  // Abort if hitting n5
+  auto abort = std::function([&](Node* node) {
+    auto abort_even_for_self = true;
+    return make_pair(node->index == n5, abort_even_for_self);
+  });
+
+  auto name = "n0"; // for error messages
+  NodeID node = n0;
+  auto success = true; // succeeds because pruning n2 leads to not reaching n5
+  vector<NodeID> expected{n0, n1, n3, n4, n6};
+  run_ortc_test(name, g, node, prune, abort, success, expected);
+
+  name = "n1";
+  node = n1;
+  success = true;
+  expected = {n1, n4, n6};
+  run_ortc_test(name, g, node, prune, abort, success, expected);
+
+  name = "n2";
+  node = n2;
+  success = true; // succeeds because pruning n2 leads to not reaching n5
+  expected = {};
+  run_ortc_test(name, g, node, prune, abort, success, expected);
+
+  name = "n3";
+  node = n3;
+  success = true;
+  expected = {n3};
+  run_ortc_test(name, g, node, prune, abort, success, expected);
+
+  name = "n4";
+  node = n4;
+  success = true;
+  expected = {n4, n6};
+  run_ortc_test(name, g, node, prune, abort, success, expected);
+
+  name = "n5";
+  node = n5;
+  success = false;
+  expected = {};
+  run_ortc_test(name, g, node, prune, abort, success, expected);
+
+  name = "n6";
+  node = n6;
+  success = true;
+  expected = {n6};
+  run_ortc_test(name, g, node, prune, abort, success, expected);
+}
+
+TEST(
+    out_nodes_reflexive_transitive_closure_test,
+    ortc_with_prune_and_abort_but_keeping_offending_nodes) {
+  /*
+                         n0
+                      /  |  \
+                    n1   n2  n3
+                     \  / \
+                      n4   n5
+                        \  /
+                         n6
+  */
+  Graph g;
+  auto n0 = g.add_constant_real(0.1);
+  auto n1 = g.add_operator(OperatorType::EXP, {n0});
+  auto n2 = g.add_operator(OperatorType::EXP, {n0});
+  auto n3 = g.add_operator(OperatorType::EXP, {n0});
+  auto n4 = g.add_operator(OperatorType::ADD, {n1, n2});
+  auto n5 = g.add_operator(OperatorType::EXP, {n2});
+  auto n6 = g.add_operator(OperatorType::ADD, {n4, n5});
+
+  // Prune at n2 but don't discard it
+  auto prune = std::function([&](Node* node) {
+    auto prune_even_for_self = false;
+    return make_pair(node->index == n2, prune_even_for_self);
+  });
+
+  // Abort if hitting n5 but don't discard it
+  auto abort = std::function([&](Node* node) {
+    auto abort_even_for_self = false;
+    return make_pair(node->index == n5, abort_even_for_self);
+  });
+
+  auto name = "n0"; // for error messages
+  NodeID node = n0;
+  auto success = true; // succeeds because pruning n2 leads to not reaching n5
+  vector<NodeID> expected{n0, n1, n2, n3, n4, n6};
+  run_ortc_test(name, g, node, prune, abort, success, expected);
+
+  name = "n1";
+  node = n1;
+  success = true;
+  expected = {n1, n4, n6};
+  run_ortc_test(name, g, node, prune, abort, success, expected);
+
+  name = "n2";
+  node = n2;
+  success = true; // succeeds because pruning n2 leads to not reaching n5
+  expected = {n2};
+  run_ortc_test(name, g, node, prune, abort, success, expected);
+
+  name = "n3";
+  node = n3;
+  success = true;
+  expected = {n3};
+  run_ortc_test(name, g, node, prune, abort, success, expected);
+
+  name = "n4";
+  node = n4;
+  success = true;
+  expected = {n4, n6};
+  run_ortc_test(name, g, node, prune, abort, success, expected);
+
+  name = "n5";
+  node = n5;
+  success = false;
+  expected = {n5};
+  run_ortc_test(name, g, node, prune, abort, success, expected);
+
+  name = "n6";
+  node = n6;
+  success = true;
+  expected = {n6};
+  run_ortc_test(name, g, node, prune, abort, success, expected);
+}

--- a/src/beanmachine/graph/tests/testing_util_test.h
+++ b/src/beanmachine/graph/tests/testing_util_test.h
@@ -29,18 +29,14 @@ std::vector<double> compute_means(
 /*
 Runs both NMC and NUTS on given graph for a number of rounds
 with a given number of samples (warmup samples is used only for NUTS),
-and calls a tester function on the means of the first query
-variable obtained by both algorithms.
-The seed is provided as a nullary function (so it can vary across rounds).
-Also prints the obtained means and the measured maximum difference over all
-rounds.
+and checkes the results are close up to a maximum difference.
 */
 void test_nmc_against_nuts(
     graph::Graph& graph,
     int num_rounds,
     int num_samples,
     int warmup_samples,
-    std::function<unsigned()> seed_getter,
-    std::function<void(double, double)> tester);
+    unsigned seed,
+    double max_abs_mean_diff);
 
 } // namespace beanmachine::util

--- a/src/beanmachine/graph/util.h
+++ b/src/beanmachine/graph/util.h
@@ -219,7 +219,7 @@ auto map(const Container& c, Function f) {
 }
 
 template <typename Container, typename R, typename... Args>
-auto map2vec(const Container& c, const std::function<R(Args...)>& f) {
+auto map2vec(const Container& c, std::function<R(Args...)> f) {
   return std::vector<R>(
       boost::make_transform_iterator(c.begin(), f),
       boost::make_transform_iterator(c.end(), f));

--- a/src/beanmachine/graph/util.h
+++ b/src/beanmachine/graph/util.h
@@ -218,6 +218,13 @@ auto map(const Container& c, Function f) {
       boost::make_transform_iterator(c.end(), f));
 }
 
+template <typename Container, typename R, typename... Args>
+auto map2vec(const Container& c, const std::function<R(Args...)>& f) {
+  return std::vector<R>(
+      boost::make_transform_iterator(c.begin(), f),
+      boost::make_transform_iterator(c.end(), f));
+}
+
 template <typename Iterator>
 auto sum(const std::pair<Iterator, Iterator>& range) {
   return std::accumulate(range.first, range.second, 0.0);

--- a/src/beanmachine/graph/util.h
+++ b/src/beanmachine/graph/util.h
@@ -9,10 +9,12 @@
 
 #define _USE_MATH_DEFINES
 #include <cmath>
+#include <sstream>
 
 #include <boost/iterator/transform_iterator.hpp>
 #include <boost/range/irange.hpp>
 #include <range/v3/action/push_back.hpp>
+#include <range/v3/view/transform.hpp>
 
 #include <Eigen/Dense>
 #include <algorithm>
@@ -229,6 +231,17 @@ auto map2vec(const Container& c, std::function<R(Args...)> f) {
       boost::make_transform_iterator(c.end(), f));
 }
 
+template <typename Container, typename T>
+std::vector<T> collect2vec(const Container& c, std::function<bool(T)> p) {
+  std::vector<T> result;
+  for (auto t : c) {
+    if (p(t)) {
+      result.push_back(t);
+    }
+  }
+  return result;
+}
+
 template <typename Iterator>
 auto sum(const std::pair<Iterator, Iterator>& range) {
   return std::accumulate(range.first, range.second, 0.0);
@@ -338,6 +351,16 @@ decltype(auto) range(Integer last) {
   return boost::irange(static_cast<Integer>(0), last);
 }
 
+template <class Integer>
+decltype(auto) range(std::pair<Integer, Integer> begin_end) {
+  return boost::irange(begin_end.first, begin_end.second);
+}
+
+template <typename T>
+inline auto find_index(const std::vector<T>& vec, const T& element) {
+  return std::find(vec.begin(), vec.end(), element) - vec.begin();
+}
+
 /*
 A generic function for breadth-first search on a directed graph.
 Parameters:
@@ -393,6 +416,20 @@ bool bfs(
 template <typename T>
 std::function<void(const T& t)> push_back_to(std::vector<T>& vec) {
   return [&](const T& t) { vec.push_back(t); };
+}
+
+template <typename Range>
+std::string join(const Range& range, const char* sep = ", ") {
+  std::ostringstream os;
+  bool first = true;
+  for (const auto& element : range) {
+    if (not first) {
+      os << sep;
+    }
+    os << element;
+    first = false;
+  }
+  return os.str();
 }
 
 } // namespace util

--- a/tests/graph/graph_test.py
+++ b/tests/graph/graph_test.py
@@ -448,7 +448,7 @@ digraph "graph" {
         self.assertTrue("neg_real must be <=0" in str(cm.exception))
         neg1 = g.add_constant_neg_real(-1.25)
         expected = """
-        Node 0 type 1 parents [ ] children [ ] negative real -1.25
+        0: CONSTANT(negative real -1.25) (out nodes: )
         """
         self.assertEqual(g.to_string().strip(), expected.strip())
         add_negs = g.add_operator(graph.OperatorType.ADD, [neg1, neg1])

--- a/tests/graph/operator_test.py
+++ b/tests/graph/operator_test.py
@@ -144,48 +144,48 @@ class TestOperators(unittest.TestCase):
 
         observed = g.to_string()
         expected = """
-Node 0 type 1 parents [ ] children [ 24 30 31 31 33 ] real 2.5
-Node 1 type 1 parents [ ] children [ 19 23 30 31 33 ] real -1.5
-Node 2 type 1 parents [ ] children [ 22 29 ] probability 0.5
-Node 3 type 1 parents [ ] children [ 16 26 28 29 ] probability 0.6
-Node 4 type 1 parents [ ] children [ 28 29 ] probability 0.7
-Node 5 type 1 parents [ ] children [ 17 ] natural 23
-Node 6 type 1 parents [ ] children [ 27 ] boolean 0
-Node 7 type 1 parents [ ] children [ 18 20 25 32 32 32 ] negative real -1.25
-Node 8 type 1 parents [ ] children [ 21 ] positive real 1.25
-Node 9 type 1 parents [ ] children [ ] matrix<boolean> 1 0
-0 1
-Node 10 type 1 parents [ ] children [ ] matrix<real> -0.1    0
-2   -1
-Node 11 type 1 parents [ ] children [ ] matrix<natural>   1   2
-0 999
-Node 12 type 1 parents [ ] children [ ] matrix<positive real> 0.1   0
-2   1
-Node 13 type 1 parents [ ] children [ ] matrix<negative real> -0.3
--0.4
-Node 14 type 1 parents [ ] children [ ] matrix<probability> 0.1
-0.9
-Node 15 type 1 parents [ ] children [ ] col_simplex_matrix<probability> 0.1   1
-0.9   0
-Node 16 type 3 parents [ 3 ] children [ ] real 0
-Node 17 type 3 parents [ 5 ] children [ ] real 0
-Node 18 type 3 parents [ 7 ] children [ ] real 0
-Node 19 type 3 parents [ 1 ] children [ ] positive real 1e-10
-Node 20 type 3 parents [ 7 ] children [ ] probability 1e-10
-Node 21 type 3 parents [ 8 ] children [ ] positive real 1e-10
-Node 22 type 3 parents [ 2 ] children [ ] negative real -1e-10
-Node 23 type 3 parents [ 1 ] children [ ] real 0
-Node 24 type 3 parents [ 0 ] children [ ] real 0
-Node 25 type 3 parents [ 7 ] children [ ] positive real 1e-10
-Node 26 type 3 parents [ 3 ] children [ ] probability 1e-10
-Node 27 type 3 parents [ 6 ] children [ ] boolean 0
-Node 28 type 3 parents [ 3 4 ] children [ ] probability 1e-10
-Node 29 type 3 parents [ 2 3 4 ] children [ ] probability 1e-10
-Node 30 type 3 parents [ 0 1 ] children [ ] real 0
-Node 31 type 3 parents [ 0 1 0 ] children [ ] real 0
-Node 32 type 3 parents [ 7 7 7 ] children [ ] negative real -1e-10
-Node 33 type 3 parents [ 0 1 ] children [ ] real 0
-        """
+0: CONSTANT(real 2.5) (out nodes: 24, 30, 31, 31, 33)
+1: CONSTANT(real -1.5) (out nodes: 19, 23, 30, 31, 33)
+2: CONSTANT(probability 0.5) (out nodes: 22, 29)
+3: CONSTANT(probability 0.6) (out nodes: 16, 26, 28, 29)
+4: CONSTANT(probability 0.7) (out nodes: 28, 29)
+5: CONSTANT(natural 23) (out nodes: 17)
+6: CONSTANT(boolean 0) (out nodes: 27)
+7: CONSTANT(negative real -1.25) (out nodes: 18, 20, 25, 32, 32, 32)
+8: CONSTANT(positive real 1.25) (out nodes: 21)
+9: CONSTANT(matrix<boolean> 1 0
+0 1) (out nodes: )
+10: CONSTANT(matrix<real> -0.1    0
+2   -1) (out nodes: )
+11: CONSTANT(matrix<natural>   1   2
+0 999) (out nodes: )
+12: CONSTANT(matrix<positive real> 0.1   0
+2   1) (out nodes: )
+13: CONSTANT(matrix<negative real> -0.3
+-0.4) (out nodes: )
+14: CONSTANT(matrix<probability> 0.1
+0.9) (out nodes: )
+15: CONSTANT(col_simplex_matrix<probability> 0.1   1
+0.9   0) (out nodes: )
+16: TO_REAL(3) (out nodes: )
+17: TO_REAL(5) (out nodes: )
+18: TO_REAL(7) (out nodes: )
+19: EXP(1) (out nodes: )
+20: EXP(7) (out nodes: )
+21: EXP(8) (out nodes: )
+22: LOG(2) (out nodes: )
+23: NEGATE(1) (out nodes: )
+24: NEGATE(0) (out nodes: )
+25: NEGATE(7) (out nodes: )
+26: COMPLEMENT(3) (out nodes: )
+27: COMPLEMENT(6) (out nodes: )
+28: MULTIPLY(3, 4) (out nodes: )
+29: MULTIPLY(2, 3, 4) (out nodes: )
+30: ADD(0, 1) (out nodes: )
+31: ADD(0, 1, 0) (out nodes: )
+32: ADD(7, 7, 7) (out nodes: )
+33: POW(0, 1) (out nodes: )
+"""
         self.assertEqual(tidy(expected), tidy(observed))
 
     def test_arithmetic(self) -> None:

--- a/tests/ppl/compiler/bm_graph_builder_test.py
+++ b/tests/ppl/compiler/bm_graph_builder_test.py
@@ -85,14 +85,15 @@ digraph "graph" {
         g = to_bmg_graph(bmg).graph
         observed = g.to_string()
         expected = """
-Node 0 type 1 parents [ ] children [ 1 ] probability 0.5
-Node 1 type 2 parents [ 0 ] children [ 2 ] unknown
-Node 2 type 3 parents [ 1 ] children [ 4 ] boolean 1
-Node 3 type 1 parents [ ] children [ 6 7 ] real 2
-Node 4 type 3 parents [ 2 ] children [ 5 ] real 0
-Node 5 type 3 parents [ 4 ] children [ 6 ] real 0
-Node 6 type 3 parents [ 3 5 ] children [ 7 ] real 0
-Node 7 type 3 parents [ 3 6 ] children [ ] real 0"""
+0: CONSTANT(probability 0.5) (out nodes: 1)
+1: BERNOULLI(0) (out nodes: 2)
+2: SAMPLE(1) (out nodes: 4) observed to be boolean 1
+3: CONSTANT(real 2) (out nodes: 6, 7)
+4: TO_REAL(2) (out nodes: 5)
+5: NEGATE(4) (out nodes: 6)
+6: ADD(3, 5) (out nodes: 7)
+7: MULTIPLY(3, 6) (out nodes: ) queried
+"""
         self.assertEqual(tidy(expected), tidy(observed))
 
         observed = to_bmg_python(bmg).code
@@ -197,16 +198,17 @@ digraph "graph" {
         observed = g.to_string()
         # Here however the orphaned nodes are never added to the graph.
         expected = """
-Node 0 type 1 parents [ ] children [ 1 ] probability 0.25
-Node 1 type 2 parents [ 0 ] children [ 2 ] unknown
-Node 2 type 3 parents [ 1 ] children [ 3 ] boolean 0
-Node 3 type 3 parents [ 2 ] children [ 4 ] boolean 0
-Node 4 type 3 parents [ 3 ] children [ 6 ] positive real 1e-10
-Node 5 type 1 parents [ ] children [ 6 ] positive real 0.5
-Node 6 type 3 parents [ 4 5 ] children [ 8 ] positive real 1e-10
-Node 7 type 1 parents [ ] children [ 8 ] positive real 2
-Node 8 type 3 parents [ 6 7 ] children [ 9 ] positive real 1e-10
-Node 9 type 3 parents [ 8 ] children [ ] real 0"""
+0: CONSTANT(probability 0.25) (out nodes: 1)
+1: BERNOULLI(0) (out nodes: 2)
+2: SAMPLE(1) (out nodes: 3)
+3: COMPLEMENT(2) (out nodes: 4)
+4: TO_POS_REAL(3) (out nodes: 6)
+5: CONSTANT(positive real 0.5) (out nodes: 6)
+6: MULTIPLY(4, 5) (out nodes: 8)
+7: CONSTANT(positive real 2) (out nodes: 8)
+8: POW(6, 7) (out nodes: 9)
+9: LOG(8) (out nodes: ) queried
+"""
         self.assertEqual(tidy(expected), tidy(observed))
 
     def test_to_positive_real(self) -> None:

--- a/tests/ppl/compiler/bmg_factor_test.py
+++ b/tests/ppl/compiler/bmg_factor_test.py
@@ -55,13 +55,13 @@ digraph "graph" {
 
         observed = to_bmg_graph(bmg).graph.to_string()
         expected = """
-Node 0 type 1 parents [ ] children [ 2 ] real 3
-Node 1 type 1 parents [ ] children [ 2 ] positive real 2
-Node 2 type 2 parents [ 0 1 ] children [ 3 ] unknown
-Node 3 type 3 parents [ 2 ] children [ 5 5 6 ] real 7
-Node 4 type 1 parents [ ] children [ 6 ] probability 0.4
-Node 5 type 3 parents [ 3 3 ] children [ 6 ] real 0
-Node 6 type 4 parents [ 3 4 5 ] children [ ] unknown
+0: CONSTANT(real 3) (out nodes: 2)
+1: CONSTANT(positive real 2) (out nodes: 2)
+2: NORMAL(0, 1) (out nodes: 3)
+3: SAMPLE(2) (out nodes: 5, 5, 6) observed to be real 7
+4: CONSTANT(probability 0.4) (out nodes: 6)
+5: MULTIPLY(3, 3) (out nodes: 6)
+6: EXP_PRODUCT(3, 4, 5) (out nodes: ) observed to be unknown
 """
         self.assertEqual(tidy(expected), tidy(observed))
 

--- a/tests/ppl/compiler/dirichlet_test.py
+++ b/tests/ppl/compiler/dirichlet_test.py
@@ -259,11 +259,12 @@ q2 = g.query(n2)
 
         # Note that what was a row vector in the original code is now a column vector.
         expected = """
-Node 0 type 1 parents [ ] children [ ] matrix<positive real> 1
-Node 1 type 1 parents [ ] children [ ] matrix<positive real>   1
- 1.5
-Node 2 type 1 parents [ ] children [ ] matrix<positive real>   1   2
- 1.5 2.5"""
+0: CONSTANT(matrix<positive real> 1) (out nodes: ) queried
+1: CONSTANT(matrix<positive real>   1
+1.5) (out nodes: ) queried
+2: CONSTANT(matrix<positive real>   1   2
+1.5 2.5) (out nodes: ) queried
+"""
         observed = to_bmg_graph(bmg).graph.to_string()
         self.assertEqual(tidy(expected), tidy(observed))
 

--- a/tests/ppl/compiler/graph_accumulation_test.py
+++ b/tests/ppl/compiler/graph_accumulation_test.py
@@ -100,39 +100,39 @@ def chi2():
 
 
 expected_bmg_1 = """
-Node 0 type 1 parents [ ] children [ 1 22 ] probability 0.5
-Node 1 type 2 parents [ 0 ] children [ 2 ] unknown
-Node 2 type 3 parents [ 1 ] children [ ] boolean 0
-Node 3 type 1 parents [ ] children [ 4 ] probability 0.119203
-Node 4 type 2 parents [ 3 ] children [ 5 ] unknown
-Node 5 type 3 parents [ 4 ] children [ ] boolean 0
-Node 6 type 1 parents [ ] children [ 8 ] real 0
-Node 7 type 1 parents [ ] children [ 8 12 12 14 25 ] positive real 1
-Node 8 type 2 parents [ 6 7 ] children [ 9 ] unknown
-Node 9 type 3 parents [ 8 ] children [ 10 19 ] real 0
-Node 10 type 2 parents [ 9 ] children [ 11 ] unknown
-Node 11 type 3 parents [ 10 ] children [ ] boolean 0
-Node 12 type 2 parents [ 7 7 ] children [ 13 ] unknown
-Node 13 type 3 parents [ 12 ] children [ ] probability 1e-10
-Node 14 type 2 parents [ 7 ] children [ 15 16 ] unknown
-Node 15 type 3 parents [ 14 ] children [ 17 19 ] positive real 1e-10
-Node 16 type 3 parents [ 14 ] children [ 17 19 ] positive real 1e-10
-Node 17 type 2 parents [ 15 16 ] children [ 18 ] unknown
-Node 18 type 3 parents [ 17 ] children [ ] probability 1e-10
-Node 19 type 2 parents [ 15 9 16 ] children [ 20 ] unknown
-Node 20 type 3 parents [ 19 ] children [ ] real 0
-Node 21 type 1 parents [ ] children [ 22 ] natural 3
-Node 22 type 2 parents [ 21 0 ] children [ 23 ] unknown
-Node 23 type 3 parents [ 22 ] children [ ] natural 0
-Node 24 type 1 parents [ ] children [ 25 ] positive real 2
-Node 25 type 2 parents [ 7 24 ] children [ 26 ] unknown
-Node 26 type 3 parents [ 25 ] children [ ] positive real 1e-10
-Node 27 type 2 parents [ ] children [ 28 ] unknown
-Node 28 type 3 parents [ 27 ] children [ ] probability 1e-10
-Node 29 type 1 parents [ ] children [ 31 ] positive real 4
-Node 30 type 1 parents [ ] children [ 31 ] positive real 0.5
-Node 31 type 2 parents [ 29 30 ] children [ 32 ] unknown
-Node 32 type 3 parents [ 31 ] children [ ] positive real 1e-10
+0: CONSTANT(probability 0.5) (out nodes: 1, 22)
+1: BERNOULLI(0) (out nodes: 2)
+2: SAMPLE(1) (out nodes: ) queried
+3: CONSTANT(probability 0.119203) (out nodes: 4)
+4: BERNOULLI(3) (out nodes: 5)
+5: SAMPLE(4) (out nodes: ) queried
+6: CONSTANT(real 0) (out nodes: 8)
+7: CONSTANT(positive real 1) (out nodes: 8, 12, 12, 14, 25)
+8: NORMAL(6, 7) (out nodes: 9)
+9: SAMPLE(8) (out nodes: 10, 19) queried
+10: BERNOULLI_LOGIT(9) (out nodes: 11)
+11: SAMPLE(10) (out nodes: ) queried
+12: BETA(7, 7) (out nodes: 13)
+13: SAMPLE(12) (out nodes: ) queried
+14: HALF_CAUCHY(7) (out nodes: 15, 16)
+15: SAMPLE(14) (out nodes: 17, 19) queried
+16: SAMPLE(14) (out nodes: 17, 19) queried
+17: BETA(15, 16) (out nodes: 18)
+18: SAMPLE(17) (out nodes: ) queried
+19: STUDENT_T(15, 9, 16) (out nodes: 20)
+20: SAMPLE(19) (out nodes: ) queried
+21: CONSTANT(natural 3) (out nodes: 22)
+22: BINOMIAL(21, 0) (out nodes: 23)
+23: SAMPLE(22) (out nodes: ) queried
+24: CONSTANT(positive real 2) (out nodes: 25)
+25: GAMMA(7, 24) (out nodes: 26)
+26: SAMPLE(25) (out nodes: ) queried
+27: FLAT() (out nodes: 28)
+28: SAMPLE(27) (out nodes: ) queried
+29: CONSTANT(positive real 4) (out nodes: 31)
+30: CONSTANT(positive real 0.5) (out nodes: 31)
+31: GAMMA(29, 30) (out nodes: 32)
+32: SAMPLE(31) (out nodes: ) queried
 """
 
 # These are cases where we have a type conversion on a sample.
@@ -156,21 +156,21 @@ def binomial_from_bools():
 
 
 expected_bmg_2 = """
-Node 0 type 1 parents [ ] children [ 1 ] probability 0.5
-Node 1 type 2 parents [ 0 ] children [ 2 ] unknown
-Node 2 type 3 parents [ 1 ] children [ 3 4 9 12 ] boolean 0
-Node 3 type 3 parents [ 2 ] children [ 5 ] real 0
-Node 4 type 3 parents [ 2 ] children [ 5 ] positive real 1e-10
-Node 5 type 2 parents [ 3 4 ] children [ 6 ] unknown
-Node 6 type 3 parents [ 5 ] children [ ] real 0
-Node 7 type 1 parents [ ] children [ 9 ] natural 1
-Node 8 type 1 parents [ ] children [ 9 ] natural 0
-Node 9 type 3 parents [ 2 7 8 ] children [ 13 ] natural 1
-Node 10 type 1 parents [ ] children [ 12 ] probability 1
-Node 11 type 1 parents [ ] children [ 12 ] probability 1e-10
-Node 12 type 3 parents [ 2 10 11 ] children [ 13 ] probability 1
-Node 13 type 2 parents [ 9 12 ] children [ 14 ] unknown
-Node 14 type 3 parents [ 13 ] children [ ] natural 0
+0: CONSTANT(probability 0.5) (out nodes: 1)
+1: BERNOULLI(0) (out nodes: 2)
+2: SAMPLE(1) (out nodes: 3, 4, 9, 12)
+3: TO_REAL(2) (out nodes: 5)
+4: TO_POS_REAL(2) (out nodes: 5)
+5: NORMAL(3, 4) (out nodes: 6)
+6: SAMPLE(5) (out nodes: ) queried
+7: CONSTANT(natural 1) (out nodes: 9)
+8: CONSTANT(natural 0) (out nodes: 9)
+9: IF_THEN_ELSE(2, 7, 8) (out nodes: 13)
+10: CONSTANT(probability 1) (out nodes: 12)
+11: CONSTANT(probability 1e-10) (out nodes: 12)
+12: IF_THEN_ELSE(2, 10, 11) (out nodes: 13)
+13: BINOMIAL(9, 12) (out nodes: 14)
+14: SAMPLE(13) (out nodes: ) queried
 """
 
 
@@ -189,16 +189,16 @@ def bool_times_natural():
 
 
 expected_bmg_3 = """
-Node 0 type 1 parents [ ] children [ 2 ] natural 3
-Node 1 type 1 parents [ ] children [ 2 4 8 ] probability 0.5
-Node 2 type 2 parents [ 0 1 ] children [ 3 ] unknown
-Node 3 type 3 parents [ 2 ] children [ 7 ] natural 0
-Node 4 type 2 parents [ 1 ] children [ 5 ] unknown
-Node 5 type 3 parents [ 4 ] children [ 7 ] boolean 0
-Node 6 type 1 parents [ ] children [ 7 ] natural 0
-Node 7 type 3 parents [ 5 3 6 ] children [ 8 ] natural 0
-Node 8 type 2 parents [ 7 1 ] children [ 9 ] unknown
-Node 9 type 3 parents [ 8 ] children [ ] natural 0
+0: CONSTANT(natural 3) (out nodes: 2)
+1: CONSTANT(probability 0.5) (out nodes: 2, 4, 8)
+2: BINOMIAL(0, 1) (out nodes: 3)
+3: SAMPLE(2) (out nodes: 7)
+4: BERNOULLI(1) (out nodes: 5)
+5: SAMPLE(4) (out nodes: 7)
+6: CONSTANT(natural 0) (out nodes: 7)
+7: IF_THEN_ELSE(5, 3, 6) (out nodes: 8)
+8: BINOMIAL(7, 1) (out nodes: 9)
+9: SAMPLE(8) (out nodes: ) queried
 """
 
 # Tests for math functions
@@ -231,24 +231,24 @@ def math4():
 
 
 expected_bmg_4 = """
-Node 0 type 1 parents [ ] children [ 1 ] positive real 1
-Node 1 type 2 parents [ 0 ] children [ 2 3 8 9 13 ] unknown
-Node 2 type 3 parents [ 1 ] children [ 4 ] positive real 1e-10
-Node 3 type 3 parents [ 1 ] children [ 5 ] positive real 1e-10
-Node 4 type 3 parents [ 2 ] children [ 6 ] real 0
-Node 5 type 3 parents [ 3 ] children [ 6 ] positive real 1e-10
-Node 6 type 2 parents [ 4 5 ] children [ 7 ] unknown
-Node 7 type 3 parents [ 6 ] children [ ] real 0
-Node 8 type 3 parents [ 1 ] children [ 10 ] positive real 1e-10
-Node 9 type 3 parents [ 1 ] children [ 10 ] positive real 1e-10
-Node 10 type 3 parents [ 8 9 ] children [ 11 ] positive real 1e-10
-Node 11 type 2 parents [ 10 ] children [ 12 ] unknown
-Node 12 type 3 parents [ 11 ] children [ ] positive real 1e-10
-Node 13 type 3 parents [ 1 ] children [ 14 ] positive real 1e-10
-Node 14 type 3 parents [ 13 ] children [ 15 ] real 0
-Node 15 type 3 parents [ 14 ] children [ 16 ] probability 1e-10
-Node 16 type 2 parents [ 15 ] children [ 17 ] unknown
-Node 17 type 3 parents [ 16 ] children [ ] boolean 0
+0: CONSTANT(positive real 1) (out nodes: 1)
+1: HALF_CAUCHY(0) (out nodes: 2, 3, 8, 9, 13)
+2: SAMPLE(1) (out nodes: 4)
+3: SAMPLE(1) (out nodes: 5)
+4: LOG(2) (out nodes: 6)
+5: EXP(3) (out nodes: 6)
+6: NORMAL(4, 5) (out nodes: 7)
+7: SAMPLE(6) (out nodes: ) queried
+8: SAMPLE(1) (out nodes: 10)
+9: SAMPLE(1) (out nodes: 10)
+10: POW(8, 9) (out nodes: 11)
+11: HALF_CAUCHY(10) (out nodes: 12)
+12: SAMPLE(11) (out nodes: ) queried
+13: SAMPLE(1) (out nodes: 14)
+14: TO_REAL(13) (out nodes: 15)
+15: PHI(14) (out nodes: 16)
+16: BERNOULLI(15) (out nodes: 17)
+17: SAMPLE(16) (out nodes: ) queried
 """
 
 # Demonstrate that we generate 1-p as a complement
@@ -260,12 +260,12 @@ def flip_complement():
 
 
 expected_bmg_5 = """
-Node 0 type 1 parents [ ] children [ 1 1 ] positive real 1
-Node 1 type 2 parents [ 0 0 ] children [ 2 ] unknown
-Node 2 type 3 parents [ 1 ] children [ 3 ] probability 1e-10
-Node 3 type 3 parents [ 2 ] children [ 4 ] probability 1e-10
-Node 4 type 2 parents [ 3 ] children [ 5 ] unknown
-Node 5 type 3 parents [ 4 ] children [ ] boolean 0
+0: CONSTANT(positive real 1) (out nodes: 1, 1)
+1: BETA(0, 0) (out nodes: 2)
+2: SAMPLE(1) (out nodes: 3)
+3: COMPLEMENT(2) (out nodes: 4)
+4: BERNOULLI(3) (out nodes: 5)
+5: SAMPLE(4) (out nodes: ) queried
 """
 
 
@@ -278,13 +278,13 @@ def beta_neg_log():
 
 
 expected_bmg_6 = """
-Node 0 type 1 parents [ ] children [ 1 1 5 ] positive real 1
-Node 1 type 2 parents [ 0 0 ] children [ 2 ] unknown
-Node 2 type 3 parents [ 1 ] children [ 3 ] probability 1e-10
-Node 3 type 3 parents [ 2 ] children [ 4 ] negative real -1e-10
-Node 4 type 3 parents [ 3 ] children [ 5 ] positive real 1e-10
-Node 5 type 2 parents [ 4 0 ] children [ 6 ] unknown
-Node 6 type 3 parents [ 5 ] children [ ] probability 1e-10
+0: CONSTANT(positive real 1) (out nodes: 1, 1, 5)
+1: BETA(0, 0) (out nodes: 2)
+2: SAMPLE(1) (out nodes: 3)
+3: LOG(2) (out nodes: 4)
+4: NEGATE(3) (out nodes: 5)
+5: BETA(4, 0) (out nodes: 6)
+6: SAMPLE(5) (out nodes: ) queried
 """
 
 # Demonstrate that identity additions and multiplications


### PR DESCRIPTION
Summary:
Modify code to test whether variables are marginalizable without throwing an exception if they are not.
Then use that to go over entire graph finding marginalizable variables and marginalizing each of them in sequence.
Checking whether a variable is marginalizable is somewhat complex because we need to determine the set of deterministic nodes directly affected by it. Because this involves computing the entire support, we now cache that. We therefore also add a mechanism to cache this and to invalidate this cache whenever appropriate.

Reviewed By: gafter

Differential Revision: D40872470

