### PR TITLE
Remove an undefined name

### DIFF
--- a/src/beanmachine/ppl/__init__.py
+++ b/src/beanmachine/ppl/__init__.py
@@ -41,7 +41,6 @@ __all__ = [
     "Diagnostics",
     "GlobalHamiltonianMonteCarlo",
     "GlobalNoUTurnSampler",
-    "Predictive",
     "RVIdentifier",
     "SingleSiteAncestralMetropolisHastings",
     "SingleSiteHamiltonianMonteCarlo",


### PR DESCRIPTION
In file: __init__.py, the list named `__all__` contains an undefined name which can result in errors  when this module is imported. I removed the undefined name from the list. 

Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.