### PR TITLE
Fix GP unit test

### DIFF
--- a/tests/ppl/experimental/gp/inference_test.py
+++ b/tests/ppl/experimental/gp/inference_test.py
@@ -35,6 +35,8 @@ class Regression(SimpleGP):
             jitter = jitter.unsqueeze(0)
         mean = self.mean(data)
         cov = self.kernel(data) + jitter
+        if cov.ndim > mean.ndim + 1:
+            cov = cov.squeeze(0)
         return MultivariateNormal(mean, cov)
 
 


### PR DESCRIPTION
Summary: Turning off fast computations in BoTorch broke this test. The MVN `covar` had 1 more batch dimension than `loc`, which the approximate `log_prob` was happy with but the exact `log_prob` did not like.

Reviewed By: Balandat

Differential Revision: D42194245

