### PR TITLE
Remove vcpkg requirement and use conda for range-v3

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,28 +48,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
         activate-environment: build_env
 
-    - name: Install Windows range-v3 dependency
-      if: matrix.os == 'windows-latest'
-      run: |
-        git clone https://github.com/Microsoft/vcpkg.git
-        cd vcpkg
-        bootstrap-vcpkg.bat
-        vcpkg integrate install
-        vcpkg install range-v3
-
-    - name: Install Unix range-v3 dependency
-      if: matrix.os != 'windows-latest'
-      run: |
-        git clone https://github.com/Microsoft/vcpkg.git
-        cd vcpkg
-        ./bootstrap-vcpkg.sh
-        ./vcpkg integrate install
-        ./vcpkg install range-v3
-        sudo mv ./packages/range-v3_x64-linux/include /usr/include/range-v3
-
     - name: Install other dependencies
       run: |
-        conda install -c conda-forge -y boost-cpp eigen=3.4.0
+        conda install -c conda-forge -y boost-cpp eigen range-v3
         python -m pip install --upgrade pip
         pip install -U build
 
@@ -124,13 +105,8 @@ jobs:
         CIBW_SKIP: "*-manylinux_i686 *-musllinux_*"
         CIBW_ARCHS_MACOS: x86_64 universal2 arm64
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-        CIBW_BEFORE_ALL_LINUX: >  # Manually install range-v3 with vcpkg and Eigen3.4 since yum is not up to date
-          yum install -y curl zip unzip tar wget boost169-devel &&
-          git clone https://github.com/Microsoft/vcpkg.git &&
-          cd vcpkg &&
-          ./bootstrap-vcpkg.sh &&
-          ./vcpkg integrate install &&
-          ./vcpkg install range-v3 &&
+        CIBW_BEFORE_ALL_LINUX: >  # Manually install Eigen3.4 since yum is not up to date
+          yum install -y curl zip unzip tar wget boost169-devel range-v3-devel &&
           wget https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz &&
           tar -xvf eigen-3.4.0.tar.gz &&
           mv eigen-3.4.0 /usr/include/eigen3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,18 +29,10 @@ jobs:
         python-version: ${{ matrix.python-version }}
         activate-environment: test_env
 
-    - name: Install range-v3 dependency
-      run: |
-        git clone https://github.com/Microsoft/vcpkg.git
-        cd vcpkg
-        ./bootstrap-vcpkg.sh
-        ./vcpkg integrate install
-        ./vcpkg install range-v3
-
     - name: Install other dependencies
       run: |
         sudo apt-get install -y yarn
-        conda install -c conda-forge -y boost-cpp eigen=3.4.0
+        conda install -c conda-forge -y boost-cpp eigen range-v3
         python -m pip install --upgrade pip
         python -m pip install setuptools
         python -m pip install notebook

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,7 +42,7 @@ jobs:
       run: pip list
 
     - name: Lint with flake8
-      run: flake8 . --exclude
+      run: flake8 .
 
     - name: Lint with ufmt (black + usort)
       run: ufmt check .*/beanmachine/src

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,18 +30,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
         activate-environment: test_env
 
-    - name: Install Unix range-v3 dependency
-      if: matrix.os != 'windows-latest'
-      run: |
-        git clone https://github.com/Microsoft/vcpkg.git
-        cd vcpkg
-        ./bootstrap-vcpkg.sh
-        ./vcpkg integrate install
-        ./vcpkg install range-v3
-
     - name: Install dependencies
       run: |
-        conda install -c conda-forge -y boost-cpp eigen=3.4.0
+        conda install -c conda-forge -y boost-cpp eigen range-v3
         pip install torch --extra-index-url https://download.pytorch.org/whl/cpu
         VERSION=$(grep "version" .pyre_configuration | sed -n -e 's/.*\(0\.0\.[0-9]*\).*/\1/p')
         pip install pyre-check-nightly==$VERSION
@@ -51,7 +42,7 @@ jobs:
       run: pip list
 
     - name: Lint with flake8
-      run: flake8 . --exclude ./vcpkg
+      run: flake8 . --exclude
 
     - name: Lint with ufmt (black + usort)
       run: ufmt check .*/beanmachine/src

--- a/.github/workflows/nightly.yml.disabled
+++ b/.github/workflows/nightly.yml.disabled
@@ -31,18 +31,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
         activate-environment: test_env
 
-    - name: Install Unix range-v3 dependency
-      if: matrix.os != 'windows-latest'
-      run: |
-        git clone https://github.com/Microsoft/vcpkg.git
-        cd vcpkg
-        ./bootstrap-vcpkg.sh
-        ./vcpkg integrate install
-        ./vcpkg install range-v3
-
     - name: Install other dependencies
       run: |
