### PR TITLE
[WIP] Aggregate all diagnostic tools together

### DIFF
--- a/src/beanmachine/ppl/diagnostics/tools/js/.prettierrc
+++ b/src/beanmachine/ppl/diagnostics/tools/js/.prettierrc
@@ -1,8 +1,0 @@
-{
-  "arrowParens": "always",
-  "bracketSpacing": false,
-  "printWidth": 88,
-  "proseWrap": "never",
-  "singleQuote": true,
-  "trailingComma": "all"
-}

--- a/src/beanmachine/ppl/diagnostics/tools/js/.prettierrc.json
+++ b/src/beanmachine/ppl/diagnostics/tools/js/.prettierrc.json
@@ -1,0 +1,19 @@
+{
+  "arrowParens": "always",
+  "bracketSameLine": false,
+  "bracketSpacing": false,
+  "embeddedLanguageFormatting": "auto",
+  "endOfLine": "lf",
+  "htmlWhitespaceSensitivity": "css",
+  "jsxSingleQuote": false,
+  "printWidth": 88,
+  "proseWrap": "never",
+  "quoteProps": "as-needed",
+  "semi": true,
+  "singleAttributePerLine": false,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "all",
+  "useTabs": false,
+  "vueIndentScriptAndStyle": false
+}

--- a/src/beanmachine/ppl/diagnostics/tools/viz.py
+++ b/src/beanmachine/ppl/diagnostics/tools/viz.py
@@ -44,8 +44,13 @@ class DiagnosticsTools:
 
     def __init__(self: DiagnosticsTools, mcs: MonteCarloSamples) -> None:
         """Initialize."""
+        from beanmachine.ppl.diagnostics.tools.marginal1d.tool import Marginal1d
+        from beanmachine.ppl.diagnostics.tools.trace.tool import Trace
+
         self.mcs = mcs
         self.idata = self.mcs.to_inference_data()
+        self.marginal1d_tool = Marginal1d
+        self.trace_tool = Trace
 
     @_requires_dev_packages
     def marginal1d(self: DiagnosticsTools) -> None:
@@ -55,9 +60,7 @@ class DiagnosticsTools:
         Returns:
             None: Displays the tool directly in a Jupyter notebook.
         """
-        from beanmachine.ppl.diagnostics.tools.marginal1d.tool import Marginal1d
-
-        Marginal1d(self.mcs).show()
+        self.marginal1d_tool(self.mcs).show()
 
     @_requires_dev_packages
     def trace(self: DiagnosticsTools) -> None:
@@ -67,6 +70,24 @@ class DiagnosticsTools:
         Returns:
             None: Displays the tool directly in a Jupyter notebook.
         """
-        from beanmachine.ppl.diagnostics.tools.trace.tool import Trace
+        self.trace_tool(self.mcs).show()
 
-        Trace(self.mcs).show()
+    @_requires_dev_packages
+    def dashboard(self: DiagnosticsTools) -> None:
+        """
+        Dashboard showing all available diagnostic tools.
+
+        Returns:
+            None: Displays the tool directly in a Jupyter notebook.
+        """
+        from bokeh.embed import file_html
+        from bokeh.models.widgets.panels import Panel, Tabs
+        from bokeh.resources import INLINE
+        from IPython.display import display, HTML
+
+        marginal1d_tool_view = self.marginal1d_tool(self.mcs).create_document()
+        marginal1d_panel = Panel(child=marginal1d_tool_view, title="Marginal 1D tool")
+        trace_tool_view = self.trace_tool(self.mcs).create_document()
+        trace_panel = Panel(child=trace_tool_view, title="Trace tool")
+        tabs = Tabs(tabs=[marginal1d_panel, trace_panel], sizing_mode="scale_both")
+        display(HTML(file_html(tabs, resources=INLINE)))


### PR DESCRIPTION
### Motivation

From an internal discussion, this is a work-in-progress that shows all diagnostic tools in a single dashboard.

### Changes proposed

- Renames the `.prettierrc` file to `.prettierrc.json` purely so editors can have the correct syntax highlighting for the file.
- Updates the `viz.py` file to show how a dashboard that contains all the diagnostic tools in one command could be generated.

### Test Plan

Visual inspection of the tool in the coin flipping tutorial, and output to a local build of the Docusaurus documentation.

### Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](https://github.com/facebookresearch/beanmachine/blob/main/CONTRIBUTING.md)** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] The title of my pull request is a short description of the requested changes.