### PR TITLE
Connect marginalization to Graph API

### DIFF
--- a/src/beanmachine/graph/graph.cpp
+++ b/src/beanmachine/graph/graph.cpp
@@ -1234,18 +1234,24 @@ void Graph::_infer(
     nmc(num_samples, seed, infer_config);
   } else if (algorithm == InferenceType::NUTS) {
     nuts(num_samples, seed, infer_config);
+  } else if (
+      algorithm == InferenceType::AUTOMATIC_DISCRETE_MARGINALIZATION_NMC) {
+    automatic_discrete_marginalization(
+        InferenceType::NMC, num_samples, seed, infer_config);
+  } else if (
+      algorithm == InferenceType::AUTOMATIC_DISCRETE_MARGINALIZATION_NUTS) {
+    automatic_discrete_marginalization(
+        InferenceType::NUTS, num_samples, seed, infer_config);
   } else {
     throw invalid_argument("unsupported inference algorithm.");
   }
 }
 
-vector<vector<NodeValue>>&
-Graph::infer(uint num_samples, InferenceType algorithm, uint seed) {
-  InferConfig infer_config = InferConfig();
-  // TODO: why don't the initialization below to be done for _infer?
-  // If they do, move them there.
-  // Not clear why we have infer and _infer instead of just infer with
-  // a default infer_config.
+vector<vector<NodeValue>>& Graph::infer(
+    uint num_samples,
+    InferenceType algorithm,
+    uint seed,
+    InferConfig infer_config) {
   agg_type = AggregationType::NONE;
   samples.clear();
   log_prob_vals.clear();
@@ -1335,9 +1341,11 @@ void Graph::_infer_parallel(
   }
 }
 
-vector<double>&
-Graph::infer_mean(uint num_samples, InferenceType algorithm, uint seed) {
-  InferConfig infer_config = InferConfig();
+vector<double>& Graph::infer_mean(
+    uint num_samples,
+    InferenceType algorithm,
+    uint seed,
+    InferConfig infer_config) {
   agg_type = AggregationType::MEAN;
   agg_samples = num_samples;
   means.clear();

--- a/src/beanmachine/graph/graph.h
+++ b/src/beanmachine/graph/graph.h
@@ -442,7 +442,13 @@ enum class InferenceType {
   GIBBS,
   NMC,
   NUTS,
+  AUTOMATIC_DISCRETE_MARGINALIZATION_NMC,
+  AUTOMATIC_DISCRETE_MARGINALIZATION_NUTS,
 };
+// Eventually we may choose to make inference types full-fledged objects.
+// This would allow automatic discrete marginalization to be a parametric type
+// taking another inference type as parameter: AMD(NUTS), AMD(NUTS), for
+// example.
 
 enum class AggregationType {
   UNKNOWN,
@@ -766,10 +772,14 @@ class Graph {
   :param algorithm: The sampling algorithm, currently supporting REJECTION,
                     GIBBS, and NMC.
   :param seed: The seed provided to the random number generator.
+  :param infer_config: inference configuration.
   :returns: The posterior samples.
   */
-  std::vector<std::vector<NodeValue>>&
-  infer(uint num_samples, InferenceType algorithm, uint seed = 5123401);
+  std::vector<std::vector<NodeValue>>& infer(
+      uint num_samples,
+      InferenceType algorithm,
+      uint seed = 5123401,
+      InferConfig infer_config = InferConfig());
   /*
   Draw Monte Carlo samples from the posterior distribution using multiple
   chains.
@@ -794,10 +804,14 @@ class Graph {
   :param num_samples: The number of the MCMC samples.
   :param algorithm: The sampling algorithm, currently supporting REJECTION,
   GIBBS, and NMC. :param seed: The seed provided to the random number generator.
+  :param infer_config: inference configuration.
   :returns: The posterior means.
   */
-  std::vector<double>&
-  infer_mean(uint num_samples, InferenceType algorithm, uint seed = 5123401);
+  std::vector<double>& infer_mean(
+      uint num_samples,
+      InferenceType algorithm,
+      uint seed = 5123401,
+      InferConfig infer_config = InferConfig());
   /*
   Make point estimates of the posterior means from multiple MCMC chains.
 
@@ -1053,7 +1067,7 @@ class Graph {
       InferenceType algorithm,
       uint seed,
       uint n_chains,
-      InferConfig infer_config);
+      InferConfig infer_config = InferConfig());
 
   uint thread_index;
   std::vector<std::unique_ptr<Node>> nodes; // all nodes in topological order
@@ -1081,6 +1095,11 @@ class Graph {
       uint steps_per_iter,
       std::mt19937& gen,
       uint elbo_samples);
+  void automatic_discrete_marginalization(
+      InferenceType base_inference_type,
+      uint num_samples,
+      uint seed,
+      InferConfig infer_config);
 
   // TODO: Review what members of this class can be made static.
 

--- a/src/beanmachine/graph/pybindings.cpp
+++ b/src/beanmachine/graph/pybindings.cpp
@@ -328,12 +328,14 @@ PYBIND11_MODULE(graph, module) {
       .def("query", &Graph::query, "query a node", py::arg("node_id"))
       .def(
           "infer_mean",
-          (std::vector<double> & (Graph::*)(uint, InferenceType, uint)) &
+          (std::vector<double> &
+           (Graph::*)(uint, InferenceType, uint, InferConfig)) &
               Graph::infer_mean,
           "infer the posterior mean of the queried nodes",
           py::arg("num_samples"),
           py::arg("algorithm") = InferenceType::GIBBS,
-          py::arg("seed") = 5123401)
+          py::arg("seed") = 5123401,
+          py::arg("infer_config") = InferConfig())
       .def(
           "infer_mean",
           (std::vector<std::vector<double>> &
@@ -348,12 +350,13 @@ PYBIND11_MODULE(graph, module) {
       .def(
           "infer",
           (std::vector<std::vector<NodeValue>> &
-           (Graph::*)(uint, InferenceType, uint)) &
+           (Graph::*)(uint, InferenceType, uint, InferConfig)) &
               Graph::infer,
           "infer the empirical distribution of the queried nodes",
           py::arg("num_samples"),
           py::arg("algorithm") = InferenceType::GIBBS,
-          py::arg("seed") = 5123401)
+          py::arg("seed") = 5123401,
+          py::arg("infer_config") = InferConfig())
       .def(
           "infer",
           (std::vector<std::vector<std::vector<NodeValue>>> &


### PR DESCRIPTION
Summary: We introduce two new values to `InferenceType` enum for automatic discrete marginalization (AMD) so AMD can be ran from the normal Graph inference API.

Differential Revision: D41060415