-        conda install -c conda-forge -y boost-cpp eigen=3.4.0
+        conda install -c conda-forge -y boost-cpp eigen range-v3
         python -m pip install --upgrade pip
 
     - name: Install Bean Machine

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,27 +35,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
         activate-environment: test_env
 
-    - name: Install Windows range-v3 dependency
-      if: matrix.os == 'windows-latest'
-      run: |
-        git clone https://github.com/Microsoft/vcpkg.git
-        cd vcpkg
-        bootstrap-vcpkg.bat
-        vcpkg integrate install
-        vcpkg install range-v3
-
-    - name: Install Unix range-v3 dependency
-      if: matrix.os != 'windows-latest'
-      run: |
-        git clone https://github.com/Microsoft/vcpkg.git
-        cd vcpkg
-        ./bootstrap-vcpkg.sh
-        ./vcpkg integrate install
-        ./vcpkg install range-v3
-
     - name: Install other dependencies
       run: |
-        conda install -c conda-forge -y boost-cpp eigen=3.4.0
+        conda install -c conda-forge -y boost-cpp eigen range-v3
         python -m pip install --upgrade pip
 
     - name: Install CPU PyTorch (only for Linux)

--- a/.gitignore
+++ b/.gitignore
@@ -121,6 +121,3 @@ website/static/js/*
 !website/static/js/code_block_buttons.js
 website/static/_sphinx-sources/
 docs/api/
-
-## ignore user's local installation of vcpkg
-vcpkg

--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -14,5 +14,5 @@
   "source_directories": [
     "./src/beanmachine/ppl"
   ],
-  "version": "0.0.101676376688"
+  "version": "0.0.101696158792"
 }

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Bean Machine supports Python 3.7-3.10 and PyTorch 1.12.
 ### Install the Latest Release with Pip
 
 ```bash
-python -m pip install beanmachine
+pip install beanmachine
 ```
 
 ### Install from Source
@@ -33,31 +33,20 @@ cd beanmachine
 
 Then, you can choose from any of the following installation options.
 
-#### Package Managers (Anaconda and Vcpkg)
+#### Package Managers (Conda)
 
 Installing Bean Machine from source requires three external dependencies: [Boost](https://www.boost.org/), [Eigen](https://eigen.tuxfamily.org/index.php?title=Main_Page), and [`range-v3`](https://github.com/ericniebler/range-v3).
-
-For installing Boost and Eigen, we recommend using [conda](https://docs.conda.io/en/latest/) to manage the virtual environment and install the necessary build dependencies.
+We recommend using [conda](https://docs.conda.io/en/latest/) to manage the virtual environment and install the necessary build dependencies.
 
 ```bash
 conda create -n {env name} python=3.8; conda activate {env name}
-conda install -c conda-forge boost-cpp eigen=3.4.0
-```
-
-There are [multiple ways of installing `range-v3`](https://github.com/ericniebler/range-v3#building-range-v3---using-vcpkg), including through [`vcpkg`](https://github.com/Microsoft/vcpkg):
-
-```
-git clone https://github.com/Microsoft/vcpkg.git
-cd vcpkg
-./bootstrap-vcpkg.sh
-./vcpkg integrate install
-./vcpkg install range-v3
+conda install -c conda-forge boost-cpp eigen range-v3
 ```
 
 Once dependencies are installed, install Bean Machine by running Pip:
 
 ```
-python -m pip install .
+pip install .
 ```
 
 #### Docker
@@ -72,7 +61,7 @@ docker run -it beanmachine:latest bash
 If you would like to run the builtin unit tests:
 
 ```bash
-python -m pip install "beanmachine[test]"
+pip install "beanmachine[test]"
 pytest .
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,11 @@ if platform.system() == "Windows":
         "/wd4244",
     ]
 else:
-    CPP_COMPILE_ARGS = ["-std=c++2a", "-Werror"]
+    CPP_COMPILE_ARGS = [
+        "-std=c++2a",
+        "-Werror",
+        "-Wno-unused-but-set-variable",  # Eigen 3.4 triggers this
+    ]
 
 
 # Check for python version
@@ -128,75 +132,6 @@ elif sys.platform.startswith("darwin"):
         glob("/usr/local/Cellar/eigen/*/include/eigen3")
         + glob("/usr/local/Cellar/boost/*/include")
     )
