### PR TITLE
Remove arviz as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ REQUIRED_MAJOR = 3
 REQUIRED_MINOR = 7
 
 INSTALL_REQUIRES = [
-    "arviz>=0.12.1",
     "astor>=0.7.1",
     "black==22.3.0",
     "botorch>=0.5.1",
@@ -36,6 +35,7 @@ INSTALL_REQUIRES = [
 ]
 TEST_REQUIRES = ["pytest>=7.0.0", "pytest-cov"]
 TUTORIALS_REQUIRES = [
+    "arviz>=0.12.1",
     "bokeh",
     "cma",
     "ipywidgets",

--- a/src/beanmachine/ppl/inference/monte_carlo_samples.py
+++ b/src/beanmachine/ppl/inference/monte_carlo_samples.py
@@ -5,7 +5,6 @@
 
 from typing import Any, Dict, Iterator, List, Mapping, NamedTuple, Optional, Union
 
-import arviz as az
 import torch
 import xarray as xr
 from beanmachine.ppl.inference.utils import detach_samples, merge_dicts
@@ -266,10 +265,11 @@ class MonteCarloSamples(Mapping[RVIdentifier, torch.Tensor]):
             if n not in self.namespaces:
                 self.namespaces[n] = mcs.namespaces[n]
 
-    def to_inference_data(self, include_adapt_steps: bool = False) -> az.InferenceData:
+    def to_inference_data(self, include_adapt_steps: bool = False):
         """
         Return an az.InferenceData from MonteCarloSamples.
         """
+        import arviz as az
 
         if "posterior" in self.namespaces:
             posterior = detach_samples(self.namespaces["posterior"].samples)


### PR DESCRIPTION
### Motivation
This removes arviz as an explicit dependency of Bean Machine. This will also prevent a circular dependency with arviz.

### Changes proposed
Updates setup.py and moves import into `to_inference_data`

### Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](https://github.com/facebookresearch/beanmachine/blob/main/CONTRIBUTING.md)** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] The title of my pull request is a short description of the requested changes.