-
-# Add range-v3 'include' directory to configuration
-RANGE_V3_INCLUDE_DIR_CANDIDATES = [
-    c for c in [os.environ.get("RANGE_V3_INCLUDE_DIR")] if c is not None
-]
-if sys.platform.startswith("linux"):
-    RANGE_V3_INCLUDE_DIR_CANDIDATES.extend(
-        [
-            os.path.join(current_dir, "vcpkg/packages/range-v3_x64-linux/include"),
-            "/usr/include/range-v3",
-        ]
-    )
-elif sys.platform.startswith("darwin"):
-    RANGE_V3_INCLUDE_DIR_CANDIDATES.extend(
-        [
-            os.path.join(current_dir, "vcpkg/packages/range-v3_x64-osx/include"),
-            *glob("/usr/local/Cellar/range-v3/*/include"),  # Homebrew
-        ]
-    )
-elif platform.system() == "Windows":
-    RANGE_V3_INCLUDE_DIR_CANDIDATES.extend(
-        [
-            os.path.join(current_dir, "vcpkg/packages/range-v3_x86-windows/include"),
-            # The following option was observed being used on GitHub Actions runner:
-            "C:/vcpkg/packages/range-v3_x86-windows/include",
-        ]
-    )
-print(
-    "Checking directories for range-v3 'include':\n",
-    "\n".join(RANGE_V3_INCLUDE_DIR_CANDIDATES),
-)
-selected_range_v3_include_dirs = [
-    candidate
-    for candidate in RANGE_V3_INCLUDE_DIR_CANDIDATES
-    if os.path.isdir(candidate)
-]
-print(
-    "Existing candidate directories for range-v3 'include':\n",
-    "\n".join(selected_range_v3_include_dirs),
-)
-if len(selected_range_v3_include_dirs) == 0:
-    if os.environ.get("RANGE_V3_INCLUDE_DIR"):
-        message = (
-            "Could not find 'include' directory for range-v3 library dependency "
-            + f"either at {os.environ.get('RANGE_V3_INCLUDE_DIR')}\n"
-            + "as indicated in environment variable RANGE_V3_INCLUDE_DIR, "
-            + "nor in some other common locations.\n"
-            + "Please make sure library is installed (see README.md) and "
-            + "set RANGE_V3_INCLUDE_DIR environment variable to the right directory."
-        )
-    else:
-        message = (
-            "Could not find 'include' directory for range-v3 library dependency "
-            + "in some common locations.\n"
-            + "Please make sure library is installed (see README.md). "
-            + "You can also manually indicate the correct 'include' directory by "
-            + "setting the environment variable RANGE_V3_INCLUDE_DIR environment "
-            + "variable to the right directory."
-        )
-        message += "Here are the directories we checked:\n " + "\n".join(
-            RANGE_V3_INCLUDE_DIR_CANDIDATES
-        )
-    sys.exit(message)
-else:
-    print(
-        "Using the following directory for range-v3 'include':\n",
-        selected_range_v3_include_dirs[0],
-    )
-    INCLUDE_DIRS.append(selected_range_v3_include_dirs[0])
 
 setup(
     name="beanmachine",

--- a/website/scripts/convert_ipynb_to_mdx.py
+++ b/website/scripts/convert_ipynb_to_mdx.py
@@ -7,7 +7,6 @@ import json
 import re
 import shutil
 import uuid
-import warnings
 from pathlib import Path
 from typing import Any, Dict, List, Tuple, Union
 
@@ -523,10 +522,7 @@ def handle_pandas(
         # Remove the index if it is just a range, and output to markdown.
         mdx = ""
         if isinstance(md_df.index, pd.RangeIndex):
-            # Ignore FutureWarning: 'showindex' is deprecated.
-            with warnings.catch_warnings():
-                warnings.filterwarnings("ignore", category=FutureWarning)
-                mdx = md_df.to_markdown(showindex=False)
+            mdx = md_df.to_markdown(index=False)
         elif not isinstance(md_df.index, pd.RangeIndex):
             mdx = md_df.to_markdown()
         output.append((index, f"\n{mdx}\n\n"))


### PR DESCRIPTION
### Motivation
Now that range-v3 is available in conda-forge (https://github.com/conda-forge/staged-recipes/pull/22443), we can simplify the installation and get rid of the need to install vcpkg just to get the range-v3 dependency.

### Changes proposed
- Remove vcpkg installation guide from README and CI
- Install `range-v3` from conda-forge together when we install Boost and Eigen

### Test Plan
I have tested and verify that the changes run on my MacOS machine (with Python 3.10). If the CI also pass then we should be good.

### Types of changes
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](https://github.com/facebookresearch/beanmachine/blob/main/CONTRIBUTING.md)** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] The title of my pull request is a short description of the requested changes.
